### PR TITLE
close #1858 - respect documented show interface for QContextMenu

### DIFF
--- a/dev/components/components/context-menu.vue
+++ b/dev/components/components/context-menu.vue
@@ -31,11 +31,13 @@
 
       <div
         style="height: 300px; margin-top: 40px;"
-        class="bg-secondary text-white row flex-center"
+        class="bg-secondary text-white row items-stretch"
       >
-        Target area
+        <div class="col-6 flex flex-center" v-for="n in 4" :key="n" >
+          Target area {{n}}
+        </div>
 
-        <q-context-menu>
+        <q-context-menu @show="onShow" @hide="onHide">
           <q-list link separator no-border style="min-width: 150px; max-height: 300px;">
             <q-item
               v-for="n in 10"
@@ -48,6 +50,8 @@
           </q-list>
         </q-context-menu>
       </div>
+      <p class="caption">Visible: {{visible}}</p>
+      <pre v-if="event && event.target">{{event.target.innerText}}</pre>
     </div>
   </div>
 </template>
@@ -67,9 +71,25 @@ export default {
     QItem,
     QItemMain
   },
+  data () {
+    return {
+      event: null,
+      visible: false
+    }
+  },
   methods: {
     showNotify () {
       this.$q.notify((this.$q.platform.is.desktop ? 'Clicked' : 'Tapped') + ' on a context menu item.')
+    },
+    onShow (showEv) {
+      console.log('Show event:', showEv)
+      this.event = showEv
+      this.visible = true
+    },
+    onHide (showEv, hideEv) {
+      console.log('Hide event:', hideEv)
+      this.event = showEv
+      this.visible = false
     }
   }
 }

--- a/src/components/context-menu/ContextMenuDesktop.js
+++ b/src/components/context-menu/ContextMenuDesktop.js
@@ -16,37 +16,38 @@ export default {
         anchorClick: false
       },
       on: {
-        show: () => { this.$emit('show') },
-        hide: () => { this.$emit('hide') }
+        show: () => { this.$emit('show', this.event) },
+        hide: (evt) => { this.$emit('hide', this.event, evt) }
       }
     }, this.$slots.default)
   },
   methods: {
-    hide () {
-      return this.$refs.popover.hide()
+    hide (evt) {
+      return this.$refs.popover.hide(evt)
     },
-    __show (evt) {
+    show (evt) {
       if (!evt || this.disable) {
         return
       }
-      this.hide()
+      this.hide(evt)
       stopAndPrevent(evt)
       /*
         Opening with a timeout for
         Firefox workaround
        */
       setTimeout(() => {
+        this.event = evt
         this.$refs.popover.show(evt)
       }, 100)
     }
   },
   mounted () {
     this.target = this.$refs.popover.$el.parentNode
-    this.target.addEventListener('contextmenu', this.__show)
+    this.target.addEventListener('contextmenu', this.show)
     this.target.addEventListener('click', this.hide)
   },
   beforeDestroy () {
-    this.target.removeEventListener('contexmenu', this.__show)
+    this.target.removeEventListener('contexmenu', this.show)
     this.target.removeEventListener('click', this.hide)
   }
 }

--- a/src/components/context-menu/ContextMenuMobile.js
+++ b/src/components/context-menu/ContextMenuMobile.js
@@ -39,7 +39,7 @@ export default {
         minimized: true
       },
       on: {
-        show: evt => { this.$emit('show', this.event) },
+        show: () => { this.$emit('show', this.event) },
         hide: evt => { this.$emit('hide', this.event, evt) }
       }
     }, this.$slots.default)

--- a/src/components/context-menu/ContextMenuMobile.js
+++ b/src/components/context-menu/ContextMenuMobile.js
@@ -39,7 +39,7 @@ export default {
         minimized: true
       },
       on: {
-        show: evt => { this.$emit('show', this.event, evt) },
+        show: evt => { this.$emit('show', this.event) },
         hide: evt => { this.$emit('hide', this.event, evt) }
       }
     }, this.$slots.default)

