### PR TITLE
close #1117: Make prop dark default to null in order to accommodate light background

### DIFF
--- a/dev/components/form/autocomplete.vue
+++ b/dev/components/form/autocomplete.vue
@@ -48,6 +48,13 @@
           @selected="selected"
         />
       </q-search>
+      <q-search inverted color="white" :dark="false" v-model="terms">
+        <q-autocomplete
+          @search="search"
+          :max-results="2"
+          @selected="selected"
+        />
+      </q-search>
 
       <p class="caption">Minimum 3 characters to trigger search</p>
       <q-input color="amber" v-model="terms" placeholder="Type 'fre'">

--- a/dev/components/form/chips-input.vue
+++ b/dev/components/form/chips-input.vue
@@ -16,6 +16,7 @@
       <q-chips-input align="right" @change="value => log('@change', value)" @input="value => log('@input', value)" color="secondary" hide-underline float-label="Float Label (hide underline)" v-model="model" placeholder="Some placeholder" />
       <q-chips-input align="right" @change="value => { model = value; log('@change', value) }" @input="value => log('@input', value)" color="secondary" float-label="Float Label (onChange)" :value="model" placeholder="Some placeholder" />
       <q-chips-input inverted color="dark" frame-color="amber" float-label="Float Label" v-model="model" placeholder="Some placeholder" />
+      <q-chips-input inverted color="dark" :dark="false" frame-color="white" float-label="Float Label" v-model="model" placeholder="Some placeholder" />
 
       <div class="bg-grey-9" style="padding: 15px">
         <q-chips-input dark color="amber" float-label="Float Label" v-model="model" placeholder="Some placeholder" />

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -50,6 +50,7 @@
       <q-datetime inverted v-model="model" type="date" />
       <q-datetime inverted color="secondary" stack-label="Stack Label" v-model="model" type="date" />
       <q-datetime inverted color="amber" float-label="Float Label" v-model="model" type="date" />
+      <q-datetime inverted color="white" :dark="false" float-label="Float Label" v-model="model" type="date" />
 
       <p class="caption">Format Model</p>
       <div class="bg-secondary text-white">

--- a/dev/components/form/input.vue
+++ b/dev/components/form/input.vue
@@ -107,6 +107,7 @@
       <q-input v-model="text" inverted stack-label="Colored" color="amber" />
       <q-input v-model="text" inverted stack-label="Colored" :after="[{icon: 'arrow_forward', content: true, handler () {}}]"/>
       <q-input v-model="text" inverted type="textarea" stack-label="Colored" color="tertiary" :min-rows="5" />
+      <q-input v-model="text" inverted type="textarea" stack-label="Colored" color="white" :dark="false" :min-rows="5" />
 
       <p class="caption">On dark background</p>
       <div class="bg-grey-9" style="width: 500px; padding: 25px">

--- a/dev/components/form/search.vue
+++ b/dev/components/form/search.vue
@@ -22,7 +22,9 @@
         <q-search inverted v-model="search" color="secondary" icon="explore" placeholder="PlacesPlacesPlacesPlacesPlacesPlacesPlaces"></q-search>
         <q-search inverted v-model="search" color="primary" icon="local_airport" placeholder="Airports"></q-search>
         <q-search inverted v-model="search" color="dark" icon="local_hotel" placeholder="Hotels"></q-search>
-        <q-search inverted stack-label="Stack Label" v-model="search" color="amber" icon="local_hotel" placeholder="Hotels"></q-search>
+        <q-search inverted v-model="search" color="amber" icon="local_hotel" placeholder="Hotels" stack-label="Stack Label"></q-search>
+        <q-search inverted v-model="search" color="white" :dark="false" icon="local_hotel" placeholder="Hotels"></q-search>
+        <q-search inverted v-model="search" color="white" :dark="false" icon="local_hotel" placeholder="Hotels" stack-label="Stack Label"></q-search>
       </div>
 
       <p class="caption">Numeric Format</p>

--- a/dev/components/form/select.vue
+++ b/dev/components/form/select.vue
@@ -16,6 +16,7 @@
       <q-select color="amber" v-model="select" :options="selectListOptions"></q-select>
       <q-select inverted color="secondary" v-model="select" :options="selectListOptions"></q-select>
       <q-select inverted float-label="Float Label" color="amber" v-model="select" :options="selectListOptions"></q-select>
+      <q-select inverted float-label="Float Label" color="white" :dark="false" v-model="select" :options="selectListOptions"></q-select>
 
       <p class="caption">Single Selection with Radio</p>
       <q-field label="gogu">

--- a/src/components/input-frame/QInputFrame.vue
+++ b/src/components/input-frame/QInputFrame.vue
@@ -98,14 +98,16 @@ export default {
         'q-if-disabled': this.disable,
         'q-if-focusable': this.focusable && !this.disable,
         'q-if-inverted': this.inverted,
-        'q-if-dark': this.dark || this.inverted,
+        'q-if-dark': this.dark || (this.inverted && this.dark !== false),
         'q-if-hide-underline': this.hideUnderline
       }]
 
       const color = this.hasError ? 'negative' : this.hasWarning ? 'warning' : this.color
       if (this.inverted) {
         cls.push(`bg-${color}`)
-        cls.push(`text-white`)
+        if (this.dark !== false) {
+          cls.push(`text-white`)
+        }
       }
       else {
         cls.push(`text-${color}`)

--- a/src/components/input-frame/input-frame.ios.styl
+++ b/src/components/input-frame/input-frame.ios.styl
@@ -99,6 +99,7 @@
   padding-left 8px
   padding-right 8px
   box-shadow $shadow-1
+.q-if-dark
   .q-if-control
     color white
 

--- a/src/components/input-frame/input-frame.mat.styl
+++ b/src/components/input-frame/input-frame.mat.styl
@@ -99,6 +99,7 @@
   padding-left 8px
   padding-right 8px
   box-shadow $shadow-1
+.q-if-dark
   .q-if-control
     color white
 

--- a/src/mixins/input-frame.js
+++ b/src/mixins/input-frame.js
@@ -29,7 +29,10 @@ export default {
     align: {
       default: 'left'
     },
-    dark: Boolean,
+    dark: {
+      type: Boolean,
+      default: null
+    },
     before: marginal,
     after: marginal,
     inverted: Boolean,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fields with white or very light background where displayed with white text color.
Allow inverted white fields.

Closes #1117 