### PR TITLE
fix: Slider next/back button not working corretly after mount()

### DIFF
--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -112,6 +112,7 @@ export default {
     },
     goToSlide (slide, noAnimation) {
       if (this.slidesNumber === 0) {
+        this.position = 0
         return
       }
       this.slide = Utils.format.between(slide, 0, this.slidesNumber - 1)

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -57,8 +57,7 @@ export default {
     arrows: Boolean,
     dots: Boolean,
     fullscreen: Boolean,
-    actions: Boolean,
-    name: String
+    actions: Boolean
   },
   data () {
     return {

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -110,14 +110,11 @@ export default {
     __getSlidesNumber () {
       return this.$slots.slide ? this.$slots.slide.length : 0
     },
-    __normalizeSlideNumber (slide) {
-      return Utils.format.between(slide, 0, this.slidesNumber - 1)
-    },
     goToSlide (slide, noAnimation) {
       if (this.slidesNumber === 0) {
         return
       }
-      this.slide = this.__normalizeSlideNumber(slide)
+      this.slide = Utils.format.between(slide, 0, this.slidesNumber - 1)
       const pos = -this.slide * 100
       if (noAnimation) {
         this.stopAnimation()

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="q-slider" :class="{fullscreen: inFullscreen}">
     <div class="q-slider-inner">
-      <p class="text-dark">{{slidesNumber}}</p>
       <div
         ref="track"
         class="q-slider-track"

--- a/src/vue-components/slider/Slider.vue
+++ b/src/vue-components/slider/Slider.vue
@@ -62,7 +62,6 @@ export default {
     return {
       position: 0,
       slide: 0,
-      slidesNumber: 0,
       inFullscreen: false,
       animUid: Utils.uid()
     }
@@ -75,6 +74,9 @@ export default {
   computed: {
     toolbar () {
       return this.dots || this.fullscreen || this.actions
+    },
+    slidesNumber () {
+      return this.$slots.slide ? this.$slots.slide.length : 0
     },
     trackPosition () {
       return Utils.dom.cssTransform(`translateX(${this.position}%)`)
@@ -164,11 +166,6 @@ export default {
     },
     stopAnimation () {
       Utils.animate.stop(this.animUid)
-    }
-  },
-  beforeUpdate () {
-    if (this.$slots.slide && this.slidesNumber !== this.$slots.slide.length) {
-      this.slidesNumber = this.$slots.slide.length
     }
   },
   mounted () {


### PR DESCRIPTION
There is a bug with the slider the first time the right arrow button is pressed - can be seen in the [demo](http://quasar-framework.org/components/slider.html#Basic-Slider), click the right arrow without dragging the slider at all and it will scroll behind the first slide, showing nothing.

This happens because `slidesNumber` isn't up to date and is still `0`, so it scrolls to `-1`. It seems like setting it in `beforeChange` should've worked, changing it to a computed property fixes the issue though.

Edit: This bug also caused the indicator dots to not show until the slider was dragged