### PR TITLE
QTootip with arrow #2105

### DIFF
--- a/dev/components/components/tooltip.vue
+++ b/dev/components/components/tooltip.vue
@@ -50,7 +50,7 @@
       <q-card style="margin-top: 75px">
         <q-card-title class="bg-primary text-center">
           <q-btn push color="orange" label="Mouse Hover">
-            <q-tooltip :anchor="anchor" :self="self">
+            <q-tooltip v-model="toggle" :anchor="anchor" :self="self" :offset="[10, 10]">
               <div>Quasar is <strong>great</strong>!</div>
               <div class="text-center">Try it.</div>
             </q-tooltip>

--- a/dev/components/components/tooltip.vue
+++ b/dev/components/components/tooltip.vue
@@ -21,7 +21,7 @@
       <p class="caption">With offset</p>
       <div class="group">
         <q-btn color="indigo" label="Hover">
-          <q-tooltip anchor="top middle" self="bottom middle" :offset="[10, 10]">
+          <q-tooltip v-model="toggle" anchor="top middle" self="bottom middle" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>top</em> (<q-icon name="keyboard_arrow_up" />)
           </q-tooltip>
         </q-btn>
@@ -50,7 +50,7 @@
       <q-card style="margin-top: 75px">
         <q-card-title class="bg-primary text-center">
           <q-btn push color="orange" label="Mouse Hover">
-            <q-tooltip v-model="toggle" :anchor="anchor" :self="self" :offset="[10, 10]">
+            <q-tooltip :anchor="anchor" :self="self" :offset="[10, 10]">
               <div>Quasar is <strong>great</strong>!</div>
               <div class="text-center">Try it.</div>
             </q-tooltip>

--- a/dev/components/components/tooltip.vue
+++ b/dev/components/components/tooltip.vue
@@ -14,34 +14,34 @@
 
       <div style="margin-top: 40px;width: 200px; height: 70px;background-color: #26A69A;">
         &nbsp;
-        <q-tooltip :delay="1000">Quasar Rulz!</q-tooltip>
+        <q-tooltip arrow :delay="1000">Quasar Rulz!</q-tooltip>
       </div>
 
       <q-toggle v-model="toggle" class="z-max fixed-top" />
       <p class="caption">With offset</p>
       <div class="group">
         <q-btn color="indigo" label="Hover">
-          <q-tooltip v-model="toggle" anchor="top middle" self="bottom middle" :offset="[10, 10]">
+          <q-tooltip arrow v-model="toggle" anchor="top middle" self="bottom middle" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>top</em> (<q-icon name="keyboard_arrow_up" />)
           </q-tooltip>
         </q-btn>
         <q-btn color="red" label="Over">
-          <q-tooltip anchor="center right" self="center left" :offset="[10, 10]">
+          <q-tooltip arrow anchor="center right" self="center left" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>right</em> (<q-icon name="keyboard_arrow_right" />)
           </q-tooltip>
         </q-btn>
         <q-btn color="purple" label="These">
-          <q-tooltip anchor="center left" self="center right" :offset="[10, 10]">
+          <q-tooltip arrow anchor="center left" self="center right" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>left</em> (<q-icon name="keyboard_arrow_left" />)
           </q-tooltip>
         </q-btn>
         <q-btn color="amber" label="Buttons">
-          <q-tooltip anchor="bottom middle" self="top middle" :offset="[10, 10]">
+          <q-tooltip arrow anchor="bottom middle" self="top middle" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>bottom</em> (<q-icon name="keyboard_arrow_down" />)
           </q-tooltip>
         </q-btn>
         <q-btn color="orange" label="With loading" :loading="loading" @click="setLoading">
-          <q-tooltip anchor="bottom middle" self="top middle" :offset="[10, 10]">
+          <q-tooltip arrow anchor="bottom middle" self="top middle" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>bottom</em> (<q-icon name="keyboard_arrow_down" />)
           </q-tooltip>
         </q-btn>
@@ -50,7 +50,7 @@
       <q-card style="margin-top: 75px">
         <q-card-title class="bg-primary text-center">
           <q-btn push color="orange" label="Mouse Hover">
