### PR TITLE
Fix QResizeObservable: start immediately instead debounce pause

### DIFF
--- a/src/components/observables/QResizeObservable.js
+++ b/src/components/observables/QResizeObservable.js
@@ -35,7 +35,10 @@ export default {
       this.size = size
       this.$emit('resize', this.size)
     },
-    trigger () {
+    trigger (immediately) {
+      if (immediately) {
+        this.onResize()
+      }
       if (this.debounce === 0) {
         this.onResize()
       }
@@ -59,7 +62,7 @@ export default {
       on: {
         load: () => {
           this.$el.contentDocument.defaultView.addEventListener('resize', this.trigger, listenOpts.passive)
-          this.trigger()
+          this.trigger(true)
         }
       }
     })
@@ -79,7 +82,7 @@ export default {
       return
     }
 
-    this.trigger()
+    this.trigger(true)
 
     if (this.$q.platform.is.ie) {
       this.url = 'about:blank'

--- a/src/components/observables/QResizeObservable.js
+++ b/src/components/observables/QResizeObservable.js
@@ -36,10 +36,7 @@ export default {
       this.$emit('resize', this.size)
     },
     trigger (immediately) {
-      if (immediately) {
-        this.onResize()
-      }
-      if (this.debounce === 0) {
+      if (immediately || this.debounce === 0) {
         this.onResize()
       }
       else if (!this.timer) {


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
