### PR TITLE
Fixes tab scroll animation and drawer slide left animation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .Thumbs.db
 node_modules/
+tmp/
 dist/
 deploy/
 npm-debug.log

--- a/src/components/layout/side-mixin.js
+++ b/src/components/layout/side-mixin.js
@@ -84,6 +84,14 @@ export default {
       }
     },
     __show (side, fn) {
+
+      if (this.$isKeyboardOpen) {
+        setTimeout(() => {
+          this.__show(side, fn)
+        }, 100)
+        return false
+      }
+
       const state = this[side + 'State']
       if (this[side + 'OverBreakpoint']) {
         state.openedBig = true

--- a/src/components/layout/side-mixin.js
+++ b/src/components/layout/side-mixin.js
@@ -53,7 +53,7 @@ export default {
       this.leftState.openedSmall = false
       this.backdrop.percentage = 0
       if (typeof fn === 'function') {
-        setTimeout(fn, 310)
+        setTimeout(fn, 370)
       }
     },
     __hide (side, fn) {

--- a/src/components/layout/side-mixin.js
+++ b/src/components/layout/side-mixin.js
@@ -84,7 +84,6 @@ export default {
       }
     },
     __show (side, fn) {
-
       if (this.$isKeyboardOpen) {
         setTimeout(() => {
           this.__show(side, fn)

--- a/src/components/tab/QTabs.vue
+++ b/src/components/tab/QTabs.vue
@@ -285,7 +285,7 @@ export default {
       }
     },
     __animScrollTo (value) {
-      if (this.$refs.scroller.scrollTo) {
+      if (this.$refs.scroller.scrollTo && !this.$q.platform.is.safari) {
         this.$refs.scroller.scrollTo({
           'behavior': 'smooth',
           'left': value,

--- a/src/components/tab/QTabs.vue
+++ b/src/components/tab/QTabs.vue
@@ -285,14 +285,25 @@ export default {
       }
     },
     __animScrollTo (value) {
-      this.__stopAnimScroll()
-      this.__scrollTowards(value)
+      if (this.$refs.scroller.scrollTo) {
+        this.$refs.scroller.scrollTo({
+          'behavior': 'smooth',
+          'left': value,
+          'top': 0
+        })
 
-      this.scrollTimer = setInterval(() => {
-        if (this.__scrollTowards(value)) {
-          this.__stopAnimScroll()
-        }
-      }, 5)
+        this.__stopAnimScroll()
+      }
+      else {
+        this.__stopAnimScroll()
+        this.__scrollTowards(value)
+
+        this.scrollTimer = setInterval(() => {
+          if (this.__scrollTowards(value)) {
+            this.__stopAnimScroll()
+          }
+        }, 5)
+      }
     },
     __stopAnimScroll () {
       clearInterval(this.scrollTimer)

--- a/src/start.js
+++ b/src/start.js
@@ -20,9 +20,14 @@ export default function (cb = function () {}) {
   }, false)
 
   if (Platform.is.mobile) {
-    const initialScreenHeight = window.innerHeight
+    let initialScreenHeight = window.innerHeight
+    let initialScreenWidth = window.innerWidth
 
     window.addEventListener('resize', throttle(() => {
+      if(window.innerWidth !== initialScreenWidth) {
+        initialScreenHeight = window.innerHeight
+        initialScreenWidth = window.innerWidth
+      }
       Vue.prototype.$isKeyboardOpen = (window.innerHeight < initialScreenHeight)
     }, false), 100)
   }

--- a/src/start.js
+++ b/src/start.js
@@ -3,6 +3,25 @@ import Platform from './features/platform'
 import throttle from './utils/throttle'
 
 export default function (cb = function () {}) {
+
+  // Handle detecting when the mobile keyboard is open or close including logic to handle device orientation changes.
+  if (Platform.is.mobile) {
+    var initialScreenHeight = window.innerHeight
+    var initialScreenWidth = window.innerWidth
+
+    window.addEventListener('resize', throttle(function () {
+      if (window.innerWidth !== initialScreenWidth) {
+        initialScreenHeight = window.innerHeight
+        initialScreenWidth = window.innerWidth
+      } else {
+        let isOpen = (window.innerHeight < initialScreenHeight)
+        if(Vue.prototype.$isKeyboardOpen !== isOpen) {
+          Vue.prototype.$isKeyboardOpen = isOpen
+        }
+      }
+    }, false), 100)
+  }
+
   /*
     if on Cordova, but not on an iframe,
     like on Quasar Play app
@@ -18,19 +37,6 @@ export default function (cb = function () {}) {
     Vue.prototype.$cordova = cordova
     cb()
   }, false)
-
-  if (Platform.is.mobile) {
-    let initialScreenHeight = window.innerHeight
-    let initialScreenWidth = window.innerWidth
-
-    window.addEventListener('resize', throttle(() => {
-      if (window.innerWidth !== initialScreenWidth) {
-        initialScreenHeight = window.innerHeight
-        initialScreenWidth = window.innerWidth
-      }
-      Vue.prototype.$isKeyboardOpen = (window.innerHeight < initialScreenHeight)
-    }, false), 100)
-  }
 
   tag.type = 'text/javascript'
   document.body.appendChild(tag)

--- a/src/start.js
+++ b/src/start.js
@@ -1,5 +1,6 @@
 import { Vue } from './deps'
 import Platform from './features/platform'
+import throttle from './utils/throttle'
 
 export default function (cb = function () {}) {
   /*
@@ -17,6 +18,14 @@ export default function (cb = function () {}) {
     Vue.prototype.$cordova = cordova
     cb()
   }, false)
+
+  if (Platform.is.mobile) {
+    const initialScreenHeight = window.innerHeight
+
+    window.addEventListener('resize', throttle(() => {
+      Vue.prototype.$isKeyboardOpen = (window.innerHeight < initialScreenHeight)
+    }, false), 100)
+  }
 
   tag.type = 'text/javascript'
   document.body.appendChild(tag)

--- a/src/start.js
+++ b/src/start.js
@@ -3,7 +3,6 @@ import Platform from './features/platform'
 import throttle from './utils/throttle'
 
 export default function (cb = function () {}) {
-
   // Handle detecting when the mobile keyboard is open or close including logic to handle device orientation changes.
   if (Platform.is.mobile) {
     var initialScreenHeight = window.innerHeight
@@ -13,9 +12,10 @@ export default function (cb = function () {}) {
       if (window.innerWidth !== initialScreenWidth) {
         initialScreenHeight = window.innerHeight
         initialScreenWidth = window.innerWidth
-      } else {
+      }
+      else {
         let isOpen = (window.innerHeight < initialScreenHeight)
-        if(Vue.prototype.$isKeyboardOpen !== isOpen) {
+        if (Vue.prototype.$isKeyboardOpen !== isOpen) {
           Vue.prototype.$isKeyboardOpen = isOpen
         }
       }

--- a/src/start.js
+++ b/src/start.js
@@ -24,7 +24,7 @@ export default function (cb = function () {}) {
     let initialScreenWidth = window.innerWidth
 
     window.addEventListener('resize', throttle(() => {
-      if(window.innerWidth !== initialScreenWidth) {
+      if (window.innerWidth !== initialScreenWidth) {
         initialScreenHeight = window.innerHeight
         initialScreenWidth = window.innerWidth
       }


### PR DESCRIPTION
Makes tab and left drawer slide animations smoother on low end devices for a more native feel. 

The scroll behavior of the tabs was causing repaints every 5 ms and was looking jittery. This replaces that with native element.scrollTo() for native scroll performance.

The left drawer would start loading a route before it was fully shut causing the animation to pause half way. By increasing the delay to 370ms from drawer close to loading the route, the animation has time to finish and appears smoother.

Also delays the closing of the drawer if the keyboard is currently open, to prevent an animation glitch and give the keyboard time to close. Tested in cordova android, not ios.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
