### PR TITLE
improve fullscreen backdrop of modal experience

### DIFF
--- a/src/css/core/positioning.styl
+++ b/src/css/core/positioning.styl
@@ -65,14 +65,12 @@
 .fullscreen
   z-index $z-fullscreen
   border-radius 0 !important
-  max-width 100vw
-  max-height 100vh
+  width 200vw
+  height 200vh
 
 .absolute-full, .fullscreen
-  top 0
-  right 0
-  bottom 0
-  left 0
+  top -50%
+  left -50%
 
 .fixed-center, .absolute-center
   top 50%

--- a/src/css/core/positioning.styl
+++ b/src/css/core/positioning.styl
@@ -67,10 +67,14 @@
   border-radius 0 !important
   width 200vw
   height 200vh
-
-.absolute-full, .fullscreen
   top -50%
   left -50%
+
+.absolute-full
+  top 0
+  right 0
+  bottom 0
+  left 0
 
 .fixed-center, .absolute-center
   top 50%


### PR DESCRIPTION
I would argue that seeing the backdrop of the modal droop over the borders on all 4 sides gives a much better user experience with dragging a bit over the edge / fast scrolling.
In case you do not agree feel free to close the PR! : D