### PR TITLE
Ability to use Date objects and numbers as values for model, min and max properties of Datetime

### DIFF
--- a/build/script.build.stylus.js
+++ b/build/script.build.stylus.js
@@ -8,6 +8,7 @@ var
   themes = ['ios', 'mat'],
   nonStandalone = process.argv[2] === 'simple' || process.argv[3] === 'simple',
   version = process.env.VERSION || require('../package.json').version,
+  pathList = [path.join(__dirname, '../src/themes/')],
   banner =
     '/*!\n' +
     ' * Quasar Framework v' + version + '\n' +
@@ -22,7 +23,7 @@ themes.forEach(function (theme) {
     data
 
   deps = stylus(readFile(src))
-    .set('paths', [path.join(__dirname, '../src/themes/')])
+    .set('paths', pathList)
     .deps()
 
   data = compile([src].concat(deps))
@@ -31,30 +32,32 @@ themes.forEach(function (theme) {
   writeFile('dist/quasar.' + theme + '.styl', data)
 
   // write compiled CSS file
-  stylus(data).render(function (err, css) {
-    if (err) {
-      logError('Stylus could not compile ' + src.gray + ' file...')
-      throw err
-    }
+  stylus(data)
+    .set('paths', pathList)
+    .render(function (err, css) {
+      if (err) {
+        logError('Stylus could not compile ' + src.gray + ' file...')
+        throw err
+      }
 
-    // write unprefixed non-standalone version
-    writeFile('dist/quasar.' + theme + '.css', css)
+      // write unprefixed non-standalone version
+      writeFile('dist/quasar.' + theme + '.css', css)
 
-    if (nonStandalone) {
-      return
-    }
+      if (nonStandalone) {
+        return
+      }
 
-    // write auto-prefixed standalone version
-    postcss([autoprefixer]).process(css).then(function (result) {
-      result.warnings().forEach(function (warn) {
-        console.warn(warn.toString())
-      })
-      writeFile('dist/quasar.' + theme + '.standalone.css', result.css)
-      cssnano.process(result.css).then(function (result) {
-        writeFile('dist/quasar.' + theme + '.standalone.min.css', result.css)
+      // write auto-prefixed standalone version
+      postcss([autoprefixer]).process(css).then(function (result) {
+        result.warnings().forEach(function (warn) {
+          console.warn(warn.toString())
+        })
+        writeFile('dist/quasar.' + theme + '.standalone.css', result.css)
+        cssnano.process(result.css).then(function (result) {
+          writeFile('dist/quasar.' + theme + '.standalone.min.css', result.css)
+        })
       })
     })
-  })
 })
 
 function logError (err) {

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -54,6 +54,12 @@
       <p class="caption">Date & Time</p>
       <q-datetime v-model="model" type="datetime"></q-datetime>
 
+      <p class="caption">Date with number model, specified display format, min and max values</p>
+      <q-datetime v-model="numModel" type="date" :min="dateMin" :max="numMax" format="L"></q-datetime>
+
+      <p class="caption">Time with Date model</p>
+      <q-datetime v-model="dateModel" type="time"></q-datetime>
+
       <p class="caption">With Label</p>
       <q-datetime v-model="model" type="date" label="Pick Date"></q-datetime>
 
@@ -157,6 +163,10 @@ export default {
   data () {
     return {
       model: '2016-09-18T10:45:00.000Z',
+      dateModel: new Date(2016, 1, 15, 11, 22),
+      numModel: new Date(2017, 2, 15).getTime(),
+      dateMin: new Date(2017, 2, 10),
+      numMax: new Date(2018, 2, 10).getTime(),
       minMaxModel: '2016-10-24T10:40:14.674Z',
       min: moment('2016-10-24T10:40:14.674Z').subtract(5, 'days').format(),
       max: moment('2016-10-24T10:40:14.674Z').add(4, 'hours').add(10, 'minutes').add(1, 'month').format()

--- a/src/vue-components/datetime/Datetime.vue
+++ b/src/vue-components/datetime/Datetime.vue
@@ -141,7 +141,7 @@ export default {
       return value
     },
     __setModel () {
-      this.model = this.value || this.__normalizeValue(moment(this.defaultSelection)).format(this.format)
+      this.model = this.value || this.__normalizeValue(moment(this.defaultSelection)).format()
     },
     __update () {
       this.$emit('input', this.model)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It is inconvenient that model for Datetime component should only be string in special form.
So I have added ability to use Date objects and numbers as values for model, min and max properties.
