### PR TITLE
fix: #641 data-table - move bg color on td/th instead of tr

### DIFF
--- a/src/components/data-table/data-table.ios.styl
+++ b/src/components/data-table/data-table.ios.styl
@@ -5,14 +5,14 @@
     width 100%
     table-layout fixed
     empty-cells hide
-    tr
-      background white
     td, th
+      background white
       text-overflow ellipsis
       white-space nowrap
       overflow hidden
     tbody tr:nth-child(odd)
-      background $grey-3
+      td, th
+        background $grey-3
     thead tr
       border-bottom 2px solid $grey-3
       min-height 56px

--- a/src/components/data-table/data-table.mat.styl
+++ b/src/components/data-table/data-table.mat.styl
@@ -5,14 +5,14 @@
     width 100%
     table-layout fixed
     empty-cells hide
-    tr
-      background white
     td, th
+      background white
       text-overflow ellipsis
       white-space nowrap
       overflow hidden
     tbody tr:nth-child(odd)
-      background $grey-3
+      td, th
+        background $grey-3
     thead tr
       border-bottom 2px solid $grey-3
       min-height 56px


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In firefox the bg color on tr covers the non-sticky cells below.