### PR TITLE
QBtnToggle Support for a Text Toggle Color

### DIFF
--- a/dev/components/components/button-toggle.vue
+++ b/dev/components/components/button-toggle.vue
@@ -66,12 +66,34 @@
                   ]"
                 />
 
+                <!-- Pizza all dressed version to test all options. Empty colors are on purpose to test defaults -->
                 <q-btn-toggle v-model="model" toggle-color="primary"
                   :push="push" :flat="flat" :outline="outline" :glossy="glossy" :rounded="rounded" :size="size"
                   :options="[
-                    {label: 'One', value: 'one'},
-                    {label: 'Two', toggleColor: 'yellow', value: 'two'},
-                    {label: 'Three', toggleColor: 'red', value: 'three'}
+                    {label: 'One',
+                      color: 'green',
+                      textColor: '',
+                      toggleColor: 'blue',
+                      textToggleColor: 'yellow',
+                      icon: 'filter_1',
+                      iconRight: 'explore',
+                      value: 'one'},
+                    {label: 'Two',
+                      color: 'yellow',
+                      textColor: 'purple',
+                      toggleColor: 'teal',
+                      textToggleColor: '',
+                      icon: 'filter_2',
+                      iconRight: 'event',
+                      value: 'two'},
+                    {label: 'Three',
+                      color: '',
+                      textColor: 'red',
+                      toggleColor: 'red',
+                      textToggleColor: 'blue',
+                      icon: 'filter_3',
+                      iconRight: 'eject',
+                      value: 'three'}
                   ]"
                 />
               </div>

--- a/src/components/btn/QBtnToggle.js
+++ b/src/components/btn/QBtnToggle.js
@@ -7,12 +7,14 @@ export default {
     value: {
       required: true
     },
+    // To avoid seeing the active raise shadow through the transparent button, give it a color (even white).
     color: String,
     textColor: String,
     toggleColor: {
       type: String,
-      required: true
+      default: 'primary'
     },
+    textToggleColor: String,
     options: {
       type: Array,
       required: true,
@@ -64,8 +66,9 @@ export default {
         props: {
           disable: this.disable,
           label: opt.label,
+          // Colors come from the button specific options first, then from general props
           color: this.val[i] ? opt.toggleColor || this.toggleColor : opt.color || this.color,
-          textColor: opt.textColor || this.textColor,
+          textColor: this.val[i] ? opt.textToggleColor || this.textToggleColor : opt.textColor || this.textColor,
           icon: opt.icon,
           iconRight: opt.iconRight,
           noCaps: this.noCaps,


### PR DESCRIPTION
A text toggle color is required for the QBtnToggle to support certain scenarios, such as toggling from a "Yellow Button" & "Blue Text" to "Blue Button" & "Yellow Text".  In addition, the text toggle color can now be specified per button in the options array.  I also added the test cases.

![qbtntoggle-texttogglecolor](https://user-images.githubusercontent.com/29619229/34975211-c8da7dce-fa5e-11e7-8f45-1fcfd454e8a6.gif)
