### PR TITLE
feat: add disable option for Toast timeout

### DIFF
--- a/src/components/toast/Toast.vue
+++ b/src/components/toast/Toast.vue
@@ -107,14 +107,14 @@ export default {
     __show () {
       Events.$emit('app:toast', this.stack[0].html)
 
-      this.timer = setTimeout(() => {
+      this.timer = this.stack[0].timeout !== -1 ? setTimeout(() => {
         if (this.stack.length > 0) {
           this.dismiss()
         }
         else {
           this.inTransition = false
         }
-      }, transitionDuration + (this.stack[0].timeout || displayDuration))
+      }, transitionDuration + (this.stack[0].timeout || displayDuration)) : null
     },
     dismiss (done) {
       clearTimeout(this.timer)


### PR DESCRIPTION
It would be better if there was a disable option for timeout of a Toast, so I thought setting timeout to -1 can be convenient for this option.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I'll add required docs for it before merging PR in case of approval.