### PR TITLE
Correct warning icon

### DIFF
--- a/icons/mdi.js
+++ b/icons/mdi.js
@@ -4,7 +4,7 @@ export default {
     positive: 'mdi-check-circle',
     negative: 'mdi-alert',
     info: 'mdi-info',
-    warning: 'mdi-priority-high'
+    warning: 'mdi-exclamation'
   },
   arrow: {
     up: 'mdi-arrow-upward',


### PR DESCRIPTION
https://materialdesignicons.com/icon/priority-high vs https://materialdesignicons.com/icon/exclamation