### PR TITLE
Fixes for QPopover and QTooltip

### DIFF
--- a/dev/components/components/popover-test.vue
+++ b/dev/components/components/popover-test.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row" style="padding: 1500px 0">
+  <div class="row" style="padding: 1500px 0; width: 2000px">
     <div class="col" style="height:2000px; width:100px; background-color:red;">
       <q-context-menu>
         <q-list link separator style="min-width: 150px; max-height: 300px;">

--- a/dev/components/components/popover.vue
+++ b/dev/components/components/popover.vue
@@ -7,7 +7,7 @@
         <em>This page has intended scroll so you can see multiple scenarios.</em>
       </div>
 
-      <div>
+      <div style="width: 400%">
         <q-toggle v-model="toggle" class="z-max fixed-top" />
         <q-btn color="primary" icon="assignment">
           <q-popover v-model="toggle" ref="popover1" persistent @show="log('@show popover1 persistent')" @hide="log('@hide popover1 persistent')">
@@ -49,16 +49,35 @@
           </q-popover>
         </q-btn>
 
-        <q-card style="margin-top: 75px">
+        <q-card style="margin-top: 800px; width: 500px; max-width: 90vw; margin-left: auto; margin-right: auto;">
           <q-card-title class="bg-primary text-center">
-            <q-btn push color="orange" label="Tap Me">
+            <q-btn push color="orange" label="Tap Me Large">
               <q-popover
                 :anchor="anchor"
                 :self="self"
               >
                 <q-list no-border link style="min-width: 100px">
                   <q-item
-                    v-for="n in 3"
+                    v-for="n in 50"
+                    :key="n"
+                    v-close-overlay
+                    @click.native="showNotify()"
+                    @keyup.native.13.32="showNotify()"
+                    :tabindex="0"
+                  >
+                    <q-item-main label="Label" />
+                  </q-item>
+                </q-list>
+              </q-popover>
+            </q-btn>
+            <q-btn push color="orange" label="Tap Me Small" class="on-right">
+              <q-popover
+                :anchor="anchor"
+                :self="self"
+              >
+                <q-list no-border link style="min-width: 100px">
+                  <q-item
+                    v-for="n in 5"
                     :key="n"
                     v-close-overlay
                     @click.native="showNotify()"

--- a/src/components/autocomplete/autocomplete.ios.styl
+++ b/src/components/autocomplete/autocomplete.ios.styl
@@ -1,2 +1,0 @@
-body.desktop .q-select-highlight
-  background $item-highlight-color !important

--- a/src/components/autocomplete/autocomplete.mat.styl
+++ b/src/components/autocomplete/autocomplete.mat.styl
@@ -1,2 +1,0 @@
-body.desktop .q-select-highlight
-  background $item-highlight-color !important

