### PR TITLE
[post v0.15] Modal auto sizing and clean up flex box #1298

### DIFF
--- a/dev/components/components/modal.vue
+++ b/dev/components/components/modal.vue
@@ -109,6 +109,21 @@
       <h4>Modal</h4><p>This one gets displayed from {{position}}.</p>
       <q-btn color="orange" @click="$refs.positionModal.hide()">Close Me</q-btn>
     </q-modal>
+    
+    <q-modal ref="noSizeModalLayout">
+      <q-modal-layout>
+        <q-toolbar slot="header">
+          Modal with layout and no minimum size (auto-sizing)
+        </q-toolbar>
+        <q-toolbar slot="footer">
+          <q-btn @click="text += testingText">Add Text (Width)</q-btn>
+          <q-btn @click="text += ('<br>' + testingText)">Add Text (Height)</q-btn>
+          <q-btn @click="$refs.noSizeModalLayout.hide()">Close</q-btn>
+        </q-toolbar>
+        <div class="layout-padding" v-html="text">
+        </div>
+      </q-modal-layout>
+    </q-modal>
   </div>
 </template>
 
@@ -139,9 +154,15 @@ export default {
         {
           label: 'Always Maximized',
           ref: 'maximizedModal'
+        },
+        {
+          label: 'Modal with Layout (auto-sizing)',
+          ref: 'noSizeModalLayout'
         }
       ],
-      position: 'bottom'
+      position: 'bottom',
+      testingText: 'testing text stretch and scrollbars! ',
+      text: ''
     }
   },
   methods: {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -77,6 +77,11 @@ export default {
     minimized: Boolean,
     maximized: Boolean
   },
+  data () {
+    return {
+      contentStaticClasses: ''
+    }
+  },
   watch: {
     $route () {
       if (!this.noRouteDismiss) {
@@ -172,6 +177,18 @@ export default {
     }
   },
   mounted () {
+    this.contentStaticClasses = 'modal-content scroll'
+
+    // Add column class to q-modal when q-modal-layout, this permits the content to grow and have scrolling in between the header and footer
+    // Class column cannot be imposed when there is no q-modal-layout child since this will change the behavior of the contents
+    if (this.$el.firstChild) {
+      if (this.$el.firstChild.firstChild) {
+        if (this.$el.firstChild.firstChild.className.search('q-modal-layout') >= 0) {
+          this.contentStaticClasses += ' column'
+        }
+      }
+    }
+
     if (this.value) {
       this.show()
     }
@@ -212,7 +229,7 @@ export default {
       }, [
         h('div', {
           ref: 'content',
-          staticClass: 'modal-content scroll',
+          staticClass: this.contentStaticClasses,
           style: this.modalCss,
           'class': this.contentClasses,
           on: {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -180,11 +180,15 @@ export default {
     this.contentStaticClasses = 'modal-content scroll'
 
     // Add column class to q-modal when q-modal-layout, this permits the content to grow and have scrolling in between the header and footer
-    // Class column cannot be imposed when there is no q-modal-layout child since this will change the behavior of the contents
+    // Class column cannot be imposed when there is no q-modal-layout child since this will change the behavior of the contents, which will be diplayed in columns
+    // This can be simplified later when the QModal and QModalLayout are consolidated.
+    // For the moment, because QModalLayout is added in a slot by the user, there is no simple way for the QModalLayout to tell QModal that it exists.
     if (this.$el.firstChild) {
       if (this.$el.firstChild.firstChild) {
-        if (this.$el.firstChild.firstChild.className.search('q-modal-layout') >= 0) {
-          this.contentStaticClasses += ' column'
+        if (this.$el.firstChild.firstChild.className) {
+          if (this.$el.firstChild.firstChild.className.search('q-modal-layout') >= 0) {
+            this.contentStaticClasses += ' column'
+          }
         }
       }
     }

--- a/src/components/modal/QModalLayout.js
+++ b/src/components/modal/QModalLayout.js
@@ -25,7 +25,7 @@ export default {
     }
 
     child.push(h('div', {
-      staticClass: 'q-modal-layout-content col scroll',
+      staticClass: 'q-modal-layout-content col-grow scroll',
       style: this.contentStyle,
       'class': this.contentClass
     }, [
@@ -44,7 +44,7 @@ export default {
     }
 
     return h('div', {
-      staticClass: 'q-modal-layout column absolute-full'
+      staticClass: 'q-modal-layout column col-grow no-wrap'
     }, child)
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

As discribed in #1298, the Modal Dialog collapses when a minimum size has not be specified.  This corrects the problem and also adds flexibility for the dialog windows to grow with it's content without requiring a minimum size.   The .col flex-basis 0 (flex.styl) has been removed since it was causing flex boxes to collapse under certain conditions, in particular in this case.

See the video below of the flexible modal working.

![modalfixed](https://user-images.githubusercontent.com/29619229/34343486-2557db36-e99e-11e7-941e-e9bd94a0bbd3.gif)

