### PR TITLE
More work on button sizes - focus on mat

### DIFF
--- a/dev/components/components/button-dropdown.vue
+++ b/dev/components/components/button-dropdown.vue
@@ -12,7 +12,7 @@
                 <q-item-tile label>Photos</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
@@ -22,7 +22,7 @@
                 <q-item-tile label>Vacation</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
           </q-list>
         </q-btn-dropdown>
@@ -35,7 +35,7 @@
                 <q-item-tile label>Photos</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
@@ -45,7 +45,7 @@
                 <q-item-tile label>Vacation</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
           </q-list>
         </q-btn-dropdown>
@@ -58,7 +58,7 @@
                 <q-item-tile label>Photos</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
@@ -68,7 +68,7 @@
                 <q-item-tile label>Vacation</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
           </q-list>
         </q-btn-dropdown>
@@ -81,7 +81,7 @@
                 <q-item-tile label>Photos</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
@@ -91,7 +91,7 @@
                 <q-item-tile label>Vacation</q-item-tile>
                 <q-item-tile sublabel>February 22, 2016</q-item-tile>
               </q-item-main>
-              </q-item-side right icon="info" />
+              <q-item-side right icon="info" />
             </q-item>
           </q-list>
         </q-btn-dropdown>
@@ -110,7 +110,7 @@ export default {
         {split: true, compact: false},
         {split: true, compact: true}
       ],
