### PR TITLE
Brazilian portuguese localization updates.

### DIFF
--- a/i18n/pt-br.js
+++ b/i18n/pt-br.js
@@ -34,11 +34,11 @@ export default {
     loading: 'Carregando...',
     selectedRecords: function (rows) {
       return rows > 0
-        ? rows + ' linha' + (rows === 1 ? ' selecionada' : 's selecionadas') + '.'
-        : 'Nenhuma linha selecionada.'
+        ? rows + ' registro' + (rows === 1 ? ' selecionado' : 's selecionados') + '.'
+        : 'Nenhum registro selecionado.'
     },
-    recordsPerPage: 'Linhas por página:',
-    allRows: 'Todas',
+    recordsPerPage: 'Registros por página:',
+    allRows: 'Todos',
     pagination: function (start, end, total) {
       return start + '-' + end + ' de ' + total
     },
@@ -50,12 +50,12 @@ export default {
     italic: 'Itálico',
     strikethrough: 'Riscado',
     underline: 'Sublinhado',
-    unorderedList: 'Lista Não-ordenada',
-    orderedList: 'Lista Ordenada',
+    unorderedList: 'Lista não-ordenada',
+    orderedList: 'Lista ordenada',
     subscript: 'Subscrito',
     superscript: 'Sobrescrito',
     hyperlink: 'Hyperlink',
-    toggleFullscreen: 'Tela Cheia',
+    toggleFullscreen: 'Tela cheia',
     quote: 'Citação',
     left: 'Alinhado à esquerda',
     center: 'Alinhado ao centro',
@@ -66,9 +66,9 @@ export default {
     indent: 'Aumentar indentação',
     removeFormat: 'Remover formatação',
     formatting: 'Formatação',
-    fontSize: 'Tamanho de Fonte',
+    fontSize: 'Tamanho de fonte',
     align: 'Alinhar',
-    hr: 'Inserir Divisória Horizontal',
+    hr: 'Inserir divisória horizontal',
     undo: 'Desfazer',
     redo: 'Refazer',
     header1: 'Cabeçalho 1',
@@ -86,7 +86,7 @@ export default {
     size5: 'Grande',
     size6: 'Enorme',
     size7: 'Máximo',
-    defaultFont: 'Fonte Padrão'
+    defaultFont: 'Fonte padrão'
   },
   tree: {
     noNodes: 'Sem nós disponíveis',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**

With the new grid layout for data tables, the current pt-br localization is not using the correct term for registers. As translated before this PR, it reffered to registers as lines.

I've also made some small changes to some capitalized letters, which were not following the correct pattern.