### PR TITLE
Prevent QSelect's filter to propagate to parent QField

### DIFF
--- a/dev/components/form/field.vue
+++ b/dev/components/form/field.vue
@@ -272,6 +272,31 @@
           <q-input class="col" v-model="model" stack-label="Stacked $ Label" suffix="#" prefix="@" :inline-count="10"/>
         </div>
       </q-field>
+
+      <q-field icon="cloud">
+        <q-select filter v-model="select" :options="selectListOptions" stack-label="Stack label with filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select filter inverted v-model="select" :options="selectListOptions" stack-label="Stack label with filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select filter v-model="select" :options="selectListOptions" float-label="Float label with filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select filter inverted v-model="select" :options="selectListOptions" float-label="Float label with filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select v-model="select" :options="selectListOptions" stack-label="Stack label without filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select inverted v-model="select" :options="selectListOptions" stack-label="Stack label without filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select v-model="select" :options="selectListOptions" float-label="Float label without filter"></q-select>
+      </q-field>
+      <q-field icon="cloud">
+        <q-select inverted v-model="select" :options="selectListOptions" float-label="Float label without filter"></q-select>
+      </q-field>
     </div>
     <label class="fixed-bottom-right">
       <q-checkbox v-model="error" />
@@ -293,7 +318,40 @@ export default {
       nullModel: null,
       knob: 10,
       knobMin: 0,
-      knobMax: 30
+      knobMax: 30,
+      select: undefined,
+      selectListOptions: [
+        {
+          label: 'Google',
+          icon: 'email',
+          value: 'goog'
+        },
+        {
+          label: 'Facebook',
+          inset: true,
+          description: 'Enables communication',
+          value: 'fb'
+        },
+        {
+          label: 'Twitter',
+          inset: true,
+          rightIcon: 'alarm',
+          value: 'twtr'
+        },
+        {
+          label: 'Apple Inc.',
+          inset: true,
+          stamp: '10 min',
+          value: 'appl'
+        },
+        {
+          label: 'Oracle',
+          description: 'Some Java for today?',
+          icon: 'mail',
+          rightIcon: 'alarm',
+          value: 'ora'
+        }
+      ]
     }
   }
 }

--- a/src/components/field/QFieldReset.vue
+++ b/src/components/field/QFieldReset.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'q-field-reset',
+  data () {
+    return {}
+  },
+  provide () {
+    return {
+      __field: undefined
+    }
+  }
+}
+</script>

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -1,5 +1,7 @@
 import QField from './QField.vue'
+import QFieldReset from './QFieldReset.vue'
 
 export {
-  QField
+  QField,
+  QFieldReset
 }

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -61,17 +61,18 @@
       @open="__onFocus"
       @close="__onClose"
     >
-      <q-search
-        v-if="filter"
-        v-model="terms"
-        @input="reposition"
-        :placeholder="filterPlaceholder"
-        :debounce="100"
-        :color="color"
-        icon="filter_list"
-        class="no-margin"
-        style="min-height: 50px; padding: 10px;"
-      ></q-search>
+      <q-field class="no-margin" style="min-height: 50px;">
+        <q-search
+          v-if="filter"
+          v-model="terms"
+          @input="reposition"
+          :placeholder="filterPlaceholder"
+          :debounce="100"
+          :color="color"
+          icon="filter_list"
+          style="min-height: 50px; padding: 10px;"
+        ></q-search>
+      </q-field>
 
       <q-list
         link
@@ -124,6 +125,7 @@
 </template>
 
 <script>
+import { QField } from '../field'
 import { QSearch } from '../search'
 import { QPopover } from '../popover'
 import { QList, QItemWrapper } from '../list'
