### PR TITLE
Focus fix for dialog|modal and fields with popup

### DIFF
--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -23,6 +23,7 @@ export default {
     preventClose: Boolean,
     noBackdropDismiss: Boolean,
     noEscDismiss: Boolean,
+    noRefocus: Boolean,
     position: String,
     color: {
       type: String,
@@ -86,6 +87,7 @@ export default {
         minimized: true,
         noBackdropDismiss: this.noBackdropDismiss || this.preventClose,
         noEscDismiss: this.noEscDismiss || this.preventClose,
+        noRefocus: this.noRefocus,
         position: this.position
       },
       on: {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -204,8 +204,8 @@ export default {
       EscapeKey.pop()
       this.__preventScroll(false)
       this.__register(false)
-      if (!this.noRefocus && this.__refocusTarget) {
-        this.__refocusTarget.focus()
+      if (!this.noRefocus) {
+        setTimeout(() => this.__refocusTarget && this.__refocusTarget.focus(), 300)
       }
     },
     __stopPropagation (e) {

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -94,6 +94,7 @@ export default {
       default: false
     },
     noRouteDismiss: Boolean,
+    noRefocus: Boolean,
     minimized: Boolean,
     maximized: Boolean
   },
@@ -168,6 +169,9 @@ export default {
       })
     },
     __show () {
+      if (!this.noRefocus) {
+        this.__refocusTarget = document.activeElement
+      }
       const body = document.body
 
       body.appendChild(this.$el)
@@ -200,6 +204,9 @@ export default {
       EscapeKey.pop()
       this.__preventScroll(false)
       this.__register(false)
+      if (!this.noRefocus && this.__refocusTarget) {
+        this.__refocusTarget.focus()
+      }
     },
     __stopPropagation (e) {
       e.stopPropagation()

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -40,6 +40,7 @@ export default {
       validator: offsetValidator
     },
     noFocus: Boolean,
+    noRefocus: Boolean,
     disable: Boolean
   },
   watch: {
@@ -93,6 +94,9 @@ export default {
   },
   methods: {
     __show (evt) {
+      if (!this.noRefocus) {
+        this.__refocusTarget = document.activeElement
+      }
       document.body.appendChild(this.$el)
       EscapeKey.register(() => { this.hide() })
       this.scrollTarget = getScrollTarget(this.anchorEl)
@@ -136,6 +140,9 @@ export default {
 
       document.body.removeChild(this.$el)
       this.hidePromise && this.hidePromiseResolve()
+      if (!this.noRefocus && this.__refocusTarget) {
+        this.__refocusTarget.focus()
+      }
     },
     reposition (event, animate) {
       if (this.fit) {

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -95,7 +95,7 @@ export default {
   methods: {
     __show (evt) {
       if (!this.noRefocus) {
-        this.__refocusTarget = document.activeElement
+        this.__refocusTarget = this.anchorEl || document.activeElement
       }
       document.body.appendChild(this.$el)
       EscapeKey.register(() => { this.hide() })

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -28,6 +28,9 @@ export default {
 
     __onFocus (e) {
       clearTimeout(this.timer)
+      if (this.focused) {
+        return
+      }
       this.focused = true
       this.$emit('focus', e)
     },
@@ -38,8 +41,10 @@ export default {
       }, 200)
     },
     __onBlur (e) {
-      this.focused = false
-      this.$emit('blur', e)
+      if (this.focused) {
+        this.focused = false
+        this.$emit('blur', e)
+      }
       this.__emit()
     },
     __emit () {


### PR DESCRIPTION
- delay refocus on modal to avoid enter key keyup
- try to get refocusTarget from anchorEl
- avoid duplicate __onFocus and __onBlur in input mixin