### PR TITLE
QBtn Round Push Active - Fix

### DIFF
--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -68,8 +68,6 @@
   min-height 0
   height 3em
   width 3em
-  &:active:not(.disabled)
-    box-shadow $shadow-8
 
 .q-btn-dense
   padding .285em


### PR DESCRIPTION
A Round Push QBtn was incorrectly displaying a raised shadow on click.  The active css code for q-btn-push was redundant because q-btn-push always also include the q-btn class wich manages the push. This fixes the problem, see the 2 videos below.

Round Push QBtn Active Raise bug
![qbtnround-push-active-bug](https://user-images.githubusercontent.com/29619229/34921130-e9a508bc-f94b-11e7-8fe6-8f64e5fc0455.gif)

Round Push QBtn Active Fix
![qbtnround-push-active-fix](https://user-images.githubusercontent.com/29619229/34921132-ef0f1586-f94b-11e7-805c-3d39a6b0522d.gif)
