### PR TITLE
Simplify Infinite Scroll markup

### DIFF
--- a/src/vue-components/infinite-scroll/InfiniteScroll.vue
+++ b/src/vue-components/infinite-scroll/InfiniteScroll.vue
@@ -3,7 +3,6 @@
     <div ref="content" class="q-infinite-scroll-content">
       <slot></slot>
     </div>
-    <br>
     <div class="q-infinite-scroll-message" v-show="fetching">
       <slot name="message"></slot>
     </div>


### PR DESCRIPTION
This `<br>` shouldn't be here. I assume its here for styling, but that should be left to css.