### PR TITLE
Dev Builds

### DIFF
--- a/build/shell.deploy.sh
+++ b/build/shell.deploy.sh
@@ -1,12 +1,20 @@
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" == "master" ]
+then
+  TAG="latest"
+else
+  TAG="$BRANCH"
+fi
+
 set -e
-echo "Enter release version: "
+echo "Enter release version @$TAG: "
 read VERSION
 
-read -p "Deploy $VERSION - are you sure? (y/n)" -n 1 -r
+read -p "Deploy $VERSION@$TAG - are you sure? (y/n)" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  echo "Deploying $VERSION ..."
+  echo "Deploying $VERSION@$TAG ..."
 
   # lint and test
   npm run lint 2>/dev/null
@@ -29,5 +37,5 @@ then
   # publish
   git push origin refs/tags/v$VERSION
   git push
-  npm publish
+  npm publish --tag=$TAG
 fi


### PR DESCRIPTION
`npm run deploy` on a branch other than `master`, will publish quasar [with that flag](https://docs.npmjs.com/cli/tag). For example:

Running `npm run deploy` from the branch `dev`, will publish quasar to `quasar-framework@dev`. To install that version, one would need to run `npm i quasar-framework@dev`.

Running `npm run deploy` from `master`, will publish quasar to `quasar-framework@latest`, which is the default and can be installed with `npm i quasar-framework` as usual.

