### PR TITLE
close #1884 - Enhance QPullToRefresh

### DIFF
--- a/dev/components/components/pull-to-refresh.vue
+++ b/dev/components/components/pull-to-refresh.vue
@@ -1,34 +1,88 @@
 <template>
-  <q-layout>
-    <div class="q-toolbar" slot="header">
-      <div class="q-toolbar-title">Pull To Refresh</div>
-    </div>
+  <q-layout view="lHh lpr fFf">
+    <q-layout-header :value="header">
+      <q-toolbar :inverted="$q.theme === 'ios'">
+        <q-toolbar-title>Pull To Refresh - Header</q-toolbar-title>
+      </q-toolbar>
+    </q-layout-header>
 
-    <div class="layout-view">
-      <q-pull-to-refresh :handler="refresher">
-        <div class="layout-padding bg-white">
-          <p class="caption">
-            Pull down to refresh on the content below.
-            On desktop it works by dragging the content down.
-          </p>
+    <q-layout-footer :value="footer">
+      <q-toolbar :inverted="$q.theme === 'ios'">
+        <q-toolbar-title>Pull To Refresh - Footer</q-toolbar-title>
+      </q-toolbar>
+    </q-layout-footer>
 
-          <p v-for="(item, index) in items" class="caption">
-            <q-chip square color="secondary" class="shadow-1">
-              {{ items.length - index }}
-            </q-chip>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          </p>
-        </div>
-      </q-pull-to-refresh>
-    </div>
+    <q-page-container>
+      <transition enter-active-class="animated fadeIn" leave-active-class="animated fadeOut" mode="out-in">
+        <q-page padding class="bg-orange-4" :class="{ 'column no-wrap no-height': hasScroll }">
+          <div class="bg-green-4 q-pa-md text-center" v-show="guardTop">Guarding text above QPullToRefresh</div>
+          <component :is="scrollArea ? 'QScrollArea' : 'div'" :class="scrollClass">
+            <q-pull-to-refresh :handler="refresher" :inline="hasScrollSimple" :disable="disable" class="overflow-hidden-y">
+              <div class="bg-white overflow-hidden-y">
+                <div>
+                  <p class="caption bg-yellow-6">
+                    Pull down to refresh on the content below.
+                    On desktop it works by dragging the content down.
+                  </p>
+
+                  <p class="caption bg-yellow-6">
+                    <q-toggle v-model="header" label="Show Header" />
+                    <q-toggle v-model="footer" label="Show Footer" />
+                    <q-toggle v-model="guardTop" label="Show Top Guard" />
+                    <q-toggle v-model="guardBottom" label="Show Bottom Guard" />
+                    <q-toggle v-model="disable" label="Disable" />
+                    <q-toggle v-model="scroll" label="Scroll" />
+                    <q-toggle v-model="scrollArea" label="QScrollArea" />
+                  </p>
+                </div>
+
+                <p v-for="(item, index) in items" :key="index" class="caption bg-yellow-6">
+                  <q-chip square color="secondary" class="shadow-1">
+                    {{ items.length - index }}
+                  </q-chip>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                </p>
+              </div>
+            </q-pull-to-refresh>
+          </component>
+          <div class="bg-green-4 q-pa-md text-center" v-show="guardBottom">Guarding text below QPullToRefresh</div>
+        </q-page>
+      </transition>
+    </q-page-container>
   </q-layout>
 </template>
