### PR TITLE
Fix CSS autofill in Chrome due to change in behavior

### DIFF
--- a/src/components/input/input.ios.styl
+++ b/src/components/input/input.ios.styl
@@ -1,4 +1,4 @@
-@-webkit-keyframes autofill
+@-webkit-keyframes webkit-autofill, @keyframes webkit-autofill
   to
     background transparent
 
@@ -14,7 +14,7 @@
   display flex
   align-items center
   &:-webkit-autofill
-    -webkit-animation-name autofill
+    -webkit-animation-name webkit-autofill
     -webkit-animation-fill-mode both
   &::-ms-clear, &::-ms-reveal
     display none

--- a/src/components/input/input.mat.styl
+++ b/src/components/input/input.mat.styl
@@ -1,4 +1,4 @@
-@-webkit-keyframes autofill
+@-webkit-keyframes webkit-autofill, @keyframes webkit-autofill
   to
     background transparent
 
@@ -14,7 +14,7 @@
   display flex
   align-items center
   &:-webkit-autofill
-    -webkit-animation-name autofill
+    -webkit-animation-name webkit-autofill
     -webkit-animation-fill-mode both
   &::-ms-clear, &::-ms-reveal
     display none


### PR DESCRIPTION
It looks like the new versions of Chrome do not accept @-webkit-keyframes any more (I just observed it in v65.0...)
This adds a normal @keyframes and scopes the name of the animation to avoid overlaps