### PR TITLE
fix: Don't limit gutter direct descendants to div

### DIFF
--- a/src/css/core/flex.styl
+++ b/src/css/core/flex.styl
@@ -113,17 +113,17 @@ for $i in (1..$flex-cols)
 for $name, $size in $flex-gutter
   .{$name}-gutter
     margin (- $size) 0 0 (- $size)
-    > div
+    > *
       padding $size 0 0 $size
 
 .no-horiz-gutter
   margin-left 0
-  > div
+  > *
     padding-left 0
 
 .no-vert-gutter
   margin-top 0
-  > div
+  > *
     padding-top 0
 
 for $name, $size in $sizes


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

There's no need to limit the direct descendants of .{$size}-gutter to be divs.