### PR TITLE
QDatetime: format when type is date and formatModel is string

### DIFF
--- a/dev/components/form/datetime.vue
+++ b/dev/components/form/datetime.vue
@@ -54,7 +54,7 @@
 
       <p class="caption">Format Model</p>
       <div class="bg-secondary text-white">
-        Model: <em>{{ modelVar }}</em> <strong>{{ modelVarType }}</strong>
+        Model: <em>{{ modelVar }}</em> - <strong>{{ modelVarType }}</strong>
       </div>
       <div class="bg-secondary text-white">
         Formatted: <em>{{ modelVarFormatted }}</em>
@@ -63,6 +63,7 @@
       <q-datetime @change="value => log('@change', value)" @input="value => log('@input', value)" v-model="modelVar" type="date" clearable stack-label="Format Model 'date'" format-model="date" />
       <q-datetime @change="value => log('@change', value)" @input="value => log('@input', value)" v-model="modelVar" type="date" clearable stack-label="Format Model 'number'" format-model="number" />
       <q-datetime @change="value => log('@change', value)" @input="value => log('@input', value)" v-model="modelVar" type="date" clearable stack-label="Format Model 'string'" format-model="string" />
+      <q-datetime @change="value => log('@change', value)" @input="value => log('@input', value)" v-model="modelVar" type="time" clearable stack-label="Set time" />
 
       <p class="caption">
         Lazy Input

--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -48,6 +48,15 @@ export default {
     }
   },
   computed: {
+    computedFormat () {
+      if (this.format) {
+        return this.format
+      }
+      if (this.type === 'date') {
+        return 'YYYY/MM/DD'
+      }
+      return this.type === 'time' ? 'HH:mm' : 'YYYY/MM/DD HH:mm:ss'
+    },
     actualValue () {
       if (this.displayValue) {
         return this.displayValue
@@ -56,22 +65,7 @@ export default {
         return ''
       }
 
-      let format
-
-      if (this.format) {
-        format = this.format
-      }
-      else if (this.type === 'date') {
-        format = 'YYYY/MM/DD'
-      }
-      else if (this.type === 'time') {
-        format = 'HH:mm'
-      }
-      else {
-        format = 'YYYY/MM/DD HH:mm:ss'
-      }
-
-      return formatDate(this.value, format, /* for reactiveness */ this.$q.i18n.date)
+      return formatDate(this.value, this.computedFormat, /* for reactiveness */ this.$q.i18n.date)
     },
     computedValue () {
       if (isValid(this.value)) {

--- a/src/components/datetime/datetime-mixin.js
+++ b/src/components/datetime/datetime-mixin.js
@@ -9,14 +9,33 @@ import {
   isValid
 } from '../../utils/date'
 
+const reDate = /^\d{4}[^\d]\d{2}[^\d]\d{2}/
+
 export default {
   props,
   computed: {
+    computedValue () {
+      if (this.type === 'date' && this.formatModel === 'string' && reDate.test(this.value)) {
+        return this.value.slice(0, 10).split(/[^\d]/).join('/')
+      }
+      return this.value
+    },
+    computedDefaultValue () {
+      if (this.type === 'date' && this.formatModel === 'string' && reDate.test(this.defaultValue)) {
+        return this.defaultValue.slice(0, 10).split(/[^\d]+/).join('/')
+      }
+      return this.defaultValue
+    },
+    computedDateFormat () {
+      if (this.type === 'date' && this.formatModel === 'string') {
+        return 'YYYY/MM/DD HH:mm:ss'
+      }
+    },
     model: {
       get () {
-        let date = isValid(this.value)
-          ? new Date(this.value)
-          : (this.defaultValue ? new Date(this.defaultValue) : startOfDate(new Date(), 'day'))
+        let date = isValid(this.computedValue)
+          ? new Date(this.computedValue)
+          : (this.computedDefaultValue ? new Date(this.computedDefaultValue) : startOfDate(new Date(), 'day'))
 
         return getDateBetween(
           date,
@@ -26,7 +45,7 @@ export default {
       },
       set (val) {
         const date = getDateBetween(val, this.pmin, this.pmax)
-        const value = convertDateToFormat(date, this.formatModel === 'auto' ? inferDateFormat(this.value) : this.formatModel)
+        const value = convertDateToFormat(date, this.formatModel === 'auto' ? inferDateFormat(this.value) : this.formatModel, this.computedDateFormat)
         this.$emit('input', value)
         this.$nextTick(() => {
           if (!isSameDate(value, this.value)) {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -225,7 +225,7 @@ export function inferDateFormat (example) {
   return 'string'
 }
 
-export function convertDateToFormat (date, type) {
+export function convertDateToFormat (date, type, format) {
   if (!date && date !== 0) {
     return
   }
@@ -236,7 +236,7 @@ export function convertDateToFormat (date, type) {
     case 'number':
       return date.getTime()
     default:
-      return formatDate(date)
+      return formatDate(date, format)
   }
 }
 


### PR DESCRIPTION
The emitted value will be formatted as "YYYY/MM/DD HH:mm:ss", with time discarded, when:
- type="date"
- format-model="string"
- value matches /^\d{4}[^\d]\d{2}[^\d]\d{2}/

fixes #2229