### PR TITLE
Allow autofocus prop to also select the text Closes #1250

### DIFF
--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -68,12 +68,10 @@ export default {
   mounted () {
     this.$nextTick(() => {
       const input = this.$refs.input
-      if (input) {
+      if (this.autofocus && input) {
+        input.focus()
         if (this.autofocus === 'select') {
           input.select()
-        }
-        if (this.autofocus) {
-          input.focus()
         }
       }
     })

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -1,6 +1,7 @@
 export default {
   props: {
     autofocus: Boolean,
+    autoselect: Boolean,
     name: String,
     maxLength: [Number, String],
     maxHeight: Number,
@@ -68,8 +69,13 @@ export default {
   mounted () {
     this.$nextTick(() => {
       const input = this.$refs.input
-      if (this.autofocus && input) {
-        input.focus()
+      if (input) {
+        if (this.autoselect) {
+          input.select()
+        }
+        if (this.autofocus) {
+          input.focus()
+        }
       }
     })
   },

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -1,7 +1,6 @@
 export default {
   props: {
-    autofocus: Boolean,
-    autoselect: Boolean,
+    autofocus: [Boolean, String],
     name: String,
     maxLength: [Number, String],
     maxHeight: Number,
@@ -70,7 +69,7 @@ export default {
     this.$nextTick(() => {
       const input = this.$refs.input
       if (input) {
-        if (this.autoselect) {
+        if (this.autofocus === 'select') {
           input.select()
         }
         if (this.autofocus) {


### PR DESCRIPTION
Closes #1250 
`autoselect` functionality. Can be used in conjunction with `autofocus`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

We may need to include documentation for this prop in v0.15 docs, right?
