### PR TITLE
Layout footer, header and drawer default to visibile

### DIFF
--- a/src/components/layout/QLayoutDrawer.js
+++ b/src/components/layout/QLayoutDrawer.js
@@ -21,7 +21,10 @@ export default {
     TouchPan
   },
   props: {
-    value: Boolean,
+    value: {
+      type: Boolean,
+      default: true
+    },
     overlay: Boolean,
     rightSide: Boolean,
     breakpoint: {

--- a/src/components/layout/QLayoutFooter.js
+++ b/src/components/layout/QLayoutFooter.js
@@ -10,7 +10,10 @@ export default {
     }
   },
   props: {
-    value: Boolean,
+    value: {
+      type: Boolean,
+      default: true
+    },
     reveal: Boolean
   },
   data () {

--- a/src/components/layout/QLayoutHeader.js
+++ b/src/components/layout/QLayoutHeader.js
@@ -10,7 +10,10 @@ export default {
     }
   },
   props: {
-    value: Boolean,
+    value: {
+      type: Boolean,
+      default: true
+    },
     reveal: Boolean,
     revealOffset: {
       type: Number,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It's expected that if a layout component (Header, Footer, Drawer) is placed on the page without visibility info it should be visible.
