### PR TITLE
QColor Explicit Popover and Modal selection

### DIFF
--- a/dev/components/form/color-picker.vue
+++ b/dev/components/form/color-picker.vue
@@ -55,6 +55,11 @@
       <h4>Lazy Input</h4>
       <q-color :value="inputModelHex" @change="val => { inputModelHex = val; log('@change', val)}" @input="value => log('@input', value)" clearable />
       <q-color :value="inputModelRgb" @change="val => inputModelRgb = val" clearable />
+      
+      <h4>Explicit Popover or Modal</h4>
+      <q-color         v-model="inputModelRgb" float-label="RGB Default" />
+      <q-color popover v-model="inputModelRgb" float-label="RGB Popover" />
+      <q-color modal   v-model="inputModelRgb" float-label="RGB Modal" />
 
       <h4>Readonly</h4>
       <div class="row gutter-md" style="width: 550px">

--- a/src/components/color/QColor.js
+++ b/src/components/color/QColor.js
@@ -1,4 +1,5 @@
 import FrameMixin from '../../mixins/input-frame'
+import DisplayModeMixin from '../../mixins/display-mode'
 import extend from '../../utils/extend'
 import { QInputFrame } from '../input-frame'
 import { QPopover } from '../popover'
@@ -21,7 +22,7 @@ const contentCss = __THEME__ === 'ios'
 
 export default {
   name: 'q-color',
-  mixins: [FrameMixin],
+  mixins: [FrameMixin, DisplayModeMixin],
   props: {
     value: {
       required: true
@@ -43,7 +44,7 @@ export default {
     readonly: Boolean
   },
   data () {
-    let data = this.isPopover() ? {} : {
+    let data = this.isPopover ? {} : {
       transition: __THEME__ === 'ios' ? 'q-modal-bottom' : 'q-modal'
     }
     data.focused = false
@@ -51,9 +52,6 @@ export default {
     return data
   },
   computed: {
-    usingPopover () {
-      return this.isPopover()
-    },
     actualValue () {
       if (this.displayValue) {
         return this.displayValue
@@ -70,9 +68,6 @@ export default {
     }
   },
   methods: {
-    isPopover () {
-      return this.$q.platform.is.desktop && !this.$q.platform.within.iframe
-    },
     toggle () {
       this[this.$refs.popup.showing ? 'hide' : 'show']()
     },
@@ -121,13 +116,13 @@ export default {
     __onHide () {
       this.focused = false
       this.$emit('blur')
-      if (this.usingPopover && !this.$refs.popup.showing) {
+      if (this.isPopover && !this.$refs.popup.showing) {
         this.__update(true)
       }
     },
     __setModel (val, forceUpdate) {
       this.model = clone(val || this.defaultSelection)
-      if (forceUpdate || (this.usingPopover && this.$refs.popup.showing)) {
+      if (forceUpdate || (this.isPopover && this.$refs.popup.showing)) {
         this.__update()
       }
     },
@@ -197,6 +192,7 @@ export default {
     }
   },
   render (h) {
+    console.log('isPopover: ' + this.isPopover)
     return h(QInputFrame, {
       props: {
         prefix: this.prefix,
@@ -232,7 +228,7 @@ export default {
         }
       }),
 
-      this.usingPopover
+      this.isPopover
         ? h(QPopover, {
           ref: 'popup',
           props: {

--- a/src/mixins/display-mode.js
+++ b/src/mixins/display-mode.js
@@ -1,0 +1,17 @@
+export default {
+  props: {
+    popover: Boolean,
+    modal: Boolean
+  },
+  computed: {
+    isPopover () {
+      debugger
+      // Explicit popover / modal choice
+      if (this.popover) return true
+      if (this.modal) return false
+
+      // Automatically determine the default popover or modal behavior
+      return this.$q.platform.is.desktop && !this.$q.platform.within.iframe
+    }
+  }
+}


### PR DESCRIPTION
Here is a first pass and integrating the Explicit Popover and Modal selection to the QColor and having a general mixin.  I will do another pass later and do more tests.

However, I think in general, the QColor and QDateTime need to have their naming convention harmonized. At the moment, it is structured as follows, which is confusing.
QColor = QDateTimePicker
QColorPicker = QColor

But even further, they could each be just one component with three modes (inline, popover, modal).  

But I don't want to do that in this right now in this PR.  I will continue going thru the flexiblity features and then see later. 

