### PR TITLE
Fix IE specific issues (polyfills and buttons)

### DIFF
--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -7,12 +7,12 @@
         <q-btn icon="alarm" color="orange">Icoon</q-btn>
         <q-btn icon="ion-shuffle">Icoon</q-btn>
         <q-btn icon="fa-bath">Icoon</q-btn>
-        <q-btn iconRight="check">Icoon</q-btn>
-        <q-btn iconRight="more_horiz">Icoon</q-btn>
-        <q-btn icon="cloud" iconRight="alarm">Icoon</q-btn>
-        <q-btn icon="edit" iconRight="alarm">Icoon</q-btn>
-        <q-btn icon="edit" iconRight="alarm" small>Icoon</q-btn>
-        <q-btn icon="edit" iconRight="alarm" big color="amber">Icoon</q-btn>
+        <q-btn icon-right="check">Icoon</q-btn>
+        <q-btn icon-right="more_horiz">Icoon</q-btn>
+        <q-btn icon="cloud" icon-right="alarm">Icoon</q-btn>
+        <q-btn icon="edit" icon-right="alarm">Icoon</q-btn>
+        <q-btn icon="edit" icon-right="alarm" small>Icoon</q-btn>
+        <q-btn icon="edit" icon-right="alarm" big color="amber">Icoon</q-btn>
 
         <q-btn small color="primary"><q-icon name="mail" /></q-btn>
         <q-btn color="primary"><q-icon name="mail" /></q-btn>
@@ -27,12 +27,12 @@
         <q-btn round color="secondary"><q-icon name="card_giftcard" /></q-btn>
 
         <q-btn icon="alarm">Icoon</q-btn>
-        <q-btn iconRight="check">Icoon</q-btn>
+        <q-btn icon-right="check">Icoon</q-btn>
         <q-btn icon="ion-shuffle">Icoon</q-btn>
         <q-btn icon="fa-bath">Icoon</q-btn>
-        <q-btn iconRight="more_horiz">Icoon</q-btn>
-        <q-btn icon="cloud" iconRight="alarm">Icoon</q-btn>
-        <q-btn icon="edit" iconRight="alarm">Icoon</q-btn>
+        <q-btn icon-right="more_horiz">Icoon</q-btn>
+        <q-btn icon="cloud" icon-right="alarm">Icoon</q-btn>
+        <q-btn icon="edit" icon-right="alarm">Icoon</q-btn>
       </p>
 
       <p class="group">
@@ -52,7 +52,7 @@
         <q-btn round loader @click="simulateProgress" color="primary"><q-icon name="mail" /></q-btn>
         <q-btn big round loader @click="simulateProgress" color="primary"><q-icon name="mail" /></q-btn>
 
-        <q-btn color="dark" small @click="simulateProgress" iconRight="alarm">
+        <q-btn color="dark" small @click="simulateProgress" icon-right="alarm">
           Button
           <q-spinner-audio slot="spinner" />
         </q-btn>
@@ -85,7 +85,7 @@
         <q-btn color="primary" icon="mail">
           On Left
         </q-btn>
-        <q-btn color="secondary" iconRight="mail">
+        <q-btn color="secondary" icon-right="mail">
           On Right
         </q-btn>
       </p>
@@ -158,8 +158,8 @@
         <q-btn color="primary" class="full-width">Full-width</q-btn>
         <q-btn color="secondary" class="full-width">Full-width</q-btn>
         <q-btn color="primary" icon="alarm" class="full-width">Full-width</q-btn>
-        <q-btn color="secondary" iconRight="alarm" class="full-width">Full-width</q-btn>
-        <q-btn color="secondary" icon="lock" iconRight="alarm" class="full-width">Full-width</q-btn>
+        <q-btn color="secondary" icon-right="alarm" class="full-width">Full-width</q-btn>
+        <q-btn color="secondary" icon="lock" icon-right="alarm" class="full-width">Full-width</q-btn>
       </div>
 
       <p class="caption">Multiline Buttons</p>
@@ -170,27 +170,27 @@
         <q-btn color="primary" icon="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon="alarm">Normal<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm">Normal<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm">Normal<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm" small>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
-        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm">Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
-        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm" big>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" icon-right="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon-right="alarm">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon-right="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" icon-right="alarm" small>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" icon-right="alarm">Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" icon-right="alarm" big>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
         <q-btn color="primary" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" iconRight="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" iconRight="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon-right="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon-right="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon-right="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
       </div>
 
       <h2>Sizes</h2>

--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -157,6 +157,40 @@
       <div class="group">
         <q-btn color="primary" class="full-width">Full-width</q-btn>
         <q-btn color="secondary" class="full-width">Full-width</q-btn>
