### PR TITLE
Dev page - Fix closing tags

### DIFF
--- a/dev/components/components/image-gallery.vue
+++ b/dev/components/components/image-gallery.vue
@@ -5,7 +5,7 @@
       <q-gallery :src="gallery"></q-gallery>
 
       <h5>Gallery Slider</h5>
-      <q-gallery-slider :src="slider"></q-gallery>
+      <q-gallery-slider :src="slider"></q-gallery-slider>
     </div>
   </div>
 </template>

--- a/dev/components/components/spinner.vue
+++ b/dev/components/components/spinner.vue
@@ -19,7 +19,7 @@
           ok-label="Pick"
           title="Spinner Color"
           style="vertical-align: middle"
-        ></q-select>
+        ></q-dialog-select>
       </div>
 
       <p class="caption">

--- a/dev/components/components/tooltip.vue
+++ b/dev/components/components/tooltip.vue
@@ -53,7 +53,7 @@
             <q-tooltip :anchor="anchor" :self="self">
               <div>Quasar is <strong>great</strong>!</div>
               <div class="text-center">Try it.</div>
-            </q-popover>
+            </q-tooltip>
           </button>
         </div>
 


### PR DESCRIPTION
The dev page wouldn't build (`npm run dev`) due to several closing tags being wrong: 

```
ERROR in ./~/vue-loader/lib/template-compiler.js?id=data-v-44aff98c!./~/vue-loader/lib/selector.js?type=template&index=0!./dev/components/components/image-gallery.vue

  Vue template syntax error:

  tag <q-gallery-slider> has no matching end tag.

 @ ./dev/components/components/image-gallery.vue 5:2-176
 @ ./dev/components async ^\.\/.*\.vue$
 @ ./dev/router.js
 @ ./dev/main.js
 @ multi ./build/hot-reload ./dev/main.js

ERROR in ./~/vue-loader/lib/template-compiler.js?id=data-v-22dc0d45!./~/vue-loader/lib/selector.js?type=template&index=0!./dev/components/components/spinner.vue

  Vue template syntax error:

  tag <q-dialog-select> has no matching end tag.

 @ ./dev/components/components/spinner.vue 5:2-170
 @ ./dev/components async ^\.\/.*\.vue$
 @ ./dev/router.js
 @ ./dev/main.js
 @ multi ./build/hot-reload ./dev/main.js

ERROR in ./~/vue-loader/lib/template-compiler.js?id=data-v-9d27b3a2!./~/vue-loader/lib/selector.js?type=template&index=0!./dev/components/components/tooltip.vue

  Vue template syntax error:

  tag <q-tooltip> has no matching end tag.

 @ ./dev/components/components/tooltip.vue 5:2-170
 @ ./dev/components async ^\.\/.*\.vue$
 @ ./dev/router.js
 @ ./dev/main.js
 @ multi ./build/hot-reload ./dev/main.js
```