### PR TITLE
QBtnToggleGroup disable bug fix

### DIFF
--- a/dev/components/components/button-toggle-group.vue
+++ b/dev/components/components/button-toggle-group.vue
@@ -11,59 +11,62 @@
           <div v-for="glossy in options" :key="glossy" v-if="!(push || flat) || !outline">
             <div v-for="rounded in options" :key="rounded">
               <div v-for="size in sizes" :key="size" class="q-ma-sm">
-                <p class="caption">
-                  {{push ? 'push ' : ''}}
-                  {{rounded ? 'rounded ' : ''}}
-                  {{outline ? 'outline ' : ''}}
-                  {{flat ? 'flat ' : ''}}
-                  {{glossy ? 'glossy ' : ''}}
-                  {{size}}
-                </p>
+                <div v-for="disable in options.slice().reverse()" :key="disable">
+                  <p class="caption">
+                    {{push ? 'push ' : ''}}
+                    {{rounded ? 'rounded ' : ''}}
+                    {{outline ? 'outline ' : ''}}
+                    {{flat ? 'flat ' : ''}}
+                    {{glossy ? 'glossy ' : ''}}
+                    {{size}}
+                    {{disable ? 'disable ' : ''}}
+                  </p>
 
-                <q-btn-toggle-group v-model="model" toggle-color="primary"
-                  :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
-                  :options="[
-                    {label: 'One', value: 'one'},
-                    {label: 'Two', value: 'two'},
-                    {label: 'Three', value: 'three'}
-                  ]"
-                />
+                  <q-btn-toggle-group v-model="model" toggle-color="primary"
+                    :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size" :disable="disable"
+                    :options="[
+                      {label: 'One', value: 'one'},
+                      {label: 'Two', value: 'two'},
+                      {label: 'Three', value: 'three'}
+                    ]"
+                  />
 
-                <q-btn-toggle-group v-model="model" toggle-color="primary"
-                  :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
-                  :options="[
-                    {label: 'One', icon: 'filter_1', value: 'one'},
-                    {label: 'Two', icon: 'filter_2', value: 'two'},
-                    {label: 'Three', icon: 'filter_3', value: 'three'}
-                  ]"
-                />
+                  <q-btn-toggle-group v-model="model" toggle-color="primary"
+                    :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size" :disable="disable"
+                    :options="[
+                      {label: 'One', icon: 'filter_1', value: 'one'},
+                      {label: 'Two', icon: 'filter_2', value: 'two'},
+                      {label: 'Three', icon: 'filter_3', value: 'three'}
+                    ]"
+                  />
 
-                <q-btn-toggle-group v-model="model" toggle-color="primary"
-                  :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
-                  :options="[
-                    {icon: 'filter_1', value: 'one'},
-                    {icon: 'filter_2', value: 'two'},
-                    {icon: 'filter_3', value: 'three'}
-                  ]"
-                />
+                  <q-btn-toggle-group v-model="model" toggle-color="primary"
+                    :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size" :disable="disable"
+                    :options="[
+                      {icon: 'filter_1', value: 'one'},
+                      {icon: 'filter_2', value: 'two'},
+                      {icon: 'filter_3', value: 'three'}
+                    ]"
+                  />
 
-                <q-btn-toggle-group v-model="model" toggle-color="primary"
-                  :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
-                  :options="[
-                    {label: 'One', iconRight: 'filter_1', value: 'one'},
-                    {label: 'Two', iconRight: 'filter_2', value: 'two'},
-                    {label: 'Three', iconRight: 'filter_3', value: 'three'}
-                  ]"
-                />
+                  <q-btn-toggle-group v-model="model" toggle-color="primary"
+                    :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size" :disable="disable"
+                    :options="[
+                      {label: 'One', iconRight: 'filter_1', value: 'one'},
+                      {label: 'Two', iconRight: 'filter_2', value: 'two'},
+                      {label: 'Three', iconRight: 'filter_3', value: 'three'}
+                    ]"
+                  />
 
-                <q-btn-toggle-group v-model="model" toggle-color="primary"
-                  :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
-                  :options="[
-                    {label: 'One', value: 'one'},
-                    {label: 'Two', toggleColor: 'yellow', value: 'two'},
-                    {label: 'Three', toggleColor: 'red', value: 'three'}
-                  ]"
-                />
+                  <q-btn-toggle-group v-model="model" toggle-color="primary"
+                    :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size" :disable="disable"
+                    :options="[
+                      {label: 'One', value: 'one'},
+                      {label: 'Two', toggleColor: 'yellow', value: 'two'},
+                      {label: 'Three', toggleColor: 'red', value: 'three'}
+                    ]"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/btn/QBtnToggleGroup.js
+++ b/src/components/btn/QBtnToggleGroup.js
@@ -61,6 +61,7 @@ export default {
         },
         on: { change: () => this.set(opt.value, opt) },
         props: {
+          disable: this.disable,
           toggled: this.val[i],
           label: opt.label,
           color: opt.color || this.color,


### PR DESCRIPTION
This adds "disable" test cases to the QBtnToggleGroup demo page and fixes the bug that the buttons where not disabled.  See the videos below:

Disable bug
![qbtntogglegroup-disablebug](https://user-images.githubusercontent.com/29619229/34898118-592977c4-f7bf-11e7-9d85-dbb2a4fe5c5f.gif)

Disable fixed
![qbtntogglegroup-disabletests](https://user-images.githubusercontent.com/29619229/34897993-d2f74a46-f7be-11e7-9a45-9a103fd086f6.gif)

