### PR TITLE
Fix #427: Make css grid width options go up to 12

### DIFF
--- a/dev/components/css/grid.vue
+++ b/dev/components/css/grid.vue
@@ -38,6 +38,22 @@
           <div class="auto"><div>auto</div></div>
         </div>
 
+        <div class="row gutter wrap justify-stretch content-center text-center">
+          <div class="width-1of2"><div>1/2</div></div>
+          <div class="width-1of3"><div>1/3</div></div>
+          <div class="width-1of6"><div>1/6</div></div>
+        </div>
+
+        <div class="row gutter wrap justify-stretch content-center text-center">
+          <div class="width-1of4"><div>1/4</div></div>
+          <div class="width-1of8"><div>1/8</div></div>
+          <div class="width-1of8"><div>1/8</div></div>
+          <div class="width-1of6"><div>1/6</div></div>
+          <div class="width-1of6"><div>1/6</div></div>
+          <div class="width-1of12"><div>1/12</div></div>
+          <div class="width-1of12"><div>1/12</div></div>
+        </div>
+
         <p class="caption">Grid in Grid in Grid</p>
         <div class="row gutter">
           <div>

--- a/src/themes/core/flex.styl
+++ b/src/themes/core/flex.styl
@@ -64,7 +64,7 @@ for i in 0..10
 .offset-0
   margin-left 0
 
-for $cols in (1..5)
+for $cols in (1..12)
   for $parts in (1..$cols)
     &.width-{$parts}of{$cols}
       flex 0 1 ($parts / $cols * 100)%
@@ -149,7 +149,7 @@ flex-media-query($type)
   .{$type}-offset-0
     margin-left 0
 
-  for $cols in (1..5)
+  for $cols in (1..12)
     for $parts in (1..$cols)
       .{$type}-width-{$parts}of{$cols}
         flex 0 1 ($parts / $cols * 100)%


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Updates an existing feature - makes `width-XofY`/`offset-XofY` maximum 12 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app

Fixes issue #427 

