### PR TITLE
 Automatic 24h time format detection, integrated with locale

### DIFF
--- a/dev/components/form/datetime-range.vue
+++ b/dev/components/form/datetime-range.vue
@@ -40,7 +40,7 @@
       <p class="caption">
         Datetime Range with Forced 12h Picker
       </p>
-      <q-datetime-range @change="onChange" type="datetime" format24h='12h' v-model="first.range" :min="first.min" :max="first.max" />
+      <q-datetime-range @change="onChange" type="datetime" format24h="12h" v-model="first.range" :min="first.min" :max="first.max" />
       
       <p class="caption">
         Datetime Range with Forced 24h Picker

--- a/dev/components/form/datetime-range.vue
+++ b/dev/components/form/datetime-range.vue
@@ -36,6 +36,16 @@
         Datetime Range
       </p>
       <q-datetime-range @change="onChange" type="datetime" v-model="first.range" :min="first.min" :max="first.max" />
+      
+      <p class="caption">
+        Datetime Range with Forced 12h Picker
+      </p>
+      <q-datetime-range @change="onChange" type="datetime" format24h='12h' v-model="first.range" :min="first.min" :max="first.max" />
+      
+      <p class="caption">
+        Datetime Range with Forced 24h Picker
+      </p>
+      <q-datetime-range @change="onChange" type="datetime" format24h v-model="first.range" :min="first.min" :max="first.max" />
 
       <p class="caption">
         Datetime Range with Default Selection

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -41,7 +41,7 @@
       <q-datetime format="YYYY-MMMM-dddd Do Qo Q" v-model="model" type="date" align="right" />
       <q-datetime stack-label="Stack Label" v-model="model" type="date" />
       <q-datetime float-label="Float Label" v-model="model" type="date" />
-      <q-datetime hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
+      <q-datetime format="DD-YY-MM" hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
 
       <q-datetime default-view="month" v-model="model" type="date" float-label="Default view" />
       <q-datetime inverted v-model="model" type="date" />

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -63,8 +63,14 @@
       </p>
       <q-datetime v-model="model" type="time" />
 
-      <p class="caption">Time 24hr Format (force)</p>
+      <p class="caption">Force 12hr Format for Picker, independent of time format</p>
+      <q-datetime v-model="model" type="time" format24h='12h' />
+      
+      <p class="caption">Force 24hr Format for Picker, independent of time format</p>
       <q-datetime v-model="model" type="time" format24h />
+      
+      <p class="caption">Force i18n Format for Picker, independent of time format</p>
+      <q-datetime v-model="model" type="time" format24h="i18n" />
 
       <p class="caption">Date & Time</p>
       <q-datetime @change="onChange" v-model="model" type="datetime" />
@@ -152,9 +158,15 @@
         </small>
       </p>
       <q-datetime-picker v-model="model" type="time" />
-
-      <p class="caption">Time 24hr Format (force)</p>
-      <q-datetime-picker v-model="model" type="time" format24h />
+      
+      <p class="caption">Force 12hr Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h='12h' />
+      
+      <p class="caption">Force 24hr Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h='24h' />
+      
+      <p class="caption">Force i18n Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h="i18n" />
 
       <p class="caption">Date & Time</p>
       <q-datetime-picker @change="onChange" color="secondary" v-model="model" type="datetime" />

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -64,7 +64,7 @@
       <q-datetime v-model="model" type="time" />
 
       <p class="caption">Force 12hr Format for Picker, independent of time format</p>
-      <q-datetime v-model="model" type="time" format24h='12h' />
+      <q-datetime v-model="model" type="time" format24h="12h" />
       
       <p class="caption">Force 24hr Format for Picker, independent of time format</p>
       <q-datetime v-model="model" type="time" format24h />
@@ -160,10 +160,10 @@
       <q-datetime-picker v-model="model" type="time" />
       
       <p class="caption">Force 12hr Format for Picker, independent of time format</p>
-      <q-datetime-picker v-model="model" type="time" format24h='12h' />
+      <q-datetime-picker v-model="model" type="time" format24h="12h" />
       
       <p class="caption">Force 24hr Format for Picker, independent of time format</p>
-      <q-datetime-picker v-model="model" type="time" format24h='24h' />
+      <q-datetime-picker v-model="model" type="time" format24h="24h" />
       
       <p class="caption">Force i18n Format for Picker, independent of time format</p>
       <q-datetime-picker v-model="model" type="time" format24h="i18n" />

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -41,7 +41,7 @@
       <q-datetime format="YYYY-MMMM-dddd Do Qo Q" v-model="model" type="date" align="right" />
       <q-datetime stack-label="Stack Label" v-model="model" type="date" />
       <q-datetime float-label="Float Label" v-model="model" type="date" />
