### PR TITLE
[Fix] QDialogSelect catch <-> then

### DIFF
--- a/src/components/select/QDialogSelect.vue
+++ b/src/components/select/QDialogSelect.vue
@@ -106,14 +106,14 @@ export default {
         },
         cancel: this.cancelLabel || true,
         ok: this.okLabel || true
-      }).catch(() => {
-        this.dialog = null
       }).then(data => {
         this.dialog = null
         if (JSON.stringify(this.value) !== JSON.stringify(data)) {
           this.$emit('input', data)
           this.$emit('change', data)
         }
+      }).catch(() => {
+        this.dialog = null
       })
     },
     hide () {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Fix Promise chain. The .catch() is catching the error and not producing a new error. It has essentially "handled" the error, and the following .then() handler is free to be called.  So when click on "Cancel" in  dialog this caused emit value 'undefined'.