### PR TITLE
QChipsInput Custom Add Icons

### DIFF
--- a/dev/components/form/chips-input.vue
+++ b/dev/components/form/chips-input.vue
@@ -22,9 +22,9 @@
       </div>
 
       <p class="caption">Custom icons</p>
-      <q-chips-input v-model="model" icon="check" />
-      <q-chips-input v-model="model" icon="add" />
-      <q-chips-input v-model="model" icon="add_circle" />
+      <q-chips-input v-model="model" add-icon="check" />
+      <q-chips-input v-model="model" add-icon="add" />
+      <q-chips-input v-model="model" add-icon="add_circle" />
       
       <p class="caption">v-model.lazy</p>
       <q-chips-input :value="model" @change="value => { model = value; log('@change', value) }"/>

--- a/dev/components/form/chips-input.vue
+++ b/dev/components/form/chips-input.vue
@@ -21,6 +21,11 @@
         <q-chips-input dark color="amber" float-label="Float Label" v-model="model" placeholder="Some placeholder" />
       </div>
 
+      <p class="caption">Custom icons</p>
+      <q-chips-input v-model="model" icon="check" />
+      <q-chips-input v-model="model" icon="add" />
+      <q-chips-input v-model="model" icon="add_circle" />
+      
       <p class="caption">v-model.lazy</p>
       <q-chips-input :value="model" @change="value => { model = value; log('@change', value) }"/>
 

--- a/icons/ionicons.js
+++ b/icons/ionicons.js
@@ -49,7 +49,7 @@ export default {
     close: 'ion-ios-close'
   },
   chipsInput: {
-    addIcon: 'ion-android-send'
+    add: 'ion-android-send'
   },
   collapsible: {
     icon: 'ion-chevron-down'

--- a/icons/ionicons.js
+++ b/icons/ionicons.js
@@ -48,6 +48,9 @@ export default {
   chip: {
     close: 'ion-ios-close'
   },
+  chipsInput: {
+    add: 'ion-android-send'
+  },
   collapsible: {
     icon: 'ion-chevron-down'
   },

--- a/icons/ionicons.js
+++ b/icons/ionicons.js
@@ -49,7 +49,7 @@ export default {
     close: 'ion-ios-close'
   },
   chipsInput: {
-    add: 'ion-android-send'
+    addIcon: 'ion-android-send'
   },
   collapsible: {
     icon: 'ion-chevron-down'

--- a/icons/material.js
+++ b/icons/material.js
@@ -48,6 +48,9 @@ export default {
   chip: {
     close: 'cancel'
   },
+  chipsInput: {
+    add: 'send'
+  },
   collapsible: {
     icon: 'keyboard_arrow_down'
   },

--- a/src/components/chips-input/QChipsInput.vue
+++ b/src/components/chips-input/QChipsInput.vue
@@ -59,7 +59,7 @@
 
     <q-icon
       v-if="editable"
-      :name="icon"
+      :name="computedIcon"
       slot="after"
       class="q-if-control self-end"
       :class="{invisible: !input.length}"
@@ -90,10 +90,7 @@ export default {
     },
     frameColor: String,
     readonly: Boolean,
-    icon: {
-      type: String,
-      default: 'send'
-    }
+    icon: String // Default icon is send (computed propery computedIcon)
   },
   data () {
     return {
@@ -116,6 +113,11 @@ export default {
       return this.model
         ? this.model.length
         : 0
+    },
+    computedIcon () {
+      if (this.icon) return this.icon
+      // Default icon
+      return this.$q.icon.chipsInput.add
     }
   },
   methods: {

--- a/src/components/chips-input/QChipsInput.vue
+++ b/src/components/chips-input/QChipsInput.vue
@@ -59,7 +59,7 @@
 
     <q-icon
       v-if="editable"
-      name="send"
+      :name="icon"
       slot="after"
       class="q-if-control self-end"
       :class="{invisible: !input.length}"
@@ -89,7 +89,11 @@ export default {
       required: true
     },
     frameColor: String,
-    readonly: Boolean
+    readonly: Boolean,
+    icon: {
+      type: String,
+      default: 'send'
+    }
   },
   data () {
     return {

--- a/src/components/chips-input/QChipsInput.vue
+++ b/src/components/chips-input/QChipsInput.vue
@@ -59,7 +59,7 @@
 
     <q-icon
       v-if="editable"
-      :name="computedIcon"
+      :name="computedAddIcon"
       slot="after"
       class="q-if-control self-end"
       :class="{invisible: !input.length}"
@@ -90,7 +90,7 @@ export default {
     },
     frameColor: String,
     readonly: Boolean,
-    icon: String // Default icon is send (computed propery computedIcon)
+    addIcon: String
   },
   data () {
     return {
@@ -114,10 +114,8 @@ export default {
         ? this.model.length
         : 0
     },
-    computedIcon () {
-      if (this.icon) return this.icon
-      // Default icon
-      return this.$q.icon.chipsInput.add
+    computedAddIcon () {
+      return this.addIcon || this.$q.icon.chipsInput.add
     }
   },
   methods: {


### PR DESCRIPTION
Adds the flexibility to specify a custom icon for the add action at the far right.  See the video below.

![customicons](https://user-images.githubusercontent.com/29619229/35127446-35470c84-fc80-11e7-9ca4-64a026ef9c3e.gif)
