### PR TITLE
Header & footer flex-shrink

### DIFF
--- a/src/vue-components/layout/layout.ios.styl
+++ b/src/vue-components/layout/layout.ios.styl
@@ -37,6 +37,7 @@ $toolbar-padding           ?= 4px 10px
   color $toolbar-color
   background $toolbar-background
   z-index $z-marginals
+  flex-shrink 0
 
 .toolbar
   padding $toolbar-padding

--- a/src/vue-components/layout/layout.mat.styl
+++ b/src/vue-components/layout/layout.mat.styl
@@ -41,6 +41,7 @@ $toolbar-padding           ?= 4px 12px
   color $toolbar-color
   background $toolbar-background
   z-index $z-marginals
+  flex-shrink 0
 
 .toolbar
   padding $toolbar-padding


### PR DESCRIPTION
Fixes #422 

[More info](https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored)