### PR TITLE
fix: #998 Stop propagation with nested touch pans

### DIFF
--- a/src/directives/touch-pan.js
+++ b/src/directives/touch-pan.js
@@ -97,6 +97,7 @@ export default {
       direction: getDirection(binding.modifiers),
 
       mouseStart (evt) {
+        evt.stopPropagation()
         if (mouse) {
           document.addEventListener('mousemove', ctx.mouseMove)
           document.addEventListener('mouseup', ctx.mouseEnd)
@@ -104,6 +105,7 @@ export default {
         ctx.start(evt)
       },
       start (evt) {
+        evt.stopPropagation()
         let pos = position(evt)
         ctx.event = {
           x: pos.left,
@@ -121,6 +123,7 @@ export default {
         ctx.move(evt)
       },
       move (evt) {
+        evt.stopPropagation()
         if (ctx.event.prevent) {
           if (!ctx.scroll) {
             evt.preventDefault()
@@ -162,6 +165,7 @@ export default {
         ctx.end(evt)
       },
       end (evt) {
+        evt.stopPropagation()
         if (!ctx.event.prevent || ctx.event.isFirst) {
           return
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

I do not believe this should break anything within the framework, but it will break confusing nested pan events on custom components.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
This PR requires more testing. It has been tested on the use case shown in #998 , and a QSlider in a QPullToRefresh (horizontal and vertical pan).