### PR TITLE
QBtn Active Raised Shadow Coherence Fix #1409

### DIFF
--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -25,10 +25,24 @@
 
   &.disabled
     opacity .7 !important
-  &:active:not(.disabled)
-    box-shadow $shadow-8
+
   &.full-width
     border-radius 0 !important
+    
+  &:active:not(.disabled):not(.q-btn-flat):not(.q-btn-outline):not(.q-btn-push):after
+    // This places the button active raise shadow behind adjacent elements
+    // Active raise shadow will still be visible under adjacent transparent elements, this is ok and coherent with a desired transparency effect.  
+    // Visible active raise shadow can be removed by specifying a background color to the button
+    // Visible active raise shadow can be removed by specifying a flat or outline button type
+    content ''
+    position absolute
+    top 0
+    right 0
+    bottom 0
+    left 0
+    box-shadow $shadow-8
+    border-radius inherit
+    z-index -1
 
 .q-btn-progress
   transition all .3s

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -58,7 +58,7 @@
   border-radius $button-border-radius
 
 .q-btn-flat, .q-btn-outline
-  box-shadow none !important
+  box-shadow none
 
 .q-btn-outline
   border 1px solid currentColor
@@ -82,6 +82,7 @@
   min-height 0
   height 3em
   width 3em
+  box-shadow none
 
 .q-btn-dense
   padding .285em

--- a/src/components/btn/btn-group.mat.styl
+++ b/src/components/btn/btn-group.mat.styl
@@ -5,7 +5,7 @@
   > .q-btn-group
     box-shadow none
   .q-btn
-    box-shadow none !important
+    box-shadow none
   .q-btn:not(:last-child)
     border-top-right-radius 0
     border-bottom-right-radius 0


### PR DESCRIPTION
There are several incoherences with the button active effects.
1) Raise-effect buttons cast a shadow, however, the placement of the shadow over adjacent elements depends on their position (and z-index).  
1a) The shadow will be cast over elements that are to the left or above, but not over those to the right not beneath it.
1b) The shadow will always be seen through transparent elements
    
2) The active effect for grouped buttons is not coherent across active effects.
2a) Push button retain a similar look between regular buttons and group buttons
2b) Raise-effect buttons do not keep their effect when in groups (split dropdown and toggle group) #1409.  Presumably this was because the raised effect was not coherent on adjacent buttons.

This fix makes the assumption that the shadow effect should always be under adjacent elements, but it could also be easily changed to be always above adjacent elements. This would be a design decision.

The only remaining side effect is for adjacent transparent elements.  In particular, most grouped buttons which are transparent will see the shadow in adjacent buttons.  This is ok, since it is coherent because it is normal that we see everything behind a transparent button.  In addition, the user does not like the transparent effect, they can specify either a button background color or a flat/outline/push style to disable the active-raised effect

However, this might require changing the default values of these raise-effect buttons, especially the grouped ones to have a default background to avoid user questions.

I am reviewing the default behavior of the buttons in a separate branch/pull. 

Shadow effects in the video are $shadow-24 to emphasize their effects

Active Raised Shadow Effect Incoherence:
![qbtn-shadow-incoherence](https://user-images.githubusercontent.com/29619229/34966082-0bb359e6-fa27-11e7-8bea-4cb64da0c71e.gif)

Active Effect Incoherence:
![qbtn-active-incoherence](https://user-images.githubusercontent.com/29619229/34966090-21468422-fa27-11e7-940b-3c74639f3847.gif)

Shadow Coherence Fix:
![qbtn-shadow-incoherence-fix](https://user-images.githubusercontent.com/29619229/34966100-38fbd9dc-fa27-11e7-8da9-0fa87ee743a2.gif)

Active Effect Coherence Fix:
![qbtn-active-incoherence-fix](https://user-images.githubusercontent.com/29619229/34966105-4790e186-fa27-11e7-97da-b9d2fe67e48f.gif)

Active Effect Coherence Fix for group toggle with background color:
![qbtn-active-incoherence-fix2](https://user-images.githubusercontent.com/29619229/34966111-55e37942-fa27-11e7-8196-454c39979e2c.gif)





