### PR TITLE
close #1911: Don't use touch-... directives when element is not editable

### DIFF
--- a/src/components/knob/QKnob.js
+++ b/src/components/knob/QKnob.js
@@ -217,14 +217,16 @@ export default {
         on: {
           click: e => !this.dragging && this.__onInput(e, void 0, true)
         },
-        directives: [{
-          name: 'touch-pan',
-          modifiers: {
-            prevent: true,
-            stop: true
-          },
-          value: this.__pan
-        }]
+        directives: this.editable
+          ? [{
+            name: 'touch-pan',
+            modifiers: {
+              prevent: true,
+              stop: true
+            },
+            value: this.__pan
+          }]
+          : null
       }, [
         h('svg', { attrs: { viewBox: '0 0 100 100' } }, [
           h('path', {

--- a/src/mixins/option.js
+++ b/src/mixins/option.js
@@ -83,7 +83,7 @@ export default {
         blur: () => { this.$emit('blur') },
         keydown: this.__handleKeyDown
       },
-      directives: this.__kebabTag === 'q-toggle'
+      directives: this.__kebabTag === 'q-toggle' && !this.disable && !this.readonly
         ? [{
           name: 'touch-swipe',
           modifiers: { horizontal: true },


### PR DESCRIPTION
Fixed in QKnob and QToggle.

close #1911
