### PR TITLE
fix QBtn: Make focus helper and ripple extend over bottom border

### DIFF
--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -315,8 +315,8 @@
       <p class="group">
         <q-btn push color="primary">Push</q-btn>
         <q-btn push color="primary" round icon="card_giftcard" />
-        <q-btn push class="bg-white text-primary">Push</q-btn>
-        <q-btn push class="bg-white text-primary" round icon="card_giftcard" />
+        <q-btn push color="white" text-color="primary">Push</q-btn>
+        <q-btn push color="white" text-color="primary" round icon="card_giftcard" />
       <p>
 
       <p class="caption">Round Buttons</p>

--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -295,6 +295,8 @@
         <q-btn round color="primary" disable icon="card_giftcard" />
         <q-btn push color="primary" disable>Push</q-btn>
         <q-btn push color="primary" disable round icon="card_giftcard" />
+        <q-btn push class="bg-white text-primary" disable>Push</q-btn>
+        <q-btn push class="bg-white text-primary" disable round icon="card_giftcard" />
       <p>
 
       <p class="caption">Flat Buttons</p>
@@ -313,6 +315,8 @@
       <p class="group">
         <q-btn push color="primary">Push</q-btn>
         <q-btn push color="primary" round icon="card_giftcard" />
+        <q-btn push class="bg-white text-primary">Push</q-btn>
+        <q-btn push class="bg-white text-primary" round icon="card_giftcard" />
       <p>
 
       <p class="caption">Round Buttons</p>

--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -295,8 +295,8 @@
         <q-btn round color="primary" disable icon="card_giftcard" />
         <q-btn push color="primary" disable>Push</q-btn>
         <q-btn push color="primary" disable round icon="card_giftcard" />
-        <q-btn push class="bg-white text-primary" disable>Push</q-btn>
-        <q-btn push class="bg-white text-primary" disable round icon="card_giftcard" />
+        <q-btn push color="white" text-color="primary" disable>Push</q-btn>
+        <q-btn push color="white" text-color="primary" disable round icon="card_giftcard" />
       <p>
 
       <p class="caption">Flat Buttons</p>

--- a/src/components/btn/btn-default.ios.styl
+++ b/src/components/btn/btn-default.ios.styl
@@ -40,6 +40,9 @@
   &:active:not(.disabled)
     transform translateY(3px)
     border-bottom-color transparent
+  .q-focus-helper, .q-ripple-container
+    height auto
+    bottom -3px
 
 .q-btn-rounded
   border-radius $button-rounded-border-radius

--- a/src/components/btn/btn-default.mat.styl
+++ b/src/components/btn/btn-default.mat.styl
@@ -68,6 +68,9 @@
     box-shadow none
     transform translateY(3px)
     border-bottom-color transparent
+  .q-focus-helper, .q-ripple-container
+    height auto
+    bottom -3px
 
 .q-btn-rounded
   border-radius $button-rounded-border-radius


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
