### PR TITLE
I18N (De): Fix table 'selectedRows' spelling mistake

### DIFF
--- a/i18n/de.js
+++ b/i18n/de.js
@@ -31,7 +31,7 @@ export default {
     noData: 'Keine Daten vorhanden.',
     noResults: 'Keine Einträge gefunden',
     loading: 'Lade...',
-    selectedRows: rows => rows > 1 ? `${rows} ausgewählte Zeilen` : `${rows === 0 ? 'Keine' : '1'} ausgewahlt.`,
+    selectedRows: rows => rows > 1 ? `${rows} ausgewählte Zeilen` : `${rows === 0 ? 'Keine' : '1'} ausgewählt.`,
     rowsPerPage: 'Zeilen pro Seite',
     allRows: 'Alle',
     pagination: (start, end, total) => `${start}-${end} von ${total}`,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Language translation fix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
This pull request fixes a slight spelling error in the german "selectedRows" translation for the quasar table component.