### PR TITLE
Collapsible component - fixed content during animation

### DIFF
--- a/src/vue-components/collapsible/Collapsible.vue
+++ b/src/vue-components/collapsible/Collapsible.vue
@@ -10,8 +10,10 @@
       <i class="item-secondary" :class="{'rotate-180': active}" @click.stop="toggle">keyboard_arrow_down</i>
     </div>
     <q-transition name="slide">
-      <div class="q-collapsible-sub-item" v-show="active">
-        <slot></slot>
+      <div v-show="active">
+        <div class="q-collapsible-sub-item">
+          <slot></slot>
+        </div>
       </div>
     </q-transition>
   </div>


### PR DESCRIPTION
I thought it looked weird to have the content size change when the collapsible component is animating. This adds a wrapper div for the animation to run on, preventing the content from moving.