### PR TITLE
close #1204: Allow custom text inside brackets in formatDate

### DIFF
--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -12,8 +12,12 @@
         </span>
       </p>
 
-      <div class="label bg-secondary text-white">
-        Model <span class="right-detail"><em>{{model}}</em></span>
+      <div class="bg-secondary text-white">
+        Model: <em>{{model}}</em>
+      </div>
+      <q-input v-model="format" float-label="Format string" />
+      <div class="bg-secondary text-white">
+        Formatted: <em>{{modelFormatted}}</em>
       </div>
 
       <p class="caption">
@@ -179,10 +183,17 @@ export default {
       model: undefined,
       defaultSelection: '2016-09-18T10:45:00.000Z',
 
+      format: 'YYYY-MM-DDTHH:mm:ss.SSSZ',
+
       minMaxModel: date.formatDate(day),
 
       min: date.subtractFromDate(day, {days: 5}),
       max: date.addToDate(day, {days: 4, month: 1, minutes: 10})
+    }
+  },
+  computed: {
+    modelFormatted () {
+      return date.formatDate(this.model, this.format)
     }
   },
   methods: {

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -183,7 +183,7 @@ export default {
       model: undefined,
       defaultSelection: '2016-09-18T10:45:00.000Z',
 
-      format: 'YYYY-MM-DDTHH:mm:ss.SSSZ',
+      format: 'MMMM D, YYYY [at] h:mm [[]a[\\]]',
 
       minMaxModel: date.formatDate(day),
 

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -250,7 +250,7 @@ export default {
 
     __set (e) {
       let val = e.target ? e.target.value : e
- 
+
       if (this.isNumber) {
         val = parseFloat(val)
         if (isNaN(val)) {
@@ -264,7 +264,7 @@ export default {
       else if (this.upperCase) {
         val = val.toUpperCase()
       }
- 
+
       if (val !== this.model) {
         this.$emit('input', val)
       }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -8,7 +8,7 @@ const
   MILLISECONDS_IN_DAY = 86400000,
   MILLISECONDS_IN_HOUR = 3600000,
   MILLISECONDS_IN_MINUTE = 60000,
-  token = /d{1,4}|M{1,4}|m{1,2}|w{1,2}|Qo|Do|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]/g
+  token = /\[((?:[^\]\\]|\\]|\\)*)\]|d{1,4}|M{1,4}|m{1,2}|w{1,2}|Qo|Do|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]/g
 
 function formatTimezone (offset, delimeter = '') {
   const
@@ -507,10 +507,10 @@ export function formatDate (val, mask = 'YYYY-MM-DDTHH:mm:ss.SSSZ') {
 
   let date = new Date(val)
 
-  return mask.replace(token, function (match) {
+  return mask.replace(token, function (match, text) {
     if (match in formatter) {
       return formatter[match](date)
     }
-    return match
+    return text === void 0 ? match : text.split('\\]').join(']')
   })
 }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -511,6 +511,8 @@ export function formatDate (val, mask = 'YYYY-MM-DDTHH:mm:ss.SSSZ') {
     if (match in formatter) {
       return formatter[match](date)
     }
-    return text === void 0 ? match : text.split('\\]').join(']')
+    return text === void 0
+      ? match
+      : text.split('\\]').join(']')
   })
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
#1204 
Any text inside square brackets is kept as it is. A right square bracket must be escaped by backslash.

'YYYY[, at ]hh[ hour []A[\]]' is formatted as '2017, at 11 hour [AM]'