### PR TITLE
QInput: add an empty row on end of textarea to prevent scroll related…

### DIFF
--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -321,8 +321,8 @@ export default {
       const shadow = this.$refs.shadow
       if (shadow) {
         let h = shadow.scrollHeight
-        const max = this.maxHeight || h
-        this.$refs.input.style.minHeight = `${between(h, 19, max)}px`
+        const minHeight = between(h, 19, this.maxHeight || h)
+        this.$refs.input.style.minHeight = `${minHeight + 19}px`
       }
     },
     __watcher (value) {


### PR DESCRIPTION
When entering new rows in QInput textarea the text jumps up (on new line) and down (on resize).
This adds the space for a new line.