### PR TITLE
fix: Removed max-width on layout style

### DIFF
--- a/src/vue-components/layout/layout.ios.styl
+++ b/src/vue-components/layout/layout.ios.styl
@@ -151,17 +151,16 @@ body.desktop
     &.horizontal
       padding 0 .5rem
   @media only screen and (min-width $layout-medium-min) and (max-width $layout-medium-max)
-    max-width (.75 * $layout-medium-max)
     padding 1.5rem 2rem
+    margin auto
     &.horizontal
       padding 0 2rem
   @media only screen and (min-width $layout-big-min) and (max-width $layout-big-max)
-    max-width (.75 * $layout-big-max)
     padding 2.5rem 3rem
+    margin auto
     &.horizontal
       padding 0 3rem
   @media only screen and (min-width $layout-large-min)
-    max-width $layout-big-max
     padding 3rem 4rem
     margin auto
     &.horizontal

--- a/src/vue-components/layout/layout.mat.styl
+++ b/src/vue-components/layout/layout.mat.styl
@@ -112,17 +112,16 @@ body.desktop
     &.horizontal
       padding 0 .5rem
   @media only screen and (min-width $layout-medium-min) and (max-width $layout-medium-max)
-    max-width (.75 * $layout-medium-max)
     padding 1.5rem 2rem
+    margin auto
     &.horizontal
       padding 0 2rem
   @media only screen and (min-width $layout-big-min) and (max-width $layout-big-max)
-    max-width (.75 * $layout-big-max)
     padding 2.5rem 3rem
+    margin auto
     &.horizontal
       padding 0 3rem
   @media only screen and (min-width $layout-large-min)
-    max-width $layout-big-max
     padding 3rem 4rem
     margin auto
     &.horizontal


### PR DESCRIPTION
Removes the max-width on layout-padding, which results in just padding on all screen sizes. If a max-width is set, it will be centered on all screens.