### PR TITLE
Fix ready() when readyState = "interactive"

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -38,7 +38,7 @@ export function ready (fn) {
     return
   }
 
-  if (document.readyState === 'complete') {
+  if (document.readyState !== 'loading') {
     return fn()
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

A callback registered with `Quasar.utils.dom.ready()` can fail to be called if the listener is added at a particular time.

In my example, it waits until `document.readyState` has just changed to `interactive`, then calls `requestAnimationFrame`, then adds a callback using `ready()`.

Steps to reproduce:
* open http://nicksellen.co.uk/upld/ready.html in Chrome
* open the console view
* observe the 3 printed statements, but the missing [the 4th one](https://github.com/nicksellen/nicksellen.github.io/blob/master/ready.html#L21)

The `interactive` state is equivelent to the `DOMContentLoaded` event (the `complete` state corresponds to the `load` event - when all sub-resources have finished loading too) - see https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState.