### PR TITLE
QChat no avatar fix #1420

### DIFF
--- a/dev/components/components/chat.vue
+++ b/dev/components/components/chat.vue
@@ -1,8 +1,8 @@
 <template>
   <div>  
     <div class="layout-padding" style="max-width: 500px;">
-      <h4>Chat with avatar section</h4>
-      <p>To mix messages with avatar and without in the same thread, use a placeholder avatar image.</p>
+      <h4>Chat with avatar</h4>
+      <p>To mix messages with avatar and without avatar in the same thread, use a placeholder avatar image.</p>
       <q-chat-message
         v-for="(msg, index) in messages"
         :key="index"
@@ -32,7 +32,7 @@
       </q-chat-message>
       
       <br><br><br><br>
-      <h4>Chat without avatar section</h4>
+      <h4>Chat without avatar</h4>
       <q-chat-message
         v-for="(msg, index) in messages"
         :key="1000 + index"

--- a/dev/components/components/chat.vue
+++ b/dev/components/components/chat.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <div class="layout-padding" style="max-width: 500px;">
+      <h4>Chat with avatar section</h4>
+      <p>To mix messages with avatar and without in the same thread, use a placeholder avatar image.</p>
       <q-chat-message
         v-for="msg in messages"
         :key="msg.label"
@@ -13,13 +15,20 @@
         :text="msg.text"
         :stamp="msg.stamp"
       />
-
+      <br><br><br><br>
+      <h4>Chat without avatar section</h4>
       <q-chat-message
-        name="Vladimir"
-        avatar="/statics/boy-avatar.png"
-      >
-        <q-spinner-dots size="2rem" />
-      </q-chat-message>
+        v-for="msg in messages"
+        :key="msg.label"
+        :label="msg.label"
+        :sent="msg.sent"
+        :text-color="msg.textColor"
+        :bg-color="msg.bgColor"
+        :name="msg.name"
+        :text="msg.text"
+        :stamp="msg.stamp"
+      />
+
     </div>
   </div>
 </template>

--- a/dev/components/components/chat.vue
+++ b/dev/components/components/chat.vue
@@ -1,11 +1,11 @@
 <template>
-  <div>
+  <div>  
     <div class="layout-padding" style="max-width: 500px;">
       <h4>Chat with avatar section</h4>
       <p>To mix messages with avatar and without in the same thread, use a placeholder avatar image.</p>
       <q-chat-message
-        v-for="msg in messages"
-        :key="msg.label"
+        v-for="(msg, index) in messages"
+        :key="index"
         :label="msg.label"
         :sent="msg.sent"
         :text-color="msg.textColor"
@@ -15,11 +15,27 @@
         :text="msg.text"
         :stamp="msg.stamp"
       />
+      <q-chat-message
+        name="Vladimir"
+        avatar="/statics/boy-avatar.png"
+      >
+        <q-spinner-dots size="2rem" />
+      </q-chat-message>
+      
+      <br><br><br><br>
+      <h4>Chat using avatar slot</h4>
+      <q-chat-message
+        name="Vladimir"
+        :text="['Use your own spacing or class q-message-avatar']"
+      >
+        <q-icon name="face" size="4em" slot="avatar"/>
+      </q-chat-message>
+      
       <br><br><br><br>
       <h4>Chat without avatar section</h4>
       <q-chat-message
-        v-for="msg in messages"
-        :key="msg.label"
+        v-for="(msg, index) in messages"
+        :key="1000 + index"
         :label="msg.label"
         :sent="msg.sent"
         :text-color="msg.textColor"
@@ -28,7 +44,11 @@
         :text="msg.text"
         :stamp="msg.stamp"
       />
-
+      <q-chat-message
+        name="Vladimir"
+      >
+        <q-spinner-dots size="2rem" />
+      </q-chat-message>
     </div>
   </div>
 </template>

