### PR TITLE
Firefox - Hide the numeric spinner

### DIFF
--- a/src/vue-components/numeric/numeric.ios.styl
+++ b/src/vue-components/numeric/numeric.ios.styl
@@ -17,3 +17,6 @@
     text-align center
     transition all .25s ease-in
     max-width 100%
+
+    input[type="number"]
+      -moz-appearance: textfield

--- a/src/vue-components/numeric/numeric.mat.styl
+++ b/src/vue-components/numeric/numeric.mat.styl
@@ -17,3 +17,6 @@
     text-align center
     transition all .25s ease-in
     max-width 100%
+
+    input[type="number"]
+      -moz-appearance: textfield


### PR DESCRIPTION
Hide the numeric spinner so the number is visible.