### PR TITLE
q-list odd/even should not apply recursively by default

### DIFF
--- a/src/components/list/list.ios.styl
+++ b/src/components/list/list.ios.styl
@@ -97,9 +97,9 @@
   padding ($item-padding * $item-sparse-factor) $item-padding
   min-height ($item-min-height * $item-sparse-factor)
 
-.q-list-striped .q-item:nth-child(even)
+.q-list-striped>.q-item:nth-child(even)
   background-color $item-stripe-color
-.q-list-striped-odd .q-item:nth-child(odd)
+.q-list-striped-odd>.q-item:nth-child(odd)
   background-color $item-stripe-color
 
 .q-list

--- a/src/components/list/list.ios.styl
+++ b/src/components/list/list.ios.styl
@@ -97,9 +97,9 @@
   padding ($item-padding * $item-sparse-factor) $item-padding
   min-height ($item-min-height * $item-sparse-factor)
 
-.q-list-striped>.q-item:nth-child(even)
+.q-list-striped > .q-item:nth-child(even)
   background-color $item-stripe-color
-.q-list-striped-odd>.q-item:nth-child(odd)
+.q-list-striped-odd > .q-item:nth-child(odd)
   background-color $item-stripe-color
 
 .q-list

--- a/src/components/list/list.mat.styl
+++ b/src/components/list/list.mat.styl
@@ -97,9 +97,9 @@
   padding ($item-padding * $item-sparse-factor) $item-padding
   min-height ($item-min-height * $item-sparse-factor)
 
-.q-list-striped .q-item:nth-child(even)
+.q-list-striped>.q-item:nth-child(even)
   background-color $item-stripe-color
-.q-list-striped-odd .q-item:nth-child(odd)
+.q-list-striped-odd>.q-item:nth-child(odd)
   background-color $item-stripe-color
 
 .q-list

--- a/src/components/list/list.mat.styl
+++ b/src/components/list/list.mat.styl
@@ -97,9 +97,9 @@
   padding ($item-padding * $item-sparse-factor) $item-padding
   min-height ($item-min-height * $item-sparse-factor)
 
-.q-list-striped>.q-item:nth-child(even)
+.q-list-striped > .q-item:nth-child(even)
   background-color $item-stripe-color
-.q-list-striped-odd>.q-item:nth-child(odd)
+.q-list-striped-odd > .q-item:nth-child(odd)
   background-color $item-stripe-color
 
 .q-list


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
