### PR TITLE
feat: allow customize q-data-table labels

### DIFF
--- a/dev/components/components/data-table.vue
+++ b/dev/components/components/data-table.vue
@@ -171,7 +171,14 @@ export default {
         labels: {
           columns: 'Coluuuuumns',
           allCols: 'Eeeeeeeeevery Cols',
-          rows: 'Rooows'
+          rows: 'Rooows',
+          selected: {
+            singular: 'item selected.',
+            plural: 'items selected.'
+          },
+          clear: 'clear',
+          search: 'Search',
+          all: 'All'
         }
       },
       columns: [

--- a/src/vue-components/data-table/DataTable.vue
+++ b/src/vue-components/data-table/DataTable.vue
@@ -25,8 +25,10 @@
 
     <div class="q-data-table-toolbar upper-toolbar row reverse-wrap items-center justify-end q-data-table-selection" v-show="toolbar === 'selection'">
       <div class="auto">
-        {{ rowsSelected }} item<span v-show="rowsSelected > 1">s</span> selected.
-        <button class="primary clear small" @click="clearSelection()">Clear</button>
+        {{ rowsSelected }}
+        <span v-if="rowsSelected === 1">{{labels.selected.singular}}</span>
+        <span v-else>{{labels.selected.plural}}</span>
+        <button class="primary clear small" @click="clearSelection()">{{labels.clear}}</button>
       </div>
       <div>
         <slot name="selection" :rows="selectedRows"></slot>

--- a/src/vue-components/data-table/DataTable.vue
+++ b/src/vue-components/data-table/DataTable.vue
@@ -26,9 +26,9 @@
     <div class="q-data-table-toolbar upper-toolbar row reverse-wrap items-center justify-end q-data-table-selection" v-show="toolbar === 'selection'">
       <div class="auto">
         {{ rowsSelected }}
-        <span v-if="rowsSelected === 1">{{labels.selected.singular}}</span>
-        <span v-else>{{labels.selected.plural}}</span>
-        <button class="primary clear small" @click="clearSelection()">{{labels.clear}}</button>
+        <span v-if="rowsSelected === 1">{{ labels.selected.singular }}</span>
+        <span v-else>{{ labels.selected.plural }}</span>
+        <button class="primary clear small" @click="clearSelection()">{{ labels.clear }}</button>
       </div>
       <div>
         <slot name="selection" :rows="selectedRows"></slot>

--- a/src/vue-components/data-table/plugins/filter/TableFilter.vue
+++ b/src/vue-components/data-table/plugins/filter/TableFilter.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-data-table-toolbar upper-toolbar row auto items-center">
-    <q-search class="auto" v-model="filtering.terms"></q-search>
+    <q-search class="auto" v-model="filtering.terms" :placeholder="labels.search"></q-search>
     <q-select
       v-model="filtering.field"
       type="list"

--- a/src/vue-components/data-table/plugins/i18n/i18n.js
+++ b/src/vue-components/data-table/plugins/i18n/i18n.js
@@ -7,7 +7,7 @@ const labels = {
     singular: 'item selected.',
     plural: 'items selected.'
   },
-  clear: 'clear',
+  clear: 'Clear',
   search: 'Search',
   all: 'All'
 }

--- a/src/vue-components/data-table/plugins/i18n/i18n.js
+++ b/src/vue-components/data-table/plugins/i18n/i18n.js
@@ -2,7 +2,14 @@ import Utils from '../../../../utils'
 const labels = {
   columns: 'Columns',
   allCols: 'All Columns',
-  rows: 'Rows'
+  rows: 'Rows',
+  selected: {
+    singular: 'item selected.',
+    plural: 'items selected.'
+  },
+  clear: 'clear',
+  search: 'Search',
+  all: 'All'
 }
 
 export default {

--- a/src/vue-components/data-table/plugins/pagination/pagination.js
+++ b/src/vue-components/data-table/plugins/pagination/pagination.js
@@ -1,17 +1,17 @@
 import TablePagination from './TablePagination.vue'
 
 const defaultOptions = [
-  {label: 'All', value: 0},
-  {label: '5', value: 5},
-  {label: '10', value: 10},
-  {label: '15', value: 15},
-  {label: '20', value: 20},
-  {label: '50', value: 50},
-  {label: '100', value: 100}
+  { label: 'All', value: 0 },
+  { label: '5', value: 5 },
+  { label: '10', value: 10 },
+  { label: '15', value: 15 },
+  { label: '20', value: 20 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 }
 ]
 
 function parseOptions (opts) {
-  return [{label: 'All', value: 0}].concat(
+  return [{ label: 'All', value: 0 }].concat(
     opts.map(opt => {
       return {
         label: '' + opt,
@@ -23,44 +23,51 @@ function parseOptions (opts) {
 
 export default {
   data () {
-    let
-      cfg = this.config.pagination,
-      rowsPerPage = 0, options = defaultOptions
-
-    if (cfg) {
-      if (cfg.rowsPerPage) {
-        rowsPerPage = cfg.rowsPerPage
-      }
-      if (cfg.options) {
-        options = parseOptions(cfg.options)
-      }
-    }
-
     return {
-      pagination: {
+      _pagination: {
         page: 1,
         entries: 0,
-        options,
-        rowsPerPage
+        rowsPerPage: null
+      }
+    }
+  },
+  computed: {
+    pagination () {
+      let self = this,
+        cfg = this.config.pagination,
+        options = defaultOptions
+
+      if (cfg) {
+        if (cfg.options) {
+          options = parseOptions(cfg.options)
+        }
+      }
+
+      options[0].label = this.labels.all
+
+      return {
+        get page () { return self.$data._pagination.page },
+        set page (page) { self.$data._pagination.page = page },
+        get entries () { return self.$data._pagination.entries },
+        set entries (entries) { self.$data._pagination.entries = entries },
+        get rowsPerPage () {
+          let rowsPerPage = self.$data._pagination.rowsPerPage
+          if (rowsPerPage == null) {
+            if (cfg && typeof cfg.rowsPerPage !== 'undefined') {
+              rowsPerPage = cfg.rowsPerPage
+            }
+            else {
+              rowsPerPage = 0
+            }
+          }
+          return rowsPerPage
+        },
+        set rowsPerPage (rowsPerPage) { self.$data._pagination.rowsPerPage = rowsPerPage },
+        options
       }
     }
   },
   watch: {
-    'config.pagination': {
-      deep: true,
-      handler (cfg) {
-        if (cfg === false) {
-          this.pagination.rowsPerPage = 0
-          return
-        }
-        if (typeof cfg.rowsPerPage !== 'undefined' && cfg.rowsPerPage !== this.pagination.rowsPerPage) {
-          this.pagination.rowsPerPage = cfg.rowsPerPage
-        }
-        if (cfg.options) {
-          this.pagination.options = parseOptions(cfg.options)
-        }
-      }
-    },
     'pagination.page' () {
       this.$refs.body.scrollTop = 0
     }


### PR DESCRIPTION
New feature to allow customize q-data-table labels “x item selected”, “CLEAR”, “Search” and “All”.

It’s important for i18n.

Default labels are:

```
{
  columns: 'Columns',
  allCols: 'All Columns',
  rows: 'Rows',
  selected: {
    singular: 'item selected.',
    plural: 'items selected.'
  },
  clear: 'clear',
  search: 'Search',
  all: 'All'
}
```