### PR TITLE
close #1774: Fix QKnob, QSlider, QRange event order

### DIFF
--- a/dev/components/form/all.vue
+++ b/dev/components/form/all.vue
@@ -327,19 +327,19 @@
         <div class="row gutter-sm">
           <div class="col-6">
             <div>Between {{minVal}} and {{maxVal}}, step {{step}}</div>
-            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" @focus="onFocus" @blur="onBlur" @change="onChange" @input="onInput" v-model="termsK" :min="minVal" :max="maxVal" />
+            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" @focus="onFocus" @blur="onBlur" @dragend="onDragEnd" @change="onChange" @input="onInput" v-model="termsK" :min="minVal" :max="maxVal" />
           </div>
           <div class="col-6">
             <div>Between {{minVal}} and {{maxVal}}, step {{step}} (onChange)</div>
-            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" @focus="onFocus" @blur="onBlur" @change="val => { termsK = val; onChange(val) }" @input="onInput" :value="termsK" :min="minVal" :max="maxVal" />
+            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" @focus="onFocus" @blur="onBlur" @dragend="onDragEnd" @change="val => { termsK = val; onChange(val) }" @input="onInput" :value="termsK" :min="minVal" :max="maxVal" />
           </div>
           <div class="col-6">
             <div>Between {{minVal}} and {{maxVal}}, step {{step}}, decimals {{decimals}}</div>
-            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" :decimals="decimals" @focus="onFocus" @blur="onBlur" @change="onChange" @input="onInput" v-model="termsK" :min="minVal" :max="maxVal" />
+            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" :decimals="decimals" @focus="onFocus" @blur="onBlur" @dragend="onDragEnd" @change="onChange" @input="onInput" v-model="termsK" :min="minVal" :max="maxVal" />
           </div>
           <div class="col-6">
             <div>Between {{minVal}} and {{maxVal}}, step {{step}}, decimals {{decimals}} (onChange)</div>
-            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" :decimals="decimals" @focus="onFocus" @blur="onBlur" @change="val => { termsK = val; onChange(val) }" @input="onInput" :value="termsK" :min="minVal" :max="maxVal" />
+            <q-knob :dark="dark" :error="error" :warning="warning" :disable="disable" :readonly="readonly" :step="step" :decimals="decimals" @focus="onFocus" @blur="onBlur" @dragend="onDragEnd" @change="val => { termsK = val; onChange(val) }" @input="onInput" :value="termsK" :min="minVal" :max="maxVal" />
           </div>
         </div>
 
