### PR TITLE
QDialog and QModal: refocus original element after hide

### DIFF
--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -23,6 +23,7 @@ export default {
     preventClose: Boolean,
     noBackdropDismiss: Boolean,
     noEscDismiss: Boolean,
+    noRefocus: Boolean,
     position: String,
     color: {
       type: String,
@@ -86,6 +87,7 @@ export default {
         minimized: true,
         noBackdropDismiss: this.noBackdropDismiss || this.preventClose,
         noEscDismiss: this.noEscDismiss || this.preventClose,
+        noRefocus: this.noRefocus,
         position: this.position
       },
       on: {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -83,6 +83,7 @@ export default {
       default: false
     },
     noRouteDismiss: Boolean,
+    noRefocus: Boolean,
     minimized: Boolean,
     maximized: Boolean
   },
@@ -146,6 +147,9 @@ export default {
       })
     },
     __show () {
+      if (!this.noRefocus) {
+        this.__refocusTarget = document.activeElement
+      }
       const body = document.body
 
       body.appendChild(this.$el)
@@ -176,6 +180,9 @@ export default {
       EscapeKey.pop()
       this.__preventScroll(false)
       this.__register(false)
+      if (!this.noRefocus && this.__refocusTarget) {
+        this.__refocusTarget.focus()
+      }
     },
     __stopPropagation (e) {
       e.stopPropagation()


### PR DESCRIPTION
- introduce noRefocus prop
- when noRefocus not present:
  - save the activeElement when modal was opened
  - restore focus on it when hidden