### PR TITLE
fix: Updated modalTransition to take into consideration enterClass and leaveClass

### DIFF
--- a/src/components/modal/QModal.vue
+++ b/src/components/modal/QModal.vue
@@ -126,10 +126,9 @@ export default {
       if (this.position) {
         return `q-modal-${this.position}`
       }
-      else if (!this.transition && !(this.enterClass && this.leaveClass)) {
-        return 'q-modal'
+      if (this.enterClass === void 0 && this.leaveClass === void 0) {
+        return this.transition || 'q-modal'
       }
-      return this.transition
     },
     modalCss () {
       if (this.position) {

--- a/src/components/modal/QModal.vue
+++ b/src/components/modal/QModal.vue
@@ -126,10 +126,10 @@ export default {
       if (this.position) {
         return `q-modal-${this.position}`
       }
-      else if (this.enterClass && this.leaveClass) {
-        return this.transition
+      else if (!this.transition && !(this.enterClass && this.leaveClass)) {
+        return 'q-modal'
       }
-      return 'q-modal'
+      return this.transition
     },
     modalCss () {
       if (this.position) {

--- a/src/components/modal/QModal.vue
+++ b/src/components/modal/QModal.vue
@@ -84,10 +84,7 @@ export default {
         return val === '' || ['top', 'bottom', 'left', 'right'].includes(val)
       }
     },
-    transition: {
-      type: String,
-      default: 'q-modal'
-    },
+    transition: String,
     enterClass: String,
     leaveClass: String,
     positionClasses: {
@@ -126,7 +123,13 @@ export default {
       return cls
     },
     modalTransition () {
-      return this.position ? `q-modal-${this.position}` : this.transition
+      if (this.position) {
+        return `q-modal-${this.position}`
+      }
+      else if (this.enterClass && this.leaveClass) {
+        return this.transition
+      }
+      return 'q-modal'
     },
     modalCss () {
       if (this.position) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This fixes a bug to make the modal component's transition work the same as the transition component's transition. Currently, if you specify an out of the box enter and leave class for a modal component the modal component won't actually use those transition classes like it would for a transition component, unless you specify an empty transition property.
I didn't create an issue for this bug, but let me know if you'd like me to.