### PR TITLE
QInput: unify watchers for textarea and autocomplete, add checks

### DIFF
--- a/dev/components/form/autocomplete.vue
+++ b/dev/components/form/autocomplete.vue
@@ -28,6 +28,10 @@
         <q-autocomplete @search="search" @selected="selected" />
       </q-input>
 
+      <q-input type="textarea" @change="onChange" @input="onInput" v-model="terms" placeholder="Start typing a country name" stack-label="Autocomplete in textarea">
+        <q-autocomplete @search="search" @selected="selected" />
+      </q-input>
+
       <q-input @change="val => { terms = val; onChange(val) }" @input="onInput" :value="terms" placeholder="Start typing a country name (onChange)">
         <q-autocomplete @search="search" @selected="selected" />
       </q-input>

--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -183,6 +183,9 @@ export default {
       this.timer = setTimeout(this.trigger, this.debounce)
     },
     __handleKeypress (e) {
+      if (!this.$refs.popover.showing) {
+        return
+      }
       switch (e.keyCode || e.which) {
         case 38: // up
           this.__moveCursor(-1, e)

--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -183,9 +183,6 @@ export default {
       this.timer = setTimeout(this.trigger, this.debounce)
     },
     __handleKeypress (e) {
-      if (!this.$refs.popover.showing) {
-        return
-      }
       switch (e.keyCode || e.which) {
         case 38: // up
           this.__moveCursor(-1, e)
@@ -194,8 +191,10 @@ export default {
           this.__moveCursor(1, e)
           break
         case 13: // enter
-          this.setCurrentSelection()
-          stopAndPrevent(e)
+          if (this.$refs.popover.showing) {
+            this.setCurrentSelection()
+            stopAndPrevent(e)
+          }
           break
         case 27: // escape
           this.__clearSearch()

--- a/src/components/chips-input/QChipsInput.vue
+++ b/src/components/chips-input/QChipsInput.vue
@@ -101,12 +101,7 @@ export default {
   },
   watch: {
     value (v) {
-      if (Array.isArray(v)) {
-        this.model = [...v]
-      }
-      else {
-        this.model = []
-      }
+      this.model = Array.isArray(v) ? [...v] : []
     }
   },
   computed: {

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -261,7 +261,7 @@ export default {
       this.focus()
       this.__set(val || (this.isNumber ? null : ''), true)
     },
-    __set (e, force) {
+    __set (e, forceUpdate) {
       let val = e && e.target ? e.target.value : e
 
       if (this.isNumber) {
@@ -269,7 +269,7 @@ export default {
         val = parseFloat(val)
         if (isNaN(val)) {
           this.isNumberError = true
-          if (force) {
+          if (forceUpdate) {
             this.$emit('input', forcedValue)
           }
           return
@@ -307,10 +307,10 @@ export default {
         this.watcher = this.$watch('model', this.__watcher)
       }
     },
-    __watcherUnregister (forced) {
+    __watcherUnregister (forceUnregister) {
       if (
         this.watcher &&
-        (forced || (!this.isTextarea && !this.shadow.watched))
+        (forceUnregister || (!this.isTextarea && !this.shadow.watched))
       ) {
         this.watcher()
         this.watcher = null


### PR DESCRIPTION
QInput:
- use a single point to register/unregister watcher (avoid multiple watchers)
- use a single watcher function
- add checks where missing
- now it can be used in textarea also

QAutocomplete:
- don't process keys when popup is not visible (allows working in textarea)