### PR TITLE
fix IE: QResizeObservable object visibility and QList main flex

### DIFF
--- a/dev/components/css/list.vue
+++ b/dev/components/css/list.vue
@@ -513,7 +513,11 @@
             sublabel="John Doe John Doe John Doe John Doe John Doe John Doe John Doe John Doe John Doe"
             sublabel-lines="2"
           />
-          <q-item-side right stamp="1 week<br>ago" />
+          <q-item-side right>
+            <q-item-tile stamp class="text-center">
+               1 week<br>ago
+            </q-item-tile>
+          </q-item-side>
         </q-item>
         <q-item multiline>
           <q-item-side avatar="/statics/boy-avatar.png" />

--- a/src/components/observables/QResizeObservable.js
+++ b/src/components/observables/QResizeObservable.js
@@ -33,7 +33,7 @@ export default {
 
     this.object = object
     object.setAttribute('aria-hidden', true)
-    object.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; right: 0; bottom: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1; visibility: hidden;')
+    object.setAttribute('style', 'display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;visibility:hidden;')
     object.onload = () => {
       object.contentDocument.defaultView.addEventListener('resize', this.onResize, listenOpts.passive)
     }

--- a/src/components/observables/QResizeObservable.js
+++ b/src/components/observables/QResizeObservable.js
@@ -33,7 +33,7 @@ export default {
 
     this.object = object
     object.setAttribute('aria-hidden', true)
-    object.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; right: 0; bottom: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;')
+    object.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; right: 0; bottom: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1; visibility: hidden;')
     object.onload = () => {
       object.contentDocument.defaultView.addEventListener('resize', this.onResize, listenOpts.passive)
     }

--- a/src/ie-compat/ie.ios.styl
+++ b/src/ie-compat/ie.ios.styl
@@ -51,7 +51,7 @@ ie_style = @block
 
   /* QList */
   .q-item-main
-    flex 1 1 100%
+    min-width 1px
 
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)
   {ie_style}

--- a/src/ie-compat/ie.mat.styl
+++ b/src/ie-compat/ie.mat.styl
@@ -51,7 +51,7 @@ ie_style = @block
 
   /* QList */
   .q-item-main
-    flex 1 1 100%
+    min-width 1px
 
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)
   {ie_style}


### PR DESCRIPTION
QResizeObservable uses object, which in IE shows border, padding, ...
Visibility hidden looks like it keeps all the properties and does not show the problem.

close #1718, close #1710