### PR TITLE
Update key to use value as key

### DIFF
--- a/src/components/action-sheet/ActionSheet.vue
+++ b/src/components/action-sheet/ActionSheet.vue
@@ -15,7 +15,7 @@
           <div v-if="gallery" class="q-action-sheet-gallery row wrap flex-center">
             <div
               v-for="button in actions"
-              :key="button"
+              :key="JSON.stringify(button)"
               class="cursor-pointer relative-position column inline flex-center"
               @click="close(button.handler)"
               @keydown.enter="close(button.handler)"
@@ -32,7 +32,7 @@
           <q-list link v-else class="no-border">
             <q-item
               v-for="button in actions"
-              :key="button"
+              :key="JSON.stringify(button)"
               @click="close(button.handler)"
               @keydown.enter="close(button.handler)"
               tabindex="0"
@@ -70,7 +70,7 @@
         <div v-if="gallery" class="q-action-sheet-gallery row wrap flex-center">
           <div
             v-for="button in actions"
-            :key="button"
+            :key="JSON.stringify(button)"
             class="cursor-pointer relative-position column inline flex-center"
             @click="close(button.handler)"
             @keydown.enter="close(button.handler)"
@@ -87,7 +87,7 @@
         <q-list link v-else class="no-border">
           <q-item
             v-for="button in actions"
-            :key="button"
+            :key="JSON.stringify(button)"
             @click="close(button.handler)"
             @keydown.enter="close(button.handler)"
             :class="button.classes"

--- a/src/components/alert/QAlert.vue
+++ b/src/components/alert/QAlert.vue
@@ -24,7 +24,7 @@
           >
             <span
               v-for="btn in actions"
-              :key="btn"
+              :key="JSON.stringify(btn)"
               @click="dismiss(btn.handler)"
               v-html="btn.label"
               class="uppercase"

--- a/src/components/autocomplete/QAutocomplete.vue
+++ b/src/components/autocomplete/QAutocomplete.vue
@@ -10,7 +10,7 @@
     <div class="list no-border" :class="{separator: separator}" :style="computedWidth">
       <q-item-wrapper
         v-for="(result, index) in computedResults"
-        :key="result"
+        :key="JSON.stringify(result)"
         :cfg="result"
         link
         :class="{active: selectedIndex === index}"

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -83,7 +83,7 @@
     >
       <q-btn
         v-for="button in buttons"
-        :key="button"
+        :key="JSON.stringify(button)"
         @click="trigger(button.handler, button.preventClose)"
         :class="button.classes"
         :style="button.style"

--- a/src/components/input-frame/QInputFrame.vue
+++ b/src/components/input-frame/QInputFrame.vue
@@ -9,7 +9,7 @@
     <template v-if="before">
       <q-icon
         v-for="item in before"
-        :key="item"
+        :key="JSON.stringify(item)"
         class="q-if-control q-if-control-before"
         :class="{hidden: __additionalHidden(item, hasError, length)}"
         :name="item.icon"
@@ -46,7 +46,7 @@
     <template v-if="after">
       <q-icon
         v-for="item in after"
-        :key="item"
+        :key="JSON.stringify(item)"
         class="q-if-control"
         :class="{hidden: __additionalHidden(item, hasError, length)}"
         :name="item.icon"

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -81,7 +81,7 @@
         <template v-if="multiple">
           <q-item-wrapper
             v-for="opt in visibleOptions"
-            :key="opt.value"
+            :key="JSON.stringify(opt)"
             :cfg="opt"
             slot-replace
             @click.capture="__toggle(opt.value)"
@@ -103,7 +103,7 @@
         <template v-else>
           <q-item-wrapper
             v-for="opt in visibleOptions"
-            :key="opt.value"
+            :key="JSON.stringify(opt)"
             :cfg="opt"
             slot-replace
             :active="value === opt.value"

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -81,7 +81,7 @@
         <template v-if="multiple">
           <q-item-wrapper
             v-for="opt in visibleOptions"
-            :key="opt"
+            :key="opt.value"
             :cfg="opt"
             slot-replace
             @click.capture="__toggle(opt.value)"
@@ -103,7 +103,7 @@
         <template v-else>
           <q-item-wrapper
             v-for="opt in visibleOptions"
-            :key="opt"
+            :key="opt.value"
             :cfg="opt"
             slot-replace
             :active="value === opt.value"

--- a/src/components/stepper/QStepper.vue
+++ b/src/components/stepper/QStepper.vue
@@ -10,7 +10,7 @@
     >
       <step-tab
         v-for="(step, index) in steps"
-        :key="step"
+        :key="JSON.stringify(step)"
         :vm="step"
       ></step-tab>
     </div>

--- a/src/components/stepper/QStepper.vue
+++ b/src/components/stepper/QStepper.vue
@@ -10,7 +10,7 @@
     >
       <step-tab
         v-for="(step, index) in steps"
-        :key="JSON.stringify(step)"
+        :key="index"
         :vm="step"
       ></step-tab>
     </div>

--- a/src/components/tree/QTree.vue
+++ b/src/components/tree/QTree.vue
@@ -3,7 +3,7 @@
     <ul>
       <q-tree-item
         v-for="item in model"
-        :key="item"
+        :key="JSON.stringify(item)"
         :model="item"
         :contract-html="contractHtml"
         :expand-html="expandHtml"

--- a/src/components/tree/TreeItem.vue
+++ b/src/components/tree/TreeItem.vue
@@ -13,7 +13,7 @@
     </div>
     <q-slide-transition>
       <ul v-show="isExpandable && model.expanded">
-        <q-tree-item v-for="item in model.children" :key="item" :model="item" :contract-html="contractHtml" :expand-html="expandHtml"></q-tree-item>
+        <q-tree-item v-for="item in model.children" :key="JSON.stringify(item)" :model="item" :contract-html="contractHtml" :expand-html="expandHtml"></q-tree-item>
       </ul>
     </q-slide-transition>
   </li>


### PR DESCRIPTION
Vue 2.4 raises a warning when using a primative as the key

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Getting the following warning in Vue 2.4 when using selects [Vue warn]: Avoid using non-primitive value as key, use string/number value instead. Using the value instead of the object in the as the key resolves this issue