### PR TITLE
fix: QDatetimeRange vertical alignment if one field is empty and one is not

### DIFF
--- a/src/components/datetime/datetime.ios.styl
+++ b/src/components/datetime/datetime.ios.styl
@@ -119,9 +119,11 @@ body.desktop .q-datetime-col-wrapper
       padding 0 6px
       text-align center
 
-.q-datetime-range.full-width
+.q-datetime-range
     display flex
     > div
-      flex 1 1 auto
+      flex 0 1 auto
+    &.full-width > div
+      flex-grow 1
     > div + div
       margin-left $datetime-range-space

--- a/src/components/datetime/datetime.mat.styl
+++ b/src/components/datetime/datetime.mat.styl
@@ -166,10 +166,12 @@ for $pos in 0..12
     top (((1 + sin($degree * 1deg)) * 100%) / 2)
     left (((1 + cos($degree * 1deg)) * 100%) / 2)
 
-.q-datetime-range.full-width
+.q-datetime-range
     display flex
     > div
-      flex 1 1 auto
+      flex 0 1 auto
+    &.full-width > div
+      flex-grow 1
     > div + div
       margin-left $datetime-range-space
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In case one of the fields in QDatetimeRange has value and one has not the fields are missaligned.
This fix uses the same styles as the .full-width version, but widthout flex-grow 1