### PR TITLE
QBtn: delay click event when type is submit

### DIFF
--- a/dev/components/components/button.vue
+++ b/dev/components/components/button.vue
@@ -65,17 +65,22 @@
       <q-btn to="/" label="To index in 2s" @click="linkClick" glossy color="secondary" class="q-ml-md" />
       <br><br>
       <div>
+        <q-toggle v-model="testD" label="Disable form buttons" />
+        <q-toggle v-model="testR" label="Wait for ripple" />
         <form @submit.prevent="submit" @reset.prevent="reset" class="shadow-2 q-pa-md row items-center">
           <div class="col row items-center gutter-md">
             <div class="col">
               <q-input v-model="test" />
             </div>
             <div class="col">
+              <q-input :value="testC" @change="v => testC = v" />
+            </div>
+            <div class="col">
               <q-input type="number" v-model="testN" />
             </div>
           </div>
-          <q-btn :tag="tag" fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" @click="onClick" />
-          <q-btn :tag="tag" fab color="primary" icon="android" type="submit" class="on-right" title="Submit" @click="onClick" />
+          <q-btn :tag="tag" fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
+          <q-btn :tag="tag" fab color="primary" icon="android" type="submit" class="on-right" title="Submit" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
         </form>
       </div>
 
@@ -518,7 +523,10 @@ export default {
       percentage: 0,
       clickTimes: 0,
       test: 'Initial value',
+      testC: 'Initial value onChange',
       testN: 0,
+      testD: false,
+      testR: false,
       tag: 'button'
     }
   },
@@ -555,8 +563,7 @@ export default {
       this.loading = {}
     },
     submit () {
-      this.$q.notify('Submit called')
-      console.log('test', this.test, 'testN', this.testN)
+      this.$q.notify(`Submit called with: [${this.test}], [${this.testC}], [${this.testN}]`)
     },
     reset () {
       this.test = 'Initial value'

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -1,6 +1,7 @@
 import BtnMixin from './btn-mixin'
 import { QSpinner } from '../spinner'
 import { between } from '../../utils/format'
+import { stopAndPrevent } from '../../utils/event'
 
 export default {
   name: 'QBtn',
@@ -50,12 +51,40 @@ export default {
     click (e) {
       this.__cleanup()
 
+      if (this.isDisabled) {
+        e && stopAndPrevent(e) // fix for submit button
+        return
+      }
+
+      if (e && e.detail !== -1 && this.type === 'submit') {
+        stopAndPrevent(e)
+        const ev = new MouseEvent('click', {
+          bubbles: e.bubbles,
+          cancelable: e.cancelable,
+          view: e.view,
+          detail: -1, // this is the number of clicks - 0 when called as submit, 1+ for real click
+          screenX: e.screenX,
+          screenY: e.screenY,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          shiftKey: e.shiftKey,
+          metaKey: e.metaKey,
+          button: e.button,
+          relatedTarget: e.relatedTarget
+        })
+        this.timer = setTimeout(() => this.$el && this.$el.dispatchEvent(ev), 200)
+        return
+      }
+
       const go = () => {
         this.$router[this.replace ? 'replace' : 'push'](this.to)
       }
 
       const trigger = () => {
         if (this.isDisabled) {
+          e && stopAndPrevent(e) // fix for submit button
           return
         }
 

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -58,22 +58,7 @@ export default {
 
       if (e && e.detail !== -1 && this.type === 'submit') {
         stopAndPrevent(e)
-        const ev = new MouseEvent('click', {
-          bubbles: e.bubbles,
-          cancelable: e.cancelable,
-          view: e.view,
-          detail: -1, // this is the number of clicks - 0 when called as submit, 1+ for real click
-          screenX: e.screenX,
-          screenY: e.screenY,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          ctrlKey: e.ctrlKey,
-          altKey: e.altKey,
-          shiftKey: e.shiftKey,
-          metaKey: e.metaKey,
-          button: e.button,
-          relatedTarget: e.relatedTarget
-        })
+        const ev = new MouseEvent('click', Object.assign({}, e, {detail: -1}))
         this.timer = setTimeout(() => this.$el && this.$el.dispatchEvent(ev), 200)
         return
       }

--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -69,7 +69,7 @@ export default {
         center: modifiers.center
       },
       click (evt) {
-        if (ctx.enabled) {
+        if (ctx.enabled && evt.detail !== -1) {
           showRipple(evt, el, ctx.modifiers)
         }
       },

--- a/src/ie-compat/ie.js
+++ b/src/ie-compat/ie.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-extend-native */
 
-if (window) {
+(function (window) {
+  if (window === void 0) { return }
+
   try {
     new MouseEvent('test') // eslint-disable-line no-new, no-use-before-define
     return
@@ -34,7 +36,7 @@ if (window) {
   MouseEvent.prototype = Event.prototype
 
   window.MouseEvent = MouseEvent
-}
+}(window))
 
 if (!Array.prototype.findIndex) {
   Object.defineProperty(Array.prototype, 'findIndex', {

--- a/src/ie-compat/ie.js
+++ b/src/ie-compat/ie.js
@@ -1,9 +1,6 @@
 /* eslint-disable no-extend-native */
 
-(function (window) {
-  if (!window) {
-    return
-  }
+if (window) {
   try {
     new MouseEvent('test') // eslint-disable-line no-new, no-use-before-define
     return
@@ -37,7 +34,7 @@
   MouseEvent.prototype = Event.prototype
 
   window.MouseEvent = MouseEvent
-})(window)
+}
 
 if (!Array.prototype.findIndex) {
   Object.defineProperty(Array.prototype, 'findIndex', {

--- a/src/ie-compat/ie.js
+++ b/src/ie-compat/ie.js
@@ -1,5 +1,44 @@
 /* eslint-disable no-extend-native */
 
+(function (window) {
+  if (!window) {
+    return
+  }
+  try {
+    new MouseEvent('test') // eslint-disable-line no-new, no-use-before-define
+    return
+  }
+  catch (e) {}
+
+  var MouseEvent = function (eventType, params) {
+    params = params || {}
+    var mouseEvent = document.createEvent('MouseEvent')
+    mouseEvent.initMouseEvent(
+      eventType,
+      params.bubbles || false,
+      params.cancelable || false,
+      params.view || window,
+      params.detail || 0,
+      params.screenX || 0,
+      params.screenY || 0,
+      params.clientX || 0,
+      params.clientY || 0,
+      params.ctrlKey || false,
+      params.altKey || false,
+      params.shiftKey || false,
+      params.metaKey || false,
+      params.button || 0,
+      params.relatedTarget || null
+    )
+
+    return mouseEvent
+  }
+
+  MouseEvent.prototype = Event.prototype
+
+  window.MouseEvent = MouseEvent
+})(window)
+
 if (!Array.prototype.findIndex) {
   Object.defineProperty(Array.prototype, 'findIndex', {
     value (predicate) {


### PR DESCRIPTION
This allows time for controls to propagate the changes (lazy or invalid number).

- prevent event when button is disabled
- prevent ripple on generated event
- add MouseEvent pollyfill for IE

Close #2171