### PR TITLE
staticData Prop now expects Array

### DIFF
--- a/src/components/autocomplete/QAutocomplete.vue
+++ b/src/components/autocomplete/QAutocomplete.vue
@@ -54,7 +54,7 @@ export default {
       type: Number,
       default: 500
     },
-    staticData: Object,
+    staticData: Array,
     delimiter: Boolean
   },
   inject: ['__input', '__inputParent'],
@@ -110,7 +110,7 @@ export default {
 
       if (this.staticData) {
         this.searchId = ''
-        this.results = filter(terms, this.staticData)
+        this.results = filter(terms, {field: 'value', list: this.staticData})
         if (this.$q.platform.is.desktop) {
           this.selectedIndex = 0
         }
@@ -157,7 +157,7 @@ export default {
     },
     setValue (result) {
       const suffix = this.__inputParent ? 'Parent' : ''
-      this[`__input${suffix}`].set(this.staticData ? result[this.staticData.field] : result.value)
+      this[`__input${suffix}`].set(result.value)
 
       this.$emit('selected', result)
       this.__clearSearch()


### PR DESCRIPTION
`staticData` Prop now expects list array, following format 

```
staticData = [
    {
      value: 'Romania', // what gets Autocompleted with
      label: 'Romania', // what gets displayed as main label for this suggestion
      secondLabel: 'Continent: Europe', // optional
      icon: 'location_city', // optional
      stamp: '18 mil', // optional
      ...
    },
    ...
  ]
```
This removes the option for custom field name altogether. 

Untested... Apologies

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
