### PR TITLE
Demo - Table Cell Button with Loader

### DIFF
--- a/dev/components/components/data-table.vue
+++ b/dev/components/components/data-table.vue
@@ -221,8 +221,7 @@
           <q-td key="protein" :props="props">{{ props.row.protein }}</q-td>
           <q-td key="sodium" :props="props">{{ props.row.sodium }}</q-td>
           <q-td key="calcium" :props="props">
-            <q-btn loader color="secondary" icon="sms_failed" @click="($event, done) => { notifyWithProps($event, done, props) }" :label="props.row.calcium"></q-btn>
-            
+            <q-btn loader color="secondary" icon="sms_failed" @click="($event, done) => { notifyWithProps(done, props) }" :label="props.row.calcium" />
           </q-td>
           <q-td key="iron" :props="props">
             <q-chip small square color="amber">{{ props.row.iron }}</q-chip>
@@ -554,7 +553,7 @@ export default {
     }
   },
   methods: {
-    notifyWithProps ($event, done, props) {
+    notifyWithProps (done, props) {
       // Row cell event with access to props
       this.$q.notify({
         message: 'The dessert ' + props.row.name + ' has ' + props.row.calcium + ' Calcium!',

--- a/dev/components/components/data-table.vue
+++ b/dev/components/components/data-table.vue
@@ -200,7 +200,7 @@
           </q-th>
         </tr>
       </q-table>
-      <h2>body template</h2>
+      <h2>body template - cell button with loader</h2>
       <q-table
         :data="data"
         :columns="columns"
@@ -220,7 +220,10 @@
           <q-td key="carbs" :props="props">{{ props.row.carbs }}</q-td>
           <q-td key="protein" :props="props">{{ props.row.protein }}</q-td>
           <q-td key="sodium" :props="props">{{ props.row.sodium }}</q-td>
-          <q-td key="calcium" :props="props">{{ props.row.calcium }}</q-td>
+          <q-td key="calcium" :props="props">
+            <q-btn loader color="secondary" icon="sms_failed" @click="($event, done) => { notifyWithProps($event, done, props) }" :label="props.row.calcium"></q-btn>
+            
+          </q-td>
           <q-td key="iron" :props="props">
             <q-chip small square color="amber">{{ props.row.iron }}</q-chip>
           </q-td>
@@ -551,6 +554,15 @@ export default {
     }
   },
   methods: {
+    notifyWithProps ($event, done, props) {
+      // Row cell event with access to props
+      this.$q.notify({
+        message: 'The dessert ' + props.row.name + ' has ' + props.row.calcium + ' Calcium!',
+        icon: 'restaurant'
+      })
+      // Remove button spinner after 3 seconds
+      setTimeout(() => { done() }, 3000)
+    },
     request (props) {
       this.loader = true
       console.log('REQUEST', props)


### PR DESCRIPTION
I have added an example of a table cell button with loader in the table demo.  This results from @rstoenescu answer to my issue #1383.  I can add these details to the documentation also.

![tablecellclickdemo](https://user-images.githubusercontent.com/29619229/34882804-b25649f6-f785-11e7-9fcc-90ef0d98dcc6.gif)
