### PR TITLE
close #2122: Workaround for loading bottom border artifact

### DIFF
--- a/src/components/table/table.ios.styl
+++ b/src/components/table/table.ios.styl
@@ -35,8 +35,8 @@
 .q-table-progress
   height 0 !important
   td
-    position relative
     padding 0 !important
+    border-bottom 1px solid transparent !important
   .q-progress
     position absolute
     height 2px

--- a/src/components/table/table.mat.styl
+++ b/src/components/table/table.mat.styl
@@ -35,8 +35,8 @@
 .q-table-progress
   height 0 !important
   td
-    position relative
     padding 0 !important
+    border-bottom 1px solid transparent !important
   .q-progress
     position absolute
     height 2px


### PR DESCRIPTION
close #2122

Border collapse with alpha on border produces a strange artifact.
Can be seen more enhanced if the border size is increased (2 color border)