### PR TITLE
fix: Allow null and objects as selected value in QSelect

### DIFF
--- a/src/components/select/select-mixin.js
+++ b/src/components/select/select-mixin.js
@@ -30,7 +30,7 @@ export default {
     length () {
       return this.multiple
         ? this.value.length
-        : (this.value.length ? 1 : 0)
+        : ([null, undefined, ''].includes(this.value) ? 0 : 1)
     },
     frameColor () {
       return this.hasChips && this.inverted


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In case of null value or object value in QSelect the lenght calculation fails.