### PR TITLE
add more slot for custom data-table

### DIFF
--- a/src/components/data-table/QDataTable.vue
+++ b/src/components/data-table/QDataTable.vue
@@ -35,7 +35,7 @@
         <slot name="selection" :rows="selectedRows"></slot>
       </div>
     </div>
-
+    <slot name="customFilter"></slot>
     <table-filter v-if="filteringCols.length" :filtering="filtering" :columns="filteringCols" :labels="labels"></table-filter>
 
     <template v-if="responsive">
@@ -71,6 +71,7 @@
       >
         <div v-if="message" class="q-data-table-message row items-center justify-center" v-html="message"></div>
         <table-content v-else :cols="cols" :selection="config.selection">
+          <slot name="customRow"></slot>
           <tr v-for="row in rows" :style="rowStyle" @click="emitRowClick(row)">
             <td v-if="config.selection"></td>
             <td v-if="leftStickyColumns" :colspan="leftStickyColumns"></td>


### PR DESCRIPTION
add 2 slots: 
- before searchbar, this allow add more custom filter or buttons...
- before render rows: this allow add custom rows. ex: quick form to add new item...

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
