### PR TITLE
Remove now unnecessary "start()" method

### DIFF
--- a/dev/main.js
+++ b/dev/main.js
@@ -21,11 +21,9 @@ Vue.use(Quasar, {
   plugins: Everything
 })
 
-Quasar.start(() => {
-  /* eslint-disable no-new */
-  new Vue({
-    el: '#q-app',
-    router,
-    render: h => h(App)
-  })
+/* eslint-disable no-new */
+new Vue({
+  el: '#q-app',
+  router,
+  render: h => h(App)
 })


### PR DESCRIPTION
Fix main.js as remove now unnecessary "start()" method

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No