### PR TITLE
QTree extensions support + DND extension POC

### DIFF
--- a/dev/components/components/tree-dnd.vue
+++ b/dev/components/components/tree-dnd.vue
@@ -1,0 +1,106 @@
+<template>
+  <div id="q-app">
+
+    <QTree
+      :nodes="simple"
+      node-key="label"
+      :extensions="extensions"
+      drag-enabled
+    />
+  </div>
+</template>
+
+<script>
+import dnd from '../../../src/components/tree/extensions/dnd.js'
+
+export default {
+  name: 'App',
+  data () {
+    return {
+      extensions: [
+        dnd({
+          dropAreaClass: 'valid-drop-area',
+          draggingClass: 'dragging-node',
+
+          dropHandler: (sourceKey, sourceParentKey, destinationKey) => {
+            if (sourceParentKey === destinationKey) return false
+
+            console.log(this.simpleMap)
+            const sourceParent = this.simpleMap[sourceParentKey]
+            const source = this.simpleMap[sourceKey]
+
+            const destination = this.simpleMap[destinationKey]
+
+            sourceParent.children.splice(sourceParent.children.indexOf(source), 1)
+            destination.children.push(source)
+
+            return true
+          }
+        })
+      ],
+      simple: [
+        {
+          label: 'Satisfied customers',
+          children: [
+            {
+              label: 'Good food',
+              children: [
+                {label: 'Quality ingredients'},
+                {label: 'Good recipe'}
+              ]
+            },
+            {
+              label: 'Good drinks',
+              children: [
+                {label: 'Good beer'},
+                {label: 'Good cider'},
+                {label: 'Good tea (sic)'}
+              ]
+            },
+            {
+              label: 'Good service (disabled node)',
+              disabled: true,
+              children: [
+                {label: 'Prompt attention'},
+                {label: 'Professional waiter'}
+              ]
+            },
+            {
+              label: 'Pleasant surroundings',
+              children: [
+                {label: 'Happy atmosphere'},
+                {label: 'Good table presentation'},
+                {label: 'Pleasing decor'}
+              ]
+            }
+          ]
+        }
+      ],
+      simpleMap: {}
+    }
+  },
+  methods: {
+  },
+  mounted () {
+    const processNode = (node) => {
+      this.simpleMap[node.label] = node
+
+      if (node.children != null) {
+        node.children.forEach(n => processNode(n))
+      }
+    }
+
+    this.simple.forEach(n => processNode(n))
+  }
+}
+</script>
+
+<style>
+  .dragging-node {
+    opacity: 0.2;
+  }
+
+  .valid-drop-area {
+    font-weight: bolder;
+  }
+</style>

--- a/src/components/tree/QTree.js
+++ b/src/components/tree/QTree.js
@@ -37,7 +37,12 @@ export default {
 
     defaultExpandAll: Boolean,
     accordion: Boolean,
-
+    extensions: {
+      type: Array,
+      default () {
+        return []
+      }
+    },
     filter: String,
     filterMethod: {
       type: Function,
@@ -422,6 +427,23 @@ export default {
         ])
       }
 
+      let events = {
+        click: () => {
+          this.__onClick(node, meta)
+        }
+      }
+      let attrs = {}
+
+      this.extensions.forEach(e => {
+        if (e.nodeEvents != null && typeof e.nodeEvents === 'function') {
+          Object.assign(events, e.nodeEvents(node, meta))
+        }
+
+        if (e.nodeAttrs != null && typeof e.nodeAttrs === 'function') {
+          Object.assign(attrs, e.nodeAttrs(node, meta))
+        }
+      })
+
       return h('div', {
         key,
         staticClass: 'q-tree-node',
@@ -434,9 +456,10 @@ export default {
             'q-tree-node-selected': meta.selected,
             disabled: meta.disabled
           },
-          on: { click: () => { this.__onClick(node, meta) } },
+          attrs: attrs,
+          on: events,
           directives: process.env.THEME === 'mat' && meta.selectable
-            ? [{ name: 'ripple' }]
+            ? [{name: 'ripple'}]
             : null
         }, [
           meta.lazy === 'loading'

--- a/src/components/tree/extensions/dnd.js
+++ b/src/components/tree/extensions/dnd.js
@@ -1,0 +1,65 @@
+export default (config) => {
+  const __onDrop = (ev, node, meta, ctx) => {
+    const src = JSON.parse(ev.dataTransfer.getData('json'))
+    config.dropHandler.bind(ctx)
+    config.dropHandler(src.key, src.parentKey, meta.key, meta.parent != null ? meta.parent.key : null)
+    ev.preventDefault()
+  }
+  const __onDragStart = (event, node, meta) => {
+    event.dataTransfer.effectAllowed = 'move'
+
+    const data = {
+      key: meta.key
+    }
+
+    if (meta.parent != null) {
+      data.parentKey = meta.parent.key
+    }
+
+    event.dataTransfer.setData('json', JSON.stringify(data))
+  }
+
+  return {
+    nodeEvents: (node, meta) => {
+      const res = {
+        dragstart: (event) => {
+          __onDragStart(event, node, meta)
+          event.target.classList.add(config.draggingClass)
+        },
+        dragend: (event) => {
+          event.target.classList.remove(config.draggingClass)
+        }
+      }
+
+      if (meta.isParent) {
+        res.dragenter = (event) => {
+          event.target.classList.add(config.dropAreaClass)
+          event.preventDefault()
+        }
+
+        res.dragleave = (event) => {
+          event.target.classList.remove(config.dropAreaClass)
+          event.preventDefault()
+        }
+
+        res.dragover = (event) => {
+          event.preventDefault()
+        }
+
+        res.drop = (event) => {
+          __onDrop(event, node, meta, this)
+          event.target.classList.remove(config.dropAreaClass)
+        }
+      }
+      return res
+    },
+    nodeAttrs: (node, meta) => {
+      if (meta.parent == null) return {}
+      else {
+        return {
+          draggable: true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
There are many components that can benefit from additional logic/small features/extensions injection. There is  of course possibility of copying source component but it will require further maintenance/merging that for big applications not really feasible. This is the way how we implemented extensions for QTree component. We really needed to get DnD and this approach allowed us to implement main DnD logic totally outside of QTree, so the source component is mostly untouched and for the users of QTree this update won't be even visible. The extensions can really be anywhere in a code, some really good ones can be taken over and further supported by quasar team. A added the example how all this can be used together. And even if DnD extension can be of course made more durable and so on, main point of the PR is to open/allow tree structure manipulations. 