### PR TITLE
feature: allow to set inverted in QSearch

### DIFF
--- a/src/components/search/QSearch.vue
+++ b/src/components/search/QSearch.vue
@@ -15,7 +15,7 @@
     :stack-label="stackLabel"
     :prefix="prefix"
     :suffix="suffix"
-    inverted
+    :inverted="inverted"
 
     :color="color"
     :before="controlBefore"
@@ -64,7 +64,11 @@ export default {
     align: String,
     disable: Boolean,
     error: Boolean,
-    color: String
+    color: String,
+    inverted: {
+      type: Boolean,
+      default: true
+    }
   },
   data () {
     return {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

With default inverted for QSearch there is no way to get a dark text on white background search control.
After the change the controll still defaults to inverted, with the option to configure it to not inverted.