### PR TITLE
[Feature] Implement q-btn sided icons - closes #1509

### DIFF
--- a/src/components/btn/btn-default.ios.styl
+++ b/src/components/btn/btn-default.ios.styl
@@ -19,6 +19,18 @@
 
   &.disabled
     opacity .7 !important
+  &.left-most-icon
+    .q-btn-inner
+      padding-left 2em
+    .q-icon
+      position absolute
+      left .5em
+  &.right-most-icon
+    .q-btn-inner
+      padding-right 2em
+    .q-icon
+      position absolute
+      right .5em
 
 .q-btn-progress
   transition all .3s

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -42,6 +42,18 @@
       // Transitions on the creation of pseudoelements do not work
       // pseudoelement must already exist, then the shadow is added when required.
       box-shadow $shadow-8
+  &.left-most-icon
+    .q-btn-inner
+      padding-left 2em
+    .q-icon
+      position absolute
+      left .5em
+  &.right-most-icon
+    .q-btn-inner
+      padding-right 2em
+    .q-icon
+      position absolute
+      right .5em
 
 .q-btn-progress
   transition all .3s

--- a/src/components/btn/btn-mixin.js
+++ b/src/components/btn/btn-mixin.js
@@ -20,6 +20,7 @@ export default {
     noCaps: Boolean,
     noWrap: Boolean,
     icon: String,
+    iconRight: String,
     iconSide: String,
     round: Boolean,
     outline: Boolean,

--- a/src/components/btn/btn-mixin.js
+++ b/src/components/btn/btn-mixin.js
@@ -20,7 +20,7 @@ export default {
     noCaps: Boolean,
     noWrap: Boolean,
     icon: String,
-    iconRight: String,
+    iconSide: String,
     round: Boolean,
     outline: Boolean,
     flat: Boolean,
@@ -97,6 +97,13 @@ export default {
       }
       else if (this.textColor) {
         cls.push(`text-${this.textColor}`)
+      }
+
+      if (this.iconSide === 'left') {
+        cls.push('left-most-icon')
+      }
+      else if (this.iconSide === 'right') {
+        cls.push('right-most-icon')
       }
 
       cls.push({


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Code example

```html
  <q-btn icon="person" icon-side="left">Some centered text</q-btn>
```

Demo: 
![https://i.imgur.com/yWnMJoB.png](https://i.imgur.com/yWnMJoB.png)

See the issue here #1509 

Don't mind on closing the PR if you don't accept the changes, it took few minutes anyway :) 
But if that's not the case, then documentation may need to get updated.