### PR TITLE
fix error then sorting value is null

### DIFF
--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -1,4 +1,7 @@
 export function sortString (a, b) {
+  if (typeof a !== 'string') {
+    throw new TypeError('The value for sorting must be a String')
+  }
   return a.localeCompare(b)
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
If the value for sorting in the dataTable === null
We get the error "Cannot read property 'localeCompare' of null"
When we have a lot of data, it is unclear why it occurs.
This PR makes more transparent the output of this error