--- a/src/components/chat/QChatMessage.vue
+++ b/src/components/chat/QChatMessage.vue
@@ -6,26 +6,29 @@
       'q-message-received': !sent
     }"
   >
+
     <p v-if="label" class="q-message-label text-center" v-html="label"></p>
 
-    <div v-if="text" class="q-message-container row items-end no-wrap">
-      <slot v-if="avatar" name="avatar">
-        <img class="q-message-avatar" :src="avatar">
-      </slot>
+    <div class="q-message-container row items-end no-wrap">
+      <slot v-if="hasAvatarSlot" name="avatar"></slot>
+      <img v-if='avatar && !hasAvatarSlot' class="q-message-avatar" :src="avatar" />
+      
       <div :class="sizeClass">
         <div v-if="name" class="q-message-name" v-html="name"></div>
-        <div
-          v-for="msg in text"
-          :key="msg"
-          class="q-message-text"
-          :class="messageClass"
-        >
-          <span class="q-message-text-content" :class="textClass">
-            <div v-html="msg"></div>
-            <div v-if="stamp" class="q-message-stamp" v-html="stamp"></div>
-          </span>
-        </div>
-        <div v-if="!text || !text.length" class="q-message-text" :class="messageClass">
+        <template v-if="text">
+          <div
+            v-for="(msg, index) in text"
+            :key="index"
+            class="q-message-text"
+            :class="messageClass"
+          >
+            <span class="q-message-text-content" :class="textClass">
+              <div v-html="msg"></div>
+              <div v-if="stamp" class="q-message-stamp" v-html="stamp"></div>
+            </span>
+          </div>
+        </template>
+        <div v-if="hasDefaultSlot" class="q-message-text" :class="messageClass">
           <span class="q-message-text-content" :class="textClass">
             <slot></slot>
             <div v-if="stamp" class="q-message-stamp" v-html="stamp"></div>
@@ -42,13 +45,10 @@ export default {
   props: {
     sent: Boolean,
     label: String,
-
     bgColor: String,
     textColor: String,
-
     name: String,
     avatar: String,
-    avatarPlaceholder: Boolean,
     text: Array,
     stamp: String,
     size: String
@@ -68,6 +68,12 @@ export default {
       if (this.size) {
         return `col-${this.size}`
       }
+    },
+    hasDefaultSlot () {
+      return Boolean(this.$slots['default'])
+    },
+    hasAvatarSlot () {
+      return Boolean(this.$slots['avatar'])
     }
   }
 }

--- a/src/components/chat/QChatMessage.vue
+++ b/src/components/chat/QChatMessage.vue
@@ -8,8 +8,8 @@
   >
     <p v-if="label" class="q-message-label text-center" v-html="label"></p>
 
-    <div v-if="avatar" class="q-message-container row items-end no-wrap">
-      <slot name="avatar">
+    <div v-if="text" class="q-message-container row items-end no-wrap">
+      <slot v-if="avatar" name="avatar">
         <img class="q-message-avatar" :src="avatar">
       </slot>
       <div :class="sizeClass">
@@ -48,6 +48,7 @@ export default {
 
     name: String,
     avatar: String,
+    avatarPlaceholder: Boolean,
     text: Array,
     stamp: String,
     size: String


### PR DESCRIPTION
As per issue #1420, a QChat message without an avatar dissapears.  Thus, the component cannot be used without avatar images.  

This fix permits the use of the QChat without avatar images.  However, all messages must have avatars to keep them aligned. I did not add support for a mix of messages with and without avatar images because the user should plan for placeholder avatar images for those users without avatars.

This fix also adds a demo test of the QChat without avatar images.

Video of no avatar bug
![qchatnoavatarbug](https://user-images.githubusercontent.com/29619229/34925583-450350d4-f978-11e7-9775-6fad83338f73.gif)

Video of fix
![qchatnoavatarfix](https://user-images.githubusercontent.com/29619229/34925585-47ac7676-f978-11e7-9a65-bf0e7f8bc294.gif)