-      sizes: ['sm', 'md', 'lg']
+      sizes: ['xs', 'sm', 'dense', 'md', 'lg', 'xl']
     }
   },
   methods: {

--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -1,9 +1,61 @@
 <template>
   <div>
     <div class="layout-padding buttons-test">
-      <p class="caption">Regular (rectangle) and Circular</p>
-      <q-btn color="primary">Some very, but very long button title that should wrap to the next line without any problems</q-btn>
+
       <p class="group">
+        <template v-for="n in ['xs', 'sm', 'dense', 'md', 'lg', 'xl']">
+          <span :key="'d0'+n">{{n}}</span>
+          <q-btn :key="'d1'+n" :size="n" icon="android" color="primary" compact />
+          <q-btn :key="'d2'+n" :size="n" icon="android" color="primary" />
+          <q-btn :key="'d3'+n" :size="n" icon="android" color="primary" label="Test" compact />
+          <q-btn :key="'d3'+n" :size="n" icon="android" color="primary" label="Test"/>
+          <q-btn :key="'d4'+n" :size="n" round icon="android" color="primary" />
+          <q-btn :key="'d5'+n" :size="n" round icon="android" color="primary" mini />
+          <q-btn :key="'d6'+n" :size="n" label="Test" color="primary" compact />
+          <q-btn :key="'d7'+n" :size="n" label="Test" color="primary" />
+          <br :key="'d8'+n"><br :key="'d9'+n">
+        </template>
+      </p>
+      <p class="group">
+        <template v-for="n in ['none', 'xs', 'sm', 'md', 'lg', 'xl']">
+          <span :key="'dp0'+n">Padding {{n}}</span>
+          <q-btn :key="'dp1'+n" :class="'q-pa-'+n" icon="android" color="primary" />
+          <q-btn :key="'dp2'+n" :class="'q-pa-'+n" icon="android" color="primary" label="Test"/>
+          <q-btn :key="'dp3'+n" :class="'q-pa-'+n" round icon="android" color="primary" />
+          <q-btn :key="'dp4'+n" :class="'q-pa-'+n" label="Test" color="primary" />
+          <br :key="'dp5'+n"><br :key="'dp6'+n">
+        </template>
+      </p>
+      <q-toolbar color="secondary" style="width: 500px">
+        <q-btn flat round icon="menu" />
+        <q-btn flat round icon="android" />
+        <q-btn flat icon="assignment_ind" />
+        <q-btn flat icon="android" />
+        <q-toolbar-title>
+          Toolbar
+        </q-toolbar-title>
+        <span>
+          <q-btn flat icon="sim_card" compact />
+        </span>
+        <q-btn flat icon="gamepad" />
+      </q-toolbar>
+      <q-toolbar color="primary" style="width: 500px">
+        <q-btn flat size="dense" icon="menu" />
+        <q-btn flat size="dense" icon="android" />
+        <q-btn flat size="dense" icon="assignment_ind" />
+        <q-btn flat size="dense" icon="android" />
+        <q-toolbar-title>
+          Toolbar
+        </q-toolbar-title>
+        <span>
+          <q-btn flat size="dense" icon="sim_card" compact />
+        </span>
+        <q-btn flat size="dense" icon="gamepad" />
+      </q-toolbar>
+
+      <p class="caption">Regular (rectangle) and Circular</p>
+      <p class="group">
+        <q-btn color="primary">Some very, but very long button title that should wrap to the next line without any problems</q-btn>
         <q-btn icon="alarm" color="orange" label="No ripple" no-ripple />
         <q-btn icon="alarm" color="orange" label="Icoon" />
         <q-btn icon="ion-shuffle" label="Icoon" />
@@ -15,7 +67,7 @@
         <q-btn icon="edit" icon-right="alarm" size="sm" label="Icoon" />
         <q-btn icon="edit" icon-right="alarm" size="lg" color="amber" label="Icoon" />
 
-        <q-btn size="sm" color="primary" icon="mail" />
+        <q-btn size="sm" color="primary" icon="mail" title="Size sm" />
         <q-btn color="primary" icon="mail" />
         <q-btn size="lg" color="primary" icon="mail" />
 
@@ -111,53 +163,86 @@
         <q-btn round loader :percentage="percentage" color="primary" @click="startProgress" icon="wifi" />
       </p>
 
-      <p class="caption">Small, Medium (default) and Big</p>
+      <p class="caption">Normal: xs, sm, dense, md (default), lg, xl</p>
       <p class="group">
-        <q-btn size="sm" color="primary" label="Button" />
-        <q-btn color="primary" label="Button" />
-        <q-btn size="lg" color="primary" label="Button" />
+        <q-btn size="xs" color="primary" label="Button xs" />
+        <q-btn size="sm" color="primary" label="Button sm" />
+        <q-btn size='dense' color="primary" label="Button dense" />
+        <q-btn color="primary" label="Button md" />
+        <q-btn size="lg" color="primary" label="Button lg" />
+        <q-btn size="xl" color="primary" label="Button xl" />
       </p>
       <p class="group">
-        <q-btn icon="check" size="sm" color="primary" label="Button" />
-        <q-btn icon="cloud" color="primary" label="Button" />
-        <q-btn icon="alarm" size="lg" color="primary" label="Button" />
+        <q-btn icon="check" size="xs" color="primary" label="Button xs" />
+        <q-btn icon="check" size="sm" color="primary" label="Button sm" />
+        <q-btn icon="check" size="dense" color="primary" label="Button dense" />
+        <q-btn icon="cloud" color="primary" label="Button md" />
+        <q-btn icon="alarm" size="lg" color="primary" label="Button lg" />
+        <q-btn icon="alarm" size="xl" color="primary" label="Button xl" />
       </p>
       <p class="group">
+        <q-btn round size="xs" icon="check" color="primary" />
         <q-btn round size="sm" icon="check" color="primary" />
         <q-btn round icon="cloud" color="primary" />
         <q-btn round size="lg" icon="alarm" color="primary" />
+        <q-btn round size="xl" icon="alarm" color="primary" />
+      </p>
+
+      <p class="caption">Compact: xs, sm, dense, md (default), lg, xl</p>
+      <p class="group">
+        <q-btn compact size="xs" color="primary" label="Button xs compact" />
+        <q-btn compact size="sm" color="primary" label="Button sm compact" />
+        <q-btn compact size='dense' color="primary" label="Button dense compact" />
+        <q-btn compact color="primary" label="Button md compact" />
+        <q-btn compact size="lg" color="primary" label="Button lg compact" />
+        <q-btn compact size="xl" color="primary" label="Button xl compact" />
+      </p>
+      <p class="group">
+        <q-btn compact icon="check" size="xs" color="primary" label="Button xs compact" />
+        <q-btn compact icon="check" size="sm" color="primary" label="Button sm compact" />
+        <q-btn compact icon="check" size="dense" color="primary" label="Button dense compact" />
+        <q-btn compact icon="cloud" color="primary" label="Button md compact" />
+        <q-btn compact icon="alarm" size="lg" color="primary" label="Button lg compact" />
+        <q-btn compact icon="alarm" size="xl" color="primary" label="Button xl compact" />
       </p>
 
       <p class="group">
-        <q-btn v-for="i in 30" :key="'a' + i" round icon="cloud" color="primary" :size="`${8 + i * 4}px`" :title="`Size ${8 + i * 4}px`" />
-        <q-btn v-for="size in sizes" :key="'aq' + size" round icon="cloud" color="primary" :size="size" :title="`Size ${size}`" />
+        <template v-for="i in 9">
+          <q-btn :key="'as' + i" round icon="cloud" color="primary" :size="`${4 + 4 * i}px`" :title="`Size ${4 + 4 * i}px`" />
+          <q-btn :key="'asm' + i" round mini icon="cloud" color="primary" :size="`${4 + 4 * i}px`" :title="`Size ${4 + 4 * i}px mini`" />
+        </template>
+      </p>
+      <p class="group">
+        <template v-for="size in sizes" v-if="size !== 'dense'">
+          <q-btn :key="'aq' + size" round icon="cloud" color="primary" :size="size" :title="`Size ${size}`" />
+          <q-btn :key="'aqm' + size" round mini icon="cloud" color="primary" :size="size" :title="`Size ${size} mini`" />
+        </template>
       </p>
 
       <p class="group">
-        <q-btn v-for="i in 15" :key="'b' + i" :label="`Size ${4 + i * 4}px`" color="primary" :size="`${4 + i * 4}px`" />
-        <q-btn v-for="size in sizes" :key="'c' + size" :label="`Size ${size}`" color="primary" :size="size" />
+        <template v-for="i in 15">
+          <q-btn :key="'bs' + i" :label="`Size ${6 + i}pt`" color="primary" :size="`${6 + i}pt`" />
+          <q-btn :key="'bsc' + i" compact :label="`Size ${6 + i}pt compact`" color="primary" :size="`${6 + i}pt`" />
+        </template>
+      </p>
+      <p class="group">
+        <template v-for="size in sizes">
+          <q-btn :key="'bq' + size" :label="`Size ${size}`" color="primary" :size="size" />
+          <q-btn :key="'bqc' + size" compact :label="`Size ${size} compact`" color="primary" :size="size" />
+        </template>
       </p>
 
       <p class="group">
-        <q-btn v-for="i in 15" :key="'d' + i" icon="cloud" :label="`Size ${4 + i * 4}px`" color="primary" :size="`${4 + i * 4}px`" />
-        <q-btn v-for="size in sizes" :key="'e' + size" icon="cloud" :label="`Size ${size}`" color="primary" :size="size" />
-      </p>
-
-      <p class="caption">Compact - Small, Medium (default) and Big</p>
-      <p class="group">
-        <q-btn compact size="sm" color="primary" label="Button" />
-        <q-btn compact color="primary" label="Button" />
-        <q-btn compact size="lg" color="primary" label="Button" />
+        <template v-for="i in 15">
+          <q-btn :key="'cs' + i" icon="cloud" :label="`Size ${6 + i}pt`" color="primary" :size="`${6 + i}pt`" />
+          <q-btn :key="'csc' + i" compact icon="cloud" :label="`Size ${6 + i}pt compact`" color="primary" :size="`${6 + i}pt`" />
+        </template>
       </p>
       <p class="group">
-        <q-btn compact icon="check" size="sm" color="primary" label="Button" />
-        <q-btn compact icon="cloud" color="primary" label="Button" />
-        <q-btn compact icon="alarm" size="lg" color="primary" label="Button" />
-      </p>
-      <p class="group">
-        <q-btn compact round size="sm" icon="check" color="primary" />
-        <q-btn compact round icon="cloud" color="primary" />
-        <q-btn compact round size="lg" icon="alarm" color="primary" />
+        <template v-for="size in sizes">
+          <q-btn :key="'cq' + size" icon="cloud" :label="`Size ${size}`" color="primary" :size="size" />
+          <q-btn :key="'cqc' + size" compact icon="cloud" :label="`Size ${size} compact`" color="primary" :size="size" />
+        </template>
       </p>
 
       <p class="caption">Regular with Icons</p>
@@ -296,7 +381,7 @@
           :glossy="extra === 'glossy'"
         >{{extra}}</q-btn>
       </div>
-      <div v-for="size in sizes" :key="'h' + size">
+      <div v-for="size in sizes" :key="'h' + size" v-if="size !== 'dense'">
         <h3 class="capitalize">{{size}}</h3>
         <q-btn color="primary" round :size="size"><q-icon :name="icon" /></q-btn>
         text
@@ -361,7 +446,7 @@ export default {
   data () {
     return {
       icon: 'alarm',
-      sizes: ['xs', 'sm', 'md', 'lg', 'xl'],
+      sizes: ['xs', 'sm', 'dense', 'md', 'lg', 'xl'],
       colors: [
         'primary', 'secondary', 'tertiary', 'positive', 'negative', 'warning', 'info', '', 'light', 'dark',
         'red', 'pink', 'purple', 'deep-purple', 'indigo', 'blue', 'light-blue', 'cyan', 'teal', 'green',

--- a/dev/components/components/pagination.vue
+++ b/dev/components/components/pagination.vue
@@ -19,6 +19,7 @@
         :boundaryLinks="boundaryLinks"
         :directionLinks="directionLinks"
         :input="inputType"
+        :size="size"
       />
 
       <p class="caption">Disabled State</p>
@@ -28,6 +29,7 @@
         :boundaryLinks="boundaryLinks"
         :directionLinks="directionLinks"
         :input="inputType"
+        :size="size"
       />
 
       <p class="caption">Page buttons</p>
@@ -40,6 +42,7 @@
         :ellipses="ellipses"
         :maxPages="maxPages"
         :input="inputType"
+        :size="size"
       />
 
       <p class="caption">Page buttons - disabled</p>
@@ -52,6 +55,7 @@
         :ellipses="ellipses"
         :maxPages="maxPages"
         :input="inputType"
+        :size="size"
       />
 
       <p class="caption">Configuration</p>
@@ -78,6 +82,9 @@
           <q-input type="number" v-model="maxPages" stack-label="Maximum number of page buttons" />
         </div>
         <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+          <q-select v-model="size" :options="sizeOptions" stack-label="Button size" />
+        </div>
+        <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
           <q-toggle v-model="inputType" label="Input type" />
         </div>
       </div>
@@ -98,11 +105,13 @@ export default {
       directionLinks: true,
       ellipses: null,
       maxPages: 5,
+      size: 'dense',
       options: [
         {label: 'Yes', value: true},
         {label: 'No', value: false},
         {label: 'Default', value: null}
-      ]
+      ],
+      sizeOptions: ['xs', 'sm', 'dense', 'md', 'lg', 'xl'].map(s => ({ label: s, value: s }))
     }
   },
   methods: {

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -110,7 +110,6 @@ export default {
     return h('button', {
       staticClass: 'q-btn row inline flex-center relative-position',
       'class': this.classes,
-      style: this.style,
       on,
       directives: this.hasRipple
         ? [{
@@ -129,12 +128,13 @@ export default {
         })
         : null,
 
-      h('span', {
-        staticClass: 'q-btn-inner row col flex-center',
+      h('div', {
+        staticClass: 'q-btn-inner row flex-center',
         'class': {
           'no-wrap': this.noWrap,
           'text-no-wrap': this.noWrap
-        }
+        },
+        style: this.style
       },
       this.loading
         ? [ this.$slots.loading || h(QSpinner) ]

--- a/src/components/btn/QBtnDropdown.js
+++ b/src/components/btn/QBtnDropdown.js
@@ -63,7 +63,6 @@ export default {
             icon: this.icon,
             label: this.label,
             iconRight: this.split ? this.iconRight : null,
-            round: this.round,
             outline: this.outline,
             flat: this.flat,
             rounded: this.rounded,
@@ -111,7 +110,6 @@ export default {
           QBtn,
           {
             props: {
-              round: this.round,
               flat: this.flat,
               rounded: this.rounded,
               push: this.push,

--- a/src/components/btn/QBtnToggle.js
+++ b/src/components/btn/QBtnToggle.js
@@ -44,7 +44,6 @@ export default {
     return h('button', {
       staticClass: 'q-btn q-btn-toggle row inline flex-center relative-position',
       'class': this.classes,
-      style: this.style,
       on: { click: this.click },
       directives: this.hasRipple
         ? [{
@@ -60,7 +59,8 @@ export default {
         'class': {
           'no-wrap': this.noWrap,
           'text-no-wrap': this.noWrap
-        }
+        },
+        style: this.style
       }, [
         this.icon
           ? h('q-icon', {

--- a/src/components/btn/btn-default.ios.styl
+++ b/src/components/btn/btn-default.ios.styl
@@ -8,17 +8,20 @@
   vertical-align -webkit-baseline-middle
   cursor pointer
   -webkit-appearance button
-  padding $button-padding
   text-decoration none
   color inherit
   background transparent
   transition $button-transition
-  min-height (100 / 38)em
+  font-size $button-size
+  padding $button-padding
+  .q-btn-inner
+    min-height 24px
+    min-width 24px
   .q-icon
-    font-size (68 / 38)em
+    font-size 1.285em
   .q-spinner
-    height (68 / 38)em
-    width (68 / 38)em
+    height 1.285em
+    width 1.285em
 
   &.disabled
     opacity .7 !important
@@ -51,19 +54,29 @@
 
 .q-btn-round
   border-radius 50%
-  padding 0
-  min-height 0
-  height 1em
-  width 1em
-  .q-icon
-    font-size .54em
-  .q-spinner
-    height .54em
-    width .54em
+  padding $button-round-padding
+  .q-btn-inner
+    height 1.285em
+    width 1.285em
+@media (max-width $breakpoint-sm-max)
+  .q-btn-round
+    padding $button-round-padding-mini
 
-.q-btn-compact
-  padding 2px 6px
+.q-btn-dense
+  font-size $button-size-dense
+  &:not(.q-btn-round)
+    padding $button-padding-dense
+  .q-btn-inner
+    min-height 22px
+    min-width 22px
+
+.q-btn-mini
+  padding $button-round-padding-mini
+
+.q-btn-compact:not(.q-btn-round)
+  padding-left $button-padding-compact
+  padding-right $button-padding-compact
   .on-left
-    margin-right 6px
+    margin-right $button-padding-compact
   .on-right
-    margin-left 6px
+    margin-left $button-padding-compact

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -8,7 +8,6 @@
   vertical-align -webkit-baseline-middle
   cursor pointer
   -webkit-appearance button
-  padding $button-padding
   font-weight $button-font-weight
   text-decoration none
   color inherit
@@ -16,12 +15,16 @@
   box-shadow $button-shadow
   transition $button-transition
   text-transform uppercase
-  min-height (100 / 38)em
+  font-size $button-size
+  padding $button-padding
+  .q-btn-inner
+    min-height 24px
+    min-width 24px
   .q-icon
-    font-size (68 / 38)em
+    font-size 1.285em
   .q-spinner
-    height (68 / 38)em
-    width (68 / 38)em
+    height 1.285em
+    width 1.285em
 
   &.disabled
     opacity .7 !important
@@ -63,22 +66,33 @@
 
 .q-btn-round
   border-radius 50%
-  padding 0
   box-shadow $button-shadow
-  min-height 0
-  height 1em
-  width 1em
-  .q-icon
-    font-size .54em
-  .q-spinner
-    height .54em
-    width .54em
+  padding $button-round-padding
+  .q-btn-inner
+    height 1.285em
+    width 1.285em
   &:active
     box-shadow $shadow-8
 
-.q-btn-compact
-  padding 2px 6px
+@media (max-width $breakpoint-sm-max)
+  .q-btn-round
+    padding $button-round-padding-mini
+
+.q-btn-dense
+  font-size $button-size-dense
+  &:not(.q-btn-round)
+    padding $button-padding-dense
+  .q-btn-inner
+    min-height 22px
+    min-width 22px
+
+.q-btn-mini
+  padding $button-round-padding-mini
+
+.q-btn-compact:not(.q-btn-round)
+  padding-left $button-padding-compact
+  padding-right $button-padding-compact
   .on-left
-    margin-right 6px
+    margin-right $button-padding-compact
   .on-right
-    margin-left 6px
+    margin-left $button-padding-compact

--- a/src/components/btn/btn-dropdown.ios.styl
+++ b/src/components/btn/btn-dropdown.ios.styl
@@ -1,6 +1,11 @@
 .q-btn-dropdown-simple .q-btn-dropdown-arrow
-  width 10px
-  font-size 24px
+  width .5em
+  font-size 1.8em
+  line-height .1
 .q-btn-dropdown-split .q-btn-dropdown-arrow
   padding 0 4px
   border-left 1px solid rgba(255, 255, 255, .3)
+@media (min-width $breakpoint-md-min)
+  .q-btn-dropdown-current, .q-btn-dropdown-simple
+    &:not(.q-btn-compact)
+      padding-left 24px

--- a/src/components/btn/btn-dropdown.mat.styl
+++ b/src/components/btn/btn-dropdown.mat.styl
@@ -1,6 +1,11 @@
 .q-btn-dropdown-simple .q-btn-dropdown-arrow
-  width 10px
-  font-size 24px
+  width .5em
+  font-size 1.8em
+  line-height .1
 .q-btn-dropdown-split .q-btn-dropdown-arrow
   padding 0 4px
   border-left 1px solid rgba(255, 255, 255, .3)
+@media (min-width $breakpoint-md-min)
+  .q-btn-dropdown-current, .q-btn-dropdown-simple
+    &:not(.q-btn-compact)
+      padding-left 24px

--- a/src/components/btn/btn-mixin.js
+++ b/src/components/btn/btn-mixin.js
@@ -2,12 +2,7 @@ import Ripple from '../../directives/ripple'
 import { QIcon } from '../icon'
 
 const sizes = {
-  rectangle: {
-    xs: 8, sm: 12, md: 16, lg: 20, xl: 24
-  },
-  round: {
-    xs: 24, sm: 40, md: 56, lg: 72, xl: 88
-  }
+  xs: '.571em', sm: '.785em', md: '1em', lg: '1.214em', xl: '1.428em'
 }
 
 export default {
@@ -33,16 +28,19 @@ export default {
     color: String,
     glossy: Boolean,
     compact: Boolean,
+    mini: Boolean,
     noRipple: Boolean
   },
   computed: {
     style () {
-      const def = sizes[this.round ? 'round' : 'rectangle']
+      if (typeof this.size !== 'string' || ['', 'dense', 'mini', 'md'].includes(this.size)) {
+        return {}
+      }
 
       return {
-        fontSize: this.size
-          ? (this.size in def ? `${def[this.size]}px` : this.size)
-          : `${def.md}px`
+        fontSize: this.size in sizes ? sizes[this.size] : this.size,
+        minHeight: 0,
+        minWidth: 0
       }
     },
     shape () {
@@ -62,9 +60,6 @@ export default {
       if (this.toggled) {
         cls.push('q-btn-toggle-active')
       }
-      if (this.compact) {
-        cls.push('q-btn-compact')
-      }
 
       if (this.flat) {
         cls.push('q-btn-flat')
@@ -83,8 +78,16 @@ export default {
         cls.push('q-focusable q-hoverable')
       }
 
+      if (this.round) {
+        (this.mini || this.size === 'mini') && cls.push('q-btn-mini')
+      }
+      else {
+        this.compact && cls.push('q-btn-compact')
+        this.rounded && cls.push('q-btn-rounded')
+      }
+
+      this.size === 'dense' && cls.push('q-btn-dense')
       this.noCaps && cls.push('q-btn-no-uppercase')
-      this.rounded && cls.push('q-btn-rounded')
       this.glossy && cls.push('glossy')
 
       if (color) {

--- a/src/components/carousel/QCarousel.js
+++ b/src/components/carousel/QCarousel.js
@@ -302,7 +302,7 @@ export default {
             props: {
               icon: this.quickNavIcon || this.$q.icon.carousel.quickNav,
               round: true,
-              size: 'sm',
+              mini: true,
               flat: true,
               color: this.color
             },
@@ -353,13 +353,13 @@ export default {
       ]),
       this.arrows ? h(QBtn, {
         staticClass: 'q-carousel-left-arrow absolute',
-        props: { color: this.color, icon: this.$q.icon.carousel.left, round: true, size: 'sm', flat: true },
+        props: { color: this.color, icon: this.$q.icon.carousel.left, round: true, mini: true, flat: true },
         directives: [{ name: 'show', value: this.canGoToPrevious }],
         on: { click: this.previous }
       }) : null,
       this.arrows ? h(QBtn, {
         staticClass: 'q-carousel-right-arrow absolute',
-        props: { color: this.color, icon: this.$q.icon.carousel.right, round: true, size: 'sm', flat: true },
+        props: { color: this.color, icon: this.$q.icon.carousel.right, round: true, mini: true, flat: true },
         directives: [{ name: 'show', value: this.canGoToNext }],
         on: { click: this.next }
       }) : null,

--- a/src/components/carousel/carousel.ios.styl
+++ b/src/components/carousel/carousel.ios.styl
@@ -31,8 +31,7 @@
 .q-carousel-right-arrow
   top 50%
   transform translateY(-50%)
-  .q-icon
-    font-size 42px !important
+  font-size 42px
 .q-carousel-left-arrow
   left 5px
 .q-carousel-right-arrow
@@ -41,9 +40,9 @@
 .q-carousel-quick-nav
   padding 2px 0
   background $carousel-quick-nav-background
-  .q-icon
-    font-size $carousel-quick-nav-icon-font-size !important
-  .q-btn.inactive
+  .q-btn
+    font-size $carousel-quick-nav-icon-font-size
+    &.inactive
     opacity .5
     .q-icon
-      font-size $carousel-quick-nav-icon-inactive-font-size !important
+      font-size $carousel-quick-nav-icon-inactive-font-size

--- a/src/components/carousel/carousel.mat.styl
+++ b/src/components/carousel/carousel.mat.styl
@@ -31,8 +31,7 @@
 .q-carousel-right-arrow
   top 50%
   transform translateY(-50%)
-  .q-icon
-    font-size 42px !important
+  font-size 42px
 .q-carousel-left-arrow
   left 5px
 .q-carousel-right-arrow
@@ -41,9 +40,9 @@
 .q-carousel-quick-nav
   padding 2px 0
   background $carousel-quick-nav-background
-  .q-icon
-    font-size $carousel-quick-nav-icon-font-size !important
-  .q-btn.inactive
-    opacity .5
-    .q-icon
-      font-size $carousel-quick-nav-icon-inactive-font-size !important
+  .q-btn
+    font-size $carousel-quick-nav-icon-font-size
+    &.inactive
+      opacity .5
+      .q-icon
+        font-size $carousel-quick-nav-icon-inactive-font-size

--- a/src/components/datetime/QDatetimePicker.mat.vue
+++ b/src/components/datetime/QDatetimePicker.mat.vue
@@ -103,8 +103,9 @@
           <div class="row items-center content-center">
             <q-btn
               round
-              size='sm'
+              mini
               flat
+              size="dense"
               :color="color"
               @click="setMonth(month - 1)"
               :disabled="beforeMinDays"
@@ -116,8 +117,9 @@
             </div>
             <q-btn
               round
-              size='sm'
+              mini
               flat
+              size="dense"
               :color="color"
               @click="setMonth(month + 1)"
               :disabled="afterMaxDays"

--- a/src/components/editor/QEditor.js
+++ b/src/components/editor/QEditor.js
@@ -33,6 +33,10 @@ export default {
       type: String,
       default: 'white'
     },
+    toolbarSize: {
+      type: String,
+      default: 'dense'
+    },
     flat: Boolean,
     outline: Boolean,
     push: Boolean,
@@ -59,7 +63,7 @@ export default {
         outline: this.outline,
         flat: this.flat,
         push: this.push,
-        size: 'sm',
+        size: this.toolbarSize,
         compact: true
       }
     },

--- a/src/components/editor/editor-utils.js
+++ b/src/components/editor/editor-utils.js
@@ -246,8 +246,8 @@ export function getLinkEditor (h, vm) {
           props: {
             color: 'negative',
             label: vm.$q.i18n.label.remove,
-            size: 'sm',
-            flat: true,
+            size: vm.toolbarSize,
+            flat: vm.flat,
             compact: true,
             noCaps: true
           },
@@ -264,8 +264,8 @@ export function getLinkEditor (h, vm) {
           props: {
             color: 'primary',
             label: vm.$q.i18n.label.update,
-            size: 'sm',
-            flat: true,
+            size: vm.toolbarSize,
+            flat: vm.flat,
             compact: true,
             noCaps: true
           },

--- a/src/components/fab/QFabAction.js
+++ b/src/components/fab/QFabAction.js
@@ -28,7 +28,7 @@ export default {
     return h(QBtn, {
       props: {
         round: true,
-        size: 'sm',
+        mini: true,
         outline: this.outline,
         push: this.push,
         flat: this.flat,

--- a/src/components/pagination/QPagination.js
+++ b/src/components/pagination/QPagination.js
@@ -22,6 +22,7 @@ export default {
       type: String,
       default: 'primary'
     },
+    size: String,
     disable: Boolean,
     input: Boolean,
     boundaryLinks: {
@@ -121,7 +122,8 @@ export default {
         props: {
           color: this.color,
           flat: true,
-          compact: true
+          compact: true,
+          size: this.size
         }
       }, props))
     }
@@ -137,8 +139,7 @@ export default {
         key: 'bls',
         props: {
           disable: this.disable || this.value <= this.min,
-          icon: this.$q.icon.pagination.first,
-          size: 'sm'
+          icon: this.$q.icon.pagination.first
         },
         on: {
           click: () => this.set(this.min)
@@ -148,8 +149,7 @@ export default {
         key: 'ble',
         props: {
           disable: this.disable || this.value >= this.max,
-          icon: this.$q.icon.pagination.last,
-          size: 'sm'
+          icon: this.$q.icon.pagination.last
         },
         on: {
           click: () => this.set(this.max)
@@ -163,8 +163,7 @@ export default {
         props: {
           disable: this.disable || this.value <= this.min,
           icon: this.$q.icon.pagination.prev,
-          repeatTimeout: this.__getRepeatEasing(),
-          size: 'sm'
+          repeatTimeout: this.__getRepeatEasing()
         },
         on: {
           click: () => this.setByOffset(-1)
@@ -175,8 +174,7 @@ export default {
         props: {
           disable: this.disable || this.value >= this.max,
           icon: this.$q.icon.pagination.next,
-          repeatTimeout: this.__getRepeatEasing(),
-          size: 'sm'
+          repeatTimeout: this.__getRepeatEasing()
         },
         on: {
           click: () => this.setByOffset(1)
@@ -188,7 +186,7 @@ export default {
       contentMiddle.push(h(QInput, {
         staticClass: 'inline no-margin no-padding',
         style: {
-          width: `${this.inputPlaceholder.length}rem`
+          width: `${this.inputPlaceholder.length}em`
         },
         props: {
           type: 'number',
@@ -243,7 +241,7 @@ export default {
         }
       }
       const style = {
-        minWidth: `${Math.max(1.5, String(this.max).length)}em`
+        minWidth: `${2.2 * Math.max(1, String(this.max).length)}ex`
       }
       if (boundaryStart) {
         contentStart.push(this.__getBtn(h, {

--- a/src/components/pagination/pagination.ios.styl
+++ b/src/components/pagination/pagination.ios.styl
@@ -3,7 +3,5 @@
   input
     text-align center
     -moz-appearance textfield
-  .q-btn
-    padding 0 5px !important
-    &.disabled
-      color $faded
+  .q-btn.disabled
+    color $faded

--- a/src/components/pagination/pagination.mat.styl
+++ b/src/components/pagination/pagination.mat.styl
@@ -3,7 +3,5 @@
   input
     text-align center
     -moz-appearance textfield
-  .q-btn
-    padding 0 5px !important
-    &.disabled
-      color $faded
+  .q-btn.disabled
+    color $faded

--- a/src/components/table/table-bottom.js
+++ b/src/components/table/table-bottom.js
@@ -71,7 +71,7 @@ export default {
               color: this.color,
               round: true,
               icon: this.$q.icon.table.prevPage,
-              size: 'sm',
+              mini: true,
               flat: true,
               disable: page === 1
             },
@@ -86,7 +86,7 @@ export default {
               color: this.color,
               round: true,
               icon: this.$q.icon.table.nextPage,
-              size: 'sm',
+              mini: true,
               flat: true,
               disable: this.lastRowIndex === 0 || page * rowsPerPage >= this.computedRowsNumber
             },

--- a/src/components/toolbar/toolbar.ios.styl
+++ b/src/components/toolbar/toolbar.ios.styl
@@ -7,9 +7,13 @@
   background $toolbar-background
 
   > .q-btn
-    margin 0 .2rem
-    padding .2rem
-    &:first-child
+    margin 0 $button-padding-compact
+    &.q-btn-dense
+      padding-left $button-padding-compact
+      padding-right $button-padding-compact
+    &:not(.q-btn-dense)
+      padding $button-padding-compact
+    &:first-child, & + .q-btn
       margin-left 0
     &:last-child
       margin-right 0

--- a/src/components/toolbar/toolbar.mat.styl
+++ b/src/components/toolbar/toolbar.mat.styl
@@ -7,9 +7,13 @@
   background $toolbar-background
 
   > .q-btn
-    margin 0 .2rem
-    padding .2rem
-    &:first-child
+    margin 0 $button-padding-compact
+    &.q-btn-dense
+      padding-left $button-padding-compact
+      padding-right $button-padding-compact
+    &:not(.q-btn-dense)
+      padding $button-padding-compact
+    &:first-child, & + .q-btn
       margin-left 0
     &:last-child
       margin-right 0

--- a/src/css/variables.ios.styl
+++ b/src/css/variables.ios.styl
@@ -17,8 +17,16 @@ $breadcrumb-secondary ?= lighten($breadcrumb-primary, 10%)
 $breadcrumb-hover     ?= $tertiary
 $breadcrumb-active    ?= darken($breadcrumb-hover, 15%)
 
+$button-size                  ?= 14pt
+$button-size-dense            ?= 13pt
 $button-border-radius         ?= $generic-border-radius
 $button-padding               ?= 0 16px
+$button-padding-dense         ?= 0 16px
+$button-padding-compact       ?= 6px
+
+$button-round-padding         ?= 16px
+$button-round-padding-mini    ?= 8px
+
 $button-transition            ?= .12s ease-in
 $button-rounded-border-radius ?= 28px
 $button-push-border-radius    ?= 7px
@@ -85,7 +93,7 @@ $collapsible-indent-left-padding ?= ($item-primary-size + $item-gutter)
 $collapsible-active-color        ?= $item-active-color
 $collapsible-menu-left-padding   ?= 48px
 
-$datetime-range-space    ?= 10px
+$datetime-range-space     ?= 10px
 $datetime-input-min-width ?= 70px
 
 $dot-color             ?= $red

--- a/src/css/variables.mat.styl
+++ b/src/css/variables.mat.styl
@@ -4,9 +4,9 @@ $typography-font-family      ?= 'Roboto', '-apple-system', 'Helvetica Neue', Hel
 $action-sheet-background       ?= white
 $action-sheet-hover-background ?= #d0d0d0
 
-$alert-padding       ?= 12px
-$alert-border-radius ?= $generic-border-radius
-$alert-min-width     ?= 200px
+$alert-padding        ?= 12px
+$alert-border-radius  ?= $generic-border-radius
+$alert-min-width      ?= 200px
 
 $breadcrumb-radius    ?= $generic-border-radius
 $breadcrumb-height    ?= 34px
@@ -16,8 +16,16 @@ $breadcrumb-secondary ?= lighten($breadcrumb-primary, 10%)
 $breadcrumb-hover     ?= $tertiary
 $breadcrumb-active    ?= darken($breadcrumb-hover, 15%)
 
+$button-size                  ?= 14pt
+$button-size-dense            ?= 13pt
 $button-border-radius         ?= $generic-border-radius
-$button-padding               ?= 3px 16px
+$button-padding               ?= 6px 16px
+$button-padding-dense         ?= 5px 16px
+$button-padding-compact       ?= 6px
+
+$button-round-padding         ?= 16px
+$button-round-padding-mini    ?= 8px
+
 $button-transition            ?= .12s ease-in
 $button-font-weight           ?= 500
 $button-shadow                ?= $shadow-2
@@ -41,7 +49,6 @@ $chat-message-received-color     ?= black
 $chat-message-received-bg        ?= $green-4
 $chat-message-sent-color         ?= black
 $chat-message-sent-bg            ?= $grey-4
-
 $chat-message-avatar-size        ?= 48px
 $chat-message-border-radius      ?= $generic-border-radius
 $chat-message-distance           ?= 8px


### PR DESCRIPTION
- props: size, mini, compact
- size can be CSS length or one of xs, sm, md, lg, xl, dense (for not round buttons size dense), mini (for round buttons)
- mini as prop and mini as size apply small button padding
- compact decreases horizontal padding left, right and between components of the button
- controlled only by styles/variables in CSS - size xs, sm, ... are relative to main size