### PR TITLE
className for QSelect, QSearch before|after, QInput focus on marginalia

### DIFF
--- a/dev/components/components/button-dropdown.vue
+++ b/dev/components/components/button-dropdown.vue
@@ -4,7 +4,7 @@
     <q-btn-dropdown v-model="toggle" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" glossy label="Dropdown Button" style="margin: 15px">
       <q-list link>
         <q-list-header inset>Folders X</q-list-header>
-        <q-item v-for="n in 3" :key="`x.${n}`" @click.native="toggle = false">
+        <q-item v-for="n in 3" :key="`x.${n}`" @click.native="toggle = false" :tabindex="0">
           <q-item-side icon="folder" inverted color="grey-6" />
           <q-item-main>
             <q-item-tile label>Photos</q-item-tile>
@@ -14,7 +14,7 @@
         </q-item>
         <q-item-separator inset />
         <q-list-header inset>Files</q-list-header>
-        <q-item v-for="n in 3" :key="`y.${n}`" @click.native="toggle = false">
+        <q-item v-for="n in 3" :key="`y.${n}`" @click.native="toggle = false" :tabindex="0">
           <q-item-side icon="assignment" inverted color="grey-6" />
           <q-item-main>
             <q-item-tile label>Vacation</q-item-tile>
@@ -28,7 +28,7 @@
     <q-btn-dropdown to="/" color="primary" split glossy label="Link /" style="margin: 15px">
       <q-list link>
         <q-list-header inset>Folders X</q-list-header>
-        <q-item v-for="n in 3" :key="`x.${n}`" @click.native="toggle = false">
+        <q-item v-for="n in 3" :key="`x.${n}`" @click.native="toggle = false" :tabindex="0">
           <q-item-side icon="folder" inverted color="grey-6" />
           <q-item-main>
             <q-item-tile label>Photos</q-item-tile>
@@ -38,7 +38,7 @@
         </q-item>
         <q-item-separator inset />
         <q-list-header inset>Files</q-list-header>
-        <q-item v-for="n in 3" :key="`y.${n}`" @click.native="toggle = false">
+        <q-item v-for="n in 3" :key="`y.${n}`" @click.native="toggle = false" :tabindex="0">
           <q-item-side icon="assignment" inverted color="grey-6" />
           <q-item-main>
             <q-item-tile label>Vacation</q-item-tile>
@@ -57,7 +57,7 @@
         <q-btn-dropdown ref="first" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" glossy label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders X</q-list-header>
-            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="hideDropdown(index1 * 3 + index2)">
+            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="hideDropdown(index1 * 3 + index2)" :tabindex="0">
               <q-item-side icon="folder" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Photos</q-item-tile>
