### PR TITLE
Updated height & width variable reference

### DIFF
--- a/src/vue-components/radio/radio.mat.styl
+++ b/src/vue-components/radio/radio.mat.styl
@@ -4,8 +4,8 @@ $radio-border-width ?= $generic-input-border-width
 
 .q-radio
   display inline-block
-  height $checkbox-size
-  width $checkbox-size
+  height $radio-size
+  width $radio-size
   vertical-align middle
 
   input


### PR DESCRIPTION
Radio component .q-radio class properties height & width were pointing at checkbox variable.