### PR TITLE
Add sv lang dictionary to quasar i18n built in languages

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -18,6 +18,7 @@
           ,{ label: 'Chinese (Simplified)', value: 'zh-hans' }
           ,{ label: 'Italian', value: 'it' }
           ,{ label: 'Spanish', value: 'es' }
+          ,{ label: 'Swedish', value: 'sv' }
           ,{ label: 'French', value: 'fr' }
           ,{ label: 'German', value: 'de' }
           ,{ label: 'Indonezian', value: 'id' }

--- a/i18n/sv.js
+++ b/i18n/sv.js
@@ -1,0 +1,95 @@
+export default {
+  lang: 'sv',
+  label: {
+    clear: 'Rensa',
+    ok: 'OK',
+    cancel: 'Avbryt',
+    close: 'Stäng',
+    set: 'Sätt',
+    select: 'Välj',
+    reset: 'Nollställ',
+    remove: 'Ta bort',
+    update: 'Uppdatera',
+    create: 'Skapa',
+    search: 'Sök',
+    filter: 'Filtrera',
+    refresh: 'Uppdatera'
+  },
+  date: {
+    days: 'Söndag_Måndag_Tisdag_Onsdag_Torsdag_Fredag_Lördag'.split('_'),
+    daysShort: 'Sön_Mån_Tis_Ons_Tor_Fre_Lör'.split('_'),
+    months: 'Januari_Februari_Mars_April_Maj_Juni_Juli_Augusti_September_Oktober_November_December'.split('_'),
+    monthsShort: 'Jan_Feb_Mar_Apr_Maj_Jun_Jul_Aug_Sep_Okt_Nov_Dec'.split('_'),
+    firstDayOfWeek: 1, // 0-6, 0 - Sunday, 1 Monday, ...
+    format24h: true
+  },
+  pullToRefresh: {
+    pull: 'Drag ned för att uppdatera',
+    release: 'Släpp för att uppdatera',
+    refresh: 'Uppdaterar...'
+  },
+  table: {
+    noData: 'Ingen data tillgänglig',
+    noResults: 'Inget resultat matchar',
+    loading: 'Laddar...',
+    selectedRows: function (rows) {
+      return rows === 1
+        ? '1 vald rad.'
+        : (rows === 0 ? 'Inga' : rows) + ' valda rader.'
+    },
+    rowsPerPage: 'Rader per sida:',
+    allRows: 'Alla',
+    pagination: function (start, end, total) {
+      return start + '-' + end + ' av ' + total
+    },
+    columns: 'Kolumner'
+  },
+  editor: {
+    url: 'URL',
+    bold: 'Fet',
+    italic: 'Kursiv',
+    strikethrough: 'Genomstruken',
+    underline: 'Understruken',
+    unorderedList: 'Punktlista',
+    orderedList: 'Numrerad lista',
+    subscript: 'Nedsänkt',
+    superscript: 'Upphöjt',
+    hyperlink: 'Länk',
+    toggleFullscreen: 'Växla helskärm',
+    quote: 'Citat',
+    left: 'Vänsterjustera',
+    center: 'Centrera',
+    right: 'Högerjustera',
+    justify: 'Justera',
+    print: 'Skriv ut',
+    outdent: 'Minska indrag',
+    indent: 'Öka indrag',
+    removeFormat: 'Ta bort formatering',
+    formatting: 'Formatering',
+    fontSize: 'Teckenstorlek',
+    align: 'Justera',
+    hr: 'Infoga vågrät linje',
+    undo: 'Ångra',
+    redo: 'Gör om',
+    header1: 'Rubrik 1',
+    header2: 'Rubrik 2',
+    header3: 'Rubrik 3',
+    header4: 'Rubrik 4',
+    header5: 'Rubrik 5',
+    header6: 'Rubrik 6',
+    paragraph: 'Stycke',
+    code: 'Kod',
+    size1: 'Väldigt liten',
+    size2: 'Liten',
+    size3: 'Normal',
+    size4: 'Större än normal',
+    size5: 'Stor',
+    size6: 'Väldigt stor',
+    size7: 'Maximalt stor',
+    defaultFont: 'Standardteckensnitt'
+  },
+  tree: {
+    noNodes: 'Inga noder tillgängliga',
+    noResults: 'Inga noder matchar'
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Added swedish language to i18n

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
