### PR TITLE
Locale and Auto24h DateTimePicker for functional component version

### DIFF
--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -83,8 +83,14 @@
       </p>
       <q-datetime v-model="model" type="time" />
 
-      <p class="caption">Time 24hr Format (force)</p>
+      <p class="caption">Force 12hr Format for Picker, independent of time format</p>
+      <q-datetime v-model="model" type="time" format24h="12h" />
+      
+      <p class="caption">Force 24hr Format for Picker, independent of time format</p>
       <q-datetime v-model="model" type="time" format24h />
+      
+      <p class="caption">Force i18n Format for Picker, independent of time format</p>
+      <q-datetime v-model="model" type="time" format24h="i18n" />
 
       <p class="caption">Date & Time</p>
       <q-datetime @change="value => log('@change', value)" v-model="model" type="datetime" />
@@ -183,8 +189,14 @@
       </p>
       <q-datetime-picker v-model="model" type="time" />
 
-      <p class="caption">Time 24hr Format (force)</p>
-      <q-datetime-picker v-model="model" type="time" format24h />
+      <p class="caption">Force 12hr Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h="12h" />
+      
+      <p class="caption">Force 24hr Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h="24h" />
+      
+      <p class="caption">Force i18n Format for Picker, independent of time format</p>
+      <q-datetime-picker v-model="model" type="time" format24h="i18n" />
 
       <p class="caption">Date & Time</p>
       @input<q-datetime-picker @input="value => log('@input', value)" @change="value => log('@change', value)" color="secondary" v-model="model" type="datetime" />

--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -46,23 +46,27 @@ export default {
       if (!isValid(this.value)) {
         return this.placeholder || ''
       }
-
-      let format
-
       if (this.format) {
-        format = this.format
-      }
-      else if (this.type === 'date') {
-        format = 'YYYY-MM-DD'
-      }
-      else if (this.type === 'time') {
-        format = 'HH:mm'
+        return formatDate(this.value, this.format, /* for reactiveness */ this.$q.i18n.date)
       }
       else {
-        format = 'YYYY-MM-DD HH:mm:ss'
+        // If no format was specified, use the locale
+        let date = new Date(this.value)
+        if (isNaN(date.valueOf())) {
+          return this.placeholder || ''
+        }
+        else {
+          if (this.type === 'date') {
+            return date.toLocaleDateString()
+          }
+          else if (this.type === 'time') {
+            return date.toLocaleTimeString()
+          }
+          else {
+            return date.toLocaleString()
+          }
+        }
       }
-
-      return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
     }
   },
   methods: {

--- a/src/components/datetime/QDatetimePicker.mat.vue
+++ b/src/components/datetime/QDatetimePicker.mat.vue
@@ -290,9 +290,41 @@ export default {
       return cls
     },
     computedFormat24h () {
-      return this.format24h !== 0
-        ? this.format24h
-        : this.$q.i18n.date.format24h
+      // 24h format determination
+      // iOS: The is currently no support for 12h format in the iOS version of the DatetimePicker. If required, add this to Mixin.
+      if (this.format24h === 'i18n') {
+        // Explicit i18n option
+        return this.$q.i18n.date.format24h
+      }
+      else if (this.format24h === '24h' || this.format24h === '') {
+        // Explicit 24h format specified
+        return true
+      }
+      else if (this.format24h === '12h') {
+        // Explicit 12h format specified
+        return false
+      }
+      else if (this.format) {
+        // Automatically determine the 24h format from the specified format string
+        if (this.format.match(/H/)) {
+          return true
+        }
+        else {
+          return false
+        }
+      }
+      else {
+        // Attempt to determine the 24h format setting from the locale
+        // 12 hour clock is mostly used in the US, however, other countries and languages might need to be supported
+        // the relevant strings can be added to the regex below once identified
+        let date = new Date(2000, 1, 1, 23, 0, 0)
+        if (date.toLocaleTimeString().match(/am|pm|a\.m\.|p\.m\./i)) {
+          return false
+        }
+        else {
+          return true
+        }
+      }
     },
     computedFirstDayOfWeek () {
       return this.firstDayOfWeek !== void 0

--- a/src/components/datetime/datetime-props.js
+++ b/src/components/datetime/datetime-props.js
@@ -38,9 +38,8 @@ export const inline = {
     validator: v => ['auto', 'date', 'number', 'string'].includes(v)
   },
   format24h: {
-    type: [Boolean, Number],
-    default: 0,
-    validator: v => [true, false, 0].includes(v)
+    type: [String],
+    validator: v => ['', '12h', '24h', 'i18n'].includes(v)
   },
   defaultView: {
     type: String,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The default format of the DatePicker was YYYY-MM-DD HH:mm:ss and there was no way to request the locale date formatting. This can be considered a bug or feature.

These proposed changes uses the locale date formatting by default when no format is specified.

If for some reason the 'YYYY-MM-DD HH:mm:ss' format is absolutely required as default instead of the locale format, I can code this instead, however, I feel that the default should be the locale.

Additionally, the 24h format is automatically derived from the specified format or the locale. Additional flexibility was added to explicitly choose the format or to choose the i18n file as the source of the format setting. Thus all existing options remain unbroken and more flexible. This set of changes includes and depends on the previous pull request that is only for enabling locale formats.

I left the format24h property and added flexibility to make certain that no one looses any functionality. However, it really is not necessary anymore since there is no good reason to ever have the picker in a different 24h/12h format that that of the displayed formated time string, the two should always be coherent. Please advise if you wish me to removed the format24h option and only keep the automatic determination.