### PR TITLE
init <input type="file"> after added a file

### DIFF
--- a/src/vue-components/uploader/Uploader.vue
+++ b/src/vue-components/uploader/Uploader.vue
@@ -167,6 +167,7 @@ export default {
       })
       this.otherFiles = this.otherFiles.concat(files.filter(file => !file.type.startsWith('image')))
       this.files = this.files.concat(files)
+      this.$refs.file.value = ''
     },
     __remove (name, done) {
       this.$emit(done ? 'upload' : 'remove', name)


### PR DESCRIPTION
If you select a file, then commit it, when you select the same file in next time, it will not trigger the `onchange` event, so the solution is set `file.value = ''` after added a file.