### PR TITLE
Fix problem in Datetime that causes momentjs warning

### DIFF
--- a/src/vue-components/datetime/Datetime.vue
+++ b/src/vue-components/datetime/Datetime.vue
@@ -141,7 +141,7 @@ export default {
       return value
     },
     __setModel () {
-      this.model = this.value || this.__normalizeValue(moment(this.defaultSelection)).format(this.format)
+      this.model = this.value || this.__normalizeValue(moment(this.defaultSelection)).format()
     },
     __update () {
       this.$emit('input', this.model)


### PR DESCRIPTION
When a non ISO format is used for a Datetime component it leads to a warning (and sometimes causes an error, it depends on format and environment).
For example, the following code
```js
<template>
  <div>
    <q-datetime v-model="time" format="DD.MM.YYYY, HH:mm:ss" type="datetime"></q-datetime>
  </div>
</template>

<script>
export default {
  data () {
    return {
      time: ''
    }
  }
}
</script>

```
produces this warning:
```
Deprecation warning: value provided is not in a recognized ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments: 
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: 01.03.2017, 11:47:08, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.eval [as createFromInputFallback] (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:318:94)
    at configFromString (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2080:15)
    at configFromInput (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2444:9)
    at prepareConfig (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2427:9)
    at createFromConfig (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2394:40)
    at createLocalOrUTC (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2481:12)
    at createLocal (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:2485:12)
    at hooks (eval at <anonymous> (http://localhost:8080/js/app.js:789:1), <anonymous>:16:25)
    at VueComponent.model (eval at <anonymous> (http://localhost:8080/js/app.js:1511:1), <anonymous>:3987:41)
    at Watcher.run (eval at <anonymous> (http://localhost:8080/js/app.js:796:1), <anonymous>:3017:19)
```

I have fixed this problem.