### PR TITLE
fix QDatetimePicker: Reset to default view after closing modal

### DIFF
--- a/dev/components/form/input-test.vue
+++ b/dev/components/form/input-test.vue
@@ -64,6 +64,7 @@
     <br><br>
     <q-datetime
       clearable
+      type="datetime"
       class="q-ma-sm"
       @focus="donFocus"
       @blur="donBlur"
@@ -77,6 +78,7 @@
 
     <q-datetime
       clearable
+      type="datetime"
       class="q-ma-sm"
       @focus="donFocus"
       @blur="donBlur"
@@ -91,6 +93,7 @@
     <br><br>
     <q-datetime
       clearable
+      type="datetime"
       class="q-ma-sm"
       @focus="donFocus"
       @blur="donBlur"
@@ -104,6 +107,7 @@
 
     <q-datetime
       clearable
+      type="datetime"
       class="q-ma-sm"
       @focus="donFocus"
       @blur="donBlur"

--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -162,6 +162,13 @@ export default {
         }
       })
     },
+    __resetView () {
+      // go back to initial entry point for that type of control
+      // if it has defaultView it's going to be reapplied anyway on focus
+      if (!this.defaultView) {
+        this.$refs.target.setView()
+      }
+    },
 
     __getPicker (h, modal) {
       return [
@@ -191,11 +198,7 @@ export default {
             canClose: () => {
               if (this.isPopover) {
                 this.hide()
-                // go back to initial entry point for that type of control
-                // if it has defaultView it's goint to be reapplied anyway on focus
-                if (!this.defaultView) {
-                  this.$refs.target.setView()
-                }
+                this.__resetView()
               }
             }
           }
@@ -216,6 +219,7 @@ export default {
                   click: () => {
                     this.__onHide()
                     this.hide()
+                    this.__resetView()
                   }
                 }
               }),
@@ -231,6 +235,7 @@ export default {
                     click: () => {
                       this.__onHide(true)
                       this.hide()
+                      this.__resetView()
                     }
                   }
                 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
