### PR TITLE
QModalLayout Parent-Child Check

### DIFF
--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -48,6 +48,11 @@ let openedModalNumber = 0
 export default {
   name: 'q-modal',
   mixins: [ModelToggleMixin],
+  provide () {
+    return {
+      modal: true
+    }
+  },
   props: {
     position: {
       type: String,

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -50,7 +50,7 @@ export default {
   mixins: [ModelToggleMixin],
   provide () {
     return {
-      modal: true
+      __qmodal: true
     }
   },
   props: {

--- a/src/components/modal/QModalLayout.js
+++ b/src/components/modal/QModalLayout.js
@@ -1,7 +1,7 @@
 export default {
   name: 'q-modal-layout',
   inject: {
-    modal: {
+    __qmodal: {
       default () {
         console.error('QModalLayout needs to be child of QModal')
       }

--- a/src/components/modal/QModalLayout.js
+++ b/src/components/modal/QModalLayout.js
@@ -1,5 +1,12 @@
 export default {
   name: 'q-modal-layout',
+  inject: {
+    modal: {
+      default () {
+        console.error('QModalLayout needs to be child of QModal')
+      }
+    }
+  },
   props: {
     headerStyle: [String, Object, Array],
     headerClass: [String, Object, Array],


### PR DESCRIPTION
This adds a check to ensure that QModalLayout is a child of QModal.

Here is a video of some tests performed after the change to validated that there were not side effects.

![parentchildcheck-tests](https://user-images.githubusercontent.com/29619229/35475812-6eac16a0-0373-11e8-81d7-8d43c19957d2.gif)
