### PR TITLE
Text-shadow in buttons

### DIFF
--- a/src/css-components/button/button.mat.styl
+++ b/src/css-components/button/button.mat.styl
@@ -102,7 +102,9 @@ button
   for $name, $color in $colors
     &.{$name}
       background $color
-      text-shadow 0 0 2px black
+      
+      //Material guidelines does not show text-shadow in buttons
+      //text-shadow 0 0 2px black
 
       if $name != 'light' && $name != 'white'
         color white

--- a/src/css-components/button/button.mat.styl
+++ b/src/css-components/button/button.mat.styl
@@ -102,14 +102,9 @@ button
   for $name, $color in $colors
     &.{$name}
       background $color
-      
-      //Material guidelines does not show text-shadow in buttons
-      //text-shadow 0 0 2px black
 
       if $name != 'light' && $name != 'white'
         color white
-      else
-        text-shadow none
 
       &:active:not(.disabled)
         background active-color($color) !important
@@ -140,7 +135,6 @@ button
 
   &.clear, &.outline
     background transparent
-    text-shadow none
     &:active:not(.disabled)
       color white
 


### PR DESCRIPTION
Material guidelines don't show text-shadow in buttons. Just to make Quasar more material ;)