### PR TITLE
QBtn Active Effect Shadow Transition Fix

### DIFF
--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -26,20 +26,25 @@
   &.full-width
     border-radius 0 !important
 
-  &:active:not(.disabled):not(.q-btn-flat):not(.q-btn-outline):not(.q-btn-push):after
-    // This places the button active raise shadow behind adjacent elements
-    // Active raise shadow will still be visible under adjacent transparent elements, this is ok and coherent with a desired transparency effect.
-    // Visible active raise shadow can be removed by specifying a background color to the button
-    // Visible active raise shadow can be removed by specifying a flat or outline button type
-    content ''
-    position absolute
-    top 0
-    right 0
-    bottom 0
-    left 0
-    box-shadow $shadow-8
-    border-radius inherit
-    z-index -1
+  &:not(.disabled):not(.q-btn-flat):not(.q-btn-outline):not(.q-btn-push)
+    &:after
+      // This places the button active raise shadow behind adjacent elements
+      // Active raise shadow will still be visible under adjacent transparent elements, this is ok and coherent with a desired transparency effect.
+      // Visible active raise shadow can be removed by specifying a background color to the button
+      // Visible active raise shadow can be removed by specifying a flat or outline button type
+      content ''
+      position absolute
+      top 0
+      right 0
+      bottom 0
+      left 0
+      border-radius inherit
+      z-index -1
+      transition $button-transition
+    &:active:after
+      // Transitions on the creation of pseudoelements do not work
+      // pseudoelement must already exist, then the shadow is added when required.
+      box-shadow $shadow-8
 
 .q-btn-progress
   transition all .3s


### PR DESCRIPTION
QBtn Active Effect Shadow Transition Fix. See the video below.  The video was done with shadow-24 and 1s transition to make the effects easily visible. 

![qbtn-active-effect-transition-fix](https://user-images.githubusercontent.com/29619229/35201051-cddf177c-fee5-11e7-8d5a-be714cd68c3e.gif)
