### PR TITLE
Add max-height option like Autocomplete one

### DIFF
--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -36,7 +36,7 @@ export default {
     chipsColor: String,
     chipsBgColor: String,
     displayValue: String,
-    maxHeight: String
+    popupMaxHeight: String
   },
   data () {
     return {
@@ -347,7 +347,7 @@ export default {
         cover: true,
         disable: !this.editable,
         anchorClick: false,    
-        maxHeight: String
+        maxHeight: this.popupMaxHeight
       },
       slot: 'after',
       on: {

--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -35,7 +35,8 @@ export default {
     },
     chipsColor: String,
     chipsBgColor: String,
-    displayValue: String
+    displayValue: String,
+    maxHeight: String
   },
   data () {
     return {
@@ -345,7 +346,8 @@ export default {
       props: {
         cover: true,
         disable: !this.editable,
-        anchorClick: false
+        anchorClick: false,    
+        maxHeight: String
       },
       slot: 'after',
       on: {


### PR DESCRIPTION
Hi

Goal : Introduce the hability to limit QPopover height on QSelect like it's already done on QAutocomplete.

This PR goal is to be able to implement with QSelect the workaround describe in :
https://github.com/quasarframework/quasar/issues/2530 
In case there is too much options to display it'll help to limit QPopover height.

Thx
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
