### PR TITLE
fix: overflow:hidden lingers after closing a drawer by dragging (fix #1809) (v0.15)

### DIFF
--- a/src/components/layout/QLayoutDrawer.js
+++ b/src/components/layout/QLayoutDrawer.js
@@ -327,8 +327,7 @@ export default {
             this.show()
           }
           else {
-            this.applyBackdrop(0)
-            this.applyPosition(this.stateDirection * width)
+            this.__hide()
             el.classList.remove('q-layout-drawer-delimiter')
           }
         })


### PR DESCRIPTION
See #1809 and sister PR, #1810.

Fixes a bug where closing a drawer in a certain way causes the page to become un-scrollable (on small viewports).

This fix is for v0.15, and #1810 is a fix for the v0.14 version of the bug.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
