### PR TITLE
feature: no padding on all contractable in QStepper for very compact display

### DIFF
--- a/dev/components/components/stepper.vue
+++ b/dev/components/components/stepper.vue
@@ -2,9 +2,10 @@
   <div>
     <div class="layout-padding">
       <q-toggle label="Alternative Labels" v-model="alt" />
+      <q-toggle label="Contractable" v-model="contractable" />
       <br><br>
 
-      <q-stepper :color="color" flat ref="stepper" v-model="step" :alternative-labels="alt">
+      <q-stepper :color="color" flat ref="stepper" v-model="step" :alternative-labels="alt" :contractable="contractable">
         <q-step default name="first" title="Ad style">
           <div v-for="n in 10">Step 1</div>
           <q-stepper-navigation>
@@ -96,6 +97,7 @@ export default {
       step: 'first',
       step2: 'first',
       alt: false,
+      contractable: false,
       color: 'secondary',
       text: ''
     }

--- a/src/components/stepper/stepper.mat.styl
+++ b/src/components/stepper/stepper.mat.styl
@@ -157,6 +157,8 @@ body.desktop .q-stepper-tab.step-done:hover
   .q-stepper-horizontal.q-stepper-contractable
     .q-stepper-header
       min-height 72px
+      .q-stepper-tab
+        padding 24px 0
     .q-stepper-tab:not(:last-child)
       .q-stepper-dot:after
         display block !important


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Contractable mode on small screens need no horizontal padding.