+        <q-btn color="primary" icon="alarm" class="full-width">Full-width</q-btn>
+        <q-btn color="secondary" iconRight="alarm" class="full-width">Full-width</q-btn>
+        <q-btn color="secondary" icon="lock" iconRight="alarm" class="full-width">Full-width</q-btn>
+      </div>
+
+      <p class="caption">Multiline Buttons</p>
+      <div class="group">
+        <q-btn color="primary" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm" small>Small<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm">Normal<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm" big>Big<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm" small>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm">Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" class="full-width" icon="lock" iconRight="alarm" big>Very long text that should wrap on the next line. I really mean it, it's a very long text. Maybe it's not clear, but it should be very, very long, so long that even a fullscreen width is not enough. I know it's not easy, but we should try.</q-btn>
+        <q-btn color="primary" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" iconRight="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm" small class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" iconRight="alarm" big class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
       </div>
 
       <h2>Sizes</h2>

--- a/dev/main.js
+++ b/dev/main.js
@@ -1,3 +1,4 @@
+require('es6-promise').polyfill()
 require('../src/themes/quasar.' + __THEME + '.styl')
 
 import Vue from 'vue'

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "colors": "^1.1.2",
     "connect-history-api-fallback": "^1.3.0",
     "css-loader": "^0.28.1",
+    "es6-promise": "^4.1.0",
     "eslint": "^3.7.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-friendly-formatter": "^2.0.6",

--- a/src/components/btn/QBtn.vue
+++ b/src/components/btn/QBtn.vue
@@ -14,7 +14,9 @@
 
       <template v-else>
         <q-icon v-if="icon" :name="icon" :class="{'on-left': !round}"></q-icon>
-        <slot></slot>
+        <span class="q-btn-inner-content" v-if="!!$slots.default">
+          <slot></slot>
+        </span>
         <q-icon v-if="!round && iconRight" :name="iconRight" class="on-right"></q-icon>
       </template>
     </span>

