### PR TITLE
Workaround QInput numeric

### DIFF
--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -184,6 +184,7 @@ export default {
   watch: {
     value (v) {
       this.model = v
+      this.isNumberError = false
     }
   },
   provide () {
@@ -254,17 +255,14 @@ export default {
       let val = e.target ? e.target.value : e
 
       if (this.isNumber) {
-        if (('' + val).length === 0) {
-          val = null
+        val = parseFloat(val)
+        if (isNaN(val)) {
+          this.isNumberError = true
+          return
         }
-        else {
-          val = parseFloat(val)
-          if (isNaN(val)) {
-            return
-          }
-          if (Number.isInteger(this.maxDecimals)) {
-            val = parseFloat(val.toFixed(this.maxDecimals))
-          }
+        this.isNumberError = false
+        if (Number.isInteger(this.maxDecimals)) {
+          val = parseFloat(val.toFixed(this.maxDecimals))
         }
       }
       else if (this.upperCase) {

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -10,7 +10,8 @@ export default {
   data () {
     return {
       focused: false,
-      timer: null
+      timer: null,
+      isNumberError: false
     }
   },
   computed: {
@@ -47,9 +48,10 @@ export default {
     __onBlur (e) {
       this.focused = false
       this.$emit('blur', e)
-      if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
-        this.$emit('input', this.model)
-        this.$emit('change', this.model)
+      let model = this.isNumber && this.isNumberError ? null : this.model
+      if (JSON.stringify(model) !== JSON.stringify(this.value)) {
+        this.$emit('input', model)
+        this.$emit('change', model)
       }
     },
     __onKeydown (e) {


### PR DESCRIPTION
On NaN value it only emits on blur and keeps tract of invalid numeric values to emit null

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
