### PR TITLE
Storing an empty string and getting it back produce a bad behavior.

### DIFF
--- a/src/plugins/web-storage.js
+++ b/src/plugins/web-storage.js
@@ -31,7 +31,7 @@ function decode (value) {
   let type, length, source
 
   length = value.length
-  if (length < 10) {
+  if (length < 9) {
     // then it wasn't encoded by us
     return value
   }


### PR DESCRIPTION
There was a test for considering the value only if it contains at least 10 chars, but 9 is the correct number. As each key plus separator '"__q_strn|".length' contains 9 chars not 10. So getting a value from "__q_strn|" was returning "__q_strn|" instead of "".

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As a workaround : Instead of storing an empty string we could erase it. But even with the workaround, this should be fixed as this bad behavior.