@@ -141,6 +143,7 @@ export default {
   name: 'q-select',
   mixins: [SelectMixin],
   components: {
+    QField,
     QSearch,
     QPopover,
     QList,

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -124,6 +124,7 @@
 </template>
 
 <script>
+import { QField } from '../field'
 import { QSearch } from '../search'
 import { QPopover } from '../popover'
 import { QList, QItemWrapper } from '../list'
@@ -141,6 +142,7 @@ export default {
   name: 'q-select',
   mixins: [SelectMixin],
   components: {
+    QField,
     QSearch,
     QPopover,
     QList,

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -61,17 +61,18 @@
       @open="__onFocus"
       @close="__onClose"
     >
-      <q-search
-        v-if="filter"
-        v-model="terms"
-        @input="reposition"
-        :placeholder="filterPlaceholder"
-        :debounce="100"
-        :color="color"
-        icon="filter_list"
-        class="no-margin"
-        style="min-height: 50px; padding: 10px;"
-      ></q-search>
+      <q-field class="no-margin" style="min-height: 50px;">
+        <q-search
+          v-if="filter"
+          v-model="terms"
+          @input="reposition"
+          :placeholder="filterPlaceholder"
+          :debounce="100"
+          :color="color"
+          icon="filter_list"
+          style="min-height: 50px; padding: 10px;"
+        ></q-search>
+      </q-field>
 
       <q-list
         link
@@ -188,11 +189,6 @@ export default {
       return this.multiple
         ? `.q-item-side > ${this.toggle ? '.q-toggle' : '.q-checkbox'} > .active`
         : `.q-item.active`
-    }
-  },
-  provide () {
-    return {
-      __field: undefined
     }
   },
   methods: {

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -61,7 +61,7 @@
       @open="__onFocus"
       @close="__onClose"
     >
-      <q-field-reset class="no-margin" style="min-height: 50px;">
+      <q-field-reset>
         <q-search
           v-if="filter"
           v-model="terms"
@@ -70,6 +70,7 @@
           :debounce="100"
           :color="color"
           icon="filter_list"
+          class="no-margin"
           style="min-height: 50px; padding: 10px;"
         ></q-search>
       </q-field-reset>

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -61,7 +61,7 @@
       @open="__onFocus"
       @close="__onClose"
     >
-      <q-field class="no-margin" style="min-height: 50px;">
+      <q-field-reset class="no-margin" style="min-height: 50px;">
         <q-search
           v-if="filter"
           v-model="terms"
@@ -72,7 +72,7 @@
           icon="filter_list"
           style="min-height: 50px; padding: 10px;"
         ></q-search>
-      </q-field>
+      </q-field-reset>
 
       <q-list
         link
@@ -125,7 +125,7 @@
 </template>
 
 <script>
-import { QField } from '../field'
+import { QFieldReset } from '../field'
 import { QSearch } from '../search'
 import { QPopover } from '../popover'
 import { QList, QItemWrapper } from '../list'
@@ -143,7 +143,7 @@ export default {
   name: 'q-select',
   mixins: [SelectMixin],
   components: {
-    QField,
+    QFieldReset,
     QSearch,
     QPopover,
     QList,

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -61,18 +61,17 @@
       @open="__onFocus"
       @close="__onClose"
     >
-      <q-field class="no-margin" style="min-height: 50px;">
-        <q-search
-          v-if="filter"
-          v-model="terms"
-          @input="reposition"
-          :placeholder="filterPlaceholder"
-          :debounce="100"
-          :color="color"
-          icon="filter_list"
-          style="min-height: 50px; padding: 10px;"
-        ></q-search>
-      </q-field>
+      <q-search
+        v-if="filter"
+        v-model="terms"
+        @input="reposition"
+        :placeholder="filterPlaceholder"
+        :debounce="100"
+        :color="color"
+        icon="filter_list"
+        class="no-margin"
+        style="min-height: 50px; padding: 10px;"
+      ></q-search>
 
       <q-list
         link
@@ -189,6 +188,11 @@ export default {
       return this.multiple
         ? `.q-item-side > ${this.toggle ? '.q-toggle' : '.q-checkbox'} > .active`
         : `.q-item.active`
+    }
+  },
+  provide () {
+    return {
+      __field: undefined
     }
   },
   methods: {

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -124,7 +124,6 @@
 </template>
 
 <script>
-import { QField } from '../field'
 import { QSearch } from '../search'
 import { QPopover } from '../popover'
 import { QList, QItemWrapper } from '../list'
@@ -142,7 +141,6 @@ export default {
   name: 'q-select',
   mixins: [SelectMixin],
   components: {
-    QField,
     QSearch,
     QPopover,
     QList,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When we have QField > QSelect[filter], the input from QSearch(filter) is published into QField's input, overriding the select. So in this case QField thought that it's child was the QSearch, not the QSelect.