### PR TITLE
Enhancement: Added auto margins (e.g. q-mx-a)

### DIFF
--- a/src/css/core.variables.styl
+++ b/src/css/core.variables.styl
@@ -25,6 +25,10 @@ $spaces = {
   xl: {
     x: ($space-x-base * 3),
     y: ($space-y-base * 3)
+  },
+  a: {
+    x: auto,
+    y: auto
   }
 }
 


### PR DESCRIPTION
Added auto margins (e.g. `q-mx-a`)

I used to heavily use my own helpers like so:
```css
.ml-auto{
    margin-left: auto;
}
.mr-auto{
    margin-right: auto;
}
.mlr-auto{
    margin-left: auto;
    margin-right: auto;
}
```

Since Quasar has a good method of helper construction, I'd like to add the `auto` keyword.

If you accept I'll also update the docs and do a PR. : )