### PR TITLE
Fix for popover.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ npm-debug.log
 test/unit/coverage/
 test/e2e/dist/
 cordova
-.idea
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 test/unit/coverage/
 test/e2e/dist/
 cordova
+.idea
+.idea/

--- a/src/vue-components/popover/Popover.vue
+++ b/src/vue-components/popover/Popover.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="q-popover animate-scale" :style="transformCSS" @click.stop>
-    <slot></slot>
+    <div style="max-height: 50vh">
+      <slot></slot>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Temporary fix to avoid popover losing target anchor. The height of the container has a max so elements inside will scroll if they are superior to 50vh.