### PR TITLE
WIP - QSelect: force top position on popup with filter on mobile

### DIFF
--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -216,7 +216,8 @@ export default {
       'class': dark ? 'bg-dark' : null,
       props: {
         fit: true,
-        anchorClick: false
+        anchorClick: false,
+        fullscreen: this.$q.platform.is.mobile
       },
       on: {
         show: () => this.$emit('show'),

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -38,6 +38,7 @@ export default {
       type: Array,
       validator: offsetValidator
     },
+    forceTop: Boolean,
     disable: Boolean
   },
   watch: {

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -73,6 +73,7 @@
       fit
       :disable="readonly || disable"
       :anchor-click="false"
+      :fullscreen="fullscreen"
       class="column no-wrap"
       :class="dark ? 'bg-dark' : null"
       @show="__onShow"
@@ -309,6 +310,9 @@ export default {
     },
     additionalLength () {
       return this.displayValue && this.displayValue.length > 0
+    },
+    fullscreen () {
+      return this.filter && this.$q.platform.is.mobile
     }
   },
   methods: {

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -122,7 +122,7 @@ export function parseHorizTransformOrigin (pos) {
   return pos === 'middle' ? 'center' : pos
 }
 
-export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset}) {
+export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset, fullscreen}) {
   let anchor
   el.style.maxHeight = maxHeight || '65vh'
 
@@ -136,7 +136,7 @@ export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, m
 
   let target = getTargetPosition(el)
   let targetPosition = {
-    top: anchor[anchorOrigin.vertical] - target[selfOrigin.vertical],
+    top: (fullscreen ? 0 : anchor[anchorOrigin.vertical] - target[selfOrigin.vertical]),
     left: anchor[anchorOrigin.horizontal] - target[selfOrigin.horizontal]
   }
 


### PR DESCRIPTION
When QSelect has filter on mobile the popover sometimes goes below soft keyboard.
As we cannot detect the new size of the available screen we can only place the popover on top