### PR TITLE
feat: QScrollArea - Added `keydown` EventListener for scroll keys:

### DIFF
--- a/src/components/scroll-area/QScrollArea.js
+++ b/src/components/scroll-area/QScrollArea.js
@@ -1,6 +1,6 @@
 import extend from '../../utils/extend'
 import { between } from '../../utils/format'
-import { getMouseWheelDistance } from '../../utils/event'
+import { getMouseWheelDistance, getEventKey } from '../../utils/event'
 import { setScrollPosition } from '../../utils/scroll'
 import { QResizeObservable, QScrollObservable } from '../observables'
 import TouchPan from '../../directives/touch-pan'
@@ -149,6 +149,44 @@ export default {
         this.active = false
         this.timer = null
       }, this.delay)
+    },
+    __handleKeys (e) {
+      const eventKey = getEventKey(e)
+
+      if ([33, 38, 36, 34, 40, 35].includes(eventKey) && !this.thumbHidden) {
+        // Exceptions
+        // ->UP
+        if ([33, 38, 36].includes(eventKey) && this.scrollPosition === 0) {
+          return
+        }
+        // ->DOWN
+        if ([34, 40, 35].includes(eventKey) && this.scrollPosition === this.scrollHeight - this.containerHeight) {
+          return
+        }
+
+        const duration = 100
+        switch (eventKey) {
+          case 33: // PAGE UP key
+            this.setScrollPosition(this.scrollPosition - this.containerHeight, duration)
+            break
+          case 34: // PAGE DOWN key
+            this.setScrollPosition(this.scrollPosition + this.containerHeight, duration)
+            break
+
+          case 38: // UP key
+            this.setScrollPosition(this.scrollPosition - 50, duration)
+            break
+          case 40: // DOWN key
+            this.setScrollPosition(this.scrollPosition + 50, duration)
+            break
+
+          case 36: // HOME key
+            this.setScrollPosition(0, duration)
+            break
+          case 35: // END key
+            this.setScrollPosition(this.scrollHeight, duration)
+        }
+      }
     }
   },
   render (h) {
@@ -167,8 +205,14 @@ export default {
     return h('div', {
       staticClass: 'q-scrollarea relative-position',
       on: {
-        mouseenter: () => { this.hover = true },
-        mouseleave: () => { this.hover = false }
+        mouseenter: () => {
+          this.hover = true
+          window.addEventListener('keydown', this.__handleKeys)
+        },
+        mouseleave: () => {
+          this.hover = false
+          window.removeEventListener('keydown', this.__handleKeys)
+        }
       }
     }, [
       h('div', {


### PR DESCRIPTION
- PAGE UP/DOWN (+containerHeight/-containerHeight)
- UP/DOWN -> +50/-50
- HOME - END -> 0/Max scroll position (scrollHeight)

I do not know if where I added the EventListener is the best option.

Please, review this @rstoenescu 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The performance is good.