### PR TITLE
Feature: Add specific stylus variable for default input frame color

### DIFF
--- a/src/components/input-frame/input-frame-mixin.js
+++ b/src/components/input-frame/input-frame-mixin.js
@@ -24,7 +24,7 @@ export default {
     disable: Boolean,
     color: {
       type: String,
-      default: 'primary'
+      default: 'input-frame-color'
     },
     dark: Boolean,
     before: marginal,

--- a/src/css/core.variables.styl
+++ b/src/css/core.variables.styl
@@ -62,6 +62,8 @@ $faded     ?= #777
 $link-color          ?= lighten($primary, 25%)
 $link-color-active   ?= $primary
 
+$input-frame-color   ?= $primary
+
 $dimmed-background       ?= rgba(0, 0, 0, .4)
 $light-dimmed-background ?= rgba(255, 255, 255, .6)
 

--- a/src/css/core/colors.styl
+++ b/src/css/core/colors.styl
@@ -38,6 +38,11 @@
 .bg-warning
   background $warning !important
 
+.text-input-frame-color
+  color $input-frame-color !important
+.bg-input-frame-color
+  background $input-frame-color !important
+
 .text-white
   color white !important
 .bg-white


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This feature is useful for users who want their primary stylus variable to be a color close to red. Currently, the color of input frames default to the primary color so if one wants to use pink, red, or purple as their primary color they have to go through a lot of work to specify the color of each form component so it doesn't look too similar to the negative/error color of red.
Let me know what you think. I could understand if you don't want to crowd the framework with too many stylus variables. This is just an issue I ran into in my own project and thought others might be experiencing something similar.