### PR TITLE
QUploader - Hardcoded content-type field unnecessary.  file has own content-type

### DIFF
--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -405,7 +405,6 @@ export default {
         this.additionalFields.forEach(field => {
           form.append(field.name, field.value)
         })
-        form.append('Content-Type', file.type || 'application/octet-stream')
         form.append(this.name, file)
       }
       catch (e) {

--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -184,6 +184,7 @@ export default {
       type: Array,
       default: () => []
     },
+    noContentType: Boolean,
     method: {
       type: String,
       default: 'POST'
@@ -405,6 +406,9 @@ export default {
         this.additionalFields.forEach(field => {
           form.append(field.name, field.value)
         })
+        if (this.noContentType !== true) {
+          form.append('Content-Type', file.type || 'application/octet-stream')
+        }
         form.append(this.name, file)
       }
       catch (e) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ x] Other, please describe:  

Unnecessary form field that is not removable from call.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

When submitting  multipart/form-data with file uploads.  The xhr file reference includes the content-type of the file being sent with the following details:

> Content-Disposition: form-data; name="files"; filename="test.csv"
> Content-Type: application/vnd.ms-excel

A hard coded "content-type" field is not necessary and will actually cause issues with some webserver back-ends/services like oracle, kinto, etc.

If a user actually needs to include a "Content-Type" field they can use the headers parameter.

