### PR TITLE
fix: Don't close drawer on resize

### DIFF
--- a/src/vue-components/drawer/Drawer.vue
+++ b/src/vue-components/drawer/Drawer.vue
@@ -205,7 +205,8 @@ export default {
     setState (state, done) {
       if (
         (!this.swipeOnly && Utils.dom.viewport().width > 920) ||
-        (typeof state === 'boolean' && this.opened === state)
+        (typeof state === 'boolean' && this.opened === state) ||
+        (done && done.type === 'resize')
       ) {
         if (typeof done === 'function') {
           done()


### PR DESCRIPTION
when there is a textbox in the drawer, the keyboard resize the window and close the drawer