### PR TITLE
Add built in easing funcs & update carousel easing

### DIFF
--- a/dev/components/components/carousel.vue
+++ b/dev/components/components/carousel.vue
@@ -64,9 +64,16 @@
       </q-carousel>
 
       <p class="caption">
-        Carousel with Custom Actions as Controls
+        Carousel with Custom Actions as Controls and Overshoot Easing
       </p>
-      <q-carousel arrows dots actions class="text-white">
+      <q-carousel
+        arrows
+        dots
+        actions
+        :swipe-easing="overshoot"
+        :easing="overshoot"
+        class="text-white"
+      >
         <div slot="slide" class="bg-primary">
           <div v-for="n in 20">Slide {{n}}</div>
         </div>
@@ -106,3 +113,13 @@
     </div>
   </div>
 </template>
+
+<script>
+import { easing } from 'quasar'
+
+export default {
+  data: () => ({
+    overshoot: easing.overshoot
+  })
+}
+</script>

--- a/src/components/carousel/QCarousel.vue
+++ b/src/components/carousel/QCarousel.vue
@@ -51,6 +51,7 @@
 <script>
 import TouchPan from '../../directives/touch-pan'
 import { cssTransform } from '../../utils/dom'
+import { isNumber } from '../../utils/is'
 import { between, normalizeToInterval } from '../../utils/format'
 import { start, stop } from '../../utils/animate'
 import { decelerate, standard } from '../../utils/easing'
@@ -206,7 +207,7 @@ export default {
       this.animUid = start({
         from: this.position,
         to: pos,
-        duration: this.duration,
+        duration: isNumber(this.animation) ? this.animation : 300,
         easing: fromSwipe
           ? this.swipeEasing || decelerate
           : this.easing || standard,
@@ -237,7 +238,7 @@ export default {
           clearTimeout(this.timer)
           this.timer = setTimeout(
             this.next,
-            typeof this.autoplay === 'number' ? this.autoplay : 5000
+            isNumber(this.autoplay) ? this.autoplay : 5000
           )
         }
       })

--- a/src/components/carousel/QCarousel.vue
+++ b/src/components/carousel/QCarousel.vue
@@ -53,6 +53,7 @@ import TouchPan from '../../directives/touch-pan'
 import { cssTransform } from '../../utils/dom'
 import { between, normalizeToInterval } from '../../utils/format'
 import { start, stop } from '../../utils/animate'
+import { decelerate, standard } from '../../utils/easing'
 import { getEventKey } from '../../utils/event'
 import CarouselMixin from './carousel-mixin'
 import { QIcon } from '../icon'
@@ -143,7 +144,8 @@ export default {
             : this.positionSlide,
           () => {
             delete this.initialPosition
-          }
+          },
+          true
         )
       }
     },
@@ -160,7 +162,7 @@ export default {
         this.goToSlide(this.slide + 1, done)
       }
     },
