### PR TITLE
Fix input autofill bgcolor

### DIFF
--- a/src/components/input/input.ios.styl
+++ b/src/components/input/input.ios.styl
@@ -23,6 +23,10 @@
   &:-webkit-autofill
     -webkit-animation-name autofill
     -webkit-animation-fill-mode both
+  &::-ms-clear, &::-ms-reveal
+    display none
+    width 0
+    height 0
 
 input.q-input-target
   height 18px

--- a/src/components/input/input.ios.styl
+++ b/src/components/input/input.ios.styl
@@ -1,3 +1,7 @@
+@-webkit-keyframes autofill
+  to
+    background transparent
+
 .q-input-target::-webkit-outer-spin-button,
 .q-input-target::-webkit-inner-spin-button
   -webkit-appearance none
@@ -16,6 +20,9 @@
   resize none
   display flex
   align-items center
+  &:-webkit-autofill
+    -webkit-animation-name autofill
+    -webkit-animation-fill-mode both
 
 input.q-input-target
   height 18px

--- a/src/components/input/input.mat.styl
+++ b/src/components/input/input.mat.styl
@@ -23,6 +23,10 @@
   &:-webkit-autofill
     -webkit-animation-name autofill
     -webkit-animation-fill-mode both
+  &::-ms-clear, &::-ms-reveal
+    display none
+    width 0
+    height 0
 
 input.q-input-target
   height 18px

--- a/src/components/input/input.mat.styl
+++ b/src/components/input/input.mat.styl
@@ -1,3 +1,7 @@
+@-webkit-keyframes autofill
+  to
+    background transparent
+
 .q-input-target::-webkit-outer-spin-button,
 .q-input-target::-webkit-inner-spin-button
   -webkit-appearance none
@@ -16,6 +20,9 @@
   resize none
   display flex
   align-items center
+  &:-webkit-autofill
+    -webkit-animation-name autofill
+    -webkit-animation-fill-mode both
 
 input.q-input-target
   height 18px


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Webkit based browsers use a forced yellow background for autofilled form fields. This changes it to transparent.
Edge browser has a reveal and a clear button for form fields. This hides the fields.