### PR TITLE
QModal no imposed value prop changes on route change fix #1502

### DIFF
--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -78,7 +78,8 @@ export default {
   },
   watch: {
     $route () {
-      this.hide()
+      // If value prop is provided, always respect it.  Therefore no hide on route change.
+      if (typeof this.value === 'undefined') this.hide()
     }
   },
   computed: {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -78,8 +78,9 @@ export default {
   },
   watch: {
     $route () {
-      // If value prop is provided, always respect it.  Therefore no hide on route change.
-      if (typeof this.value === 'undefined') this.hide()
+      if (this.value === void 0) {
+        this.hide()
+      }
     }
   },
   computed: {

--- a/src/mixins/model-toggle.js
+++ b/src/mixins/model-toggle.js
@@ -3,7 +3,10 @@ import History from '../plugins/history'
 
 export default {
   props: {
-    value: Boolean
+    value: {
+      type: Boolean,
+      default: undefined // Undefined required to identify when the value prop is not provided.  Undefined is falsly, so no impact
+    }
   },
   data () {
     return {

--- a/src/mixins/model-toggle.js
+++ b/src/mixins/model-toggle.js
@@ -3,10 +3,7 @@ import History from '../plugins/history'
 
 export default {
   props: {
-    value: {
-      type: Boolean,
-      default: undefined // Undefined required to identify when the value prop is not provided.  Undefined is falsly, so no impact
-    }
+    value: Boolean
   },
   data () {
     return {


### PR DESCRIPTION
As per issue #1502, route changes should not impose a v-model change. 

Another alternative would be to have a noRouteChangeDismiss option. 

Please advise.
