### PR TITLE
fix: QBtn push make the rest of content jumpy

### DIFF
--- a/src/components/btn/btn-default.ios.styl
+++ b/src/components/btn/btn-default.ios.styl
@@ -11,6 +11,8 @@ button-round-factor($size)
   outline 0
   border 0
   vertical-align middle
+  vertical-align -webkit-baseline-middle
+  vertical-align -moz-middle-with-baseline
   cursor pointer
   -webkit-appearance button
   padding $button-padding

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -11,6 +11,8 @@ button-round-factor($size)
   outline 0
   border 0
   vertical-align middle
+  vertical-align -webkit-baseline-middle
+  vertical-align -moz-middle-with-baseline
   cursor pointer
   -webkit-appearance button
   padding $button-padding

--- a/src/components/btn/btn-group.ios.styl
+++ b/src/components/btn/btn-group.ios.styl
@@ -1,6 +1,6 @@
 .q-btn-group
   border-radius $button-border-radius
-  vertical-align middle
+  vertical-align text-bottom
   .q-btn:not(:last-child)
     border-top-right-radius 0
     border-bottom-right-radius 0

--- a/src/components/btn/btn-group.mat.styl
+++ b/src/components/btn/btn-group.mat.styl
@@ -1,7 +1,7 @@
 .q-btn-group
   border-radius $button-border-radius
   box-shadow $button-shadow
-  vertical-align middle
+  vertical-align text-bottom
   > .q-btn-group
     box-shadow none
   .q-btn


### PR DESCRIPTION
As can be seen in btn, button-toggle-group demo

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When we push on a QBtn push button the content below or on the same row jumps up/down