### PR TITLE
QModal and QPopover refocus: if the target is not .q-if do a blur after focus

### DIFF
--- a/dev/components/global/dialog.vue
+++ b/dev/components/global/dialog.vue
@@ -47,6 +47,9 @@
       <q-btn label="Options" @click="adHoc2" />
       <q-btn label="Confirm" @click="adHoc3" />
       <q-btn label="Method" @click="asMethod" />
+      <q-btn label="Toggle ref and test tooltip on close" @click="toggle">
+        <q-tooltip>Tooltip</q-tooltip>
+      </q-btn>
     </div>
 
     <q-input v-model="text" @keyup.enter="adHoc" />

--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -213,7 +213,10 @@ export default {
       EscapeKey.pop()
       preventScroll(false)
       this.__register(false)
-      !this.noRefocus && this.__refocusTarget && this.__refocusTarget.focus()
+      if (!this.noRefocus && this.__refocusTarget) {
+        this.__refocusTarget.focus()
+        !this.__refocusTarget.classList.contains('q-if') && this.__refocusTarget.blur()
+      }
     },
     __stopPropagation (e) {
       e.stopPropagation()

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -159,6 +159,7 @@ export default {
       this.hidePromise && this.hidePromiseResolve()
       if (!this.noRefocus && this.__refocusTarget) {
         this.__refocusTarget.focus()
+        !this.__refocusTarget.classList.contains('q-if') && this.__refocusTarget.blur()
       }
       this.$emit('hide')
     },


### PR DESCRIPTION
It looks like focus() + blur() keeps the flow of keyboard navigation.
This fixes the nuisance when refocusing elements with tooltips.