### PR TITLE
Avoid horizontal overflow of card title

### DIFF
--- a/src/components/card/card.ios.styl
+++ b/src/components/card/card.ios.styl
@@ -23,6 +23,7 @@
   padding 16px
 
 .q-card-title
+  max-width 100%
   font-size 18px
   font-weight 400
   letter-spacing normal
@@ -30,6 +31,7 @@
   &:empty
     display none
 .q-card-subtitle, .q-card-title-extra
+  max-width 100%
   font-size 14px
   color $card-faded-color
   .q-icon

--- a/src/components/card/card.mat.styl
+++ b/src/components/card/card.mat.styl
@@ -23,6 +23,7 @@
   padding 16px
 
 .q-card-title
+  max-width 100%
   font-size 18px
   font-weight 400
   letter-spacing normal
@@ -30,6 +31,7 @@
   &:empty
     display none
 .q-card-subtitle, .q-card-title-extra
+  max-width 100%
   font-size 14px
   color $card-faded-color
   .q-icon


### PR DESCRIPTION
Avoid horizontal overflow of content inside card title

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**

Avoid horizontal overflow of content inside qcard's title and subtitle.