### PR TITLE
Misc fixes related to layout and order of mounter/destroyed

### DIFF
--- a/dev/components/new-layout/new-layout.vue
+++ b/dev/components/new-layout/new-layout.vue
@@ -84,10 +84,13 @@
       <transition enter-active-class="animated fadeIn" leave-active-class="animated fadeOut" mode="out-in">
         <router-view />
       </transition>
+      <div class="fixed-bottom-right bg-grey-5 q-pa-sm z-max" style="bottom: 8px; right: 8px;">
+        <q-toggle v-model="showConfig" label="Config" />
+      </div>
     </q-page-container>
   </q-layout>
 
-  <div class="fixed-center bg-amber z-fullscreen">
+  <div class="fixed-center bg-amber z-fullscreen" v-if="showConfig">
     <div class="row no-wrap">
       <div class="col gutter-xs q-ma-xs">
         <div>
@@ -193,13 +196,13 @@
           </div>
         </div>
       </div>
-      <q-modal v-model="toggle" :content-css="{padding: '50px', minWidth: '50vw'}">
-        <h4>Basic Modal</h4>
-        <p v-for="n in 25" :key="`basic-${n}`">Scroll down to close</p>
-        <q-btn color="primary" @click="toggle = false">Close</q-btn>
-      </q-modal>
     </div>
   </div>
+  <q-modal v-model="toggle" :content-css="{padding: '50px', minWidth: '50vw'}">
+    <h4>Basic Modal</h4>
+    <p v-for="n in 25" :key="`basic-${n}`">Scroll down to close</p>
+    <q-btn color="primary" @click="toggle = false">Close</q-btn>
+  </q-modal>
 </div>
 </template>
 
