### PR TITLE
Add icon to QAlert actions and add default close action to notificati…

### DIFF
--- a/dev/components/components/alert.vue
+++ b/dev/components/components/alert.vue
@@ -30,7 +30,7 @@
         type="negative"
         dismissible
         style="margin-bottom: 1.5rem"
-        :actions="[{label: 'Snooze', handler () {}}]"
+        :actions="[ { icon: 'snooze', handler: () => { visible2 = false } } ]"
       >
         Lorem ipsum dolor sit amet.
       </q-alert>

--- a/icons/material.js
+++ b/icons/material.js
@@ -92,6 +92,9 @@ export default {
     hidePass: 'visibility_off',
     clear: 'cancel'
   },
+  notify: {
+    close: 'close'
+  },
   pagination: {
     first: 'first_page',
     prev: 'keyboard_arrow_left',

--- a/src/components/alert/QAlert.js
+++ b/src/components/alert/QAlert.js
@@ -71,7 +71,8 @@ export default {
               h(QBtn, {
                 props: {
                   flat: true,
-                  compact: true
+                  compact: true,
+                  icon: action.icon
                 },
                 on: {
                   click: () => action.handler()

--- a/src/plugins/notify.js
+++ b/src/plugins/notify.js
@@ -61,12 +61,21 @@ export default {
 
           notif.__uid = uid()
 
-          const action = notif.position.indexOf('top') > -1 ? 'unshift' : 'push'
-          this.notifs[notif.position][action](notif)
-
           const close = () => {
             this.remove(notif)
           }
+
+          if (!notif.timeout && (!notif.actions || !notif.actions.length)) {
+            notif.actions = [
+              {
+                icon: this.$q.icon.notify.close,
+                handler: close
+              }
+            ]
+          }
+
+          const action = notif.position.indexOf('top') > -1 ? 'unshift' : 'push'
+          this.notifs[notif.position][action](notif)
 
           if (notif.timeout) {
             notif.__timeout = setTimeout(() => {


### PR DESCRIPTION
…ons without timeout and action

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Add icon property for actions in QAlert (was present in tests but missing in implementation)
Add a default close action (close icon) to notifications without timeout and without actions.