### PR TITLE
Slider infinite scrolling

### DIFF
--- a/dev/components/components/slider.vue
+++ b/dev/components/components/slider.vue
@@ -34,9 +34,9 @@
       </q-slider>
 
       <p class="caption">
-        Slider with Centered Content
+        Slider with Centered Content and Infinite Scrolling
       </p>
-      <q-slider arrows dots class="text-white">
+      <q-slider infinite arrows dots class="text-white">
         <div slot="slide" class="bg-primary centered">
           Slide 1
         </div>

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -5,22 +5,24 @@
         ref="track"
         class="q-slider-track"
         :style="trackPosition"
-        :class="{'with-arrows': arrows, 'with-toolbar': toolbar}"
+        :class="{'with-arrows': arrows, 'with-toolbar': toolbar, 'infinite-left': infiniteLeft, 'infinite-right': infiniteRight}"
         v-touch-pan.horizontal="__pan"
       >
+        <div v-show="infiniteRight"></div>
         <slot name="slide"></slot>
+        <div v-show="infiniteLeft"></div>
       </div>
       <div
         v-if="arrows"
         class="q-slider-left-button row items-center justify-center"
-        :class="{hidden: slide === 0}"
+        :class="{hidden: slide === 0 && !infinite}"
       >
         <i @click="goToSlide(slide - 1)">keyboard_arrow_left</i>
       </div>
       <div
         v-if="arrows"
         class="q-slider-right-button row items-center justify-center"
-        :class="{hidden: slide === slidesNumber - 1}"
+        :class="{hidden: slide === slidesNumber - 1 && !infinite}"
         @click="goToSlide(slide + 1)"
       >
         <i>keyboard_arrow_right</i>
@@ -56,7 +58,8 @@ export default {
     arrows: Boolean,
     dots: Boolean,
     fullscreen: Boolean,
-    actions: Boolean
+    actions: Boolean,
+    infinite: Boolean
   },
   data () {
     return {
@@ -78,6 +81,12 @@ export default {
     },
     trackPosition () {
       return Utils.dom.cssTransform(`translateX(${this.position}%)`)
+    },
+    infiniteRight () {
+      return this.infinite && this.slidesNumber > 0 && this.slide >= (this.slidesNumber - 1)
+    },
+    infiniteLeft () {
+      return this.infinite && this.slide <= 0
     }
   },
   methods: {
@@ -90,8 +99,8 @@ export default {
       let delta = (event.direction === 'left' ? -1 : 1) * event.distance.x
 
       if (
-        (this.slide === 0 && delta > 0) ||
-        (this.slide === this.slidesNumber - 1 && delta < 0)
+        (!this.infinite && this.slide === 0 && delta > 0) ||
+        (!this.infinite && this.slide === this.slidesNumber - 1 && delta < 0)
       ) {
         delta = delta / 10
       }
@@ -108,7 +117,23 @@ export default {
       }
     },
     goToSlide (slide, noAnimation) {
-      this.slide = Utils.format.between(slide, 0, this.slidesNumber - 1)
+      // Quick fix for getting stuck on the moved slide
+      // Seems like animation done callback might not always be called
+      if (this.infinite) {
+        if (slide < -1) {
+          this.goToSlide(this.slidesNumber - 1, true)
+          slide = this.slidesNumber - 2
+        }
+        else if (slide > this.slidesNumber) {
+          this.goToSlide(0, true)
+          slide = 1
+        }
+      }
+
+      this.slide = this.infinite
+        ? Utils.format.between(slide, -1, this.slidesNumber)
+        : Utils.format.between(slide, 0, this.slidesNumber - 1)
+
       const pos = -this.slide * 100
       if (noAnimation) {
         this.stopAnimation()
@@ -121,6 +146,18 @@ export default {
         finalPos: pos,
         apply: (pos) => {
           this.position = pos
+        },
+        done: () => {
+          if (!this.infinite) {
+            return
+          }
+
+          if (slide === -1) {
+            this.goToSlide(this.slidesNumber - 1, true)
+          }
+          else if (slide === this.slidesNumber) {
+            this.goToSlide(0, true)
+          }
         }
       })
     },

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -72,6 +72,16 @@ export default {
   },
   watch: {
     slide (value) {
+      // Correct value while infinite scrolling
+      // TODO: Can this be avoided and just set slide itself to the right value
+      //       while still scrolling correctly?
+      if (value === -1) {
+        value = this.slidesNumber - 1
+      }
+      else if (value === this.slidesNumber) {
+        value = 0
+      }
+
       this.$emit('slide', value)
     }
   },

--- a/src/vue-components/slider/slider.ios.styl
+++ b/src/vue-components/slider/slider.ios.styl
@@ -38,6 +38,13 @@ $slider-dots-size        ?= .8rem
       align-items center
       justify-content center
 
+  &.infinite-left > div:nth-last-child(2)
+    order -100
+    margin-left -100%
+
+  &.infinite-right > div:nth-child(2)
+    order 100
+
   &.with-arrows
     > div
       padding-left 10%

--- a/src/vue-components/slider/slider.mat.styl
+++ b/src/vue-components/slider/slider.mat.styl
@@ -26,7 +26,7 @@ $slider-dots-size        ?= .9rem
   flex-wrap nowrap
   height 100%
 
-  > div
+  > div, & > span
     flex 0 0 100%
     min-height $slider-min-height
     margin 0
@@ -37,6 +37,13 @@ $slider-dots-size        ?= .9rem
       flex-direction column
       align-items center
       justify-content center
+
+  &.infinite-left > div:nth-last-child(2)
+    order -100
+    margin-left -100%
+
+  &.infinite-right > div:nth-child(2)
+    order 100
 
   &.with-arrows
     > div

--- a/src/vue-components/slider/slider.mat.styl
+++ b/src/vue-components/slider/slider.mat.styl
@@ -26,7 +26,7 @@ $slider-dots-size        ?= .9rem
   flex-wrap nowrap
   height 100%
 
-  > div, & > span
+  > div
     flex 0 0 100%
     min-height $slider-min-height
     margin 0


### PR DESCRIPTION
I needed infinite scrolling so I modified this quickly, it should probably be cleaned up some. Opening this for some feedback.

This works by moving the first slide to the right of the last one when it is scrolled to the end, and the last to the left of the first when scrolled to the start (using the `order` css property). Empty divs were added before and after the `slot` to fill the space when the order is changed.