### PR TITLE
Fix ripple effect when QBtn is clicked with keyboard

### DIFF
--- a/src/utils/event.js
+++ b/src/utils/event.js
@@ -31,6 +31,11 @@ export function position (e) {
     e = e.changedTouches[0]
   }
 
+  if (!e.clientX && !e.clientY) {
+    const elemOffset = targetElement(e).getBoundingClientRect()
+    posx = ((elemOffset.right - elemOffset.left) / 2) + elemOffset.left
+    posy = ((elemOffset.bottom - elemOffset.top) / 2) + elemOffset.top
+  }
   if (e.clientX || e.clientY) {
     posx = e.clientX
     posy = e.clientY

--- a/src/utils/event.js
+++ b/src/utils/event.js
@@ -31,11 +31,6 @@ export function position (e) {
     e = e.changedTouches[0]
   }
 
-  if (!e.clientX && !e.clientY) {
-    const elemOffset = targetElement(e).getBoundingClientRect()
-    posx = ((elemOffset.right - elemOffset.left) / 2) + elemOffset.left
-    posy = ((elemOffset.bottom - elemOffset.top) / 2) + elemOffset.top
-  }
   if (e.clientX || e.clientY) {
     posx = e.clientX
     posy = e.clientY
@@ -43,6 +38,11 @@ export function position (e) {
   else if (e.pageX || e.pageY) {
     posx = e.pageX - document.body.scrollLeft - document.documentElement.scrollLeft
     posy = e.pageY - document.body.scrollTop - document.documentElement.scrollTop
+  }
+  else {
+    const offset = targetElement(e).getBoundingClientRect()
+    posx = ((offset.right - offset.left) / 2) + offset.left
+    posy = ((offset.bottom - offset.top) / 2) + offset.top
   }
 
   return {


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When testing QBtn with keyboard I noticed that the ripple effect got broken. This is due to such specific keyboard events translated into mouse events with (0, 0) coordinates. Added a bit of logic to handle such a case. Now then button is pressed via keyboard instead of mouse click the ripple effect will expand from the center of QBtn (and any other elements with similar effect).