### PR TITLE
[Fix] QAutocompete hide popover when blur input (#951)

### DIFF
--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -204,7 +204,8 @@ export default {
     }
     this.$nextTick(() => {
       this.inputEl = this.__input.getEl()
-      this.inputEl.addEventListener('keyup', this.__handleKeypress)
+      this.inputEl.addEventListener('keydown', this.__handleKeypress)
+      this.inputEl.addEventListener('blur', this.hide)
     })
   },
   beforeDestroy () {
@@ -215,6 +216,7 @@ export default {
     }
     if (this.inputEl) {
       this.inputEl.removeEventListener('keydown', this.__handleKeypress)
+      this.inputEl.removeEventListener('blur', this.hide)
       this.hide()
     }
   },


### PR DESCRIPTION
*Fix QAutocompete hide popover when blur input (#951)
*Fix QAutocomplete addEventListener keyup -> keydown

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
