### PR TITLE
Fixes #420

### DIFF
--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -20,7 +20,7 @@ function animate ({id, finalPos, pos, threshold, factor, done, apply}) {
 export default function start ({name, finalPos, pos, threshold = 1, factor = 5, done, apply}) {
   let id = name
   if (id) {
-    stop(id)
+    start.stop(id)
   }
   else {
     id = uid()


### PR DESCRIPTION
Tested on Win10 Pro with IE11 (and es6 polyfill), Firefox, Chrome and Edge.

Used the left drawer, which fails in IE11 with `"stop()" is undefined` without this change. 

Scott