### PR TITLE
fix HMR reload problem with parent field

### DIFF
--- a/src/components/field/QField.js
+++ b/src/components/field/QField.js
@@ -122,8 +122,10 @@ export default {
     __registerInput (vm) {
       this.input = vm
     },
-    __unregisterInput () {
-      this.input = {}
+    __unregisterInput (vm) {
+      if (!vm || vm === this.input) {
+        this.input = {}
+      }
     },
     __getBottomContent (h) {
       if (this.hasError && this.errorLabel) {

--- a/src/mixins/parent-field.js
+++ b/src/mixins/parent-field.js
@@ -15,7 +15,7 @@ export default {
   },
   beforeDestroy () {
     if (!this.noParentField && this.field) {
-      this.field.__unregisterInput()
+      this.field.__unregisterInput(this)
     }
   }
 }


### PR DESCRIPTION
beforeMount is sometimes executed before the previous versions of the component's beforeDestroy, so the parent->child link is lost in the beforeDestroy.

Only uninstalls itself.