### PR TITLE
Add optional button color props to QDialog

### DIFF
--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -24,14 +24,8 @@ export default {
       type: String,
       default: 'primary'
     },
-    okColor: {
-      type: String,
-      default: ''
-    },
-    cancelColor: {
-      type: String,
-      default: ''
-    }
+    okColor: String,
+    cancelColor: String
   },
   render (h) {
     const

--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -23,6 +23,14 @@ export default {
     color: {
       type: String,
       default: 'primary'
+    },
+    okColor: {
+      type: String,
+      default: ''
+    },
+    cancelColor: {
+      type: String,
+      default: ''
     }
   },
   render (h) {
@@ -195,13 +203,13 @@ export default {
 
       if (this.cancel) {
         child.push(h(QBtn, {
-          props: { color: this.color, flat: true, label: this.cancelLabel, waitForRipple: true },
+          props: { color: this.cancelColor || this.color, flat: true, label: this.cancelLabel, waitForRipple: true },
           on: { click: this.__onCancel }
         }))
       }
       if (this.ok) {
         child.push(h(QBtn, {
-          props: { color: this.color, flat: true, label: this.okLabel, waitForRipple: true },
+          props: { color: this.okColor || this.color, flat: true, label: this.okLabel, waitForRipple: true },
           on: { click: this.__onOk }
         }))
       }


### PR DESCRIPTION
Add optional color props for button colors.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
My use case is a QDialog for confirming a delete action. In that instance, it's really useful visual feedback to the user to pass `{ok: 'Delete', okColor: 'red'}` so that the 'ok' button is shown as the one that will actually cause something to be deleted.