@@ -67,7 +67,7 @@
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
-            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.first[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.first[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="assignment" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Vacation</q-item-tile>
@@ -80,7 +80,7 @@
         <q-btn-dropdown ref="second" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
-            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.second[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.second[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="folder" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Photos</q-item-tile>
@@ -90,7 +90,7 @@
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
-            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.second[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.second[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="assignment" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Vacation</q-item-tile>
@@ -103,7 +103,7 @@
         <q-btn-dropdown ref="third" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="primary" icon="map" glossy style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
-            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.third[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.third[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="folder" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Photos</q-item-tile>
@@ -113,7 +113,7 @@
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
-            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.third[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.third[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="assignment" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Vacation</q-item-tile>
@@ -126,7 +126,7 @@
         <q-btn-dropdown ref="fourth" :size="size" :split="cfg.split" :dense="cfg.dense" :disable="cfg.disable" @show="log('open')" @hide="log('close')" @click="log('click')" color="yellow" glossy icon="map" label="Dropdown Button" style="margin: 15px">
           <q-list link>
             <q-list-header inset>Folders</q-list-header>
-            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.fourth[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`1.${n}`" @click.native="$refs.fourth[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="folder" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Photos</q-item-tile>
@@ -136,7 +136,7 @@
             </q-item>
             <q-item-separator inset />
             <q-list-header inset>Files</q-list-header>
-            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.fourth[index1 * 3 + index2].hide()">
+            <q-item v-for="n in 3" :key="`2.${n}`" @click.native="$refs.fourth[index1 * 3 + index2].hide()" :tabindex="0">
               <q-item-side icon="assignment" inverted color="grey-6" />
               <q-item-main>
                 <q-item-tile label>Vacation</q-item-tile>

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -278,7 +278,12 @@ export default {
     __setModel (val) {
       clearTimeout(this.timer)
       this.focus()
-      this.__set(this.isNumber && val === 0 ? val : val || (this.isNumber ? null : ''), true)
+      this.__set(
+        this.isNumber && val === 0
+          ? val
+          : val || (this.isNumber ? null : ''),
+        true
+      )
     },
     __set (e, forceUpdate) {
       let val = e && e.target ? e.target.value : e

--- a/src/components/input/QInput.vue
+++ b/src/components/input/QInput.vue
@@ -278,7 +278,7 @@ export default {
     __setModel (val) {
       clearTimeout(this.timer)
       this.focus()
-      this.__set(val || (this.isNumber ? null : ''), true)
+      this.__set(this.isNumber && val === 0 ? val : val || (this.isNumber ? null : ''), true)
     },
     __set (e, forceUpdate) {
       let val = e && e.target ? e.target.value : e

--- a/src/components/search/QSearch.js
+++ b/src/components/search/QSearch.js
@@ -64,31 +64,30 @@ export default {
         : this.debounce
     },
     controlBefore () {
-      return this.before || (
-        this.noIcon
-          ? null
-          : [{
-            icon: this.icon || this.$q.icon.search.icon,
-            handler: this.focus
-          }]
-      )
+      const before = (this.before || []).slice()
+      if (!this.noIcon) {
+        before.unshift({
+          icon: this.icon || this.$q.icon.search.icon,
+          handler: this.focus
+        })
+      }
+      return before
     },
     controlAfter () {
-      if (this.after) {
-        return this.after
-      }
-      if (this.editable && this.clearable) {
-        return [{
+      const after = (this.after || []).slice()
+      if (this.isClearable) {
+        after.push({
           icon: this.$q.icon.search[`clear${this.isInverted ? 'Inverted' : ''}`],
           content: true,
           handler: this.clear
-        }]
+        })
       }
+      return after
     }
   },
   methods: {
-    clear () {
-      this.$refs.input.clear()
+    clear (evt) {
+      this.$refs.input.clear(evt)
     }
   },
   render (h) {

--- a/src/components/select/QSelect.vue
+++ b/src/components/select/QSelect.vue
@@ -71,7 +71,7 @@
     <q-popover
       ref="popover"
       fit
-      :disable="readonly || disable"
+      :disable="!editable"
       :anchor-click="false"
       class="column no-wrap"
       :class="dark ? 'bg-dark' : null"
@@ -108,7 +108,8 @@
             :class="[
               opt.disable ? 'text-faded' : 'cursor-pointer',
               index === keyboardIndex ? 'q-select-highlight' : '',
-              opt.disable ? '' : 'cursor-pointer'
+              opt.disable ? '' : 'cursor-pointer',
+              opt.className || ''
             ]"
             slot-replace
             @click.capture.native="__toggleMultiple(opt.value, opt.disable)"
@@ -144,7 +145,8 @@
             :class="[
               opt.disable ? 'text-faded' : 'cursor-pointer',
               index === keyboardIndex ? 'q-select-highlight' : '',
-              opt.disable ? '' : 'cursor-pointer'
+              opt.disable ? '' : 'cursor-pointer',
+              opt.className || ''
             ]"
             slot-replace
             :active="value === opt.value"
@@ -211,7 +213,6 @@ export default {
     multiple: Boolean,
     toggle: Boolean,
     chips: Boolean,
-    readonly: Boolean,
     options: {
       type: Array,
       required: true,

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -32,6 +32,7 @@ export default {
         return
       }
       this.focused = true
+      this.$refs.input && this.$refs.input.focus()
       this.$emit('focus', e)
     },
     __onInputBlur (e) {


### PR DESCRIPTION
- QSelect: use className from option item in list
- QSearch: combine before/after with search and clear icons (can be disabled)
- QInput and friends: focus input field in __onFocus

close #2017, close #2005, close #1953