### PR TITLE
Fix linear gradient for DateTime component on iOS

### DIFF
--- a/src/components/datetime/datetime.ios.styl
+++ b/src/components/datetime/datetime.ios.styl
@@ -79,7 +79,7 @@ body.desktop .q-datetime-col-wrapper
   left 0
   height 100%
   width 100%
-  background linear-gradient(to top, white, transparent 50%, white)
+  background linear-gradient(to top, white, rgba(255, 255, 255, 0.0) 50%, white)
   pointer-events none
 
 .q-datetime-highlight


### PR DESCRIPTION
On iOS, the linear-gradient on the .q-datetime-mask element indicated that the middle of the gradient use a color stop of "transparent 50%", using transparent in a linear-gradient is not support on mobile Safari. See https://stackoverflow.com/a/27118826

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

![img_0020](https://user-images.githubusercontent.com/73688/29690588-d828641c-88e4-11e7-8b6c-1e711fba6556.PNG)
![img_0019](https://user-images.githubusercontent.com/73688/29690589-d82a2a7c-88e4-11e7-8f5f-972cce043a62.PNG)