@@ -504,6 +504,9 @@ export default {
     },
     onInput (val) {
       console.log('@input', JSON.stringify(val))
+    },
+    onDragEnd (val) {
+      console.log('@dragend', JSON.stringify(val))
     },
     onFocus (val) {
       console.log('@focus', JSON.stringify(val), name)

--- a/src/components/knob/QKnob.js
+++ b/src/components/knob/QKnob.js
@@ -185,11 +185,11 @@ export default {
       this.model = value
       this.$emit('input', value)
       this.$nextTick(() => {
-        if (emitChange && JSON.stringify(value) !== JSON.stringify(this.value)) {
-          this.$emit('change', value)
-        }
         if (dragStop) {
           this.$emit('dragend', value)
+        }
+        if (emitChange && JSON.stringify(value) !== JSON.stringify(this.value)) {
+          this.$emit('change', value)
         }
       })
     },
@@ -212,7 +212,7 @@ export default {
     }, [
       h('div', {
         on: {
-          click: e => this.__onInput(e, undefined, true)
+          click: e => !this.dragging && this.__onInput(e, undefined, true)
         },
         directives: [{
           name: 'touch-pan',

--- a/src/components/range/QRange.js
+++ b/src/components/range/QRange.js
@@ -236,18 +236,9 @@ export default {
       this.__updateInput(pos)
     },
     __end () {
-      setTimeout(() => {
-        this.dragging = false
-      }, 100)
       this.currentMinPercentage = (this.model.min - this.min) / (this.max - this.min)
       this.currentMaxPercentage = (this.model.max - this.min) / (this.max - this.min)
-      this.$emit('input', this.model)
-      this.$nextTick(() => {
-        this.$emit('dragend', this.model)
-        if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
-          this.$emit('change', this.model)
-        }
-      })
+      this.__endEmit()
     },
     __updateInput ({min = this.model.min, max = this.model.max}) {
       const model = {min, max}

--- a/src/components/range/QRange.js
+++ b/src/components/range/QRange.js
@@ -161,7 +161,9 @@ export default {
       }
 
       if (this.dragOnlyRange && type !== dragType.RANGE) {
-        this.dragging = false
+        setTimeout(() => {
+          this.dragging = false
+        }, 100)
         return
       }
 
@@ -234,14 +236,17 @@ export default {
       this.__updateInput(pos)
     },
     __end () {
-      this.dragging = false
+      setTimeout(() => {
+        this.dragging = false
+      }, 100)
       this.currentMinPercentage = (this.model.min - this.min) / (this.max - this.min)
       this.currentMaxPercentage = (this.model.max - this.min) / (this.max - this.min)
+      this.$emit('input', this.model)
       this.$nextTick(() => {
+        this.$emit('dragend', this.model)
         if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
           this.$emit('change', this.model)
         }
-        this.$emit('dragend', this.model)
       })
     },
     __updateInput ({min = this.model.min, max = this.model.max}) {

--- a/src/components/slider/QSlider.js
+++ b/src/components/slider/QSlider.js
@@ -87,13 +87,16 @@ export default {
       this.$emit('input', model)
     },
     __end () {
-      this.dragging = false
+      setTimeout(() => {
+        this.dragging = false
+      }, 100)
       this.currentPercentage = (this.model - this.min) / (this.max - this.min)
+      this.$emit('input', this.model)
       this.$nextTick(() => {
+        this.$emit('dragend', this.model)
         if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
           this.$emit('change', this.model)
         }
-        this.$emit('dragend', this.model)
       })
     },
     __validateProps () {

--- a/src/components/slider/QSlider.js
+++ b/src/components/slider/QSlider.js
@@ -87,17 +87,8 @@ export default {
       this.$emit('input', model)
     },
     __end () {
-      setTimeout(() => {
-        this.dragging = false
-      }, 100)
       this.currentPercentage = (this.model - this.min) / (this.max - this.min)
-      this.$emit('input', this.model)
-      this.$nextTick(() => {
-        this.$emit('dragend', this.model)
-        if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
-          this.$emit('change', this.model)
-        }
-      })
+      this.__endEmit()
     },
     __validateProps () {
       if (this.min >= this.max) {

--- a/src/components/slider/slider-utils.js
+++ b/src/components/slider/slider-utils.js
@@ -112,7 +112,7 @@ export let SliderMixin = {
       }
     },
     __click (event) {
-      if (this.clickDisabled) {
+      if (this.clickDisabled || this.dragging) {
         return
       }
       this.__setActive(event)

--- a/src/components/slider/slider-utils.js
+++ b/src/components/slider/slider-utils.js
@@ -111,6 +111,18 @@ export let SliderMixin = {
         this.__update(event.evt)
       }
     },
+    __endEmit () {
+      setTimeout(() => {
+        this.dragging = false
+      }, 100)
+      this.$emit('input', this.model)
+      this.$nextTick(() => {
+        this.$emit('dragend', this.model)
+        if (JSON.stringify(this.model) !== JSON.stringify(this.value)) {
+          this.$emit('change', this.model)
+        }
+      })
+    },
     __click (event) {
       if (this.clickDisabled || this.dragging) {
         return


### PR DESCRIPTION
- emit input..., dragend, change in that order
- avoid emitting the last input for the click after drag

close #1774
