### PR TITLE
fix(Notify): set onDismiss handler

### DIFF
--- a/src/plugins/notify.js
+++ b/src/plugins/notify.js
@@ -88,6 +88,10 @@ function init ({ $q, Vue }) {
           })
         }
 
+        if (notif.onDismiss) {
+          notif.onDismiss = config.onDismiss
+        }
+
         if (notif.closeBtn) {
           const btn = [{
             closeBtn: true,

--- a/src/plugins/notify.js
+++ b/src/plugins/notify.js
@@ -88,7 +88,7 @@ function init ({ $q, Vue }) {
           })
         }
 
-        if (notif.onDismiss) {
+        if (typeof config.onDismiss === 'function') {
           notif.onDismiss = config.onDismiss
         }
 


### PR DESCRIPTION
After clone of notify config onDismiss was not set to the original function.