### PR TITLE
fix: Dialog/ActionSheet are not destroyed in some situations

### DIFF
--- a/src/components/action-sheet/ActionSheet.vue
+++ b/src/components/action-sheet/ActionSheet.vue
@@ -5,6 +5,7 @@
     position-classes="items-end justify-center"
     transition="q-modal-actions"
     :content-css="css"
+    @close="$root.$destroy()"
   >
     <!-- Material -->
     <div v-once v-if="$quasar.theme === 'mat'">
@@ -153,7 +154,6 @@ export default {
         return
       }
       this.$refs.dialog.close(() => {
-        this.$root.$destroy()
         if (typeof fn === 'function') {
           fn()
         }

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-modal class="minimized" ref="dialog">
+  <q-modal class="minimized" ref="dialog" @close="$root.$destroy()">
     <div class="modal-header" v-html="title || ''"></div>
     <div v-if="message" class="modal-body modal-scroll" v-html="message"></div>
 
@@ -150,7 +150,6 @@ export default {
         if (typeof fn === 'function') {
           fn()
         }
-        this.$root.$destroy()
       })
     }
   },


### PR DESCRIPTION
These components are not properly destroyed when they are closed using the Escape key or clicking the Modal backdrop.  Although hidden, the instances are alive and it could lead to memory leak.

![quasar](https://cloud.githubusercontent.com/assets/1206248/20637007/7e63a946-b379-11e6-93b9-c256a8df89ca.png)