--- a/src/components/btn/button.ios.styl
+++ b/src/components/btn/button.ios.styl
@@ -33,11 +33,17 @@ $button-round-sizes = {
 
   &.full-width
     border-radius 0 !important
+    align-items stretch
 
   .q-btn-inner
     flex-wrap nowrap
     flex 1 0 auto
     white-space normal
+
+    &> :not(.q-btn-inner-content)
+     flex 0 0 auto
+    .q-btn-inner-content
+      flex 1 1 auto
 
 .q-btn-rectangle
   border-radius $button-border-radius
@@ -63,8 +69,11 @@ for $name, $size in $button-sizes
   .q-btn-{$name}
     min-height $size
     font-size round($size * .38)
-    .q-btn-inner
-      -ms-flex-preferred-size $size
+    .q-btn-inner:before
+      content ""
+      height $size
+      display inline-block
+      vertical-align middle
     .q-icon
       font-size round($size * .68)
     .q-spinner

--- a/src/components/btn/button.ios.styl
+++ b/src/components/btn/button.ios.styl
@@ -18,7 +18,6 @@ $button-round-sizes = {
   display inline-flex
   align-items center
   justify-content center
-  flex-direction column
   outline 0
   border 0
   vertical-align middle
@@ -36,8 +35,8 @@ $button-round-sizes = {
     align-items stretch
 
   .q-btn-inner
-    flex-wrap nowrap
     flex 1 0 auto
+    flex-wrap nowrap
     white-space normal
 
     &> :not(.q-btn-inner-content)
@@ -67,7 +66,6 @@ $button-round-sizes = {
 
 for $name, $size in $button-sizes
   .q-btn-{$name}
-    min-height $size
     font-size round($size * .38)
     .q-btn-inner:before
       content ""

--- a/src/components/btn/button.ios.styl
+++ b/src/components/btn/button.ios.styl
@@ -18,6 +18,7 @@ $button-round-sizes = {
   display inline-flex
   align-items center
   justify-content center
+  flex-direction column
   outline 0
   border 0
   vertical-align middle
@@ -32,6 +33,11 @@ $button-round-sizes = {
 
   &.full-width
     border-radius 0 !important
+
+  .q-btn-inner
+    flex-wrap nowrap
+    flex 1 0 auto
+    white-space normal
 
 .q-btn-rectangle
   border-radius $button-border-radius
@@ -57,6 +63,8 @@ for $name, $size in $button-sizes
   .q-btn-{$name}
     min-height $size
     font-size round($size * .38)
+    .q-btn-inner
+      -ms-flex-preferred-size $size
     .q-icon
       font-size round($size * .68)
     .q-spinner

--- a/src/components/btn/button.mat.styl
+++ b/src/components/btn/button.mat.styl
@@ -19,7 +19,6 @@ $button-round-sizes = {
   display inline-flex
   align-items center
   justify-content center
-  flex-direction column
   outline 0
   border 0
   vertical-align middle
@@ -40,8 +39,8 @@ $button-round-sizes = {
     align-items stretch
 
   .q-btn-inner
-    flex-wrap nowrap
     flex 1 0 auto
+    flex-wrap nowrap
     white-space normal
 
     &> :not(.q-btn-inner-content)
@@ -81,7 +80,6 @@ $button-round-sizes = {
 
 for $name, $size in $button-sizes
   .q-btn-{$name}
-    min-height $size
     font-size round($size * .38)
     .q-btn-inner:before
       content ""

--- a/src/components/btn/button.mat.styl
+++ b/src/components/btn/button.mat.styl
@@ -37,11 +37,17 @@ $button-round-sizes = {
 
   &.full-width
     border-radius 0 !important
+    align-items stretch
 
   .q-btn-inner
     flex-wrap nowrap
     flex 1 0 auto
     white-space normal
+
+    &> :not(.q-btn-inner-content)
+     flex 0 0 auto
+    .q-btn-inner-content
+      flex 1 1 auto
 
 .q-btn-no-uppercase
   text-transform none
@@ -77,8 +83,11 @@ for $name, $size in $button-sizes
   .q-btn-{$name}
     min-height $size
     font-size round($size * .38)
-    .q-btn-inner
-      -ms-flex-preferred-size $size
+    .q-btn-inner:before
+      content ""
+      height $size
+      display inline-block
+      vertical-align middle
     .q-icon
       font-size round($size * .68)
     .q-spinner

--- a/src/components/btn/button.mat.styl
+++ b/src/components/btn/button.mat.styl
@@ -19,6 +19,7 @@ $button-round-sizes = {
   display inline-flex
   align-items center
   justify-content center
+  flex-direction column
   outline 0
   border 0
   vertical-align middle
@@ -36,6 +37,11 @@ $button-round-sizes = {
 
   &.full-width
     border-radius 0 !important
+
+  .q-btn-inner
+    flex-wrap nowrap
+    flex 1 0 auto
+    white-space normal
 
 .q-btn-no-uppercase
   text-transform none
@@ -71,6 +77,8 @@ for $name, $size in $button-sizes
   .q-btn-{$name}
     min-height $size
     font-size round($size * .38)
+    .q-btn-inner
+      -ms-flex-preferred-size $size
     .q-icon
       font-size round($size * .68)
     .q-spinner

--- a/src/components/popover/QPopover.vue
+++ b/src/components/popover/QPopover.vue
@@ -74,6 +74,9 @@ export default {
       if (this.anchorEl.classList.contains('q-btn-inner')) {
         this.anchorEl = this.anchorEl.parentNode
       }
+      if (this.anchorEl.classList.contains('q-btn-inner-content')) {
+        this.anchorEl = this.anchorEl.parentNode.parentNode
+      }
       if (this.anchorClick) {
         this.anchorEl.classList.add('cursor-pointer')
         this.anchorEl.addEventListener('click', this.toggle)

--- a/src/components/tooltip/QTooltip.vue
+++ b/src/components/tooltip/QTooltip.vue
@@ -128,6 +128,9 @@ export default {
       if (this.anchorEl.classList.contains('q-btn-inner')) {
         this.anchorEl = this.anchorEl.parentNode
       }
+      if (this.anchorEl.classList.contains('q-btn-inner-content')) {
+        this.anchorEl = this.anchorEl.parentNode.parentNode
+      }
       if (Platform.is.mobile) {
         this.anchorEl.addEventListener('click', this.open)
       }

--- a/src/features/polyfills.js
+++ b/src/features/polyfills.js
@@ -53,6 +53,12 @@ if (!String.prototype.endsWith) {
   }
 }
 
+Number.isInteger = Number.isInteger || function (value) {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value
+}
+
 if (typeof Element.prototype.matches !== 'function') {
   Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.webkitMatchesSelector || function matches (selector) {
     let
@@ -80,6 +86,22 @@ if (typeof Element.prototype.closest !== 'function') {
     return null
   }
 }
+
+(function (arr) {
+  arr.forEach(function (item) {
+    if (item.hasOwnProperty('remove')) {
+      return
+    }
+    Object.defineProperty(item, 'remove', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function remove () {
+        return this.parentNode ? this.parentNode.removeChild(this) : this
+      }
+    })
+  })
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype])
 
 if (!Array.prototype.find) {
   Object.defineProperty(Array.prototype, 'find', {


### PR DESCRIPTION
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Polyfills for IE.
Fix buttons for IE - buttons with multi-line text are truncated on IE, but I can't find a fix that works both in IE and in other browsers.

If we use 
.q-btn-inner
      min-height $size
instead of
.q-btn-inner
      -ms-flex-preferred-size $size
the text is not truncated, but the alignment is wrong.

Need some feedback.