### PR TITLE
close #1903: Fix QEditor not emitting after ENTER

### DIFF
--- a/dev/components/css/typography.vue
+++ b/dev/components/css/typography.vue
@@ -155,7 +155,7 @@ export default {
       return this.testHeight ? ' [Apjyq]' : ''
     },
     testFonts () {
-      return fonts.map((f) => ({ label: `Font ${f}`, value: f }))
+      return fonts.map(f => ({ label: `Font ${f}`, value: f }))
     }
   }
 }

--- a/src/components/editor/QEditor.js
+++ b/src/components/editor/QEditor.js
@@ -234,8 +234,11 @@ export default {
   methods: {
     onInput (e) {
       if (this.editWatcher) {
-        this.editWatcher = false
-        this.$emit('input', this.$refs.content.innerHTML)
+        const val = this.$refs.content.innerHTML
+        if (val !== this.value) {
+          this.editWatcher = false
+          this.$emit('input', val)
+        }
       }
     },
     onKeydown (e) {

--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -346,7 +346,7 @@ export default {
                 this.__computeTotalSize()
                 resolve(true)
               }
-              reader.onerror = e => reject(e)
+              reader.onerror = e => { reject(e) }
             })
 
             reader.readAsDataURL(file)

--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -338,7 +338,7 @@ export default {
           else {
             const reader = new FileReader()
             let p = new Promise((resolve, reject) => {
-              reader.onload = (e) => {
+              reader.onload = e => {
                 let img = new Image()
                 img.src = e.target.result
                 file.__img = img
@@ -346,9 +346,7 @@ export default {
                 this.__computeTotalSize()
                 resolve(true)
               }
-              reader.onerror = (e) => {
-                reject(e)
-              }
+              reader.onerror = e => reject(e)
             })
 
             reader.readAsDataURL(file)

--- a/src/install.js
+++ b/src/install.js
@@ -19,7 +19,7 @@ function bodyInit () {
   Platform.is.electron && cls.push('electron')
 
   if (Platform.is.ie && Platform.is.versionNumber === 11) {
-    cls.forEach((c) => document.body.classList.add(c))
+    cls.forEach(c => document.body.classList.add(c))
   }
   else {
     document.body.classList.add.apply(document.body.classList, cls)


### PR DESCRIPTION
On enter some browsers have the same innerHtml as before, and think they are not editWatched, so they stop emitting.

- also fix some forgotten arrow-parens

close #1903
