### PR TITLE
QBtn Disable Active Effect Fix

### DIFF
--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -237,6 +237,8 @@
       <p class="group">
         <q-btn color="primary" disable>Disabled</q-btn>
         <q-btn round color="primary" disable icon="card_giftcard" />
+        <q-btn push color="primary" disable>Push</q-btn>
+        <q-btn push color="primary" disable round icon="card_giftcard" />
       <p>
 
       <p class="caption">Flat Buttons</p>

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -25,7 +25,7 @@
 
   &.disabled
     opacity .7 !important
-  &:not([disabled]):active
+  &:active:not(.disabled)
     box-shadow $shadow-8
   &.full-width
     border-radius 0 !important
@@ -68,7 +68,7 @@
   min-height 0
   height 3em
   width 3em
-  &:active
+  &:active:not(.disabled)
     box-shadow $shadow-8
 
 .q-btn-dense


### PR DESCRIPTION
When the QBtn is "disable", the active lift shadow effect was still occurring.  This fixes it and adds two pushbuttons to the demo tests.  See the videos below.

Bug
![qbtn-disable-raiseonactive-bug](https://user-images.githubusercontent.com/29619229/34903972-23893334-f80a-11e7-9f90-3f4b92389772.gif)

Fix
![qbtn-disable-raiseonactive-fix](https://user-images.githubusercontent.com/29619229/34903973-28abfd10-f80a-11e7-9a53-ddc5cece26cd.gif)

