### PR TITLE
#1063 cancel debounce qtabs

### DIFF
--- a/src/components/tab/QTabs.vue
+++ b/src/components/tab/QTabs.vue
@@ -346,6 +346,8 @@ export default {
   },
   beforeDestroy () {
     clearTimeout(this.timer)
+    this.__redraw.cancel()
+    this.__updateScrollIndicator.cancel()
     this.__stopAnimScroll()
     this.$refs.scroller.removeEventListener('scroll', this.__updateScrollIndicator)
     window.removeEventListener('resize', this.__redraw)

--- a/src/components/tab/QTabs.vue
+++ b/src/components/tab/QTabs.vue
@@ -337,20 +337,17 @@ export default {
         this.selectTab(this.value)
       }
 
-      // let browser drawing stabilize then
-      setTimeout(() => {
-        this.__redraw()
-        this.__findTabAndScroll(this.data.tabName, true)
-      }, debounceDelay)
+      this.__redraw()
+      this.__findTabAndScroll(this.data.tabName, true)
     })
   },
   beforeDestroy () {
     clearTimeout(this.timer)
-    this.__redraw.cancel()
-    this.__updateScrollIndicator.cancel()
     this.__stopAnimScroll()
     this.$refs.scroller.removeEventListener('scroll', this.__updateScrollIndicator)
     window.removeEventListener('resize', this.__redraw)
+    this.__redraw.cancel()
+    this.__updateScrollIndicator.cancel()
   }
 }
 </script>

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,7 +1,16 @@
 
 export function debounce (fn, wait = 250, immediate) {
   let timeout
-  return function (...args) {
+
+  // Prevents execution of debounced function, or noop if
+  // never invoked/already executed
+  function cancel() {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+
+  function debounced (...args) {
     const later = () => {
       timeout = null
       if (!immediate) {
@@ -15,6 +24,9 @@ export function debounce (fn, wait = 250, immediate) {
     }
     timeout = setTimeout(later, wait)
   }
+
+  debounced.cancel = cancel
+  return debounced
 }
 
 export function frameDebounce (fn) {

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -4,7 +4,7 @@ export function debounce (fn, wait = 250, immediate) {
 
   // Prevents execution of debounced function, or noop if
   // never invoked/already executed
-  function cancel() {
+  function cancel () {
     if (timeout) {
       clearTimeout(timeout)
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
This pull request fixes the "Failed to execute 'getComputedStyle' on 'Window' in QTabs" as mentioned in #1063 . It also allows other code to cancel a debounce in the future if it is needed. QInfiniteScroll may have a similar issue for example, but I do not have a test case for it right now. I prefer this solution over just checking if the ref exists, because this actually prevents the function from running instead of cutting it short to suppress errors.

I cannot test it with Cordova or Electron currently, but I have tested it with the test case mentioned in the issue and confirmed it does no longer cause that error in the web version.