### PR TITLE
close #1274: Don't hide popover that has child popover on click in child

### DIFF
--- a/dev/components/components/popover.vue
+++ b/dev/components/components/popover.vue
@@ -9,7 +9,7 @@
 
       <div>
         <q-toggle v-model="toggle" class="z-max fixed-top" />
-        <q-btn color="primary" icon="assignment">
+        <q-btn color="primary" icon="assignment" class="q-ma-xs">
           <q-popover v-model="toggle" ref="popover1">
             <q-list link separator class="scroll" style="min-width: 100px">
               <q-item
@@ -42,6 +42,88 @@
         <q-btn ref="target4" color="negative" label="Disabled Popover">
           <q-popover disable>
             This Popover content won't be shown because of "disable"
+          </q-popover>
+        </q-btn>
+
+        <q-btn color="info" label="Autocomplete static in popup" class="q-ma-xs">
+          <q-popover anchor="bottom right" self="top right" fit>
+            <div class="row">
+              <div class="col-12 q-pa-sm">
+                <q-search v-model="terms" placeholder="Search">
+                  <q-autocomplete
+                    :static-data="{field: 'value', list}"
+                    @selected="selected"
+                  />
+                </q-search>
+              </div>
+            </div>
+          </q-popover>
+        </q-btn>
+
+        <q-btn color="info" label="Autocomplete debounced in popup" class="q-ma-xs">
+          <q-popover anchor="bottom right" self="top right" fit>
+            <div class="row">
+              <div class="col-12 q-pa-sm">
+                <q-search v-model="terms" placeholder="Search" :debounce="500">
+                  <q-autocomplete
+                    @search="search"
+                    @selected="selected"
+                  />
+                </q-search>
+              </div>
+            </div>
+          </q-popover>
+        </q-btn>
+
+        <q-btn color="info" label="Select in popup" class="q-ma-xs">
+          <q-popover anchor="bottom right" self="top right" fit>
+            <div class="row">
+              <div class="col-12 q-pa-sm">
+                <q-select
+                  v-model="terms"
+                  :options="list"
+                  filter
+                  @input="selected"
+                />
+              </div>
+            </div>
+          </q-popover>
+        </q-btn>
+
+        <q-btn color="info" label="More controls in popup" class="q-ma-xs">
+          <q-popover anchor="bottom right" self="top right" fit>
+            <div class="row">
+              <div class="col-12 q-pa-sm">
+                <q-knob
+                  v-model="model"
+                  :min="min"
+                  :max="max"
+                >
+                  <q-icon class="on-left" name="volume_up" /> {{model}}
+                </q-knob>
+              </div>
+              <div class="col-12 q-pa-sm">
+                <q-datetime v-model="modelDate" type="datetime" />
+              </div>
+              <div class="col-12 q-px-sm q-py-lg">
+                <q-slider v-model="model" :min="min" :max="max" square label></q-slider>
+              </div>
+              <div class="col-12 q-pa-sm">
+                <q-select radio
+                  v-model="terms"
+                  :options="list"
+                  filter
+                  @input="selected"
+                />
+              </div>
+              <div class="col-12 q-pa-sm">
+                <q-toggle v-model="toggleModal" label="Toggle modal" />
+                <q-modal v-model="toggleModal" position="right" :content-css="{padding: '20px'}">
+                  <h4>Modal</h4><p>This one gets displayed from right.</p>
+                  <q-btn color="orange" @click="toggleModal = false">Close Me</q-btn>
+                </q-modal>
+              </div>
+            </div>
           </q-popover>
         </q-btn>
 
@@ -151,6 +233,8 @@
 </template>
 
 <script>
+import { filter } from 'quasar'
+
 export default {
   data () {
     let list = []
@@ -161,6 +245,7 @@ export default {
     }
     return {
       toggle: false,
+      toggleModal: false,
       anchorOrigin: {vertical: 'bottom', horizontal: 'left'},
       selfOrigin: {vertical: 'top', horizontal: 'left'},
       terms: '',
@@ -182,6 +267,14 @@ export default {
   methods: {
     showNotify () {
       this.$q.notify((this.$q.platform.is.desktop ? 'Clicked' : 'Tapped') + ' on a Popover item')
+    },
+    search (terms, done) {
+      setTimeout(() => {
+        done(filter(terms, {field: 'value', list: this.list}))
+      }, 1000)
+    },
+    selected (item) {
+      this.$q.notify(`Selected suggestion "${JSON.stringify(item)}"`)
     }
   }
 }

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -103,16 +103,18 @@ export default {
 
       clearTimeout(this.timer)
       this.timer = setTimeout(() => {
-        document.body.addEventListener('click', this.__bodyHide, true)
-        document.body.addEventListener('touchstart', this.__bodyHide, true)
+        document.body.addEventListener('click', this.__bodyHide)
         this.showPromise && this.showPromiseResolve()
       }, 0)
     },
     __bodyHide (evt) {
       if (
-        evt && evt.target &&
-        (this.$el.contains(evt.target) || this.anchorEl.contains(evt.target))
+        evt && (
+          evt.skipPopup ||
+          (evt.target && (this.$el.contains(evt.target) || this.anchorEl.contains(evt.target)))
+        )
       ) {
+        evt.skipPopup = true
         return
       }
 


### PR DESCRIPTION
- also refocus QAutocomplete input element after click in option (so the behavior is the same as on enter)
- consider an anchorEl for popover if it's q-if-inner
- don't use capture for __bodyHide, so we can stop propagation

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
close #1274 