### PR TITLE
Add text keyboard toggle for number QInput

### DIFF
--- a/icons/material.js
+++ b/icons/material.js
@@ -90,6 +90,8 @@ export default {
   input: {
     showPass: 'visibility',
     hidePass: 'visibility_off',
+    showNumber: 'keyboard',
+    hideNumber: 'keyboard_hide',
     clear: 'cancel'
   },
   pagination: {

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -96,6 +96,16 @@
     ></q-icon>
 
     <q-icon
+      v-if="isNumber && !noNumberToggle && length"
+      slot="after"
+      :name="$q.icon.input[showNumber ? 'showNumber' : 'hideNumber']"
+      class="q-if-control"
+      @mousedown="__clearTimer"
+      @touchstart="__clearTimer"
+      @click="toggleNumber"
+    ></q-icon>
+
+    <q-icon
       v-if="editable && clearable && length"
       slot="after"
       :name="$q.icon.input.clear"
@@ -145,6 +155,7 @@ export default {
     minRows: Number,
     clearable: Boolean,
     noPassToggle: Boolean,
+    noNumberToggle: Boolean,
     readonly: Boolean,
     attributes: Object,
 
@@ -160,6 +171,7 @@ export default {
   data () {
     return {
       showPass: false,
+      showNumber: true,
       model: this.value,
       shadow: {
         val: this.model,
@@ -218,7 +230,11 @@ export default {
     inputType () {
       return this.isPassword
         ? (this.showPass ? 'text' : 'password')
-        : this.type
+        : (
+          this.isNumber
+            ? (this.showNumber ? 'number' : 'text')
+            : this.type
+        )
     },
     length () {
       return this.model !== null && this.model !== undefined
@@ -232,6 +248,11 @@ export default {
   methods: {
     togglePass () {
       this.showPass = !this.showPass
+      clearTimeout(this.timer)
+      this.focus()
+    },
+    toggleNumber () {
+      this.showNumber = !this.showNumber
       clearTimeout(this.timer)
       this.focus()
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
It allows to change to a more lax text input field (you can enter things like 5e-2) and allows to toggle text keyboard on mobiles.