@@ -244,7 +247,9 @@ export default {
         { label: 'Behave Normal', value: 'default' },
         { label: 'Behave Mobile', value: 'mobile' },
         { label: 'Behave Desktop', value: 'desktop' }
-      ]
+      ],
+
+      showConfig: true
     }
   },
   computed: {

--- a/dev/components/new-layout/pages/default.vue
+++ b/dev/components/new-layout/pages/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page padding class="bg-yellow">
+  <q-page padding class="bg-yellow page-default-padding">
     <div v-for="n in 50">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </div>
@@ -25,6 +25,11 @@
     </q-page-sticky>
   </q-page>
 </template>
+
+<style lang="stylus">
+.page-default-padding
+  padding-top calc(2.5rem + 50px)
+</style>
 
 <script>
 export default {

--- a/src/components/ajax-bar/QAjaxBar.js
+++ b/src/components/ajax-bar/QAjaxBar.js
@@ -5,6 +5,7 @@ import { isSSR } from '../../plugins/platform'
 const
   xhr = isSSR ? null : XMLHttpRequest,
   send = isSSR ? null : xhr.prototype.send
+let highjackCount = 0
 
 function translate ({p, pos, active, horiz, reverse, dir}) {
   let x = 1, y = 1
@@ -55,10 +56,14 @@ function highjackAjax (startHandler, endHandler) {
 
     send.apply(this, args)
   }
+  highjackCount += 1
 }
 
 function restoreAjax () {
-  xhr.prototype.send = send
+  highjackCount = Math.max(0, highjackCount - 1)
+  if (!highjackCount) {
+    xhr.prototype.send = send
+  }
 }
 
 export default {

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -172,15 +172,15 @@ export default {
         val: this.model,
         set: this.__set,
         loading: false,
-        watched: false,
+        watched: 0,
         isDark: () => this.dark,
         hasFocus: () => document.activeElement === this.$refs.input,
         register: () => {
-          this.shadow.watched = true
+          this.shadow.watched += 1
           this.__watcherRegister()
         },
         unregister: () => {
-          this.shadow.watched = false
+          this.shadow.watched = Math.max(0, this.shadow.watched - 1)
           this.__watcherUnregister()
         },
         getEl: () => this.$refs.input

--- a/src/components/layout/QLayout.js
+++ b/src/components/layout/QLayout.js
@@ -26,22 +26,26 @@ export default {
       header: {
         size: 0,
         offset: 0,
-        space: true
+        space: true,
+        instance: null
       },
       right: {
         size: 300,
         offset: 0,
-        space: false
+        space: false,
+        instance: null
       },
       footer: {
         size: 0,
         offset: 0,
-        space: true
+        space: true,
+        instance: null
       },
       left: {
         size: 300,
         offset: 0,
-        space: false
+        space: false,
+        instance: null
       },
 
       scrollHeight: 0,

--- a/src/components/layout/QLayoutDrawer.js
+++ b/src/components/layout/QLayoutDrawer.js
@@ -257,6 +257,7 @@ export default {
     ]))
   },
   created () {
+    this.__update('instance', this)
     if (this.onLayout) {
       this.__update('space', true)
       this.__update('offset', this.offset)
@@ -273,8 +274,11 @@ export default {
   },
   beforeDestroy () {
     clearTimeout(this.timer)
-    this.__update('size', 0)
-    this.__update('space', false)
+    if (this.layout[this.side].instance === this) {
+      this.__update('instance', null)
+      this.__update('size', 0)
+      this.__update('space', false)
+    }
   },
   methods: {
     applyPosition (position) {
@@ -352,6 +356,10 @@ export default {
     },
     __show () {
       if (this.belowBreakpoint) {
+        const otherSide = this.layout[this.rightSide ? 'left' : 'right']
+        if (otherSide.instance && otherSide.instance.mobileOpened) {
+          otherSide.instance.hide()
+        }
         this.mobileOpened = true
         this.applyBackdrop(1)
       }

--- a/src/components/layout/QLayoutFooter.js
+++ b/src/components/layout/QLayoutFooter.js
@@ -31,6 +31,11 @@ export default {
     offset (val) {
       this.__update('offset', val)
     },
+    reveal (val) {
+      if (!val) {
+        this.__updateLocal('revealed', this.value)
+      }
+    },
     revealed (val) {
       this.layout.__animate()
       this.$emit('reveal', val)
@@ -95,11 +100,15 @@ export default {
     ])
   },
   created () {
+    this.__update('instance', this)
     this.__update('space', this.value)
   },
-  destroyed () {
-    this.__update('size', 0)
-    this.__update('space', false)
+  beforeDestroy () {
+    if (this.layout.footer.instance === this) {
+      this.__update('instance', null)
+      this.__update('size', 0)
+      this.__update('space', false)
+    }
   },
   methods: {
     __onResize ({ height }) {

--- a/src/components/layout/QLayoutHeader.js
+++ b/src/components/layout/QLayoutHeader.js
@@ -35,6 +35,11 @@ export default {
     offset (val) {
       this.__update('offset', val)
     },
+    reveal (val) {
+      if (!val) {
+        this.__updateLocal('revealed', this.value)
+      }
+    },
     revealed (val) {
       this.layout.__animate()
       this.$emit('reveal', val)
@@ -45,8 +50,8 @@ export default {
       }
       this.__updateLocal('revealed',
         scroll.direction === 'up' ||
-        scroll.position <= this.revealOffset ||
-        scroll.position - scroll.inflexionPosition < 100
+          scroll.position <= this.revealOffset ||
+          scroll.position - scroll.inflexionPosition < 100
       )
     }
   },
@@ -99,11 +104,15 @@ export default {
     ])
   },
   created () {
+    this.__update('instance', this)
     this.__update('space', this.value)
   },
-  destroyed () {
-    this.__update('size', 0)
-    this.__update('space', false)
+  beforeDestroy () {
+    if (this.layout.header.instance === this) {
+      this.__update('instance', null)
+      this.__update('size', 0)
+      this.__update('space', false)
+    }
   },
   methods: {
     __onResize ({ height }) {

--- a/src/components/layout/QLayoutHeader.js
+++ b/src/components/layout/QLayoutHeader.js
@@ -50,8 +50,8 @@ export default {
       }
       this.__updateLocal('revealed',
         scroll.direction === 'up' ||
-          scroll.position <= this.revealOffset ||
-          scroll.position - scroll.inflexionPosition < 100
+        scroll.position <= this.revealOffset ||
+        scroll.position - scroll.inflexionPosition < 100
       )
     }
   },

--- a/src/components/layout/QPageSticky.js
+++ b/src/components/layout/QPageSticky.js
@@ -42,13 +42,13 @@ export default {
       return this.layout.header.offset
     },
     right () {
-      return this.layout.right.offset
+      return this.layout.right.space ? this.layout.right.offset : 0
     },
     bottom () {
       return this.layout.footer.offset
     },
     left () {
-      return this.layout.left.offset
+      return this.layout.left.space ? this.layout.left.offset : 0
     },
     computedStyle () {
       const


### PR DESCRIPTION
Change the registration/deregistration for:
- QAjaxBar - to use counter check
- QInput - to use counter check
- QLayout components - to use instance check

QLayoutDrawer - on mobile view hide the other drawer before showing the current one
QLayoutHeader|Footer - recompute revealed status when reveal property is changed to false
QPageSticky - if left|right drawers are in overlay mode let them cover the sticky (don't translate sticky)