--- a/src/components/context-menu/ContextMenuMobile.js
+++ b/src/components/context-menu/ContextMenuMobile.js
@@ -7,13 +7,14 @@ export default {
     disable: Boolean
   },
   methods: {
-    hide () {
+    hide (evt) {
       this.target.classList.remove('non-selectable')
-      return this.$refs.dialog.hide()
+      return this.$refs.dialog.hide(evt)
     },
-    __show () {
+    show (evt) {
       if (!this.disable && this.$refs.dialog) {
-        this.$refs.dialog.show()
+        this.event = evt
+        this.$refs.dialog.show(evt)
       }
     },
     __touchStartHandler (evt) {
@@ -22,7 +23,7 @@ export default {
         stopAndPrevent(evt)
         setTimeout(() => {
           this.__cleanup()
-          this.__show()
+          this.show(evt)
         }, 10)
       }, 600)
     },
@@ -38,8 +39,8 @@ export default {
         minimized: true
       },
       on: {
-        show: () => { this.$emit('show') },
-        hide: () => { this.$emit('hide') }
+        show: () => { this.$emit('show', this.event) },
+        hide: (evt) => { this.$emit('hide', this.event, evt) }
       }
     }, this.$slots.default)
   },

--- a/src/components/context-menu/ContextMenuMobile.js
+++ b/src/components/context-menu/ContextMenuMobile.js
@@ -39,8 +39,8 @@ export default {
         minimized: true
       },
       on: {
-        show: () => { this.$emit('show', this.event) },
-        hide: (evt) => { this.$emit('hide', this.event, evt) }
+        show: evt => { this.$emit('show', this.event, evt) },
+        hide: evt => { this.$emit('hide', this.event, evt) }
       }
     }, this.$slots.default)
   },

--- a/src/directives/close-overlay.js
+++ b/src/directives/close-overlay.js
@@ -1,12 +1,12 @@
 export default {
   name: 'close-overlay',
   bind (el, binding, vnode) {
-    const handler = () => {
+    const handler = (ev) => {
       let vm = vnode.componentInstance
       while ((vm = vm.$parent)) {
         const name = vm.$options.name
         if (name === 'QPopover' || name === 'QModal') {
-          vm.hide()
+          vm.hide(ev)
           break
         }
       }

--- a/src/directives/close-overlay.js
+++ b/src/directives/close-overlay.js
@@ -1,7 +1,7 @@
 export default {
   name: 'close-overlay',
   bind (el, binding, vnode) {
-    const handler = (ev) => {
+    const handler = ev => {
       let vm = vnode.componentInstance
       while ((vm = vm.$parent)) {
         const name = vm.$options.name

--- a/src/mixins/model-toggle.js
+++ b/src/mixins/model-toggle.js
@@ -48,14 +48,14 @@ export default {
       }
 
       if (!this.__show) {
-        this.$emit('show')
+        this.$emit('show', evt)
         return Promise.resolve(evt)
       }
 
       this.showPromise = new Promise((resolve, reject) => {
         this.showPromiseResolve = () => {
           this.showPromise = null
-          this.$emit('show')
+          this.$emit('show', evt)
           resolve(evt)
         }
         this.showPromiseReject = () => {
@@ -85,14 +85,14 @@ export default {
       }
 
       if (!this.__hide) {
-        this.$emit('hide')
+        this.$emit('hide', evt)
         return Promise.resolve()
       }
 
       this.hidePromise = new Promise((resolve, reject) => {
         this.hidePromiseResolve = () => {
           this.hidePromise = null
-          this.$emit('hide')
+          this.$emit('hide', evt)
           resolve()
         }
         this.hidePromiseReject = () => {


### PR DESCRIPTION
- use source event as payload for show/hide events in model-toggle mixin
- use source event as payload when calling hide in v-close-overlay
- show event in QContextMenu has source event as payload
- hide event in QContextMenu has event that showed it and the event that closed it as payload

close #1858
