### PR TITLE
QDatetime - restart from start view after canClose

### DIFF
--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -176,6 +176,11 @@ export default {
             canClose: () => {
               if (this.isPopover) {
                 this.hide()
+                // go back to initial entry point for that type of control
+                // if it has defaultView it's goint to be reapplied anyway on focus
+                if (!this.defaultView) {
+                  this.$refs.target.setView()
+                }
               }
             }
           }


### PR DESCRIPTION
If QInput receives canClose it means the cycle of setting the value is complete, so it is normal to start a new cycle.

closes #1663