--- a/src/components/color/QColor.js
+++ b/src/components/color/QColor.js
@@ -276,6 +276,7 @@ export default {
           ref: 'popup',
           props: {
             cover: true,
+            keepOnScreen: true,
             disable: this.disable,
             anchorClick: false,
             maxHeight: '100vh'

--- a/src/components/context-menu/QContextMenu.js
+++ b/src/components/context-menu/QContextMenu.js
@@ -101,7 +101,8 @@ export default {
     return h(QPopover, {
       ref: 'popup',
       props: {
-        anchorClick: false
+        anchorClick: false,
+        touchPosition: true
       },
       on: {
         show: this.__desktopOnShow,

--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -312,6 +312,7 @@ export default {
           ref: 'popup',
           props: {
             cover: true,
+            keepOnScreen: true,
             disable: this.disable,
             anchorClick: false,
             maxHeight: '100vh'

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -82,18 +82,23 @@ export default {
     this.$nextTick(() => {
       this.anchorEl = this.$el.parentNode
       this.anchorEl.removeChild(this.$el)
-      if (this.anchorEl.classList.contains('q-btn-inner') || this.anchorEl.classList.contains('q-if-inner') || this.anchorEl.classList.contains('no-pointer-events')) {
+
+      if (
+        this.anchorEl.classList.contains('q-btn-inner') ||
+        this.anchorEl.classList.contains('q-if-inner') ||
+        this.anchorEl.classList.contains('no-pointer-events')
+      ) {
         this.anchorEl = this.anchorEl.parentNode
       }
+
       if (this.anchorClick) {
         this.anchorEl.classList.add('cursor-pointer')
         this.anchorEl.addEventListener('click', this.toggle)
         this.anchorEl.addEventListener('keyup', this.__toggleKey)
       }
     })
-    if (this.value) {
-      this.show()
-    }
+
+    this.value && this.show()
   },
   beforeDestroy () {
     this.showing && this.__cleanup()
@@ -169,7 +174,10 @@ export default {
     reposition (event, animate) {
       const { top, bottom, left, right } = this.anchorEl.getBoundingClientRect()
 
-      if (!this.keepOnScreen && (bottom < 0 || top > window.innerHeight || right < 0 || left > window.innerWidth)) {
+      if (
+        !this.keepOnScreen &&
+        (bottom < 0 || top > window.innerHeight || right < 0 || left > window.innerWidth)
+      ) {
         return this.hide()
       }
 

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -167,9 +167,9 @@ export default {
       this.$el.remove()
     },
     reposition (event, animate) {
-      const { top, bottom, left } = this.anchorEl.getBoundingClientRect()
+      const { top, bottom, left, right } = this.anchorEl.getBoundingClientRect()
 
-      if (!this.keepOnScreen && (bottom < 0 || top > window.innerHeight)) {
+      if (!this.keepOnScreen && (bottom < 0 || top > window.innerHeight || right < 0 || left > window.innerWidth)) {
         return this.hide()
       }
 

--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -152,6 +152,11 @@ export default {
     },
     __keyboardCustomKeyHandle (key, e) {
       switch (key) {
+        case 27: // ESCAPE
+          if (this.$refs.popover.showing) {
+            this.hide()
+          }
+          break
         case 13: // ENTER key
         case 32: // SPACE key
           if (!this.$refs.popover.showing) {
@@ -195,6 +200,7 @@ export default {
       this.__onFocus()
       if (this.filter && this.$refs.filter) {
         this.$refs.filter.focus()
+        this.reposition()
       }
     },
     __onBlur (e) {
@@ -346,6 +352,7 @@ export default {
       'class': this.dark ? 'bg-dark' : null,
       props: {
         cover: true,
+        keepOnScreen: true,
         disable: !this.editable,
         anchorClick: false,
         maxHeight: this.popupMaxHeight

--- a/src/components/select/select.ios.styl
+++ b/src/components/select/select.ios.styl
@@ -1,2 +1,0 @@
-body.desktop .q-select-highlight
-  background $item-highlight-color !important

--- a/src/components/select/select.mat.styl
+++ b/src/components/select/select.mat.styl
@@ -1,2 +1,0 @@
-body.desktop .q-select-highlight
-  background $item-highlight-color !important

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -121,9 +121,14 @@ export default {
 
       this.anchorEl = this.$el.parentNode
       this.anchorEl.removeChild(this.$el)
-      if (this.anchorEl.classList.contains('q-btn-inner') || this.anchorEl.classList.contains('q-if-inner') || this.anchorEl.classList.contains('no-pointer-events')) {
+      if (
+        this.anchorEl.classList.contains('q-btn-inner') ||
+        this.anchorEl.classList.contains('q-if-inner') ||
+        this.anchorEl.classList.contains('no-pointer-events')
+      ) {
         this.anchorEl = this.anchorEl.parentNode
       }
+
       if (this.$q.platform.is.mobile) {
         this.anchorEl.addEventListener('click', this.show)
       }
@@ -134,9 +139,7 @@ export default {
         this.anchorEl.addEventListener('blur', this.__delayHide)
       }
 
-      if (this.value) {
-        this.show()
-      }
+      this.value && this.show()
     })
   },
   beforeDestroy () {
@@ -145,6 +148,7 @@ export default {
     if (!this.anchorEl) {
       return
     }
+
     if (this.$q.platform.is.mobile) {
       this.anchorEl.removeEventListener('click', this.show)
     }

--- a/src/components/tooltip/QTooltip.js
+++ b/src/components/tooltip/QTooltip.js
@@ -121,7 +121,7 @@ export default {
 
       this.anchorEl = this.$el.parentNode
       this.anchorEl.removeChild(this.$el)
-      if (this.anchorEl.classList.contains('q-btn-inner')) {
+      if (this.anchorEl.classList.contains('q-btn-inner') || this.anchorEl.classList.contains('q-if-inner') || this.anchorEl.classList.contains('no-pointer-events')) {
         this.anchorEl = this.anchorEl.parentNode
       }
       if (this.$q.platform.is.mobile) {

--- a/src/css/core/helpers.styl
+++ b/src/css/core/helpers.styl
@@ -54,3 +54,6 @@ a.q-link
   outline 0
   color inherit
   text-decoration none
+
+.q-select-highlight
+  background $item-highlight-color !important

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -75,30 +75,37 @@ export function getPositions (anchor, target) {
 }
 
 export function repositionIfNeeded (anchor, target, selfOrigin, anchorOrigin, targetPosition) {
-  const {positions, anchorPos} = getPositions(anchorOrigin, selfOrigin)
+  const { positions, anchorPos } = getPositions(anchorOrigin, selfOrigin)
+  let { innerHeight, innerWidth } = window
+  // simple treatment of possible scrollbar
+  innerHeight -= 20
+  innerWidth -= 20
 
-  if (targetPosition.top < 0 || targetPosition.top + target.bottom > window.innerHeight) {
+  if (targetPosition.top < 0) {
+    targetPosition.top = 0
+  }
+  else if (targetPosition.top + target.bottom > innerHeight) {
     let newTop = anchor[anchorPos.vertical] - target[positions.y[0]]
-    if (newTop + target.bottom <= window.innerHeight) {
+    if (newTop + target.bottom <= innerHeight) {
       targetPosition.top = newTop
     }
     else {
       newTop = anchor[anchorPos.vertical] - target[positions.y[1]]
-      if (newTop + target.bottom <= window.innerHeight) {
-        targetPosition.top = newTop
-      }
+      targetPosition.top = (newTop + target.bottom <= innerHeight) ? newTop : innerHeight - target.bottom
     }
   }
-  if (targetPosition.left < 0 || targetPosition.left + target.right > window.innerWidth) {
+
+  if (targetPosition.left < 0) {
+    targetPosition.left = 0
+  }
+  else if (targetPosition.left + target.right > innerWidth) {
     let newLeft = anchor[anchorPos.horizontal] - target[positions.x[0]]
-    if (newLeft + target.right <= window.innerWidth) {
+    if (newLeft + target.right <= innerWidth) {
       targetPosition.left = newLeft
     }
     else {
       newLeft = anchor[anchorPos.horizontal] - target[positions.x[1]]
-      if (newLeft + target.right <= window.innerWidth) {
-        targetPosition.left = newLeft
-      }
+      targetPosition.left = (newLeft + target.right <= innerWidth) ? newLeft : innerWidth - target.right
     }
   }
 
@@ -109,7 +116,7 @@ export function parseHorizTransformOrigin (pos) {
   return pos === 'middle' ? 'center' : pos
 }
 
-export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset}) {
+export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset, touchOffset}) {
   let anchor
   el.style.maxHeight = maxHeight || '65vh'
 
@@ -118,7 +125,16 @@ export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, m
     anchor = {top, left, width: 1, height: 1, right: left + 1, center: top, middle: left, bottom: top + 1}
   }
   else {
-    anchor = getAnchorPosition(anchorEl, offset)
+    if (touchOffset) {
+      const
+        { top: anchorTop, left: anchorLeft } = anchorEl.getBoundingClientRect(),
+        top = anchorTop + touchOffset.top,
+        left = anchorLeft + touchOffset.left
+      anchor = {top, left, width: 1, height: 1, right: left + 1, center: top, middle: left, bottom: top + 1}
+    }
+    else {
+      anchor = getAnchorPosition(anchorEl, offset)
+    }
   }
 
   let target = getTargetPosition(el)


### PR DESCRIPTION
- add keepOnScreen prop to QPopover to prevent hiding when anchor goes out of screen
- when touchPosition is used keep relative offset when scrolling
- adjust how the popover is positioned on scroll

close #2542, close #2530, close #2489