### PR TITLE
Select Disable Opacity Fix

### DIFF
--- a/dev/components/form/select.vue
+++ b/dev/components/form/select.vue
@@ -63,6 +63,8 @@
 
       <p class="caption">Disabled State</p>
       <q-select disable float-label="Disabled Select" multiple v-model="multipleSelect" :options="selectOptions"></q-select>
+      <q-select disable @change="onChange" @input="onInput" multiple chips v-model="multipleSelect" :options="selectListOptions" float-label="Disabled Select" max-height="36px" clearable></q-select>
+      <q-select disable inverted color="dark" frame-color="amber" multiple chips v-model="multipleSelect" :options="selectListOptions" float-label="Disabled Select" max-height="36px"></q-select>
 
       <p class="caption">Error State</p>
       <q-select error multiple v-model="multipleSelect" :options="selectOptions"></q-select>

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -28,7 +28,7 @@
   >
     <div
       v-if="hasChips"
-      class="col row items-center group q-input-chips"
+      class="col row items-center group q-input-chips q-if-control"
       :class="alignClass"
     >
       <q-chip
@@ -46,7 +46,7 @@
 
     <div
       v-else
-      class="col row items-center q-input-target"
+      class="col row items-center q-input-target q-if-control"
       :class="alignClass"
       v-html="actualValue"
     ></div>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The Select component does not get the typical disabled 0.6 opacity.  This corrects it and adds two tests cases to select.vue.

Incorrect opacity for disabled control:
![2018-01-08 19_11_14-quasar development](https://user-images.githubusercontent.com/29619229/34699007-27ac091e-f4a9-11e7-9767-92f391e4c2b9.png)

Reference disabled input control:
![2018-01-08 19_12_55-quasar development](https://user-images.githubusercontent.com/29619229/34699040-4ac85966-f4a9-11e7-8dc0-70565a9c5b97.png)

Select control after the fix:
![2018-01-08 19_15_38-quasar development](https://user-images.githubusercontent.com/29619229/34699052-5c53a46a-f4a9-11e7-8685-3cf7bff5dd4d.png)