-      <q-datetime format="DD-YY-MM" hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
+      <q-datetime hide-underline float-label="Float Label (hide underline)" v-model="model" type="date" />
 
       <q-datetime default-view="month" v-model="model" type="date" float-label="Default view" />
       <q-datetime inverted v-model="model" type="date" />

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -43,7 +43,7 @@
         :type="type"
         :min="min"
         :max="max"
-        :format24h="computedFormat24h"
+        :format24h="format24h"
         :first-day-of-week="firstDayOfWeek"
         :color="color"
         :default-view="defaultView"
@@ -179,39 +179,6 @@ export default {
           else {
             return date.toLocaleString()
           }
-        }
-      }
-    },
-    computedFormat24h () {
-      // 24h format determination
-      // Note that currently there is not support for 12h format in the iOS version of the DatetimePicker
-      if (this.format24h === 'i18n') {
-        // Explicit i18n option
-        return this.$q.i18n.date.format24h
-      }
-      else if (this.format24h === true || this.format24h === '') {
-        // Explicit 24h format specified
-        return true
-      }
-      else if (this.format) {
-        // Automatically determine the 24h format from the specified format string
-        if (this.format.match(/H/)) {
-          return true
-        }
-        else {
-          return false
-        }
-      }
-      else {
-        // Attempt to determine the 24h format setting from the locale
-        // 12 hour clock is mostly used in the US, however, other countries and languages might need to be supported
-        // the relevant strings can be added to the regex below once identified
-        let date = new Date(2000, 1, 1, 23, 0, 0)
-        if (date.toLocaleTimeString().match(/am|pm|a\.m\.|p\.m\./i)) {
-          return false
-        }
-        else {
-          return true
         }
       }
     }

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -104,7 +104,7 @@ import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
 import QDatetimePicker from './QDatetimePicker'
 import { QBtn } from '../btn'
-import { formatDate, isSameDate } from '../../utils/date'
+import { formatDate, isSameDate, isValid } from '../../utils/date'
 import { QModal } from '../modal'
 
 let contentCSS = __THEME__ === 'ios'
