### PR TITLE
[Feature] Add enter event to search component

### DIFF
--- a/src/vue-components/search/Search.vue
+++ b/src/vue-components/search/Search.vue
@@ -29,6 +29,7 @@
         v-model="model"
         @focus="focus"
         @blur="blur"
+        @keyup.enter="enter"
         :disabled="disable"
         :readonly="readonly"
         tabindex="0"
@@ -118,6 +119,9 @@ export default {
     blur () {
       this.focused = false
       this.$emit('blur')
+    },
+    enter () {
+      this.$emit('enter')
     }
   },
   beforeDestroy () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

I would only like to search when enter is pressed, right now the only option is to use the `input` event and run queries while you type.

**Other information:**

It would be better if all key codes could be passed up and then Vue's [`@keyup` events](https://vuejs.org/v2/guide/events.html#Key-Modifiers) could be used on the search component, I'm not sure if there's a clean way of doing that though.