### PR TITLE
Auto size q-input-target, add group to select, misc fixes

### DIFF
--- a/dev/components/form/all.vue
+++ b/dev/components/form/all.vue
@@ -52,6 +52,12 @@
         </form>
 
         <p class="q-subtitle">Country selected: {{ JSON.stringify(terms) }}</p>
+        <q-search :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :clearable="clearable" class="q-ma-sm" @focus="onFocus" @blur="onBlur" @change="onChange" @input="onInput" @clear="onClear" v-model="terms" placeholder="Start typing a country name - search">
+          <q-autocomplete :static-data="{field: 'value', list: countries}" @selected="selected" />
+        </q-search>
+        <q-search :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" inverted :clearable="clearable" class="q-ma-sm" @focus="onFocus" @blur="onBlur" @change="onChange" @input="onInput" @clear="onClear" v-model="terms" placeholder="Start typing a country name - search">
+          <q-autocomplete :static-data="{field: 'value', list: countries}" @selected="selected" />
+        </q-search>
         <q-search :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :clearable="clearable" class="q-ma-sm" @focus="onFocus" @blur="onBlur" @change="onChange" @input="onInput" @clear="onClear" v-model="terms" float-label="Start typing a country name - search">
           <q-autocomplete :static-data="{field: 'value', list: countries}" @selected="selected" />
         </q-search>
@@ -412,6 +418,29 @@ function randomIcon () {
   return v >= 30 ? icons[v - 30] : null
 }
 
