### PR TITLE
Add uploadFactory to the QUploader component

### DIFF
--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -181,6 +181,10 @@ export default {
       type: Function,
       required: false
     },
+    uploadFactory: {
+      type: Function,
+      required: false
+    },
     additionalFields: {
       type: Array,
       default: () => []
@@ -375,9 +379,13 @@ export default {
         name = file.name,
         done = file.__doneUploading
 
-      if (this.uploading && !done) {
+      if (this.uploading && !done && !this.uploadFactory) {
         this.$emit('remove:abort', file, file.xhr)
         file.xhr.abort()
+        this.uploadedSize -= file.__uploaded
+      }
+      else if (this.uploading && !done && this.uploadFactory) {
+        this.$emit('remove:abort', file)
         this.uploadedSize -= file.__uploaded
       }
       else {
@@ -390,6 +398,11 @@ export default {
 
       file.__removed = true
       this.files = this.files.filter(obj => obj.name !== name)
+
+      if (!this.files.length) {
+        this.uploading = false
+      }
+
       this.__computeTotalSize()
     },
     __pick () {
@@ -414,6 +427,34 @@ export default {
       }
 
       initFile(file)
+
+      if (this.uploadFactory) {
+        const updateProgress = (percentage) => {
+          let uploaded = percentage * file.size
+          this.uploadedSize += uploaded - file.__uploaded
+          file.__uploaded = uploaded
+          file.__progress = Math.min(99, parseInt(percentage * 100, 10))
+          this.$forceUpdate()
+        }
+
+        return new Promise((resolve, reject) => {
+          this.uploadFactory(file, updateProgress)
+            .then(file => {
+              file.__doneUploading = true
+              file.__progress = 100
+              this.$emit('uploaded', file)
+              this.$forceUpdate()
+              resolve(file)
+            })
+            .catch(error => {
+              file.__failed = true
+              this.$emit('fail', file)
+              this.$forceUpdate()
+              reject(error)
+            })
+        })
+      }
+
       file.xhr = xhr
       return new Promise((resolve, reject) => {
         xhr.upload.addEventListener('progress', e => {
@@ -507,6 +548,7 @@ export default {
     abort () {
       this.xhrs.forEach(xhr => { xhr.abort() })
       this.uploading = false
+      this.$emit('abort')
     },
     reset () {
       this.abort()

--- a/src/components/uploader/QUploader.vue
+++ b/src/components/uploader/QUploader.vue
@@ -181,10 +181,7 @@ export default {
       type: Function,
       required: false
     },
-    uploadFactory: {
-      type: Function,
-      required: false
-    },
+    uploadFactory: Function,
     additionalFields: {
       type: Array,
       default: () => []
@@ -379,13 +376,9 @@ export default {
         name = file.name,
         done = file.__doneUploading
 
-      if (this.uploading && !done && !this.uploadFactory) {
+      if (this.uploading && !done) {
         this.$emit('remove:abort', file, file.xhr)
-        file.xhr.abort()
-        this.uploadedSize -= file.__uploaded
-      }
-      else if (this.uploading && !done && this.uploadFactory) {
-        this.$emit('remove:abort', file)
+        file.xhr && file.xhr.abort()
         this.uploadedSize -= file.__uploaded
       }
       else {
@@ -411,21 +404,6 @@ export default {
       }
     },
     __getUploadPromise (file) {
-      const
-        form = new FormData(),
-        xhr = new XMLHttpRequest()
-
-      try {
-        this.additionalFields.forEach(field => {
-          form.append(field.name, field.value)
-        })
-        form.append('Content-Type', file.type || 'application/octet-stream')
-        form.append(this.name, file)
-      }
-      catch (e) {
-        return
-      }
-
       initFile(file)
 
       if (this.uploadFactory) {
@@ -453,6 +431,21 @@ export default {
               reject(error)
             })
         })
+      }
+      
+      const
+        form = new FormData(),
+        xhr = new XMLHttpRequest()
+
+      try {
+        this.additionalFields.forEach(field => {
+          form.append(field.name, field.value)
+        })
+        form.append('Content-Type', file.type || 'application/octet-stream')
+        form.append(this.name, file)
+      }
+      catch (e) {
+        return
       }
 
       file.xhr = xhr


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This will allow users to override the default XHR mechanism for file uploads and file status updates. Users may then call the included updateProgress(percentage: float) method to feed back status updates to the component. Also added global 'abort' $emit to notify parent component of full-blown abort(). This allows users to take action, provide any feedback and/or reset the component if desired.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
