### PR TITLE
fix: Use rem for the width of the input box in QPagination

### DIFF
--- a/src/components/pagination/QPagination.vue
+++ b/src/components/pagination/QPagination.vue
@@ -14,7 +14,7 @@
       v-model="newPage"
       :min="min"
       :max="max"
-      :style="{width: `${inputPlaceholder.length * 10}px`}"
+      :style="{width: `${inputPlaceholder.length}rem`}"
       :placeholder="inputPlaceholder"
       :disable="disable"
       @keyup.enter="__update"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The placeholder.length * 10 width of the input box is too small and not depending on the font size. Using rem gives approximation.