### PR TITLE
Enhance QSelect - fix scroll, keep search on top, add global toggle, colorize

### DIFF
--- a/dev/components/form/select.vue
+++ b/dev/components/form/select.vue
@@ -92,6 +92,20 @@
       <q-select filter v-model="select" :options="selectLongListOptions"></q-select>
       <q-select filter multiple v-model="multipleSelect" :options="selectLongListOptions"></q-select>
       <q-select filter multiple toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select filter multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select filter multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select inverted multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select inverted multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select inverted filter v-model="select" :options="selectLongListOptions"></q-select>
+      <q-select inverted filter multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select inverted filter multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select color="orange" inverted multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select color="orange" inverted multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select color="orange" inverted filter v-model="select" :options="selectLongListOptions"></q-select>
+      <q-select color="orange" inverted filter multiple multipleToggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
+      <q-select color="orange" inverted filter multiple multipleToggle toggle v-model="multipleSelect" :options="selectLongListOptions"></q-select>
 
       <p class="caption">Display Value</p>
       <q-select multiple v-model="multipleSelect" float-label="Gigi" :options="selectLongListOptions" :display-value="`${ multipleSelect.length } item${ multipleSelect.length !== 1 ? 's' : '' } selected`"></q-select>

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -254,7 +254,6 @@ export default {
       this.focused = true
       this.$emit('focus')
       const selected = this.$refs.popover.$el.querySelector(this.activeItemSelector)
-      console.log(selected, this.activeItemSelector)
       if (selected) {
         selected.scrollIntoView()
       }

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -56,18 +56,30 @@
       :anchor-click="false"
       @open="__onFocus"
       @close="__onClose"
+      class="column no-wrap"
     >
-      <q-search
-        v-if="filter"
-        v-model="terms"
-        :placeholder="filterPlaceholder"
-        :debounce="50"
-      ></q-search>
+      <q-toolbar v-if="hasToolbar" :color="color" :inverted="!inverted">
+        <q-search
+          v-if="filter"
+          v-model="terms"
+          :placeholder="filterPlaceholder"
+          :debounce="50"
+          :color="color"
+          :inverted="inverted"
+        ></q-search>
+        <q-toolbar-title v-if="!filter"></q-toolbar-title>
+        <q-btn flat v-if="multipleToggle" @click="__toggleAll(false)">
+          <q-icon name="check_box_outline_blank" />
+        </q-btn>
+        <q-btn flat v-if="multipleToggle" @click="__toggleAll(true)">
+          <q-icon name="check_box" />
+        </q-btn>
+      </q-toolbar>
 
       <q-list
         link
         :delimiter="delimiter"
-        class="no-border"
+        class="no-border scroll"
       >
         <template v-if="multiple">
           <q-item-wrapper
@@ -141,6 +153,7 @@ export default {
       required: true
     },
     multiple: Boolean,
+    multipleToggle: Boolean,
     radio: Boolean,
     toggle: Boolean,
     chips: Boolean,
@@ -222,6 +235,9 @@ export default {
       return this.multiple
         ? `.q-item-side > ${this.toggle ? '.q-toggle' : '.q-checkbox'} > .active`
         : `.q-item.active`
+    },
+    hasToolbar () {
+      return this.filter || (this.multiple && this.multipleToggle)
     }
   },
   methods: {
@@ -257,14 +273,21 @@ export default {
       this.$emit('blur')
       this.terms = ''
     },
-    __toggle (value) {
+    __toggle (value, select) {
       let index = this.model.indexOf(value)
       if (index > -1) {
-        this.model.splice(index, 1)
+        if (select !== true) {
+          this.model.splice(index, 1)
+        }
       }
       else {
-        this.model.push(value)
+        if (select !== false) {
+          this.model.push(value)
+        }
       }
+    },
+    __toggleAll (status) {
+      this.visibleOptions.forEach(opt => this.__toggle(opt.value, status))
     },
     __select (val) {
       this.model = val

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -220,8 +220,8 @@ export default {
     },
     activeItemSelector () {
       return this.multiple
-        ? `.item-${this.toggle ? 'secondary' : 'primary'} > .active`
-        : `.item.active`
+        ? `.q-item-side > ${this.toggle ? '.q-toggle' : '.q-checkbox'} > .active`
+        : `.q-item.active`
     }
   },
   methods: {
@@ -238,6 +238,7 @@ export default {
       this.focused = true
       this.$emit('focus')
       const selected = this.$refs.popover.$el.querySelector(this.activeItemSelector)
+      console.log(selected, this.activeItemSelector)
       if (selected) {
         selected.scrollIntoView()
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Global toggle (multipleToggle) allows to quickly select/unselect all the filtered options.
I tried to match the color of the top bar with the color of the select control (color and inverted).