### PR TITLE
Increase height to stop letters from being cut off

### DIFF
--- a/src/components/input/input.ios.styl
+++ b/src/components/input/input.ios.styl
@@ -8,7 +8,7 @@
   padding 0
   color black
   background transparent
-  min-height 18px
+  min-height 22px
   font-size inherit
   overflow hidden
   resize none
@@ -25,7 +25,7 @@
     box-shadow inherit
 
 input.q-input-target
-  height 18px
+  height 22px
   outline 0
 .q-input-chips
   min-height 36px !important

--- a/src/components/input/input.mat.styl
+++ b/src/components/input/input.mat.styl
@@ -8,7 +8,7 @@
   padding 0
   color black
   background transparent
-  min-height 18px
+  min-height 22px
   font-size inherit
   overflow hidden
   resize none
@@ -25,7 +25,7 @@
     box-shadow inherit
 
 input.q-input-target
-  height 18px
+  height 22px
   outline 0
 .q-input-chips
   min-height 36px !important


### PR DESCRIPTION
Letters like "j" get their bottoms cut off if the height is only 18px. Change to 22px.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.
- [ ] It's been tested on a Electron app

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