-    goToSlide (slide, done) {
+    goToSlide (slide, done, fromSwipe = false) {
       let direction = ''
       this.__cleanup()
 
@@ -204,6 +206,10 @@ export default {
       this.animUid = start({
         from: this.position,
         to: pos,
+        duration: this.duration,
+        easing: fromSwipe
+          ? this.swipeEasing || decelerate
+          : this.easing || standard,
         apply: pos => {
           this.position = pos
         },

--- a/src/components/carousel/carousel-mixin.js
+++ b/src/components/carousel/carousel-mixin.js
@@ -6,12 +6,11 @@ export default {
     infinite: Boolean,
     actions: Boolean,
     animation: {
-      type: Boolean,
+      type: [Number, Boolean],
       default: true
     },
     easing: Function,
     swipeEasing: Function,
-    duration: Number,
     handleArrowKeys: Boolean,
     autoplay: [Number, Boolean]
   }

--- a/src/components/carousel/carousel-mixin.js
+++ b/src/components/carousel/carousel-mixin.js
@@ -9,6 +9,9 @@ export default {
       type: Boolean,
       default: true
     },
+    easing: Function,
+    swipeEasing: Function,
+    duration: Number,
     handleArrowKeys: Boolean,
     autoplay: [Number, Boolean]
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ import * as colors from './utils/colors'
 import * as date from './utils/date'
 import { debounce, frameDebounce } from './utils/debounce'
 import * as dom from './utils/dom'
+import * as easing from './utils/easing'
 import * as event from './utils/event'
 import extend from './utils/extend'
 import filter from './utils/filter'
@@ -23,6 +24,7 @@ export {
   debounce,
   frameDebounce,
   dom,
+  easing,
   event,
   extend,
   filter,

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -1,10 +1,7 @@
 import uid from './uid'
+import { linear } from './easing'
 
 let ids = {}
-
-function defaultEasing (progress) {
-  return progress
-}
 
 export function start ({name, duration = 300, to, from, apply, done, cancel, easing}) {
   let id = name
@@ -17,7 +14,7 @@ export function start ({name, duration = 300, to, from, apply, done, cancel, eas
     id = uid()
   }
 
-  const delta = easing || defaultEasing
+  const delta = easing || linear
   const handler = () => {
     let progress = (performance.now() - start) / duration
     if (progress > 1) {

--- a/src/utils/easing.js
+++ b/src/utils/easing.js
@@ -1,0 +1,48 @@
+export const linear = t => t
+
+export const easeInQuad = t => t * t
+export const easeOutQuad = t => t * (2 - t)
+export const easeInOutQuad = t => t < 0.5
+  ? 2 * t * t
+  : -1 + (4 - 2 * t) * t
+
+export const easeInCubic = t => t ** 3
+export const easeOutCubic = t => 1 + (t - 1) ** 3
+export const easeInOutCubic = t => t < 0.5
+  ? 4 * t ** 3
+  : 1 + (t - 1) * (2 * t - 2) ** 2
+
+export const easeInQuart = t => t ** 4
+export const easeOutQuart = t => 1 - (t - 1) ** 4
+export const easeInOutQuart = t => t < 0.5
+  ? 8 * t ** 4
+  : 1 - 8 * (t - 1) ** 4
+
+export const easeInQuint = t => t ** 5
+export const easeOutQuint = t => 1 + (t - 1) ** 5
+export const easeInOutQuint = t => t < 0.5
+  ? 16 * t ** 5
+  : 1 + 16 * (t - 1) ** 5
+
+export const easeInCirc = t => -1 * Math.sqrt(1 - t ** 2) + 1
+export const easeOutCirc = t => Math.sqrt(-1 * (t - 2) * t)
+export const easeInOutCirc = t => t < 0.5
+  ? 0.5 * (1 - Math.sqrt(1 - 4 * t * t))
+  : 0.5 * (1 + Math.sqrt(-3 + 8 * t - 4 * t * t))
+
+const dampener = t => Math.E ** (-6.3 * t)
+const bounce = t => Math.cos(5 * t)
+export const overshoot = t => -1 * dampener(t) * bounce(t) + 1
+
+/* -- Material Design curves -- */
+
+/**
+ * Faster ease in, slower ease out
+ */
+export const standard = t => t < 0.4031
+  ? 12 * t ** 4
+  : 1 / 1290 * (11 * Math.sqrt(-40000 * t * t + 80000 * t - 23359) - 129)
+
+export const decelerate = easeOutCubic
+export const accelerate = easeInCubic
+export const sharp = easeInOutQuad


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This adds some built in easing functions, makes the animation easing and duration configurable for the carousel, and changes the default carousel easing functions.

Adds optional properties `easing` and `swipe-easing` to the carousel and changes `animation` to accept a number to specify the duration.

When swiping, the carousel uses an ease-out function, otherwise uses an ease-in-out. This makes it feel much more natural, and is recommended in the [Material Design guidelines](https://material.io/guidelines/motion/duration-easing.html#duration-easing-natural-easing-curves). The default easing functions I picked are modeled on the ones outlined there (`standard` and `deceleration`).

Thanks to this [gist by gre](https://gist.github.com/gre/1650294) for the basis of many of the functions.

PR for docs is shown below