### PR TITLE
feat(Datetime): use date/number for value, min, max

### DIFF
--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -54,6 +54,12 @@
       <p class="caption">Date & Time</p>
       <q-datetime v-model="model" type="datetime"></q-datetime>
 
+      <p class="caption">Date with number model, specified display format, min and max values</p>
+      <q-datetime v-model="numModel" type="date" :min="dateMin" :max="numMax" format="L"></q-datetime>
+
+      <p class="caption">Time with Date model</p>
+      <q-datetime v-model="dateModel" type="time"></q-datetime>
+
       <p class="caption">With Label</p>
       <q-datetime v-model="model" type="date" label="Pick Date"></q-datetime>
 
@@ -157,6 +163,10 @@ export default {
   data () {
     return {
       model: '2016-09-18T10:45:00.000Z',
+      dateModel: new Date(2016, 1, 15, 11, 22),
+      numModel: new Date(2017, 2, 15).getTime(),
+      dateMin: new Date(2017, 2, 10),
+      numMax: new Date(2018, 2, 10).getTime(),
       minMaxModel: '2016-10-24T10:40:14.674Z',
       min: moment('2016-10-24T10:40:14.674Z').subtract(5, 'days').format(),
       max: moment('2016-10-24T10:40:14.674Z').add(4, 'hours').add(10, 'minutes').add(1, 'month').format()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It is inconvenient that model for Datetime component should only be string in special form.
So I have added ability to use Date objects and numbers as values for model, min and max properties.