### PR TITLE
feat: QInput | Add v-on:paste event handler

### DIFF
--- a/src/components/input/QInput.js
+++ b/src/components/input/QInput.js
@@ -297,7 +297,8 @@ export default {
             focus: this.__onFocus,
             blur: this.__onInputBlur,
             keydown: this.__onKeydown,
-            keyup: this.__onKeyup
+            keyup: this.__onKeyup,
+            paste: this.__onPaste
           }
         })
       ])
@@ -322,6 +323,7 @@ export default {
           blur: this.__onInputBlur,
           keydown: this.__onKeydown,
           keyup: this.__onKeyup,
+          paste: this.__onPaste,
           animationstart: this.__onAnimationStart
         }
       })
@@ -344,7 +346,8 @@ export default {
       props: this.frameProps,
       on: {
         click: this.__onClick,
-        focus: this.__onFocus
+        focus: this.__onFocus,
+        paste: this.__onPaste
       }
     },
     [].concat(this.$slots.before).concat([

--- a/src/components/search/QSearch.js
+++ b/src/components/search/QSearch.js
@@ -135,6 +135,7 @@ export default {
         keyup: this.__onKeyup,
         keydown: this.__onKeydown,
         click: this.__onClick,
+        paste: this.__onPaste,
         clear: val => {
           this.$emit('clear', val)
           this.__emit()

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -79,6 +79,9 @@ export default {
     __onClick (e) {
       this.focus()
       this.$emit('click', e)
+    },
+    __onPaste (e) {
+      this.$emit('paste', e)
     }
   },
   mounted () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR is just adding the `@paste` event handler to `QInput` and `QSearch` components