### PR TITLE
Improve keyboard navigation for all framework

### DIFF
--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -50,10 +50,17 @@
         <q-btn label="Go to index page" to="/" />
       </p>
       <div>
-        <form @submit.prevent="submit" @reset.prevent="reset" class="shadow-2 row q-pa-md items-center">
-          <q-input v-model="test" class="col" />
-          <q-btn fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" />
-          <q-btn fab color="primary" icon="android" type="submit" class="on-right" title="Submit" />
+        <form @submit.prevent="submit" @reset.prevent="reset" class="shadow-2 q-pa-md row items-center">
+          <div class="col row items-center gutter-md">
+            <div class="col">
+              <q-input v-model="test" />
+            </div>
+            <div class="col">
+              <q-input type="number" v-model="testN" />
+            </div>
+          </div>
+          <q-btn :tag="tag" fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" @click="onClick" />
+          <q-btn :tag="tag" fab color="primary" icon="android" type="submit" class="on-right" title="Submit" @click="onClick" />
         </form>
       </div>
 
@@ -480,7 +487,9 @@ export default {
       loading2: false,
       percentage: 0,
       clickTimes: 0,
-      test: 'Initial value'
+      test: 'Initial value',
+      testN: 0,
+      tag: 'button'
     }
   },
   methods: {
@@ -517,9 +526,11 @@ export default {
     },
     submit () {
       this.$q.notify('Submit called')
+      console.log('test', this.test, 'testN', this.testN)
     },
     reset () {
       this.test = 'Initial value'
+      this.testN = 0
       this.$q.notify('Reset called')
     }
   },

--- a/dev/components/components/fab.vue
+++ b/dev/components/components/fab.vue
@@ -19,7 +19,6 @@
 
         <br>
 
-        <q-toggle v-model="toggle" class="z-max fixed-top" />
         <q-fab v-model="toggle" icon="keyboard_arrow_left" direction="left">
           <q-fab-action @click="notify('mail')" icon="mail" />
           <q-fab-action @click="notify('alarm')" icon="alarm" />
@@ -51,6 +50,8 @@
           <q-fab-action color="amber" @click="notify('alarm')" icon="alarm" />
         </q-fab>
       </div>
+
+      <q-toggle v-model="toggle" class="z-max fixed-top" />
 
       <p class="caption" style="margin-bottom: 100px;">
         There's also the absolute positioned one on bottom

--- a/dev/components/components/popover.vue
+++ b/dev/components/components/popover.vue
@@ -17,6 +17,8 @@
                 :key="n"
                 v-close-overlay
                 @click.native="showNotify()"
+                @keyup.native.13.32="showNotify()"
+                :tabindex="0"
               >
                 <q-item-main label="Label" sublabel="Click me" />
               </q-item>
@@ -32,6 +34,8 @@
                 :key="n"
                 v-close-overlay
                 @click.native="showNotify()"
+                @keyup.native.13.32="showNotify()"
+                :tabindex="0"
               >
                 <q-item-main label="X Label" sublabel="X Click me" />
               </q-item>
@@ -57,7 +61,9 @@
                     v-for="n in 3"
                     :key="n"
                     v-close-overlay
-                    @click="showNotify()"
+                    @click.native="showNotify()"
+                    @keyup.native.13.32="showNotify()"
+                    :tabindex="0"
                   >
                     <q-item-main label="Label" />
                   </q-item>
@@ -118,6 +124,8 @@
               src="~assets/map.png"
               style="height: 150px; width: 200px;"
               @click="showNotify(), $refs.popover3.hide()"
+              @keyup.13.32="showNotify(), $refs.popover3.hide()"
+              :tabindex="0"
             >
           </q-popover>
         </q-btn>
@@ -140,6 +148,8 @@
               v-for="n in 20"
               :key="n"
               @click.native="showNotify(), $refs.popover5.hide()"
+              @keyup.native.13.32="showNotify(), $refs.popover5.hide()"
+              :tabindex="0"
             >
               <q-item-main label="Label" sublabel="Click me" />
             </q-item>

--- a/dev/components/form/select.vue
+++ b/dev/components/form/select.vue
@@ -58,11 +58,11 @@
       <q-select simple v-model="select" :options="selectOptions"/>
 
       <p class="caption">With Filter</p>
