### PR TITLE
Update to QSelect

### DIFF
--- a/dev/components/form/select.vue
+++ b/dev/components/form/select.vue
@@ -72,6 +72,13 @@
       <q-select disable @change="onChange" @input="onInput" multiple chips v-model="multipleSelect" :options="selectListOptions" float-label="Disabled Select" max-height="36px" clearable/>
       <q-select disable inverted inverted-light color="amber" multiple chips v-model="multipleSelect" :options="selectListOptions" float-label="Disabled Select" max-height="36px"/>
 
+      <p class="caption">Read Only State</p>
+      <q-select readonly float-label="Read Only Select with Custom Icon" multiple v-model="multipleSelect" :options="selectOptions" :after="[{icon: 'visibility_off'}]"/>
+      <q-select readonly @change="onChange" @input="onInput" multiple chips v-model="multipleSelect" :options="selectListOptions" float-label="Read Only Select" max-height="36px" clearable/>
+
+      <p class="caption">With Custom Right Side Icon </p>
+      <q-select color="amber" multiple v-model="multipleSelect" :options="selectListOptions" float-label="With Custom Icon" max-height="36px" :after="[{icon: 'radio_button_checked'}]"/>
+
       <p class="caption">Error State</p>
       <q-select error multiple v-model="multipleSelect" :options="selectOptions"/>
 

--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -443,18 +443,15 @@ export default {
         }
       }))
     }
-    if (this.readonly) {
-      child.push(h(QIcon, {
-        slot: 'after'
-      }))
-    }
-    else {
-      child.push(h(QIcon, {
+
+    child.push(
+      h(QIcon, this.readonly ? { slot: 'after' } : {
         slot: 'after',
         staticClass: 'q-if-control',
         props: { name: this.$q.icon.input.dropdown }
-      }))
-    }
+      })
+    )
+
     return h(QInputFrame, {
       ref: 'input',
       staticClass: 'q-select',

--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -443,13 +443,18 @@ export default {
         }
       }))
     }
-
-    child.push(h(QIcon, {
-      slot: 'after',
-      staticClass: 'q-if-control',
-      props: { name: this.$q.icon.input.dropdown }
-    }))
-
+    if (this.readonly) {
+      child.push(h(QIcon, {
+        slot: 'after'
+      }))
+    }
+    else {
+      child.push(h(QIcon, {
+        slot: 'after',
+        staticClass: 'q-if-control',
+        props: { name: this.$q.icon.input.dropdown }
+      }))
+    }
     return h(QInputFrame, {
       ref: 'input',
       staticClass: 'q-select',


### PR DESCRIPTION
This addresses #2465.

It hides the drop down arrow, when in read only mode. 

It allows for `after` icon to still be set. 

I hope it is ok. 😄 If it is, I'll add some additional documentation to note the behavior of read only mode. 

Scott 

Close #2465

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
