### PR TITLE
feat: QBtn justify (and alert actions justify start)

### DIFF
--- a/dev/components/components/alert.vue
+++ b/dev/components/components/alert.vue
@@ -54,7 +54,7 @@
     <q-alert
       icon="map"
       color="primary"
-      :actions="[ { label: 'Reply', icon: 'map', handler: () => {} }, { label: 'Reply', icon: 'map', handler: () => {} }, { label: 'Dismiss', handler: () => {} } ]"
+      :actions="[ { label: 'Reply', icon: 'map', handler: () => {} }, { label: 'Reply long', icon: 'map', handler: () => {} }, { label: 'Dismiss', handler: () => {} } ]"
     >Learn how you can get there</q-alert>
     <br>
     <q-alert

--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -271,11 +271,12 @@
 
       <p class="caption">Full Width Buttons</p>
       <div class="group">
-        <q-btn color="primary" class="full-width">Full-width Full-width Full-width Full-width Full-width Full-width Full-width Full-width Full-width</q-btn>
-        <q-btn color="secondary" class="full-width">Full-width</q-btn>
-        <q-btn color="primary" icon="alarm" class="full-width">Full-width</q-btn>
-        <q-btn color="secondary" icon-right="alarm" class="full-width">Full-width</q-btn>
-        <q-btn color="secondary" icon="lock" icon-right="alarm" class="full-width">Full-width</q-btn>
+        <q-btn color="primary" class="full-width" label="Full-width Full-width Full-width Full-width Full-width Full-width Full-width Full-width Full-width" />
+        <q-btn color="secondary" class="full-width" label="Full-width" justify="start" />
+        <q-btn color="primary" icon="alarm" class="full-width" label="Full-width" justify="end" />
+        <q-btn color="secondary" icon-right="alarm" class="full-width" label="Full-width" justify="center" />
+        <q-btn color="secondary" icon="lock" icon-right="alarm" class="full-width" label="Full-width" justify="between" />
+        <q-btn color="secondary" icon="lock" icon-right="alarm" class="full-width" label="Full-width" justify="around" />
       </div>
 
       <p class="caption">Multiline Buttons</p>
@@ -304,9 +305,9 @@
         <q-btn color="primary" icon-right="alarm" size="sm" class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon-right="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
         <q-btn color="primary" icon-right="alarm" size="lg" class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" icon-right="alarm" size="sm" class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" icon-right="alarm" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
-        <q-btn color="primary" icon="lock" icon-right="alarm" size="lg" class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" justify="between" size="sm" class="full-width">Small Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" justify="between" class="full-width">Normal Full-width<br/>Multiline<br/>Button</q-btn>
+        <q-btn color="primary" icon="lock" icon-right="alarm" justify="between" size="lg" class="full-width">Big Full-width<br/>Multiline<br/>Button</q-btn>
       </div>
 
       <p class="caption">Wrap test</p>

--- a/src/components/alert/QAlert.js
+++ b/src/components/alert/QAlert.js
@@ -69,10 +69,12 @@ export default {
           this.actions.map(action =>
             h('div', [
               h(QBtn, {
+                staticClass: 'full-width',
                 props: {
                   flat: true,
                   dense: true,
                   icon: action.icon,
+                  justify: 'start',
                   label: action.closeBtn === true
                     ? (typeof action.label === 'string' ? action.label : this.$q.i18n.label.close)
                     : action.label

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -130,10 +130,11 @@ export default {
         : null,
 
       h('div', {
-        staticClass: 'q-btn-inner row col flex-center',
+        staticClass: 'q-btn-inner row col items-center',
         'class': {
           'no-wrap': this.noWrap,
-          'text-no-wrap': this.noWrap
+          'text-no-wrap': this.noWrap,
+          [`justify-${this.justify}`]: this.justify
         }
       },
       this.loading

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -131,11 +131,7 @@ export default {
 
       h('div', {
         staticClass: 'q-btn-inner row col items-center',
-        'class': {
-          'no-wrap': this.noWrap,
-          'text-no-wrap': this.noWrap,
-          [`justify-${this.justify}`]: this.justify
-        }
+        'class': this.innerClasses
       },
       this.loading
         ? [ this.$slots.loading || h(QSpinner) ]

--- a/src/components/btn/QBtnToggle.js
+++ b/src/components/btn/QBtnToggle.js
@@ -56,10 +56,11 @@ export default {
       h('div', { staticClass: 'q-focus-helper' }),
 
       h('div', {
-        staticClass: 'q-btn-inner row col flex-center',
+        staticClass: 'q-btn-inner row col items-center',
         'class': {
           'no-wrap': this.noWrap,
-          'text-no-wrap': this.noWrap
+          'text-no-wrap': this.noWrap,
+          [`justify-${this.justify}`]: this.justify
         }
       }, [
         this.icon

--- a/src/components/btn/QBtnToggle.js
+++ b/src/components/btn/QBtnToggle.js
@@ -57,11 +57,7 @@ export default {
 
       h('div', {
         staticClass: 'q-btn-inner row col items-center',
-        'class': {
-          'no-wrap': this.noWrap,
-          'text-no-wrap': this.noWrap,
-          [`justify-${this.justify}`]: this.justify
-        }
+        'class': this.innerClasses
       }, [
         this.icon
           ? h('q-icon', {

--- a/src/components/btn/btn-mixin.js
+++ b/src/components/btn/btn-mixin.js
@@ -109,6 +109,13 @@ export default {
       })
 
       return cls
+    },
+    innerClasses () {
+      const classes = [`justify-${this.justify}`]
+      if (this.noWrap) {
+        classes.push('no-wrap', 'text-no-wrap')
+      }
+      return classes
     }
   },
   methods: {

--- a/src/components/btn/btn-mixin.js
+++ b/src/components/btn/btn-mixin.js
@@ -31,7 +31,12 @@ export default {
     textColor: String,
     glossy: Boolean,
     dense: Boolean,
-    noRipple: Boolean
+    noRipple: Boolean,
+    justify: {
+      type: String,
+      default: 'center',
+      validator: v => ['start', 'end', 'center', 'between', 'around'].includes(v)
+    }
   },
   computed: {
     style () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Allows to justify content of the QBtn.
Make all action buttons in QAlert full-width and justify-start