### PR TITLE
Making container center on >big screens (1280px)

### DIFF
--- a/src/vue-components/layout/layout.ios.styl
+++ b/src/vue-components/layout/layout.ios.styl
@@ -163,5 +163,6 @@ body.desktop
   @media only screen and (min-width $layout-large-min)
     max-width $layout-big-max
     padding 3rem 4rem
+    margin auto
     &.horizontal
       padding 0 4rem

--- a/src/vue-components/layout/layout.mat.styl
+++ b/src/vue-components/layout/layout.mat.styl
@@ -124,5 +124,6 @@ body.desktop
   @media only screen and (min-width $layout-large-min)
     max-width $layout-big-max
     padding 3rem 4rem
+    margin auto
     &.horizontal
       padding 0 4rem


### PR DESCRIPTION
Added margin auto to ios and mat to get `layout-padding` container center, as it should be