### PR TITLE
Workaround for QBtn repeat on devices with touch and mouse

### DIFF
--- a/src/components/pagination/QPagination.js
+++ b/src/components/pagination/QPagination.js
@@ -114,7 +114,7 @@ export default {
       this.newPage = null
     },
     __getRepeatEasing (from = 300, step = 10, to = 100) {
-      return (cnt) => cnt ? Math.max(to, from - cnt * cnt * step) : 100
+      return cnt => cnt ? Math.max(to, from - cnt * cnt * step) : 100
     },
     __getBool (val, otherwise) {
       return [true, false].includes(val)


### PR DESCRIPTION
- On devices with both touch and mouse the events were doubled.
- Also perform disable checks on trigger execution