### PR TITLE
Add validation to DrawerLink

### DIFF
--- a/src/vue-components/drawer/DrawerLink.vue
+++ b/src/vue-components/drawer/DrawerLink.vue
@@ -10,10 +10,9 @@
 <script>
 export default {
   props: {
-    icon: {
-      type: String
-    }, 
+    icon: String,
     to: {
+      type: [Object, String],
       required: true
     }
   }

--- a/src/vue-components/drawer/DrawerLink.vue
+++ b/src/vue-components/drawer/DrawerLink.vue
@@ -9,6 +9,13 @@
 
 <script>
 export default {
-  props: ['icon', 'to']
+  props: {
+    icon: {
+      type: String
+    }, 
+    to: {
+      required: true
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Leaving off the "to" attr causes a nasty error that is difficult to track down. If it's going to error without 'to', make it required.