### PR TITLE
Add size attr to manage the size (in col) of each message.

### DIFF
--- a/src/components/chat/QChatMessage.vue
+++ b/src/components/chat/QChatMessage.vue
@@ -12,7 +12,7 @@
       <slot name="avatar">
         <img class="q-message-avatar" :src="avatar">
       </slot>
-      <div class="column">
+      <div :class="sizeClass">
         <div v-if="name" class="q-message-name" v-html="name"></div>
         <div
           v-for="msg in text"
@@ -49,7 +49,8 @@ export default {
     name: String,
     avatar: String,
     text: Array,
-    stamp: String
+    stamp: String,
+    size: String
   },
   computed: {
     textClass () {
@@ -60,6 +61,11 @@ export default {
     messageClass () {
       if (this.bgColor) {
         return `text-${this.bgColor}`
+      }
+    },
+    sizeClass () {
+      if (this.size) {
+        return `col-${this.size}`
       }
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Add a new attribute to set the size of the message. Today, the size is automatic, then I let it automatic if not set. If arrt size is specified : from 1 to 12, the `col-X` class is added to set the size.
Very usefull for enterprise/business message displayed on desktop mode (ie. large width for the chat section) - it make the reading more confortable.
