### PR TITLE
feat(QInput, QChipsInput, QUploader): Add custom loading slot as QBtn

### DIFF
--- a/src/components/chips-input/QChipsInput.js
+++ b/src/components/chips-input/QChipsInput.js
@@ -278,11 +278,18 @@ export default {
       ])),
 
       this.isLoading
-        ? h(QSpinner, {
-          slot: 'after',
-          staticClass: 'q-if-control',
-          props: { size: '24px' }
-        })
+        ? (
+          this.$slots.loading
+            ? h('div', {
+              staticClass: 'q-if-control',
+              slot: 'after'
+            }, this.$slots.loading)
+            : h(QSpinner, {
+              slot: 'after',
+              staticClass: 'q-if-control',
+              props: { size: '24px' }
+            })
+        )
         : ((this.editable && h(QIcon, {
           slot: 'after',
           staticClass: 'q-if-control',

--- a/src/components/input/QInput.js
+++ b/src/components/input/QInput.js
@@ -397,11 +397,16 @@ export default {
         }
       })) || void 0,
 
-      (this.isLoading && h(QSpinner, {
-        slot: 'after',
-        staticClass: 'q-if-control',
-        props: { size: '24px' }
-      })) || void 0
+      (this.isLoading && (this.$slots.loading
+        ? h('div', {
+          staticClass: 'q-if-control',
+          slot: 'after'
+        }, this.$slots.loading)
+        : h(QSpinner, {
+          slot: 'after',
+          staticClass: 'q-if-control',
+          props: { size: '24px' }
+        }))) || void 0
     ]).concat(this.$slots.after).concat(this.$slots.default
       ? h('div', { staticClass: 'absolute-full no-pointer-events', slot: 'after' }, this.$slots.default)
       : void 0

--- a/src/components/uploader/QUploader.js
+++ b/src/components/uploader/QUploader.js
@@ -434,11 +434,16 @@ export default {
 
     if (this.uploading) {
       child.push(
-        h(QSpinner, {
-          slot: 'after',
-          staticClass: 'q-if-end self-center',
-          props: { size: '24px' }
-        }),
+        this.$slots.loading
+          ? h('div', {
+            slot: 'after',
+            staticClass: 'q-if-end self-center q-if-control'
+          }, this.$slots.loading)
+          : h(QSpinner, {
+            slot: 'after',
+            staticClass: 'q-if-end self-center',
+            props: { size: '24px' }
+          }),
         h(QIcon, {
           slot: 'after',
           staticClass: 'q-if-end self-center q-if-control',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

https://github.com/quasarframework/quasar-framework.org/pull/586

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR introduces the `loading` slot to components:
* `QInput`
* `QChipsInput`
* `QUploader`

It emulates the behaviour of `QBtn` of having a custom UI that indicates that the component is loading instead of the default theme `QSpinner`.  This keeps consistency of spinners when using custom `QSpinner.*` or any other way to indicate `loading` states.