### PR TITLE
QDateTime+QColor: Explicit Popover/Modal props and cleanup

### DIFF
--- a/dev/components/form/color-picker.vue
+++ b/dev/components/form/color-picker.vue
@@ -55,6 +55,11 @@
       <h4>Lazy Input</h4>
       <q-color :value="inputModelHex" @change="val => { inputModelHex = val; log('@change', val)}" @input="value => log('@input', value)" clearable />
       <q-color :value="inputModelRgb" @change="val => inputModelRgb = val" clearable />
+      
+      <h4>Explicit Popover or Modal</h4>
+      <q-color         v-model="inputModelRgb" float-label="RGB Default" />
+      <q-color popover v-model="inputModelRgb" float-label="RGB Popover" />
+      <q-color modal   v-model="inputModelRgb" float-label="RGB Modal" />
 
       <h4>Readonly</h4>
       <div class="row gutter-md" style="width: 550px">

--- a/dev/components/form/color-picker.vue
+++ b/dev/components/form/color-picker.vue
@@ -60,6 +60,7 @@
       <q-color         v-model="inputModelRgb" float-label="RGB Default" />
       <q-color popover v-model="inputModelRgb" float-label="RGB Popover" />
       <q-color modal   v-model="inputModelRgb" float-label="RGB Modal" />
+      <q-color modal   v-model="inputModelRgb" float-label="RGB Modal Readonly " readonly  />
 
       <h4>Readonly</h4>
       <div class="row gutter-md" style="width: 550px">

--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -81,6 +81,16 @@
       <q-datetime v-model="model" :default-selection="defaultSelection" type="datetime" />
       <q-datetime v-model="model" :default-selection="defaultSelection" type="time" />
 
+      <p class="caption">With explicit popover</p>
+      <q-datetime v-model="model" popover type="date"     float-label="Pick Date" />
+      <q-datetime v-model="model" popover type="time"     float-label="Pick Time" />
+      <q-datetime v-model="model" popover type="datetime" float-label="Pick DateTime" />
+      
+      <p class="caption">With explicit modal</p>
+      <q-datetime v-model="model" modal type="date"     float-label="Pick Date" />
+      <q-datetime v-model="model" modal type="time"     float-label="Pick Time" />
+      <q-datetime v-model="model" modal type="datetime" float-label="Pick DateTime" />
+      
       <p class="caption">With Label</p>
       <q-datetime v-model="model" type="date" label="Pick Date" />
 

--- a/src/components/color/QColor.js
+++ b/src/components/color/QColor.js
@@ -1,4 +1,5 @@
 import FrameMixin from '../../mixins/input-frame'
+import DisplayModeMixin from '../../mixins/display-mode'
 import extend from '../../utils/extend'
 import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
@@ -21,7 +22,7 @@ const contentCss = __THEME__ === 'ios'
 
 export default {
   name: 'q-color',
-  mixins: [FrameMixin],
+  mixins: [FrameMixin, DisplayModeMixin],
   props: {
     value: {
       required: true
@@ -43,7 +44,7 @@ export default {
     readonly: Boolean
   },
   data () {
-    let data = this.isPopover() ? {} : {
+    let data = this.isPopover ? {} : {
       transition: __THEME__ === 'ios' ? 'q-modal-bottom' : 'q-modal'
     }
     data.focused = false
@@ -51,9 +52,6 @@ export default {
     return data
   },
   computed: {
-    usingPopover () {
-      return this.isPopover()
-    },
     actualValue () {
       if (this.displayValue) {
         return this.displayValue
@@ -70,9 +68,6 @@ export default {
     }
   },
   methods: {
-    isPopover () {
-      return this.$q.platform.is.desktop && !this.$q.platform.within.iframe
-    },
     toggle () {
       this[this.$refs.popup.showing ? 'hide' : 'show']()
     },
@@ -121,13 +116,13 @@ export default {
     __onHide () {
       this.focused = false
       this.$emit('blur')
-      if (this.usingPopover && !this.$refs.popup.showing) {
+      if (this.isPopover && !this.$refs.popup.showing) {
         this.__update(true)
       }
     },
     __setModel (val, forceUpdate) {
       this.model = clone(val || this.defaultSelection)
-      if (forceUpdate || (this.usingPopover && this.$refs.popup.showing)) {
+      if (forceUpdate || (this.isPopover && this.$refs.popup.showing)) {
         this.__update()
       }
     },
@@ -197,6 +192,7 @@ export default {
     }
   },
   render (h) {
+    console.log('isPopover: ' + this.isPopover)
     return h(QInputFrame, {
       props: {
         prefix: this.prefix,
@@ -232,7 +228,7 @@ export default {
         }
       }),
 
-      this.usingPopover
+      this.isPopover
         ? h(QPopover, {
           ref: 'popup',
           props: {

--- a/src/components/color/QColor.js
+++ b/src/components/color/QColor.js
@@ -192,7 +192,6 @@ export default {
     }
   },
   render (h) {
-    console.log('isPopover: ' + this.isPopover)
     return h(QInputFrame, {
       props: {
         prefix: this.prefix,

--- a/src/components/datetime/datetime-mixin.js
+++ b/src/components/datetime/datetime-mixin.js
@@ -4,7 +4,8 @@ import {
   convertDateToFormat,
   getDateBetween,
   startOfDate,
-  isSameDate
+  isSameDate,
+  isValid
 } from '../../utils/date'
 
 export default {
@@ -12,7 +13,7 @@ export default {
   computed: {
     model: {
       get () {
-        let date = this.value === 0 || this.value
+        let date = isValid(this.value)
           ? new Date(this.value)
           : (this.defaultSelection ? new Date(this.defaultSelection) : startOfDate(new Date(), 'day'))
 

--- a/src/mixins/display-mode.js
+++ b/src/mixins/display-mode.js
@@ -5,7 +5,6 @@ export default {
   },
   computed: {
     isPopover () {
-      debugger
       // Explicit popover / modal choice
       if (this.popover) return true
       if (this.modal) return false

--- a/src/mixins/display-mode.js
+++ b/src/mixins/display-mode.js
@@ -1,0 +1,17 @@
+export default {
+  props: {
+    popover: Boolean,
+    modal: Boolean
+  },
+  computed: {
+    isPopover () {
+      debugger
+      // Explicit popover / modal choice
+      if (this.popover) return true
+      if (this.modal) return false
+
+      // Automatically determine the default popover or modal behavior
+      return this.$q.platform.is.desktop && !this.$q.platform.within.iframe
+    }
+  }
+}


### PR DESCRIPTION
This adds the flexibility to explicitly require a popover or modal QDateTime, thus overriding the default behavior when desired.

Minor cleanups included:
-Consolidated the isPopover/usingPopover into one computed property and made the reference to the global `this.$q.platform` variable reactive
-Replaced all the `this.value === 0 || this.value` with isValid from date utils.  This is cleaner, more general and avoids code duplication.

See the video below, the last part of the video is to show that the other scenarios continue working as is.

![qdatetime-explicitpopovermodal](https://user-images.githubusercontent.com/29619229/35069929-a39224da-fba9-11e7-8d6f-5090701651bb.gif)
