### PR TITLE
QTable did not have a global background color css variable

### DIFF
--- a/dev/components/components/data-table.vue
+++ b/dev/components/components/data-table.vue
@@ -38,8 +38,6 @@
       <h2>NO templates</h2>
       <q-table
         dark
-        class="bg-black"
-        color="grey-3"
         :separator="separator"
         :data="data"
         :columns="columns"

--- a/dev/components/components/data-table2.vue
+++ b/dev/components/components/data-table2.vue
@@ -33,8 +33,6 @@
     <h4>Dark</h4>
     <q-table
       dark
-      class="bg-grey-10"
-      color="grey-3"
       :data="data"
       :columns="columns"
       title="Client side"

--- a/src/components/table/table.mat.styl
+++ b/src/components/table/table.mat.styl
@@ -2,7 +2,7 @@
   border-radius $table-border-radius
   box-shadow $table-box-shadow
   position relative
-  background white
+  background $table-background
 
 .q-table-top
   min-height 64px
@@ -176,6 +176,7 @@ table-dense()
  * On dark background
  */
 .q-table-dark
+  background $table-dark-background
   color $table-dark-color
 
   .q-table-bottom, .q-table-top

--- a/src/css/variables.ios.styl
+++ b/src/css/variables.ios.styl
@@ -122,12 +122,14 @@ $table-border-radius            ?= $generic-border-radius
 $table-box-shadow               ?= $shadow-2
 
 $table-border-color             ?= rgba(0, 0, 0, .12)
+$table-background               ?= white
 $table-color                    ?= rgba(0, 0, 0, .87)
 $table-header-color             ?= rgba(0, 0, 0, .54)
 $table-hover-background         ?= rgba(0, 0, 0, .03)
 $table-selected-background      ?= rgba(0, 0, 0, .06)
 
 $table-dark-border-color        ?= rgba(255, 255, 255, .12)
+$table-dark-background          ?= $grey-10
 $table-dark-color               ?= white
 $table-dark-header-color        ?= rgba(255, 255, 255, .64)
 $table-dark-hover-background    ?= rgba(255, 255, 255, .1)

--- a/src/css/variables.mat.styl
+++ b/src/css/variables.mat.styl
@@ -124,16 +124,19 @@ $table-border-radius            ?= $generic-border-radius
 $table-box-shadow               ?= $shadow-2
 
 $table-border-color             ?= rgba(0, 0, 0, .12)
+$table-background               ?= white
 $table-color                    ?= rgba(0, 0, 0, .87)
 $table-header-color             ?= rgba(0, 0, 0, .54)
 $table-hover-background         ?= rgba(0, 0, 0, .03)
 $table-selected-background      ?= rgba(0, 0, 0, .06)
 
 $table-dark-border-color        ?= rgba(255, 255, 255, .12)
-$table-dark-color               ?= white
+$table-dark-background          ?= $grey-10
+$table-dark-color               ?= $grey-3
 $table-dark-header-color        ?= rgba(255, 255, 255, .64)
 $table-dark-hover-background    ?= rgba(255, 255, 255, .1)
 $table-dark-selected-background ?= rgba(255, 255, 255, .2)
+
 
 $input-frame-transition ?= all .45s cubic-bezier(.23, 1, .32, 1)
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

There were not variable `$table-background` and `$table-dark-background ` in `variables.***.styl`. The table's background color was hardcoded to `white`. To simply theme/color customizing, those variables has been added.
