### PR TITLE
Date time picker locale

### DIFF
--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -41,7 +41,7 @@
       <q-datetime format="YYYY-MMMM-dddd Do Qo Q" v-model="model" type="date" align="right" />
       <q-datetime stack-label="Stack Label" v-model="model" type="date" />
       <q-datetime float-label="Float Label" v-model="model" type="date" />
-      <q-datetime hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
+      <q-datetime format="DD-YY-MM" hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
 
       <q-datetime default-view="month" v-model="model" type="date" float-label="Default view" />
       <q-datetime inverted v-model="model" type="date" />

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -41,7 +41,7 @@
       <q-datetime format="YYYY-MMMM-dddd Do Qo Q" v-model="model" type="date" align="right" />
       <q-datetime stack-label="Stack Label" v-model="model" type="date" />
       <q-datetime float-label="Float Label" v-model="model" type="date" />
-      <q-datetime format="DD-YY-MM" hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
+      <q-datetime hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
 
       <q-datetime default-view="month" v-model="model" type="date" float-label="Default view" />
       <q-datetime inverted v-model="model" type="date" />

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -104,7 +104,7 @@ import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
 import QDatetimePicker from './QDatetimePicker'
 import { QBtn } from '../btn'
-import { formatDate, isSameDate, isValid } from '../../utils/date'
+import { formatDate, isSameDate } from '../../utils/date'
 import { QModal } from '../modal'
 
 let contentCSS = __THEME__ === 'ios'
@@ -165,8 +165,11 @@ export default {
       }
       else {
         // If no format was specified, use the locale
-        if (isValid(this.value)) {
-          let date = new Date(this.value)
+        let date = new Date(this.value)
+        if (isNaN(date.valueOf())) {
+          return this.placeholder || ''
+        }
+        else {
           if (this.type === 'date') {
             return date.toLocaleDateString()
           }
@@ -176,9 +179,6 @@ export default {
           else {
             return date.toLocaleString()
           }
-        }
-        else {
-          return this.placeholder || ''
         }
       }
     }

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -104,7 +104,7 @@ import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
 import QDatetimePicker from './QDatetimePicker'
 import { QBtn } from '../btn'
-import { formatDate, isSameDate } from '../../utils/date'
+import { formatDate, isSameDate, isValid } from '../../utils/date'
 import { QModal } from '../modal'
 
 let contentCSS = __THEME__ === 'ios'
@@ -163,19 +163,27 @@ export default {
       let format
 
       if (this.format) {
-        format = this.format
-      }
-      else if (this.type === 'date') {
-        format = 'YYYY-MM-DD'
-      }
-      else if (this.type === 'time') {
-        format = 'HH:mm'
+        return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
       }
       else {
-        format = 'YYYY-MM-DD HH:mm:ss'
+        debugger
+        // If no format was specified, use the locale
+        if (isValid(this.value)) {
+          let date = new Date(this.value)
+          if (this.type === 'date') {
+            return date.toLocaleDateString()
+          }
+          else if (this.type === 'time') {
+            return date.toLocaleTimeString()
+          }
+          else {
+            return date.toLocaleString()
+          }
+        }
+        else {
+          return this.placeholder || ''
+        }
       }
-
-      return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
     }
   },
   methods: {

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -160,13 +160,10 @@ export default {
         return this.placeholder || ''
       }
 
-      let format
-
       if (this.format) {
-        return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
+        return formatDate(this.value, this.format, /* for reactiveness */ this.$q.i18n.date)
       }
       else {
-        debugger
         // If no format was specified, use the locale
         if (isValid(this.value)) {
           let date = new Date(this.value)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

The default format of the DatePicker was YYYY-MM-DD HH:mm:ss and there was no way to request the locale date formatting.  This can be considered a bug or feature.

These proposed changes uses the locale date formatting by default when no format is specified.  

If for some reason the 'YYYY-MM-DD HH:mm:ss' format is absolutely required as default instead of the locale format, I can code this instead, however, I feel that the default should be the locale.

**Other information:**