+
+<style lang="stylus">
+  .no-height
+    height 0
+</style>
 
 <script>
 export default {
   data () {
     return {
-      items: [{}, {}, {}, {}, {}, {}]
+      items: [{}, {}, {}],
+      guardTop: true,
+      guardBottom: true,
+      header: true,
+      footer: true,
+      disable: false,
+      scroll: false,
+      scrollArea: false
+    }
+  },
+  computed: {
+    hasScroll () {
+      return this.scrollArea || this.scroll
+    },
+    hasScrollSimple () {
+      return this.scroll && !this.scrollArea
+    },
+    scrollClass () {
+      if (this.scrollArea) {
+        return 'col'
+      }
+      return this.scroll ? 'scroll' : null
     }
   },
   methods: {

--- a/src/components/pull-to-refresh/QPullToRefresh.js
+++ b/src/components/pull-to-refresh/QPullToRefresh.js
@@ -57,7 +57,9 @@ export default {
       }
     },
     style () {
-      return [cssTransform(`translateY(${this.pullPosition}px)`), { marginBottom: `${height}px` }]
+      const css = cssTransform(`translateY(${this.pullPosition}px)`)
+      css.marginBottom = `${height}px`
+      return css
     },
     messageClass () {
       return `text-${this.color}`

--- a/src/components/pull-to-refresh/QPullToRefresh.js
+++ b/src/components/pull-to-refresh/QPullToRefresh.js
@@ -3,6 +3,8 @@ import { cssTransform } from '../../utils/dom'
 import { QIcon } from '../icon'
 import TouchPan from '../../directives/touch-pan'
 
+const height = -65
+
 export default {
   name: 'QPullToRefresh',
   directives: {
@@ -29,15 +31,17 @@ export default {
     disable: Boolean
   },
   data () {
-    let height = 65
-
     return {
       state: 'pull',
-      pullPosition: -height,
-      height: height,
+      pullPosition: height,
       animating: false,
       pulling: false,
       scrolling: false
+    }
+  },
+  watch: {
+    inline (val) {
+      this.setScrollContainer(val)
     }
   },
   computed: {
@@ -53,7 +57,7 @@ export default {
       }
     },
     style () {
-      return cssTransform(`translateY(${this.pullPosition}px)`)
+      return [cssTransform(`translateY(${this.pullPosition}px)`), { marginBottom: `${height}px` }]
     },
     messageClass () {
       return `text-${this.color}`
@@ -74,7 +78,7 @@ export default {
           this.trigger()
         }
         else if (this.state === 'pull') {
-          this.__animateTo(-this.height)
+          this.__animateTo(height)
         }
         return
       }
@@ -88,14 +92,14 @@ export default {
         if (this.pulling) {
           this.pulling = false
           this.state = 'pull'
-          this.__animateTo(-this.height)
+          this.__animateTo(height)
         }
         return true
       }
 
       event.evt.preventDefault()
       this.pulling = true
-      this.pullPosition = -this.height + Math.max(0, Math.pow(event.distance.y, 0.85))
+      this.pullPosition = height + Math.max(0, Math.pow(event.distance.y, 0.85))
       this.state = this.pullPosition > this.distance ? 'pulled' : 'pull'
     },
     __animateTo (target, done, previousCall) {
@@ -120,30 +124,35 @@ export default {
     },
     trigger () {
       this.handler(() => {
-        this.__animateTo(-this.height, () => {
+        this.__animateTo(height, () => {
           this.state = 'pull'
         })
+      })
+    },
+    setScrollContainer (inline) {
+      this.$nextTick(() => {
+        this.scrollContainer = inline ? this.$el.parentNode : getScrollTarget(this.$el)
       })
     }
   },
   mounted () {
-    this.$nextTick(() => {
-      this.scrollContainer = this.inline ? this.$el.parentNode : getScrollTarget(this.$el)
-    })
+    this.setScrollContainer(this.inline)
   },
   render (h) {
-    return h('div', { staticClass: 'pull-to-refresh' }, [
+    return h('div', { staticClass: 'pull-to-refresh overflow-hidden-y' }, [
       h('div', {
         staticClass: 'pull-to-refresh-container',
         style: this.style,
-        directives: [{
-          name: 'touch-pan',
-          modifiers: {
-            vertical: true,
-            mightPrevent: true
-          },
-          value: this.__pull
-        }]
+        directives: this.disable
+          ? null
+          : [{
+            name: 'touch-pan',
+            modifiers: {
+              vertical: true,
+              mightPrevent: true
+            },
+            value: this.__pull
+          }]
       }, [
         h('div', {
           staticClass: 'pull-to-refresh-message row flex-center',

--- a/src/components/pull-to-refresh/pull-to-refresh.ios.styl
+++ b/src/components/pull-to-refresh/pull-to-refresh.ios.styl
@@ -1,6 +1,5 @@
 .pull-to-refresh
   position relative
-  max-height 100vh
 
 .pull-to-refresh-message
   height 65px

--- a/src/components/pull-to-refresh/pull-to-refresh.mat.styl
+++ b/src/components/pull-to-refresh/pull-to-refresh.mat.styl
@@ -1,6 +1,5 @@
 .pull-to-refresh
   position relative
-  max-height 100vh
 
 .pull-to-refresh-message
   height 65px

--- a/src/css/core/visibility.styl
+++ b/src/css/core/visibility.styl
@@ -44,6 +44,8 @@
   overflow auto !important
 .overflow-hidden
   overflow hidden !important
+.overflow-hidden-y
+  overflow-y hidden !important
 
 .dimmed, .light-dimmed
   &:after


### PR DESCRIPTION
- move height to external constant
- remove max-height
- add negative margin-bottom on pull-to-refresh-container and add overflow-y on pull-to-refresh (to hide the arrow when in normal position and to compensate for the negative translateY)
- remove touch-pan directive when disable

Problems that show in demo page:
- with QScrollArea, if height of content is too small bottom guard stays on bottom

close #1884, close #983