-      <q-select filter autofocus-filter v-model="select" :options="selectListOptions"/>
-      <q-select filter autofocus-filter v-model="select" :options="selectLongListOptions"/>
-      <q-select filter autofocus-filter inverted v-model="select" :options="selectListOptions"/>
-      <q-select filter inverted v-model="select" :options="selectLongListOptions"/>
-      <q-select filter multiple checkbox v-model="multipleSelect" :options="selectListOptions"/>
+      <q-select filter v-model="select" :options="selectListOptions" />
+      <q-select filter v-model="select" :options="selectLongListOptions" />
+      <q-select filter inverted v-model="select" :options="selectListOptions" />
+      <q-select filter inverted v-model="select" :options="selectLongListOptions" />
+      <q-select filter multiple checkbox v-model="multipleSelect" :options="selectListOptions" />
 
       <p class="caption">With Static Label</p>
       <q-select multiple v-model="multipleSelect" :options="selectOptions" static-label="Company"/>

--- a/src/components/action-sheet/QActionSheet.js
+++ b/src/components/action-sheet/QActionSheet.js
@@ -59,7 +59,7 @@ export default {
             },
             nativeOn: {
               click: this.__onCancel,
-              keydown: this.__onKeyCancel
+              keyup: this.__onKeyCancel
             }
           }, [
             h(QItemMain, { staticClass: 'text-center text-primary' }, [
@@ -116,7 +116,7 @@ export default {
           },
           [this.grid ? 'on' : 'nativeOn']: {
             click: () => this.__onOk(action),
-            keydown: e => {
+            keyup: e => {
               if (getEventKey(e) === /* Enter */ 13) {
                 this.__onOk(action)
               }

--- a/src/components/autocomplete/QAutocomplete.js
+++ b/src/components/autocomplete/QAutocomplete.js
@@ -218,7 +218,8 @@ export default {
       'class': dark ? 'bg-dark' : null,
       props: {
         fit: true,
-        anchorClick: false
+        anchorClick: false,
+        noFocus: true
       },
       on: {
         show: () => {

--- a/src/components/color/QColorPicker.js
+++ b/src/components/color/QColorPicker.js
@@ -127,8 +127,7 @@ export default {
           ? [{
             name: 'touch-pan',
             modifiers: {
-              prevent: true,
-              stop: true
+              mightPrevent: true
             },
             value: this.__saturationPan
           }]

--- a/src/components/datetime/QDatetimePicker.mat.vue
+++ b/src/components/datetime/QDatetimePicker.mat.vue
@@ -7,23 +7,35 @@
           <span
             :class="{active: view === 'month'}"
             class="q-datetime-link small col-auto col-md-12"
-            @click="!disable && (view = 'month')"
+            @keydown.down.left="setMonth(month - 1, true)"
+            @keydown.up.right="setMonth(month + 1, true)"
+            :tabindex="0"
           >
-            {{ monthString }}
+            <span @click="!disable && (view = 'month')" :tabindex="-1">
+              {{ monthString }}
+            </span>
           </span>
           <span
             :class="{active: view === 'day'}"
             class="q-datetime-link col-auto col-md-12"
-            @click="!disable && (view = 'day')"
+            @keydown.down.left="setDay(day - 1, true)"
+            @keydown.up.right="setDay(day + 1, true)"
+            :tabindex="0"
           >
-            {{ day }}
+            <span @click="!disable && (view = 'day')" :tabindex="-1">
+              {{ day }}
+            </span>
           </span>
           <span
             :class="{active: view === 'year'}"
             class="q-datetime-link small col-auto col-md-12"
-            @click="!disable && (view = 'year')"
+            @keydown.down.left="setYear(year - 1, true)"
+            @keydown.up.right="setYear(year + 1, true)"
+            :tabindex="0"
           >
-            {{ year }}
+            <span @click="!disable && (view = 'year')" :tabindex="-1">
+              {{ year }}
+            </span>
           </span>
         </div>
       </div>
@@ -31,34 +43,52 @@
         v-if="typeHasTime"
         class="q-datetime-time row flex-center"
       >
-        <div class="q-datetime-clockstring col-auto col-md-12">
+        <div class="q-datetime-clockstring col-auto col-md-12 row no-wrap flex-center">
           <span
             :class="{active: view === 'hour'}"
-            class="q-datetime-link col-auto col-md-12"
-            @click="!disable && (view = 'hour')"
+            class="q-datetime-link col-md text-right q-pr-sm"
+            @keydown.down.left="setHour(hour - 1, true)"
+            @keydown.up.right="setHour(hour + 1, true)"
+            :tabindex="0"
           >
-            {{ __pad(hour, '&nbsp;&nbsp;') }}
+            <span @click="!disable && (view = 'hour')" :tabindex="-1">
+              {{ hour }}
+            </span>
           </span>
           <span style="opacity: 0.6">:</span>
           <span
             :class="{active: view === 'minute'}"
-            class="q-datetime-link col-auto col-md-12"
-            @click="!disable && (view = 'minute')"
+            class="q-datetime-link col-md text-left q-pl-sm"
+            @keydown.down.left="setMinute(minute - 1, true)"
+            @keydown.up.right="setMinute(minute + 1, true)"
+            :tabindex="0"
           >
-            {{ __pad(minute) }}
+            <span @click="!disable && (view = 'minute')" :tabindex="-1">
+              {{ __pad(minute) }}
+            </span>
           </span>
         </div>
         <div v-if="!computedFormat24h" class="q-datetime-ampm column col-auto col-md-12 justify-around">
           <div
             :class="{active: am}"
             class="q-datetime-link"
-            @click="toggleAmPm()"
-          >AM</div>
+            @keyup.13.32="toggleAmPm()"
+            :tabindex="0"
+          >
+            <span @click="toggleAmPm()" :tabindex="-1">
+              AM
+            </span>
+          </div>
           <div
             :class="{active: !am}"
             class="q-datetime-link"
-            @click="toggleAmPm()"
-          >PM</div>
+            @keyup.13.32="toggleAmPm()"
+            :tabindex="0"
+          >
+            <span @click="toggleAmPm()" :tabindex="-1">
+              PM
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -76,6 +106,7 @@
             :class="{active: n + yearMin === year}"
             :disable="!editable"
             @click="setYear(n + yearMin)"
+            :tabindex="-1"
           >
             {{ n + yearMin }}
           </q-btn>
@@ -93,6 +124,7 @@
             :class="{active: month === index + monthMin}"
             :disable="!editable"
             @click="setMonth(index + monthMin, true)"
+            :tabindex="-1"
           >
             {{ $q.i18n.date.months[index + monthMin - 1] }}
           </q-btn>
@@ -112,6 +144,7 @@
               :repeat-timeout="__repeatTimeout"
               :disable="beforeMinDays > 0 || disable || readonly"
               @click="setMonth(month - 1)"
+              :tabindex="-1"
             />
             <div class="col q-datetime-month-stamp">
               {{ monthStamp }}
@@ -125,6 +158,7 @@
               :repeat-timeout="__repeatTimeout"
               :disable="afterMaxDays > 0 || disable || readonly"
               @click="setMonth(month + 1)"
+              :tabindex="-1"
             />
           </div>
           <div class="q-datetime-weekdays row items-center justify-start">
@@ -392,25 +426,29 @@ export default {
   },
   methods: {
     /* date */
-    setYear (value) {
+    setYear (value, skipView) {
       if (this.editable) {
-        this.view = 'day'
+        if (!skipView) {
+          this.view = 'day'
+        }
         this.model = new Date(this.model.setFullYear(this.__parseTypeValue('year', value)))
       }
     },
-    setMonth (value) {
+    setMonth (value, skipView) {
       if (this.editable) {
-        this.view = 'day'
+        if (!skipView) {
+          this.view = 'day'
+        }
         this.model = adjustDate(this.model, {month: value})
       }
     },
-    setDay (value) {
+    setDay (value, skipView) {
       if (this.editable) {
         this.model = new Date(this.model.setDate(this.__parseTypeValue('date', value)))
         if (this.type === 'date') {
           this.$emit('canClose')
         }
-        else {
+        else if (!skipView) {
           this.view = 'hour'
         }
       }

--- a/src/components/datetime/datetime.mat.styl
+++ b/src/components/datetime/datetime.mat.styl
@@ -39,6 +39,10 @@ div + .q-datetime-time
 .q-datetime-link
   cursor pointer
   opacity .6
+  > span
+    display inline-block
+    width 100%
+    outline none
   &.active
     opacity 1
 
@@ -168,10 +172,11 @@ div + .q-datetime-time
     &.q-datetime-day-active > span, &:not(.q-datetime-fillerday):not(.disabled):not(.q-datetime-day-active):hover
       color black
 
-body.desktop .q-datetime-clock-position:not(.active):hover
-  background $grey-2 !important
-body.desktop .q-datetime-dark .q-datetime-clock-position:not(.active):hover
-  color black
+body.desktop
+  .q-datetime-clock-position:not(.active):hover
+    background $grey-2 !important
+  .q-datetime-dark .q-datetime-clock-position:not(.active):hover
+    color black
 
 .q-datetime-clock-position
   position absolute

--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -23,6 +23,7 @@ export default {
     preventClose: Boolean,
     noBackdropDismiss: Boolean,
     noEscDismiss: Boolean,
+    noRefocus: Boolean,
     position: String,
     color: {
       type: String,
@@ -86,6 +87,7 @@ export default {
         minimized: true,
         noBackdropDismiss: this.noBackdropDismiss || this.preventClose,
         noEscDismiss: this.noEscDismiss || this.preventClose,
+        noRefocus: this.noRefocus,
         position: this.position
       },
       on: {
@@ -95,7 +97,7 @@ export default {
         show: () => {
           this.$emit('show')
 
-          if (!this.$q.platform.is.desktop || (!this.prompt && !this.options)) {
+          if (!this.$q.platform.is.desktop) {
             return
           }
 
@@ -108,7 +110,7 @@ export default {
             return
           }
 
-          node = this.$refs.modal.$el.getElementsByTagName('BUTTON')
+          node = this.$refs.modal.$el.getElementsByClassName('q-btn')
           if (node.length) {
             node[node.length - 1].focus()
           }

--- a/src/components/fab/QFab.js
+++ b/src/components/fab/QFab.js
@@ -8,7 +8,10 @@ export default {
   mixins: [FabMixin, ModelToggleMixin],
   provide () {
     return {
-      __qFabClose: this.hide
+      __qFabClose: evt => this.hide(evt).then(() => {
+        this.$refs.trigger && this.$refs.trigger.$el && this.$refs.trigger.$el.focus()
+        return evt
+      })
     }
   },
   props: {
@@ -37,6 +40,7 @@ export default {
       }
     }, [
       h(QBtn, {
+        ref: 'trigger',
         props: {
           fab: true,
           outline: this.outline,
@@ -64,7 +68,7 @@ export default {
       h('div', {
         staticClass: 'q-fab-actions flex no-wrap inline items-center',
         'class': `q-fab-${this.direction}`
-      }, this.$slots.default)
+      }, this.showing ? this.$slots.default : null)
     ])
   }
 }

--- a/src/components/knob/QKnob.js
+++ b/src/components/knob/QKnob.js
@@ -66,6 +66,9 @@ export default {
     },
     computedDecimals () {
       return this.decimals !== void 0 ? this.decimals || 0 : (String(this.step).trim('0').split('.')[1] || '').length
+    },
+    computedStep () {
+      return this.decimals !== void 0 ? 1 / Math.pow(10, this.decimals || 0) : this.step
     }
   },
   data () {
@@ -142,18 +145,35 @@ export default {
       }, 100)
       this.__onInput(ev, this.centerPosition, true)
     },
+    __onKeyDown (ev) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      const step = ev.ctrlKey ? 10 * this.computedStep : this.computedStep
+      const offset = [37, 40].includes(keyCode) ? -step : step
+      this.__onInputValue(between(this.model + offset, this.min, this.max))
+    },
+    __onKeyUp (ev) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      this.__emitChange()
+    },
     __onInput (ev, center = this.__getCenter(), emitChange) {
       if (!this.editable) {
         return
       }
-      let
+      const
         pos = position(ev),
         height = Math.abs(pos.top - center.top),
         distance = Math.sqrt(
           Math.pow(Math.abs(pos.top - center.top), 2) +
           Math.pow(Math.abs(pos.left - center.left), 2)
-        ),
-        angle = Math.asin(height / distance) * (180 / Math.PI)
+        )
+
+      let angle = Math.asin(height / distance) * (180 / Math.PI)
 
       if (pos.top < center.top) {
         angle = center.left < pos.left ? 90 - angle : 270 + angle
@@ -166,16 +186,18 @@ export default {
         angle = 360 - angle
       }
 
-      let
+      const
         model = this.min + (angle / 360) * (this.max - this.min),
         modulo = model % this.step
 
-      let value = between(
+      const value = between(
         model - modulo + (Math.abs(modulo) >= this.step / 2 ? (modulo < 0 ? -1 : 1) * this.step : 0),
         this.min,
         this.max
       )
-
+      this.__onInputValue(value, emitChange)
+    },
+    __onInputValue (value, emitChange) {
       if (this.computedDecimals) {
         value = parseFloat(value.toFixed(this.computedDecimals))
       }
@@ -192,12 +214,15 @@ export default {
 
       this.$emit('input', value)
       if (emitChange) {
-        this.$nextTick(() => {
-          if (JSON.stringify(value) !== JSON.stringify(this.value)) {
-            this.$emit('change', value)
-          }
-        })
+        this.__emitChange(value)
       }
+    },
+    __emitChange (value = this.model) {
+      this.$nextTick(() => {
+        if (JSON.stringify(value) !== JSON.stringify(this.value)) {
+          this.$emit('change', value)
+        }
+      })
     },
     __getCenter () {
       let knobOffset = offset(this.$el)
@@ -255,7 +280,16 @@ export default {
 
         h(
           'div',
-          { staticClass: 'q-knob-label row flex-center content-center' },
+          {
+            staticClass: 'q-knob-label row flex-center content-center',
+            attrs: {
+              tabindex: this.editable ? 0 : -1
+            },
+            on: {
+              keydown: this.__onKeyDown,
+              keyup: this.__onKeyUp
+            }
+          },
           this.$slots.default || [
             h('span', [ this.model ])
           ]

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -94,6 +94,7 @@ export default {
       default: false
     },
     noRouteDismiss: Boolean,
+    noRefocus: Boolean,
     minimized: Boolean,
     maximized: Boolean
   },
@@ -168,6 +169,9 @@ export default {
       })
     },
     __show () {
+      if (!this.noRefocus) {
+        this.__refocusTarget = document.activeElement
+      }
       const body = document.body
 
       body.appendChild(this.$el)
@@ -178,6 +182,7 @@ export default {
         if (!this.noEscDismiss) {
           this.hide().then(() => {
             this.$emit('escape-key')
+            this.$emit('dismiss')
           })
         }
       })
@@ -199,6 +204,9 @@ export default {
       EscapeKey.pop()
       this.__preventScroll(false)
       this.__register(false)
+      if (!this.noRefocus && this.__refocusTarget) {
+        this.__refocusTarget.focus()
+      }
     },
     __stopPropagation (e) {
       e.stopPropagation()

--- a/src/components/modal/modal.ios.styl
+++ b/src/components/modal/modal.ios.styl
@@ -19,6 +19,7 @@ maximized-modal()
   max-height 80vh
   border-radius $modal-border-radius
   -webkit-backface-visibility hidden
+  outline none
 
 .modal
   z-index $z-modal

--- a/src/components/modal/modal.mat.styl
+++ b/src/components/modal/modal.mat.styl
@@ -17,6 +17,7 @@ maximized-modal()
   min-width 280px
   max-height 80vh
   -webkit-backface-visibility hidden
+  outline none
 
 .modal
   z-index $z-modal

--- a/src/components/popover/popover.ios.styl
+++ b/src/components/popover/popover.ios.styl
@@ -6,6 +6,7 @@
   overflow-y auto
   overflow-x hidden
   max-width $popover-max-width
+  outline none
   > .q-list:only-child
     border none
 

--- a/src/components/popover/popover.mat.styl
+++ b/src/components/popover/popover.mat.styl
@@ -6,6 +6,7 @@
   overflow-y auto
   overflow-x hidden
   max-width $popover-max-width
+  outline none
   > .q-list:only-child
     border none
 

--- a/src/components/range/QRange.js
+++ b/src/components/range/QRange.js
@@ -240,6 +240,29 @@ export default {
       this.currentMinPercentage = (this.model.min - this.min) / (this.max - this.min)
       this.currentMaxPercentage = (this.model.max - this.min) / (this.max - this.min)
     },
+    __onKeyDown (ev, type) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      const
+        decimals = this.computedDecimals,
+        step = ev.ctrlKey ? 10 * this.computedStep : this.computedStep,
+        offset = [37, 40].includes(keyCode) ? -step : step,
+        model = decimals ? parseFloat((this.model[type] + offset).toFixed(decimals)) : (this.model[type] + offset)
+
+      this.model[type] = between(model, type === 'min' ? this.min : this.model.min, type === 'max' ? this.max : this.model.max)
+      this.currentMinPercentage = (this.model.min - this.min) / (this.max - this.min)
+      this.currentMaxPercentage = (this.model.max - this.min) / (this.max - this.min)
+      this.__update()
+    },
+    __onKeyUp (ev, type) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      this.__update(true)
+    },
     __validateProps () {
       if (this.min >= this.max) {
         console.error('Range error: min >= max', this.$el, this.min, this.max)
@@ -266,7 +289,12 @@ export default {
         'class': [
           edge ? 'handle-at-minimum' : null,
           { dragging: this.dragging }
-        ]
+        ],
+        attrs: { tabindex: this.editable ? 0 : -1 },
+        on: {
+          keydown: ev => this.__onKeyDown(ev, lower),
+          keyup: ev => this.__onKeyUp(ev, lower)
+        }
       }, [
         this.label || this.labelAlways
           ? h(QChip, {

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -77,13 +77,13 @@
       :class="dark ? 'bg-dark' : null"
       @show="__onShow"
       @hide="__onClose(true)"
+      @keydown.native="__keyboardHandleKey"
     >
       <q-search
         v-if="filter"
         ref="filter"
         v-model="terms"
         @input="reposition"
-        @keydown.native="__keyboardHandleKey"
         :placeholder="filterPlaceholder || $q.i18n.label.filter"
         :debounce="100"
         :color="color"
@@ -204,7 +204,6 @@ export default {
   props: {
     filter: [Function, Boolean],
     filterPlaceholder: String,
-    autofocusFilter: Boolean,
     radio: Boolean,
     placeholder: String,
     separator: Boolean,

--- a/src/components/slider/QSlider.js
+++ b/src/components/slider/QSlider.js
@@ -4,6 +4,7 @@ import {
   notDivides,
   SliderMixin
 } from './slider-utils'
+import { between } from '../../utils/format'
 import { QChip } from '../chip'
 
 export default {
@@ -94,6 +95,28 @@ export default {
       this.model = getModel(percentage, this.min, this.max, this.step, this.computedDecimals)
       this.currentPercentage = (this.model - this.min) / (this.max - this.min)
     },
+    __onKeyDown (ev) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      const
+        decimals = this.computedDecimals,
+        step = ev.ctrlKey ? 10 * this.computedStep : this.computedStep,
+        offset = [37, 40].includes(keyCode) ? -step : step,
+        model = decimals ? parseFloat((this.model + offset).toFixed(decimals)) : (this.model + offset)
+
+      this.model = between(model, this.min, this.max)
+      this.currentPercentage = (this.model - this.min) / (this.max - this.min)
+      this.__update()
+    },
+    __onKeyUp (ev) {
+      const keyCode = ev.keyCode
+      if (!this.editable || ![37, 40, 39, 38].includes(keyCode)) {
+        return
+      }
+      this.__update(true)
+    },
     __validateProps () {
       if (this.min >= this.max) {
         console.error('Range error: min >= max', this.$el, this.min, this.max)
@@ -121,6 +144,11 @@ export default {
           'class': {
             dragging: this.dragging,
             'handle-at-minimum': !this.fillHandleAlways && this.model === this.min
+          },
+          attrs: { tabindex: this.editable ? 0 : -1 },
+          on: {
+            keydown: this.__onKeyDown,
+            keyup: this.__onKeyUp
           }
         }, [
           this.label || this.labelAlways

--- a/src/components/slider/slider-utils.js
+++ b/src/components/slider/slider-utils.js
@@ -88,6 +88,9 @@ export let SliderMixin = {
     },
     computedDecimals () {
       return this.decimals !== void 0 ? this.decimals || 0 : (String(this.step).trim('0').split('.')[1] || '').length
+    },
+    computedStep () {
+      return this.decimals !== void 0 ? 1 / Math.pow(10, this.decimals || 0) : this.step
     }
   },
   methods: {

--- a/src/components/tab/QRouteTab.js
+++ b/src/components/tab/QRouteTab.js
@@ -51,7 +51,8 @@ export default {
         exactActiveClass: 'q-router-link-exact-active'
       },
       nativeOn: {
-        click: this.select
+        click: this.select,
+        keyup: e => e.keyCode === 13 && this.select(e)
       },
       staticClass: 'q-tab column flex-center relative-position',
       'class': this.classes,

--- a/src/components/tab/QTab.js
+++ b/src/components/tab/QTab.js
@@ -24,7 +24,8 @@ export default {
       staticClass: 'q-tab column flex-center relative-position',
       'class': this.classes,
       on: {
-        click: this.select
+        click: this.select,
+        keyup: e => e.keyCode === 13 && this.select(e)
       },
       directives: process.env.THEME === 'mat'
         ? [{ name: 'ripple' }]

--- a/src/components/tab/tab-mixin.js
+++ b/src/components/tab/tab-mixin.js
@@ -24,7 +24,8 @@ export default {
     },
     alert: Boolean,
     count: [Number, String],
-    color: String
+    color: String,
+    tabindex: Number
   },
   inject: {
     data: {
@@ -71,6 +72,9 @@ export default {
       if (!this.active || !this.data.highlight) {
         return 'display: none;'
       }
+    },
+    computedTabIndex () {
+      return this.disable || this.active ? -1 : this.tabindex || 0
     }
   },
   methods: {
@@ -122,6 +126,11 @@ export default {
           style: this.barStyle
         }))
       }
+
+      child.push(h('div', {
+        staticClass: 'q-tab-focus-helper absolute-full',
+        attrs: { tabindex: this.computedTabIndex }
+      }))
 
       return child
     }

--- a/src/components/tab/tabs.ios.styl
+++ b/src/components/tab/tabs.ios.styl
@@ -55,6 +55,14 @@
 .q-tab-icon
   font-size $tabs-icon-font-size
 
+.q-tab-focus-helper
+  z-index -1
+  outline none
+  &:focus
+    z-index unset
+    background currentColor
+    opacity .1
+
 @media (max-width $breakpoint-sm-max)
   .q-tab
     &.hide-icon .q-tab-icon-parent,

--- a/src/components/tab/tabs.mat.styl
+++ b/src/components/tab/tabs.mat.styl
@@ -48,6 +48,14 @@
 .q-tab-icon
   font-size $tabs-icon-font-size
 
+.q-tab-focus-helper
+  z-index -1
+  outline none
+  &:focus
+    z-index unset
+    background currentColor
+    opacity .1
+
 @media (max-width $breakpoint-sm-max)
   .q-tab
     &.hide-icon .q-tab-icon-parent,

--- a/src/directives/back-to-top.js
+++ b/src/directives/back-to-top.js
@@ -54,6 +54,11 @@ export default {
       },
       goToTop () {
         setScrollPosition(ctx.scrollTarget, 0, ctx.animate ? ctx.duration : 0)
+      },
+      goToTopKey (evt) {
+        if (evt.keyCode === 13) {
+          setScrollPosition(ctx.scrollTarget, 0, ctx.animate ? ctx.duration : 0)
+        }
       }
     }
     ctx.update = debounce(ctx.updateNow, 25)
@@ -68,6 +73,7 @@ export default {
     ctx.scrollTarget.addEventListener('scroll', ctx.update, listenOpts.passive)
     window.addEventListener('resize', ctx.update, listenOpts.passive)
     el.addEventListener('click', ctx.goToTop)
+    el.addEventListener('keyup', ctx.goToTopKey)
   },
   update (el, binding) {
     if (JSON.stringify(binding.oldValue) !== JSON.stringify(binding.value)) {
@@ -85,6 +91,7 @@ export default {
     ctx.scrollTarget.removeEventListener('scroll', ctx.update, listenOpts.passive)
     window.removeEventListener('resize', ctx.update, listenOpts.passive)
     el.removeEventListener('click', ctx.goToTop)
+    el.removeEventListener('keyup', ctx.goToTopKey)
     delete el.__qbacktotop
   }
 }

--- a/src/directives/close-overlay.js
+++ b/src/directives/close-overlay.js
@@ -1,23 +1,31 @@
 export default {
   name: 'close-overlay',
   bind (el, binding, vnode) {
-    const handler = ev => {
-      let vm = vnode.componentInstance
-      while ((vm = vm.$parent)) {
-        const name = vm.$options.name
-        if (name === 'QPopover' || name === 'QModal') {
-          vm.hide(ev)
-          break
+    const
+      handler = ev => {
+        let vm = vnode.componentInstance
+        while ((vm = vm.$parent)) {
+          const name = vm.$options.name
+          if (name === 'QPopover' || name === 'QModal') {
+            vm.hide(ev)
+            break
+          }
+        }
+      },
+      handlerKey = ev => {
+        if (ev.keyCode === 13) {
+          handler(ev)
         }
       }
-    }
-    el.__qclose = { handler }
+    el.__qclose = { handler, handlerKey }
     el.addEventListener('click', handler)
+    el.addEventListener('keyup', handlerKey)
   },
   unbind (el) {
     const ctx = el.__qclose
     if (!ctx) { return }
     el.removeEventListener('click', ctx.handler)
+    el.removeEventListener('keyup', ctx.handlerKey)
     delete el.__qclose
   }
 }

--- a/src/directives/go-back.js
+++ b/src/directives/go-back.js
@@ -15,9 +15,15 @@ export default {
         vnode.context.$router.replace(ctx.value)
       }
     }
+    ctx.goBackKey = ev => {
+      if (ev.keyCode === 13) {
+        ctx.goBack(ev)
+      }
+    }
 
     el.__qgoback = ctx
     el.addEventListener('click', ctx.goBack)
+    el.addEventListener('keyup', ctx.goBackKey)
   },
   update (el, binding) {
     if (binding.oldValue !== binding.value) {
@@ -28,6 +34,7 @@ export default {
     const ctx = el.__qgoback
     if (!ctx) { return }
     el.removeEventListener('click', ctx.goBack)
+    el.removeEventListener('keyup', ctx.goBackKey)
     delete el.__qgoback
   }
 }

--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -64,11 +64,17 @@ export default {
         if (ctx.enabled) {
           showRipple(evt, el, modifiers.stop)
         }
+      },
+      keyup (evt) {
+        if (ctx.enabled && evt.keyCode === 13) {
+          showRipple(evt, el, modifiers.stop)
+        }
       }
     }
 
     el.__qripple = ctx
     el.addEventListener('click', ctx.click, false)
+    el.addEventListener('keyup', ctx.keyup, false)
   },
   update (el, { value, oldValue }) {
     if (el.__qripple && value !== oldValue) {
@@ -82,6 +88,7 @@ export default {
     }
 
     el.removeEventListener('click', ctx.click, false)
+    el.removeEventListener('keyup', ctx.keyup, false)
     delete el.__qripple
   }
 }

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -55,6 +55,9 @@ export default {
       })
     },
     __onKeydown (e) {
+      if (e.keyCode === 13) {
+        this.__emit()
+      }
       this.$emit('keydown', e)
     },
     __onKeyup (e) {


### PR DESCRIPTION
- QModal
  - fix not emmiting dismiss on ESC
  - focus after show
- QPopover
  - focus after show
  - refocus after hide (noRefocus prop)
  - allow toggle by keyboard ENTER
- QDialog
  - fix button focus
  - find button by class name (q-btn)
- QFab - refocus after hide
- QTab / QRouteTab
  - focus with keyboard
  - allow select with keyboard ENTER
- QColor and QDatetime
  - fix tabindex lost on close
  - fix popup not closing on blur
- QColorPicker
  - fix incorrect tabindex on disable
  - allow to select saturation on click on mobile (was working only on drag)
- QDatetimePicker.mat - allow keyboard adjustment of all values
- QActionsheet
  - select option with ENTER/SPACE, navigation with TAB
  - trigger selection on keyup to avoid click on original button
- QAutocomplete - use QPopup with noFocus
- QKnob, QSlider, QRange - keyboard updating (UP|RIGHT +, DOWN|LEFT -, CTRL+... 10*)
- QSelect
  - remove autofocusFilter - always select filter if present
  - move keyboard navigation on QPopover
  - delay popover.reposition on filter to allow resize
- v-back-to-top, v-close-overlay, v-go-back, v-ripple - trigger by keyboard ENTER

close #2121, close #1996, close #2113, close #2137, close #1038