-            <q-tooltip :anchor="anchor" :self="self" :offset="[10, 10]">
+            <q-tooltip arrow :anchor="anchor" :self="self">
               <div>Quasar is <strong>great</strong>!</div>
               <div class="text-center">Try it.</div>
             </q-tooltip>

--- a/dev/components/components/tooltip.vue
+++ b/dev/components/components/tooltip.vue
@@ -21,7 +21,7 @@
       <p class="caption">With offset</p>
       <div class="group">
         <q-btn color="indigo" label="Hover">
-          <q-tooltip v-model="toggle" anchor="top middle" self="bottom middle" :offset="[10, 10]">
+          <q-tooltip anchor="top middle" self="bottom middle" :offset="[10, 10]">
             <strong>Tooltip</strong> on <em>top</em> (<q-icon name="keyboard_arrow_up" />)
           </q-tooltip>
         </q-btn>

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -32,6 +32,7 @@ export default {
       type: Number,
       default: 0
     },
+    arrow: Boolean,
     maxHeight: String,
     disable: Boolean
   },
@@ -47,7 +48,9 @@ export default {
     selfOrigin () {
       return parsePosition(this.self)
     },
-    arrowDirection () {
+    arrowClass () {
+      if (!this.arrow) { return }
+
       if (this.anchor === 'center left' && this.self === 'center right') {
         return 'arrow-right'
       }
@@ -59,9 +62,6 @@ export default {
       }
       if (this.anchor === 'bottom middle' && this.self === 'top middle') {
         return 'arrow-top'
-      }
-      else {
-        return ''
       }
     }
   },
@@ -117,7 +117,7 @@ export default {
     if (!this.canRender) { return }
 
     return h('div', { staticClass: 'q-tooltip animate-popup' }, [
-      h('div', { class: this.arrowDirection }),
+      (this.arrowClass && h('div', { class: this.arrowClass })) || void 0,
       h('div', { staticClass: 'q-tooltip-inner' }, this.$slots.default)
     ])
   },

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -50,7 +50,7 @@ export default {
     },
     arrowClass () {
       if (!this.arrow) { return }
-      
+
       const name = 'q-tooltip-arrow q-tooltip-arrow-'
 
       if (this.anchor === 'center left' && this.self === 'center right') {

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -46,6 +46,23 @@ export default {
     },
     selfOrigin () {
       return parsePosition(this.self)
+    },
+    arrowDirection () {
+      if (this.anchor === 'center left' && this.self === 'center right') {
+        return 'arrow-right'
+      }
+      if (this.anchor === 'center right' && this.self === 'center left') {
+        return 'arrow-left'
+      }
+      if (this.anchor === 'top middle' && this.self === 'bottom middle') {
+        return 'arrow-bottom'
+      }
+      if (this.anchor === 'bottom middle' && this.self === 'top middle') {
+        return 'arrow-top'
+      }
+      else {
+        return ''
+      }
     }
   },
   methods: {
@@ -100,7 +117,8 @@ export default {
     if (!this.canRender) { return }
 
     return h('div', { staticClass: 'q-tooltip animate-popup' }, [
-      h('div', this.$slots.default)
+      h('div', { class: this.arrowDirection }),
+      h('div', { staticClass: 'q-tooltip-inner' }, this.$slots.default)
     ])
   },
   beforeMount () {

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -50,18 +50,20 @@ export default {
     },
     arrowClass () {
       if (!this.arrow) { return }
+      
+      const name = 'q-tooltip-arrow q-tooltip-arrow-'
 
       if (this.anchor === 'center left' && this.self === 'center right') {
-        return 'arrow-right'
+        return name + 'right'
       }
       if (this.anchor === 'center right' && this.self === 'center left') {
-        return 'arrow-left'
+        return name + 'left'
       }
       if (this.anchor === 'top middle' && this.self === 'bottom middle') {
-        return 'arrow-bottom'
+        return name + 'bottom'
       }
       if (this.anchor === 'bottom middle' && this.self === 'top middle') {
-        return 'arrow-top'
+        return name + 'top'
       }
     }
   },

--- a/src/components/tooltip/tooltip.ios.styl
+++ b/src/components/tooltip/tooltip.ios.styl
@@ -1,59 +1,46 @@
-.q-tooltip {
+.q-tooltip
   position fixed
   z-index $z-tooltip
-  box-shadow $tooltip-box-shadow
   pointer-events none
-}
 
-.q-tooltip .q-tooltip-inner {
-  background $tooltip-background
-  color $tooltip-color
-  border-radius $tooltip-border-radius
-  padding $tooltip-padding
-  overflow-y auto
-  overflow-x hidden
-}
+  .q-tooltip-inner
+    background $tooltip-background
+    color $tooltip-color
+    border-radius $tooltip-border-radius
+    padding $tooltip-padding
+    overflow-y auto
+    overflow-x hidden
 
-.q-tooltip .arrow-bottom {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 9px 0 9px
-  border-left-color transparent 
-  border-right-color transparent
-  bottom -8px
-  left calc(50% - 10px)
-}
+  .q-tooltip-arrow
+    border-style solid
+    position absolute
+    border-color $tooltip-background
 
-.q-tooltip .arrow-top {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 0 9px 9px 9px
-  border-left-color transparent
-  border-right-color transparent
-  top -8px
-  left calc(50% - 10px)
-}
+  > .q-tooltip-arrow-
+    &bottom
+      border-width 9px 9px 0 9px
+      border-left-color transparent 
+      border-right-color transparent
+      bottom -8px
+      left calc(50% - 10px)
 
-.q-tooltip .arrow-left {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 9px 9px 0
-  border-top-color transparent
-  border-bottom-color transparent
-  left -8px
-  top calc(50% - 10px)
-}
+    &top
+      border-width 0 9px 9px 9px
+      border-left-color transparent
+      border-right-color transparent
+      top -8px
+      left calc(50% - 10px)
 
-.q-tooltip .arrow-right {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 0 9px 9px
-  border-top-color transparent
-  border-bottom-color transparent
-  right -8px
-  top calc(50% - 10px)
-}
+    &left
+      border-width 9px 9px 9px 0
+      border-top-color transparent
+      border-bottom-color transparent
+      left -8px
+      top calc(50% - 10px)
+
+    &right
+      border-width 9px 0 9px 9px
+      border-top-color transparent
+      border-bottom-color transparent
+      right -8px
+      top calc(50% - 10px)

--- a/src/components/tooltip/tooltip.ios.styl
+++ b/src/components/tooltip/tooltip.ios.styl
@@ -1,12 +1,59 @@
-.q-tooltip
+.q-tooltip {
   position fixed
-  font-size $tooltip-fontsize
-  color $tooltip-color
-  background $tooltip-background
-  box-shadow $tooltip-box-shadow
   z-index $z-tooltip
-  padding $tooltip-padding
+  box-shadow $tooltip-box-shadow
+  pointer-events none
+}
+
+.q-tooltip .q-tooltip-inner {
+  background $tooltip-background
+  color $tooltip-color
   border-radius $tooltip-border-radius
+  padding $tooltip-padding
   overflow-y auto
   overflow-x hidden
-  pointer-events none
+}
+
+.q-tooltip .arrow-bottom {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 9px 0 9px
+  border-left-color transparent 
+  border-right-color transparent
+  bottom -8px
+  left calc(50% - 10px)
+}
+
+.q-tooltip .arrow-top {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 0 9px 9px 9px
+  border-left-color transparent
+  border-right-color transparent
+  top -8px
+  left calc(50% - 10px)
+}
+
+.q-tooltip .arrow-left {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 9px 9px 0
+  border-top-color transparent
+  border-bottom-color transparent
+  left -8px
+  top calc(50% - 10px)
+}
+
+.q-tooltip .arrow-right {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 0 9px 9px
+  border-top-color transparent
+  border-bottom-color transparent
+  right -8px
+  top calc(50% - 10px)
+}

--- a/src/components/tooltip/tooltip.mat.styl
+++ b/src/components/tooltip/tooltip.mat.styl
@@ -1,58 +1,46 @@
-.q-tooltip {
+.q-tooltip
   position fixed
   z-index $z-tooltip
   pointer-events none
-}
 
-.q-tooltip .q-tooltip-inner {
-  background $tooltip-background
-  color $tooltip-color
-  border-radius $tooltip-border-radius
-  padding $tooltip-padding
-  overflow-y auto
-  overflow-x hidden
-}
+  .q-tooltip-inner
+    background $tooltip-background
+    color $tooltip-color
+    border-radius $tooltip-border-radius
+    padding $tooltip-padding
+    overflow-y auto
+    overflow-x hidden
 
-.q-tooltip .arrow-bottom {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 9px 0 9px
-  border-left-color transparent 
-  border-right-color transparent
-  bottom -8px
-  left calc(50% - 10px)
-}
+  .q-tooltip-arrow
+    border-style solid
+    position absolute
+    border-color $tooltip-background
 
-.q-tooltip .arrow-top {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 0 9px 9px 9px
-  border-left-color transparent
-  border-right-color transparent
-  top -8px
-  left calc(50% - 10px)
-}
+  > .q-tooltip-arrow-
+    &bottom
+      border-width 9px 9px 0 9px
+      border-left-color transparent 
+      border-right-color transparent
+      bottom -8px
+      left calc(50% - 10px)
 
-.q-tooltip .arrow-left {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 9px 9px 0
-  border-top-color transparent
-  border-bottom-color transparent
-  left -8px
-  top calc(50% - 10px)
-}
+    &top
+      border-width 0 9px 9px 9px
+      border-left-color transparent
+      border-right-color transparent
+      top -8px
+      left calc(50% - 10px)
 
-.q-tooltip .arrow-right {
-  border-style solid
-  position absolute
-  border-color $tooltip-background
-  border-width 9px 0 9px 9px
-  border-top-color transparent
-  border-bottom-color transparent
-  right -8px
-  top calc(50% - 10px)
-}
+    &left
+      border-width 9px 9px 9px 0
+      border-top-color transparent
+      border-bottom-color transparent
+      left -8px
+      top calc(50% - 10px)
+
+    &right
+      border-width 9px 0 9px 9px
+      border-top-color transparent
+      border-bottom-color transparent
+      right -8px
+      top calc(50% - 10px)

--- a/src/components/tooltip/tooltip.mat.styl
+++ b/src/components/tooltip/tooltip.mat.styl
@@ -1,12 +1,58 @@
-.q-tooltip
+.q-tooltip {
   position fixed
-  font-size $tooltip-fontsize
-  color $tooltip-color
-  background $tooltip-background
-  box-shadow $tooltip-box-shadow
   z-index $z-tooltip
-  padding $tooltip-padding
+  pointer-events none
+}
+
+.q-tooltip .q-tooltip-inner {
+  background $tooltip-background
+  color $tooltip-color
   border-radius $tooltip-border-radius
+  padding $tooltip-padding
   overflow-y auto
   overflow-x hidden
-  pointer-events none
+}
+
+.q-tooltip .arrow-bottom {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 9px 0 9px
+  border-left-color transparent 
+  border-right-color transparent
+  bottom -8px
+  left calc(50% - 10px)
+}
+
+.q-tooltip .arrow-top {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 0 9px 9px 9px
+  border-left-color transparent
+  border-right-color transparent
+  top -8px
+  left calc(50% - 10px)
+}
+
+.q-tooltip .arrow-left {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 9px 9px 0
+  border-top-color transparent
+  border-bottom-color transparent
+  left -8px
+  top calc(50% - 10px)
+}
+
+.q-tooltip .arrow-right {
+  border-style solid
+  position absolute
+  border-color $tooltip-background
+  border-width 9px 0 9px 9px
+  border-top-color transparent
+  border-bottom-color transparent
+  right -8px
+  top calc(50% - 10px)
+}


### PR DESCRIPTION
This is my attempt at adding arrows to the tool tip. 

It only adds the arrow, when the tooltip popup is directly above, below, to the right or left. I didn't know how to handle the other locations. 

Scott


close #2418 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
