### PR TITLE
Add margin to label in data table toolbar row label

### DIFF
--- a/src/components/data-table/data-table.ios.styl
+++ b/src/components/data-table/data-table.ios.styl
@@ -31,6 +31,8 @@
     min-height 50px
   &.bottom-toolbar
     border-top 2px solid $grey-3
+    .q-data-table-row-label
+      margin-right: 15px
   > div:not(:first-of-type):not(:last-of-type)
     margin 0 30px
   .q-search

--- a/src/components/data-table/data-table.ios.styl
+++ b/src/components/data-table/data-table.ios.styl
@@ -32,7 +32,7 @@
   &.bottom-toolbar
     border-top 2px solid $grey-3
     .q-data-table-row-label
-      margin-right: 15px
+      margin-right 15px
   > div:not(:first-of-type):not(:last-of-type)
     margin 0 30px
   .q-search

--- a/src/components/data-table/data-table.mat.styl
+++ b/src/components/data-table/data-table.mat.styl
@@ -32,7 +32,7 @@
   &.bottom-toolbar
     border-top 2px solid $grey-3
     .q-data-table-row-label
-      margin-right: 15px
+      margin-right 15px
   > div + div
     margin-left 30px
   input, .q-input

--- a/src/components/data-table/data-table.mat.styl
+++ b/src/components/data-table/data-table.mat.styl
@@ -31,6 +31,8 @@
     min-height 50px
   &.bottom-toolbar
     border-top 2px solid $grey-3
+    .q-data-table-row-label
+      margin-right: 15px
   > div + div
     margin-left 30px
   input, .q-input

--- a/src/components/data-table/plugins/pagination/TablePagination.vue
+++ b/src/components/data-table/plugins/pagination/TablePagination.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="q-data-table-toolbar bottom-toolbar row reverse-wrap items-center justify-end">
     <div>
-      {{labels.rows}}
+      <span class="q-data-table-row-label">{{labels.rows}}</span>
       <q-select
         v-model="pagination.rowsPerPage"
         :options="pagination.options"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

As suggested in the [forum](http://forum.quasar-framework.org/topic/637/pagination-rows-per-page-select-padding), this PR adds 15px (half of the amount a div in the toolbar has) margin to the row label.
