### PR TITLE
stepper: allow custom action before moving to next step

### DIFF
--- a/src/vue-components/stepper/Step.vue
+++ b/src/vue-components/stepper/Step.vue
@@ -48,6 +48,10 @@ export default {
     ready: {
       type: Boolean,
       default: true
+    },
+    beforeNext: {
+      type: Function,
+      default: null
     }
   },
   data () {
@@ -63,7 +67,12 @@ export default {
   methods: {
     nextStep () {
       if (this.ready) {
-        this.$parent.nextStep()
+        if (this.beforeNext) {
+          this.beforeNext(this.$parent.nextStep)
+        }
+        else {
+          this.$parent.nextStep()
+        }
       }
     },
     previousStep () {


### PR DESCRIPTION
Allow inject custom action before the stepper moving to next step.

Usage: 

In template:

```
<q-stepper>
  <q-step :beforeNext="verifiyAnswer">
     <input v-model="answer">
  </q-step>
  <q-step>Congrats!</q-step>
</q-stepper>
```

In script:
```
export default {
  data () { return { answer: "foo" } },
  methods: {
     verifyAnswer (next) {
        if (this.answer === "bar") {
           next()
        }
        else {
           alert('wrong answer')
        }
     }
  }
}
```