### PR TITLE
Added jump to step on click if step is active

### DIFF
--- a/src/vue-components/stepper/Step.vue
+++ b/src/vue-components/stepper/Step.vue
@@ -3,7 +3,7 @@
     class="timeline-item"
     :class="{incomplete: step > stepper.currentStep}"
   >
-    <div class="timeline-badge">
+    <div class="timeline-badge" @click="goToStep()">
       <i v-show="!done">
         done
       </i>
@@ -73,6 +73,12 @@ export default {
     }
   },
   methods: {
+    goToStep () {
+      if (!this.ready) {
+        return
+      }
+      this.$parent.goToStep(this.step)
+    },
     nextStep () {
       if (!this.ready) {
         return

--- a/src/vue-components/stepper/Stepper.vue
+++ b/src/vue-components/stepper/Stepper.vue
@@ -52,6 +52,10 @@ export default {
       this.config.currentStep = this.config.steps + 1
       this.$emit('step', this.config.currentStep)
       this.$emit('finish')
+    },
+    goToStep (i) {
+      this.config.currentStep = i
+      this.$emit('step', this.config.currentStep)
     }
   },
   mounted () {


### PR DESCRIPTION
Whenever a user clicks on a step's badge, the stepper jumps to that step but only if that step is ready.