### PR TITLE
QBtnDropdown Disable Bug Fixes

### DIFF
--- a/dev/components/components/button-dropdown.vue
+++ b/dev/components/components/button-dropdown.vue
@@ -1,11 +1,11 @@
 <template>
   <div style="padding: 25px">
-    <div v-for="(cfg, index1) in conf" :key="`${cfg.split}-${cfg.dense}`">
+    <div v-for="(cfg, index1) in conf" :key="`${cfg.split}-${cfg.dense}-${cfg.disable}`">
       <div v-for="(size, index2) in sizes" :key="size">
         <p class="caption">{{ label(cfg) }} - {{ size }}</p>
         text
-        <q-btn :size="size" color="primary" glossy :dense="cfg.dense" label="Test" />
-        <q-btn-dropdown ref="first" :size="size" :split="cfg.split" :dense="cfg.dense" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" glossy label="Dropdown Button" style="margin: 15px">
+        <q-btn :size="size" color="primary" glossy :dense="cfg.dense" :disable="cfg.disable" label="Test" />
+        <q-btn-dropdown ref="first" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" glossy label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders X</q-list-header>
             <q-item v-for="n in 3" :key="`1.${n}`" @click.native="hideDropdown(index1 * 3 + index2)">
@@ -28,7 +28,7 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
-        <q-btn-dropdown ref="second" :size="size" :split="cfg.split" :dense="cfg.dense" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy label="Dropdown Button" style="margin: 15px">
+        <q-btn-dropdown ref="second" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
             <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.second[index1 * 3 + index2].hide()">
@@ -51,7 +51,7 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
-        <q-btn-dropdown ref="third" :size="size" :split="cfg.split" :dense="cfg.dense" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy style="margin: 15px">
+        <q-btn-dropdown ref="third" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
             <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.third[index1 * 3 + index2].hide()">
@@ -74,7 +74,7 @@
             </q-item>
           </q-list>
         </q-btn-dropdown>
-        <q-btn-dropdown ref="fourth" :size="size" :split="cfg.split" :dense="cfg.dense" @show="log('open')" @hide="log('close')" @click="log('click')" color="yellow" glossy icon="map" label="Dropdown Button" style="margin: 15px">
+        <q-btn-dropdown ref="fourth" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="yellow" glossy icon="map" label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
             <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.fourth[index1 * 3 + index2].hide()">
@@ -107,10 +107,14 @@ export default {
   data () {
     return {
       conf: [
-        {split: false, dense: false},
-        {split: false, dense: true},
-        {split: true, dense: false},
-        {split: true, dense: true}
+        {split: false, dense: false, disable: false},
+        {split: false, dense: true, disable: false},
+        {split: true, dense: false, disable: false},
+        {split: true, dense: true, disable: false},
+        {split: false, dense: false, disable: true},
+        {split: false, dense: true, disable: true},
+        {split: true, dense: false, disable: true},
+        {split: true, dense: true, disable: true}
       ],
       sizes: ['sm', 'md', 'lg']
     }
@@ -126,6 +130,9 @@ export default {
       }
       if (cfg.dense) {
         label += ' dense'
+      }
+      if (cfg.disable) {
+        label += ' disable'
       }
       return label
     },

--- a/src/components/btn/QBtnDropdown.js
+++ b/src/components/btn/QBtnDropdown.js
@@ -18,6 +18,7 @@ export default {
         {
           ref: 'popover',
           props: {
+            disable: this.disable,
             fit: true,
             anchorClick: !this.split,
             anchor: 'bottom right',
@@ -110,6 +111,7 @@ export default {
           QBtn,
           {
             props: {
+              disable: this.disable,
               flat: this.flat,
               rounded: this.rounded,
               push: this.push,
@@ -121,13 +123,7 @@ export default {
               waitForRipple: this.waitForRipple
             },
             staticClass: 'q-btn-dropdown-arrow',
-            on: {
-              click: () => {
-                if (!this.disable) {
-                  this.toggle()
-                }
-              }
-            }
+            on: { click: () => { this.toggle() } }
           },
           [ Icon ]
         ),


### PR DESCRIPTION
This adds "disable" test cases to the QBtnDropdown demo page and corrects the following bugs:
1) Non-split QBtnDropdown still does popup when in disable state
2) Split QBtnDropdown right dropdown sections is not in a faded color

In the fix for 2, I also removed the redundant check for disable state since this click is no longer possible in disable state.

Video of bugs
![qbtndropdowndisabledbugs](https://user-images.githubusercontent.com/29619229/34895875-923cd6be-f7b5-11e7-9d11-9b8e1a5ffe29.gif)

Video of the fixed version
![qbtndropdowndisabledfixes](https://user-images.githubusercontent.com/29619229/34895881-968e8f50-f7b5-11e7-9b6f-d05507fa08c7.gif)