+let prevFirstLetter
+const countriesList = countries.reduce((acc, country, i) => {
+  if (prevFirstLetter !== country[0]) {
+    prevFirstLetter = country[0].toUpperCase()
+    const t = `Countries starting with "${prevFirstLetter}"`
+    acc.push({
+      label: t,
+      group: true,
+      disable: true,
+      color: 'primary',
+      rightIcon: randomIcon()
+    })
+  }
+  acc.push({
+    label: country,
+    value: country,
+    color: randomColor(),
+    rightIcon: randomIcon(),
+    disable: !i || Math.random() > 0.9
+  })
+  return acc
+}, [])
+
 export default {
   data () {
     return {
@@ -445,7 +474,7 @@ export default {
       maxVal: 6,
       step: 0.01,
       decimals: 1,
-      countries: countries.slice(0, 40).map(country => ({ label: country, value: country, color: randomColor(), rightIcon: randomIcon() })),
+      countries: countriesList,
       numbers: [1, 2, 3, 4, 5, 1111, 2222, 3333, 4444, 5555].map(v => ({ label: String(v), value: v }))
     }
   },

--- a/dev/components/form/size-test.vue
+++ b/dev/components/form/size-test.vue
@@ -60,6 +60,17 @@
       </div>
 
       <p class="caption">Items Baseline</p>
+      <div class="row no-wrap gutter-sm size-test-example-base items-baseline" style="width: 100%">
+        <div class="col-auto">Text</div>
+        <div class="col"><q-input v-model="text" clearable /></div>
+        <div class="col"><q-select v-model="select" :options="selectOptions" clearable /></div>
+        <div class="col"><q-search v-model="text" clearable /></div>
+        <div class="col"><q-search stack-label="Label" v-model="text" clearable /></div>
+        <div class="col"><q-search hide-underline v-model="text" clearable /></div>
+        <div class="col"><q-datetime type="datetime" v-model="date" clearable /></div>
+        <div class="self-end"><q-btn color="primary" size="form-sm" outline label="Button" /></div>
+        <div class="self-end"><q-btn color="primary" size="form-sm" flat label="Button" /></div>
+      </div>
       <div class="row no-wrap gutter-sm size-test-example-base items-baseline">
         <div>Text</div>
         <div><q-input v-model="text" clearable /></div>

--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -98,7 +98,7 @@ export default {
         this.results = this.filter(terms, this.staticData)
         const popover = this.$refs.popover
         if (this.results.length) {
-          this.__keyboardShow(this.$q.platform.is.desktop ? 0 : -1)
+          this.__keyboardShow(-1)
           if (popover.showing) {
             popover.reposition()
           }
@@ -122,7 +122,7 @@ export default {
 
         if (Array.isArray(results) && results.length > 0) {
           this.results = results
-          this.__keyboardShow(this.$q.platform.is.desktop ? 0 : -1)
+          this.__keyboardShow(-1)
           this.$refs.popover.show()
           return
         }
@@ -152,6 +152,9 @@ export default {
     },
     __keyboardShowTrigger () {
       this.trigger()
+    },
+    __keyboardIsSelectableIndex (index) {
+      return index > -1 && index < this.computedResults.length && !this.computedResults[index].disable
     },
     setValue (result) {
       const value = this.staticData ? result[this.staticData.field] : result.value
@@ -232,7 +235,8 @@ export default {
         key: result.id || JSON.stringify(result),
         'class': {
           active: this.keyboardIndex === index,
-          'cursor-pointer': !result.disable
+          'cursor-pointer': !result.disable,
+          'text-faded': result.disable
         },
         props: { cfg: result },
         nativeOn: {

--- a/src/components/chips-input/QChipsInput.vue
+++ b/src/components/chips-input/QChipsInput.vue
@@ -41,22 +41,25 @@
         {{ label }}
       </q-chip>
 
-      <input
-        ref="input"
-        class="col q-input-target"
-        :class="alignClass"
-        v-model="input"
+      <div class="col q-input-target-wrapper">
+        <input
+          ref="input"
+          class="col q-input-target"
+          :class="alignClass"
+          v-model="input"
 
-        :placeholder="inputPlaceholder"
-        :disabled="disable"
-        :readonly="readonly"
-        v-bind="$attrs"
+          :placeholder="inputPlaceholder"
+          :disabled="disable"
+          :readonly="readonly"
+          v-bind="$attrs"
 
-        @focus="__onFocus"
-        @blur="__onInputBlur"
-        @keydown="__handleKeyDown"
-        @keyup="__onKeyup"
-      />
+          @focus="__onFocus"
+          @blur="__onInputBlur"
+          @keydown="__handleKeyDown"
+          @keyup="__onKeyup"
+        />
+        <div>{{inputTargetText}}</div>
+      </div>
     </div>
 
     <q-icon
@@ -79,6 +82,10 @@ import { QInputFrame } from '../input-frame'
 import { QChip } from '../chip'
 import { getEventKey, stopAndPrevent } from '../../utils/event'
 
+function uniqueValues (value) {
+  return Array.isArray(value) ? [...new Set(value)] : []
+}
+
 export default {
   name: 'q-chips-input',
   mixins: [FrameMixin, InputMixin],
@@ -99,15 +106,18 @@ export default {
   data () {
     return {
       input: '',
-      model: [...this.value]
+      model: uniqueValues(this.value)
     }
   },
   watch: {
     value (v) {
-      this.model = Array.isArray(v) ? [...v] : []
+      this.model = uniqueValues(v)
     }
   },
   computed: {
+    inputTargetText () {
+      return this.input || this.input === 0 ? this.input : this.inputPlaceholder || ' '
+    },
     length () {
       return this.model
         ? this.model.length
@@ -149,7 +159,7 @@ export default {
     add (value = this.input) {
       clearTimeout(this.timer)
       this.focus()
-      if (this.editable && value) {
+      if (this.editable && value && this.model.indexOf(value) === -1) {
         this.model.push(value)
         this.$emit('input', this.model)
         this.input = ''

--- a/src/components/color/QColor.js
+++ b/src/components/color/QColor.js
@@ -223,17 +223,20 @@ export default {
         keydown: this.__handleKeyDown
       }
     }, [
-      h('input', {
-        staticClass: 'col q-input-target cursor-inherit non-selectable no-pointer-events',
-        'class': this.alignClass,
-        attrs: {
-          value: this.actualValue,
-          placeholder: this.inputPlaceholder,
-          readonly: true,
-          disabled: this.disable,
-          tabindex: -1
-        }
-      }),
+      h('div', { staticClass: 'col q-input-target-wrapper' }, [
+        h('input', {
+          staticClass: 'col q-input-target cursor-inherit non-selectable no-pointer-events',
+          'class': this.alignClass,
+          attrs: {
+            value: this.actualValue,
+            placeholder: this.inputPlaceholder,
+            readonly: true,
+            disabled: this.disable,
+            tabindex: -1
+          }
+        }),
+        h('div', [this.actualValue || this.actualValue === 0 ? this.actualValue : this.inputPlaceholder || ' '])
+      ]),
 
       this.isPopover
         ? h(QPopover, {

--- a/src/components/color/color.ios.styl
+++ b/src/components/color/color.ios.styl
@@ -23,7 +23,7 @@
   border-radius 50%
   transform translate(-5px, -5px)
 
-.q-color-swatch:after, .q-color-alpha .q-slider-track
+.q-color-swatch, .q-color-alpha .q-slider-track
   background-image url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAH0lEQVQoU2NkYGAwZkAFZ5G5jPRRgOYEVDeB3EBjBQBOZwTVugIGyAAAAABJRU5ErkJggg==') !important
 
 .q-color-swatch
@@ -39,7 +39,7 @@
     top 0
     bottom 0
     border-radius $generic-border-radius
-    z-index -1
+    background-color inherit
 
 .q-color-hue .q-slider-track
   border-radius 2px

--- a/src/components/color/color.mat.styl
+++ b/src/components/color/color.mat.styl
@@ -23,7 +23,7 @@
   border-radius 50%
   transform translate(-5px, -5px)
 
-.q-color-swatch:after, .q-color-alpha .q-slider-track
+.q-color-swatch, .q-color-alpha .q-slider-track
   background-image url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAH0lEQVQoU2NkYGAwZkAFZ5G5jPRRgOYEVDeB3EBjBQBOZwTVugIGyAAAAABJRU5ErkJggg==') !important
 
 .q-color-swatch
@@ -39,7 +39,7 @@
     top 0
     bottom 0
     border-radius $generic-border-radius
-    z-index -1
+    background-color inherit
 
 .q-color-hue .q-slider-track
   border-radius 2px

--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -242,17 +242,20 @@ export default {
         keydown: this.__handleKeyDown
       }
     }, [
-      h('input', {
-        staticClass: 'col q-input-target cursor-inherit non-selectable no-pointer-events',
-        'class': this.alignClass,
-        attrs: {
-          value: this.actualValue,
-          placeholder: this.inputPlaceholder,
-          readonly: true,
-          disabled: this.disable,
-          tabindex: -1
-        }
-      }),
+      h('div', { staticClass: 'col q-input-target-wrapper' }, [
+        h('input', {
+          staticClass: 'col q-input-target cursor-inherit non-selectable no-pointer-events',
+          'class': this.alignClass,
+          attrs: {
+            value: this.actualValue,
+            placeholder: this.inputPlaceholder,
+            readonly: true,
+            disabled: this.disable,
+            tabindex: -1
+          }
+        }),
+        h('div', [this.actualValue || this.actualValue === 0 ? this.actualValue : this.inputPlaceholder || ' '])
+      ]),
 
       this.isPopover
         ? h(QPopover, {

--- a/src/components/input-frame/input-frame.ios.styl
+++ b/src/components/input-frame/input-frame.ios.styl
@@ -135,3 +135,17 @@
     background-position bottom
     background-size 3px 1px
     background-repeat repeat-x
+
+.q-input-target-wrapper
+  overflow hidden
+  position relative
+  & > div
+    white-space pre
+    height 19px
+    padding-right 1em
+    color transparent
+  & > .q-input-target
+    position absolute
+    left 0
+    right 0
+    width 100%

--- a/src/components/input-frame/input-frame.mat.styl
+++ b/src/components/input-frame/input-frame.mat.styl
@@ -135,3 +135,17 @@
     background-position bottom
     background-size 3px 1px
     background-repeat repeat-x
+
+.q-input-target-wrapper
+  overflow hidden
+  position relative
+  & > div
+    white-space pre
+    height 19px
+    padding-right 1em
+    color transparent
+  & > .q-input-target
+    position absolute
+    left 0
+    right 0
+    width 100%

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -56,29 +56,31 @@
       </div>
     </template>
 
-    <input
-      v-else
-      ref="input"
-      class="col q-input-target q-no-input-spinner"
-      :class="inputClasses"
+    <div class="col q-input-target-wrapper" v-else>
+      <input
+        ref="input"
+        class="col q-input-target q-no-input-spinner"
+        :class="inputClasses"
 
-      :placeholder="inputPlaceholder"
-      :disabled="disable"
-      :readonly="readonly"
-      :step="computedStep"
-      v-bind="$attrs"
+        :placeholder="inputPlaceholder"
+        :disabled="disable"
+        :readonly="readonly"
+        :step="computedStep"
+        v-bind="$attrs"
 
-      :type="inputType"
-      :value="model"
-      @input="__set"
+        :type="inputType"
+        :value="model"
+        @input="__set"
 
-      @focus="__onFocus"
-      @blur="__onInputBlur"
-      @keydown="__onKeydown"
-      @keyup="__onKeyup"
+        @focus="__onFocus"
+        @blur="__onInputBlur"
+        @keydown="__onKeydown"
+        @keyup="__onKeyup"
 
-      @animationstart="__onAnimationStart"
-    />
+        @animationstart="__onAnimationStart"
+      />
+      <div>{{inputTargetText}}</div>
+    </div>
 
     <q-icon
       v-if="!disable && isPassword && !noPassToggle && length"
@@ -208,6 +210,9 @@ export default {
     },
     isLoading () {
       return this.loading || this.shadow.loading
+    },
+    inputTargetText () {
+      return this.model || this.model === 0 ? this.model : this.inputPlaceholder || ' '
     },
     pattern () {
       if (this.isNumber) {

--- a/src/components/pagination/QPagination.js
+++ b/src/components/pagination/QPagination.js
@@ -187,10 +187,7 @@ export default {
 
     if (this.input) {
       contentMiddle.push(h(QInput, {
-        staticClass: 'inline no-padding',
-        style: {
-          width: `${this.inputPlaceholder.length}rem`
-        },
+        staticClass: 'inline',
         props: {
           type: 'number',
           value: this.newPage,

--- a/src/components/pagination/pagination.ios.styl
+++ b/src/components/pagination/pagination.ios.styl
@@ -5,3 +5,5 @@
     padding 0 5px !important
     &.disabled
       color $faded
+  .q-if-hide-underline
+    margin-bottom -8px

--- a/src/components/pagination/pagination.mat.styl
+++ b/src/components/pagination/pagination.mat.styl
@@ -5,3 +5,5 @@
     padding 0 5px !important
     &.disabled
       color $faded
+  .q-if-hide-underline
+    margin-bottom -8px

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -57,12 +57,12 @@ export default {
   },
   render (h) {
     return h('div', {
-      staticClass: 'q-popover animate-popup scroll',
+      staticClass: 'q-popover animate-popup',
       on: {
         click (e) { e.stopPropagation() }
       }
     }, [
-      h('div', [
+      h('div', { staticClass: 'column no-wrap scroll' }, [
         this.$slots.default
       ])
     ])
@@ -98,7 +98,7 @@ export default {
       this.scrollTarget = getScrollTarget(this.anchorEl)
       this.scrollTarget.addEventListener('scroll', this.__updatePosition, listenOpts.passive)
       window.addEventListener('resize', this.__updatePosition, listenOpts.passive)
-      this.reposition(evt)
+      this.reposition(evt, true)
 
       clearTimeout(this.timer)
       this.timer = setTimeout(() => {
@@ -129,7 +129,7 @@ export default {
       document.body.removeChild(this.$el)
       this.hidePromise && this.hidePromiseResolve()
     },
-    reposition (event) {
+    reposition (event, setClass) {
       this.$nextTick(() => {
         if (this.fit) {
           this.$el.style.minWidth = width(this.anchorEl) + 'px'
@@ -139,7 +139,7 @@ export default {
         if (top < 0 || top > height) {
           return this.hide()
         }
-        setPosition({
+        const direction = setPosition({
           event,
           el: this.$el,
           offset: this.offset,
@@ -150,6 +150,9 @@ export default {
           anchorClick: this.anchorClick,
           touchPosition: this.touchPosition
         })
+        if (setClass) {
+          this.$el.classList[direction === 'up' ? 'add' : 'remove']('animate-popup-up')
+        }
       })
     }
   }

--- a/src/components/popover/popover.ios.styl
+++ b/src/components/popover/popover.ios.styl
@@ -1,10 +1,9 @@
 .q-popover
   position fixed
-  box-shadow $popover-box-shadow
   background $popover-background
   z-index $z-popover
-  overflow-y auto
-  overflow-x hidden
   max-width $popover-max-width
-  > div > .q-list:only-child
-    border none
+  > div
+    box-shadow $popover-box-shadow
+    > .q-list:only-child
+      border none

--- a/src/components/popover/popover.mat.styl
+++ b/src/components/popover/popover.mat.styl
@@ -1,10 +1,9 @@
 .q-popover
   position fixed
-  box-shadow $popover-box-shadow
   background $popover-background
   z-index $z-popover
-  overflow-y auto
-  overflow-x hidden
   max-width $popover-max-width
-  > div > .q-list:only-child
-    border none
+  > div
+    box-shadow $popover-box-shadow
+    > .q-list:only-child
+      border none

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -50,16 +50,18 @@
       </q-chip>
     </div>
 
-    <input
-      v-else
-      class="col q-input-target cursor-inherit non-selectable no-pointer-events"
-      :class="alignClass"
-      :value="actualValue"
-      :placeholder="inputPlaceholder"
-      readonly
-      :disabled="this.disable"
-      tabindex="-1"
-    />
+    <div class="col q-input-target-wrapper" v-else>
+      <input
+        class="q-input-target cursor-inherit non-selectable no-pointer-events"
+        :class="alignClass"
+        :value="actualValue"
+        :placeholder="inputPlaceholder"
+        readonly
+        :disabled="this.disable"
+        tabindex="-1"
+      />
+      <div>{{inputTargetText}}</div>
+    </div>
 
     <q-icon
       v-if="!disable && !readonly && clearable && length"
@@ -92,7 +94,7 @@
         :dark="dark"
         no-parent-field
         icon="filter_list"
-        style="min-height: 50px; padding: 10px;"
+        style="min-height: 50px; padding: 13px 10px;"
       />
 
       <q-list
@@ -105,35 +107,37 @@
             v-for="(opt, index) in visibleOptions"
             :key="JSON.stringify(opt)"
             :cfg="opt"
-            :link="!opt.disable"
+            :link="!opt.disable && !opt.group"
             :class="[
-              opt.disable ? 'text-faded' : 'cursor-pointer',
+              opt.group ? `text-${opt.color}` : (opt.disable ? 'text-faded' : 'cursor-pointer'),
               index === keyboardIndex ? 'q-select-highlight' : ''
             ]"
             slot-replace
-            @click.capture.native="__toggleMultiple(opt.value, opt.disable)"
-            @mouseenter.native="e => !opt.disable && __mouseEnterHandler(e, index)"
+            @click.capture.native="__toggleMultiple(opt.value, opt.disable || opt.group)"
+            @mouseenter.native="e => !opt.disable && !opt.group && __mouseEnterHandler(e, index)"
           >
-            <q-toggle
-              v-if="toggle"
-              slot="right"
-              keep-color
-              :color="opt.color || color"
-              :dark="dark"
-              :value="optModel[opt.index]"
-              :disable="opt.disable"
-              no-focus
-            />
-            <q-checkbox
-              v-else
-              slot="left"
-              keep-color
-              :color="opt.color || color"
-              :dark="dark"
-              :value="optModel[opt.index]"
-              :disable="opt.disable"
-              no-focus
-            />
+            <template v-if="!opt.group">
+              <q-toggle
+                v-if="toggle"
+                slot="right"
+                keep-color
+                :color="opt.color || color"
+                :dark="dark"
+                :value="optModel[opt.index]"
+                :disable="opt.disable"
+                no-focus
+              />
+              <q-checkbox
+                v-else
+                slot="left"
+                keep-color
+                :color="opt.color || color"
+                :dark="dark"
+                :value="optModel[opt.index]"
+                :disable="opt.disable"
+                no-focus
+              />
+            </template>
           </q-item-wrapper>
         </template>
         <template v-else>
@@ -143,16 +147,16 @@
             :cfg="opt"
             :link="!opt.disable"
             :class="[
-              opt.disable ? 'text-faded' : 'cursor-pointer',
+              opt.group ? `text-${opt.color}` : (opt.disable ? 'text-faded' : 'cursor-pointer'),
               index === keyboardIndex ? 'q-select-highlight' : ''
             ]"
             slot-replace
             :active="value === opt.value"
-            @click.capture.native="__singleSelect(opt.value, opt.disable)"
-            @mouseenter.native="e => !opt.disable && __mouseEnterHandler(e, index)"
+            @click.capture.native="__singleSelect(opt.value, opt.disable || opt.group)"
+            @mouseenter.native="e => !opt.disable && !opt.group && __mouseEnterHandler(e, index)"
           >
             <q-radio
-              v-if="radio"
+              v-if="radio && !opt.group"
               keep-color
               :color="opt.color || color"
               slot="left"
@@ -216,7 +220,7 @@ export default {
     options: {
       type: Array,
       required: true,
-      validator: v => v.every(o => 'label' in o && 'value' in o)
+      validator: v => v.every(o => 'label' in o && ('value' in o || o.group))
     },
     chipsColor: String,
     chipsBgColor: String,
@@ -292,6 +296,9 @@ export default {
       const opt = this.selectedOptions.map(opt => opt.label)
       return opt.length ? opt.join(', ') : ''
     },
+    inputTargetText () {
+      return this.actualValue || this.actualValue === 0 ? this.actualValue : this.inputPlaceholder || ' '
+    },
     selectedOptions () {
       if (this.multiple) {
         return this.length > 0
@@ -330,10 +337,16 @@ export default {
     },
 
     __keyboardCalcIndex () {
-      this.keyboardMoveDirection = true
       this.keyboardIndex = -1
       const sel = this.multiple ? this.selectedOptions.map(o => o.value) : [this.model]
-      this.$nextTick(() => this.__keyboardShow(sel === void 0 ? 0 : Math.max(0, this.visibleOptions.findIndex(opt => sel.includes(opt.value)))))
+      this.$nextTick(() => {
+        const index = sel === void 0 ? -1 : Math.max(-1, this.visibleOptions.findIndex(opt => sel.includes(opt.value)))
+        if (index > -1) {
+          this.keyboardMoveDirection = true
+          setTimeout(() => { this.keyboardMoveDirection = false }, 500)
+        }
+        this.__keyboardShow(index)
+      })
     },
     __keyboardCustomKeyHandle (key, e) {
       switch (key) {
@@ -352,14 +365,14 @@ export default {
       const opt = this.visibleOptions[index]
 
       if (this.multiple) {
-        this.__toggleMultiple(opt.value, opt.disable)
+        this.__toggleMultiple(opt.value, opt.disable || opt.group)
       }
       else {
-        this.__singleSelect(opt.value, opt.disable)
+        this.__singleSelect(opt.value, opt.disable || opt.group)
       }
     },
     __keyboardIsSelectableIndex (index) {
-      return index > -1 && index < this.visibleOptions.length && !this.visibleOptions[index].disable
+      return index > -1 && index < this.visibleOptions.length && !this.visibleOptions[index].disable && !this.visibleOptions[index].group
     },
     __mouseEnterHandler (e, index) {
       if (!this.keyboardMoveDirection) {

--- a/src/components/table/QTable.js
+++ b/src/components/table/QTable.js
@@ -67,7 +67,7 @@ export default {
     }
   },
   computed: {
-    computedRows () {
+    filteredRows () {
       let rows = this.data.slice().map((row, i) => {
         row.__index = i
         return row
@@ -80,7 +80,7 @@ export default {
         return rows
       }
 
-      const { sortBy, descending, rowsPerPage } = this.computedPagination
+      const { sortBy, descending } = this.computedPagination
 
       if (this.hasFilter) {
         rows = this.filterMethod(rows, this.filter, this.computedCols, this.getCellValue)
@@ -90,16 +90,21 @@ export default {
         rows = this.sortMethod(rows, sortBy, descending)
       }
 
-      if (rowsPerPage) {
-        rows = rows.slice(this.firstRowIndex, this.lastRowIndex)
+      return rows
+    },
+    computedRows () {
+      const { rowsPerPage } = this.computedPagination
+
+      if (this.isServerSide || !rowsPerPage) {
+        return this.filteredRows
       }
 
-      return rows
+      return this.filteredRows.slice(this.firstRowIndex, this.lastRowIndex)
     },
     computedRowsNumber () {
       return this.isServerSide
         ? this.computedPagination.rowsNumber || 0
-        : this.data.length
+        : this.filteredRows.length
     },
     nothingToDisplay () {
       return this.computedRows.length === 0

--- a/src/components/table/table-bottom.js
+++ b/src/components/table/table-bottom.js
@@ -22,7 +22,7 @@ export default {
 
       const bottom = this.$scopedSlots.bottom
 
-      return h('div', { staticClass: 'q-table-bottom row items-center' },
+      return h('div', { staticClass: 'q-table-bottom row no-wrap items-center' },
         bottom ? [ bottom(this.marginalsProps) ] : this.getPaginationRow(h)
       )
     },
@@ -38,15 +38,12 @@ export default {
             ? (this.selectedRowsLabel || this.$q.i18n.table.selectedRows)(this.rowsSelectedNumber)
             : ''
         ]),
-        h('div', { staticClass: 'flex items-center' }, [
+        h('div', { staticClass: 'col-auto flex items-center justify-end no-wrap' }, [
           h('span', { staticClass: 'q-mr-lg' }, [
             this.rowsPerPageLabel || this.$q.i18n.table.rowsPerPage
           ]),
           h(QSelect, {
-            staticClass: 'inline q-my-none q-ml-none q-mr-lg',
-            style: {
-              minWidth: '50px'
-            },
+            staticClass: 'inline q-ml-none q-mr-lg',
             props: {
               color: this.color,
               value: rowsPerPage,

--- a/src/components/table/table.ios.styl
+++ b/src/components/table/table.ios.styl
@@ -100,6 +100,8 @@
 
 .q-table-col-auto-width
   width 1px
+  > .q-option .q-radial-ripple
+    margin-bottom -100%
 
 /*
  * Separators
@@ -193,3 +195,7 @@ table-dense()
       background $table-dark-selected-background
     &:hover
       background $table-dark-hover-background
+
+.q-table-top, .q-table-bottom
+  .q-if-hide-underline
+    margin-bottom -8px

--- a/src/components/table/table.mat.styl
+++ b/src/components/table/table.mat.styl
@@ -100,6 +100,8 @@
 
 .q-table-col-auto-width
   width 1px
+  > .q-option .q-radial-ripple
+    margin-bottom -100%
 
 /*
  * Separators
@@ -194,3 +196,7 @@ table-dense()
       background $table-dark-selected-background
     &:hover
       background $table-dark-hover-background
+
+.q-table-top, .q-table-bottom
+  .q-if-hide-underline
+    margin-bottom -8px

--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -26,14 +26,17 @@
       :length="queueLength"
       additional-length
     >
-      <input
-        class="col q-input-target cursor-inherit non-selectable no-pointer-events"
-        :class="alignClass"
-        :value="label"
-        readonly
-        :disabled="this.disable"
-        tabindex="-1"
-      />
+      <div class="col q-input-target-wrapper">
+        <input
+          class="col q-input-target cursor-inherit non-selectable no-pointer-events"
+          :class="alignClass"
+          :value="label"
+          readonly
+          :disabled="this.disable"
+          tabindex="-1"
+        />
+        <div>{{label || ' '}}</div>
+      </div>
 
       <q-spinner
         v-if="uploading"

--- a/src/css/core/motion.styl
+++ b/src/css/core/motion.styl
@@ -82,15 +82,27 @@
 .animate-popup
   animation q-popup .35s
   > div
-    animation q-popup-inner .5s
+    animation q-popup-inner .35s
     transform-origin left top 0px
   &, > div
     animation-timing-function cubic-bezier(0.23, 1, 0.32, 1)
+  &.animate-popup-up
+    animation q-popup-up .35s
+    > div
+      transform-origin left bottom 0px
 
 @keyframes q-popup
   0%
     opacity 0
     transform translateY(-40px)
+    pointer-events none
+  100%
+    opacity 1
+
+@keyframes q-popup-up
+  0%
+    opacity 0
+    transform translateY(40px)
     pointer-events none
   100%
     opacity 1

--- a/src/ie-compat/ie.ios.styl
+++ b/src/ie-compat/ie.ios.styl
@@ -1,7 +1,9 @@
 ie_style = @block
   /* Flex */
-  .absolute .q-if-inner, .fixed .q-if-inner
-    min-width 10em
+  .absolute, .fixed
+    .q-if-inner, .q-input-target-wrapper
+      min-width auto
+      flex-basis auto
 
   /* QAlert */
   .q-alert-container

--- a/src/ie-compat/ie.mat.styl
+++ b/src/ie-compat/ie.mat.styl
@@ -1,7 +1,9 @@
 ie_style = @block
   /* Flex */
-  .absolute .q-if-inner, .fixed .q-if-inner
-    min-width 10em
+  .absolute, .fixed
+    .q-if-inner, .q-input-target-wrapper
+      min-width auto
+      flex-basis auto
 
   /* QAlert */
   .q-alert-container

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -143,6 +143,7 @@ export function setPosition ({el, anchorEl, anchorOrigin, selfOrigin, maxHeight,
 
   el.style.top = Math.max(0, targetPosition.top) + 'px'
   el.style.left = Math.max(0, targetPosition.left) + 'px'
+  return targetPosition.top < anchor.top ? 'up' : 'down'
 }
 
 export function positionValidator (pos) {


### PR DESCRIPTION
All .q-input-target
- autosize based on content

QAutocomplete
- mark disabled items and do not allow navigation
- start keyboard navigation from -1

QChipsInput
- enforce unique values

QColor
- fix color swatch's transparency

QPopover
- animate with direction (up or down)
- internal div is .column to allow flex inside
- shadow animation when opening

QSelect
- scrollable content with search fixed on top
- group option in options - show item unselectable with color
- start keyboard navigation from -1

QTable
- pagination uses the length of filtered data
- fix aspect on mobile and dense