@@ -163,19 +163,27 @@ export default {
       let format
 
       if (this.format) {
-        format = this.format
-      }
-      else if (this.type === 'date') {
-        format = 'YYYY-MM-DD'
-      }
-      else if (this.type === 'time') {
-        format = 'HH:mm'
+        return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
       }
       else {
-        format = 'YYYY-MM-DD HH:mm:ss'
+        debugger
+        // If no format was specified, use the locale
+        if (isValid(this.value)) {
+          let date = new Date(this.value)
+          if (this.type === 'date') {
+            return date.toLocaleDateString()
+          }
+          else if (this.type === 'time') {
+            return date.toLocaleTimeString()
+          }
+          else {
+            return date.toLocaleString()
+          }
+        }
+        else {
+          return this.placeholder || ''
+        }
       }
-
-      return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
     }
   },
   methods: {

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -160,13 +160,10 @@ export default {
         return this.placeholder || ''
       }
 
-      let format
-
       if (this.format) {
-        return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
+        return formatDate(this.value, this.format, /* for reactiveness */ this.$q.i18n.date)
       }
       else {
-        debugger
         // If no format was specified, use the locale
         if (isValid(this.value)) {
           let date = new Date(this.value)

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -43,7 +43,7 @@
         :type="type"
         :min="min"
         :max="max"
-        :format24h="format24h"
+        :format24h="computedFormat24h"
         :first-day-of-week="firstDayOfWeek"
         :color="color"
         :default-view="defaultView"
@@ -179,6 +179,39 @@ export default {
         }
         else {
           return this.placeholder || ''
+        }
+      }
+    },
+    computedFormat24h () {
+      // 24h format determination
+      // Note that currently there is not support for 12h format in the iOS version of the DatetimePicker
+      if (this.format24h === 'i18n') {
+        // Explicit i18n option
+        return this.$q.i18n.date.format24h
+      }
+      else if (this.format24h === true || this.format24h === '') {
+        // Explicit 24h format specified
+        return true
+      }
+      else if (this.format) {
+        // Automatically determine the 24h format from the specified format string
+        if (this.format.match(/H/)) {
+          return true
+        }
+        else {
+          return false
+        }
+      }
+      else {
+        // Attempt to determine the 24h format setting from the locale
+        // 12 hour clock is mostly used in the US, however, other countries and languages might need to be supported
+        // the relevant strings can be added to the regex below once identified
+        let date = new Date(2000, 1, 1, 23, 0, 0)
+        if (date.toLocaleTimeString().match(/am|pm|a\.m\.|p\.m\./i)) {
+          return false
+        }
+        else {
+          return true
         }
       }
     }

--- a/src/components/datetime/QDatetime.vue
+++ b/src/components/datetime/QDatetime.vue
@@ -104,7 +104,7 @@ import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
 import QDatetimePicker from './QDatetimePicker'
 import { QBtn } from '../btn'
-import { formatDate, isSameDate, isValid } from '../../utils/date'
+import { formatDate, isSameDate } from '../../utils/date'
 import { QModal } from '../modal'
 
 let contentCSS = __THEME__ === 'ios'
@@ -165,8 +165,11 @@ export default {
       }
       else {
         // If no format was specified, use the locale
-        if (isValid(this.value)) {
-          let date = new Date(this.value)
+        let date = new Date(this.value)
+        if (isNaN(date.valueOf())) {
+          return this.placeholder || ''
+        }
+        else {
           if (this.type === 'date') {
             return date.toLocaleDateString()
           }
@@ -176,9 +179,6 @@ export default {
           else {
             return date.toLocaleString()
           }
-        }
-        else {
-          return this.placeholder || ''
         }
       }
     },

--- a/src/components/datetime/QDatetimePicker.mat.vue
+++ b/src/components/datetime/QDatetimePicker.mat.vue
@@ -48,7 +48,7 @@
             {{ __pad(minute) }}
           </span>
         </div>
-        <div v-if="!computedFormat24h" class="q-datetime-ampm column col-auto col-md-12 justify-around">
+        <div v-if="!format24h" class="q-datetime-ampm column col-auto col-md-12 justify-around">
           <div
             :class="{active: am}"
             class="q-datetime-link"
@@ -175,7 +175,7 @@
               <div class="q-datetime-clock-pointer" :style="clockPointerStyle">
                 <span></span>
               </div>
-              <div v-if="computedFormat24h">
+              <div v-if="format24h">
                 <div
                   v-for="n in 24"
                   :key="`hi${n}`"
@@ -288,11 +288,6 @@ export default {
       }
       return cls
     },
-    computedFormat24h () {
-      return this.format24h !== 0
-        ? this.format24h
-        : this.$q.i18n.date.format24h
-    },
     computedFirstDayOfWeek () {
       return this.firstDayOfWeek !== void 0
         ? this.firstDayOfWeek
@@ -353,7 +348,7 @@ export default {
 
     hour () {
       const h = this.model.getHours()
-      return this.computedFormat24h
+      return this.format24h
         ? h
         : convertToAmPm(h)
     },
@@ -365,7 +360,7 @@ export default {
     },
     clockPointerStyle () {
       let
-        divider = this.view === 'minute' ? 60 : (this.computedFormat24h ? 24 : 12),
+        divider = this.view === 'minute' ? 60 : (this.format24h ? 24 : 12),
         degrees = Math.round((this.view === 'minute' ? this.minute : this.hour) * (360 / divider)) - 180
 
       return cssTransform(`rotate(${degrees}deg)`)
@@ -404,7 +399,7 @@ export default {
 
       value = this.__parseTypeValue('hour', value)
 
-      if (!this.computedFormat24h && value < 12 && !this.am) {
+      if (!this.format24h && value < 12 && !this.am) {
         value += 12
       }
 
@@ -494,7 +489,7 @@ export default {
       }
 
       if (this.view === 'hour') {
-        this.setHour(Math.round(angle / (this.computedFormat24h ? 15 : 30)))
+        this.setHour(Math.round(angle / (this.format24h ? 15 : 30)))
       }
       else {
         this.setMinute(Math.round(angle / 6))

--- a/src/components/datetime/datetime-props.js
+++ b/src/components/datetime/datetime-props.js
@@ -35,9 +35,8 @@ export const inline = {
   },
   firstDayOfWeek: Number,
   format24h: {
-    type: [Boolean, Number],
-    default: 0,
-    validator: v => [true, false, 0].includes(v)
+    type: [Boolean, String],
+    validator: v => [true, false, '', 'i18n'].includes(v)
   },
   defaultView: {
     type: String,

--- a/src/components/datetime/datetime-props.js
+++ b/src/components/datetime/datetime-props.js
@@ -35,8 +35,8 @@ export const inline = {
   },
   firstDayOfWeek: Number,
   format24h: {
-    type: [Boolean, String],
-    validator: v => [true, false, '', 'i18n'].includes(v)
+    type: [String],
+    validator: v => ['', '12h', '24h', 'i18n'].includes(v)
   },
   defaultView: {
     type: String,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x]  Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

The 24h format is automatically derived from the specified format or the locale.  Additional flexibility was added to explicitly choose the format or to choose the i18n file as the source of the format setting. Thus all existing options remain unbroken and more flexible.  This set of changes includes and depends on the previous pull request that is only for enabling locale formats.

**Other information:**
