### PR TITLE
Fixes for QDatetime Mat (more responsive) and QPopup

### DIFF
--- a/dev/components/form/datetime-responsive.vue
+++ b/dev/components/form/datetime-responsive.vue
@@ -1,13 +1,15 @@
 <template>
   <div>
     <div class="layout-padding">
+      <q-toggle v-model="typeDate" label="With date" />
+      <q-toggle v-model="typeTime" label="With time" />
       <div class="bg-secondary text-white">
         Model: <em>{{ model }}</em>
       </div>
       <q-datetime
         class="q-my-md"
         v-model="model"
-        type="datetime"
+        :type="computedType"
         clearable
         format24h
         @change="value => log('@change', value)"
@@ -18,7 +20,7 @@
       <q-datetime
         class="q-my-md"
         v-model="model"
-        type="datetime"
+        :type="computedType"
         clearable
         format24h
         minimal
@@ -31,7 +33,7 @@
         <div>
           <q-datetime
             v-model="model"
-            type="datetime"
+            :type="computedType"
             clearable
             @change="value => log('@change', value)"
             @input="value => log('@input', value)"
@@ -42,7 +44,7 @@
         <div>
           <q-datetime
             v-model="model"
-            type="datetime"
+            :type="computedType"
             clearable
             minimal
             @change="value => log('@change', value)"
@@ -54,7 +56,7 @@
       </div>
       <q-datetime
         v-model="model"
-        type="datetime"
+        :type="computedType"
         clearable
         modal
         @change="value => log('@change', value)"
@@ -64,7 +66,7 @@
       />
       <q-datetime
         v-model="model"
-        type="datetime"
+        :type="computedType"
         clearable
         modal
         minimal
@@ -77,7 +79,7 @@
         <div>
           <q-datetime-picker
             v-model="model"
-            type="datetime"
+            :type="computedType"
             format24h
             default-view="month"
             @change="value => log('@change', value)"
@@ -89,7 +91,7 @@
         <div>
           <q-datetime-picker
             v-model="model"
-            type="datetime"
+            :type="computedType"
             format24h
             minimal
             default-view="year"
@@ -103,7 +105,7 @@
       <q-datetime-picker
         class="q-my-md"
         v-model="model"
-        type="datetime"
+        :type="computedType"
         @change="value => log('@change', value)"
         @input="value => log('@input', value)"
         @focus="log('@focus')"
@@ -112,7 +114,7 @@
       <q-datetime-picker
         class="q-my-md"
         v-model="model"
-        type="datetime"
+        :type="computedType"
         minimal
         @change="value => log('@change', value)"
         @input="value => log('@input', value)"
@@ -127,7 +129,7 @@
       <q-datetime-picker
         class="q-my-md"
         v-model="model"
-        type="datetime"
+        :type="computedType"
         format24h
         :min="min"
         :max="max"
@@ -136,6 +138,31 @@
         @focus="log('@focus')"
         @blur="log('@blur')"
       />
+      <div class="q-my-md">
+        <div style="width: 290px; outline: 2px solid red">
+          <q-datetime-picker
+            v-model="model"
+            :type="computedType"
+            clearable
+            @change="value => log('@change', value)"
+            @input="value => log('@input', value)"
+            @focus="log('@focus')"
+            @blur="log('@blur')"
+          />
+        </div>
+        <div style="width: 320px; outline: 2px solid red">
+          <q-datetime-picker
+            v-model="model"
+            :type="computedType"
+            clearable
+            minimal
+            @change="value => log('@change', value)"
+            @input="value => log('@input', value)"
+            @focus="log('@focus')"
+            @blur="log('@blur')"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -151,7 +178,17 @@ export default {
       model: undefined,
       minMaxModel: date.formatDate(day),
       min: date.subtractFromDate(day, {days: 45}),
-      max: date.addToDate(day, {days: 8, month: 4, minutes: 10})
+      max: date.addToDate(day, {days: 8, month: 4, minutes: 10}),
+      typeDate: true,
+      typeTime: true
+    }
+  },
+  computed: {
+    computedType () {
+      if (this.typeDate && this.typeTime) {
+        return 'datetime'
+      }
+      return this.typeTime ? 'time' : 'date'
     }
   },
   methods: {

--- a/src/components/datetime/QDatetimePicker.mat.js
+++ b/src/components/datetime/QDatetimePicker.mat.js
@@ -62,9 +62,6 @@ export default {
       this.color && cls.push(`text-${this.color}`)
       return cls
     },
-    contentClasses () {
-      return this.minimal ? 'col-md-12' : 'col-md-8'
-    },
     dateArrow () {
       const val = [ this.$q.icon.datetime.arrowLeft, this.$q.icon.datetime.arrowRight ]
       return this.$q.i18n.rtl ? val.reverse() : val
@@ -427,14 +424,15 @@ export default {
     },
 
     __getTopSection (h) {
-      const child = []
+      const child = [
+        this.typeHasDate
+          ? h('div', { staticClass: 'q-datetime-weekdaystring' }, [this.weekDayString])
+          : void 0,
+        h('div', { staticClass: 'col' })
+      ]
 
       if (this.typeHasDate) {
         const content = [
-          h('div', { staticClass: 'q-datetime-weekdaystring col-12' }, [
-            this.weekDayString
-          ]),
-
           h('div', { staticClass: 'q-datetime-datestring row flex-center' }, [
             h('span', {
               staticClass: 'q-datetime-link small col-auto col-md-12',
@@ -628,8 +626,10 @@ export default {
         ]))
       }
 
+      child.push(h('div', { staticClass: 'col' }))
+
       return h('div', {
-        staticClass: 'q-datetime-header column col-md-4 justify-center'
+        staticClass: 'q-datetime-header column items-center'
       }, child)
     },
 
@@ -779,7 +779,7 @@ export default {
         ]),
 
         h('div', {
-          staticClass: 'q-datetime-weekdays row items-center justify-start'
+          staticClass: 'q-datetime-weekdays row no-wrap items-center justify-start'
         }, this.headerDayNames.map(day => h('div', [ day ]))),
 
         h('div', {
@@ -892,14 +892,15 @@ export default {
       (!this.minimal && this.__getTopSection(h)) || void 0,
 
       h('div', {
-        staticClass: 'q-datetime-content',
-        'class': this.contentClasses
+        staticClass: 'q-datetime-content'
       }, [
         h('div', {
           ref: 'selector',
-          staticClass: 'q-datetime-selector row flex-center'
+          staticClass: 'q-datetime-selector row items-center'
         }, [
-          this.__getViewSection(h)
+          h('div', { 'class': 'col' }),
+          this.__getViewSection(h),
+          h('div', { 'class': 'col' })
         ])
       ].concat(this.$slots.default))
     ])

--- a/src/components/datetime/datetime.mat.styl
+++ b/src/components/datetime/datetime.mat.styl
@@ -9,7 +9,6 @@
   text-align center
   user-select none
   line-height initial
-  min-width 290px
   .modal-buttons
     padding-top 8px
 
@@ -19,10 +18,16 @@
   > div
     color white
 
+.q-datetime-header
+.q-datetime-content
+  min-width 290px
+
 .q-datetime-weekdaystring
   font-size .8rem
   background rgba(0, 0, 0, .1)
   padding 5px 0
+  width 100%
+  margin-bottom -10px
 
 .q-datetime-time
   padding 10px 0
@@ -237,11 +242,11 @@ for $pos in 13..23
   .q-datetime-ampm
     margin-left 1.5rem
   .q-datetime-datestring .q-datetime-link
-    margin 10px 5px
+    margin 5px
+    &.small
+      margin-top 1.3rem
     span
       padding 10px 5px
-      &.small
-        margin-top 1.3rem
   .q-datetime
     &:not(.no-border)
       &:not(.q-datetime-dark) .q-datetime-content
@@ -255,8 +260,6 @@ for $pos in 13..23
         border 1px solid var(--q-color-dark)
 
 @media (min-width $breakpoint-md-min)
-  .q-datetime:not(.q-datetime-minimal)
-    min-width 170px * 3
   .q-datetime-datestring
     padding 10px 0
   .q-datetime-ampm
@@ -265,11 +268,10 @@ for $pos in 13..23
       margin 2px 0
   .q-datetime-header
     position relative
-  .q-datetime-weekdaystring
-    position absolute
-    top 0
-    left 0
-    right 0
+    flex 1 1 170px !important
+    min-width 170px
+  .q-datetime-content
+    flex 2 2 290px !important
   .q-datetime
     &:not(.no-border)
       &:not(.q-datetime-dark) .q-datetime-content

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -210,7 +210,8 @@ export default {
         maxHeight: this.maxHeight,
         anchorClick: this.anchorClick,
         touchPosition: this.touchPosition,
-        touchOffset: this.touchOffset
+        touchOffset: this.touchOffset,
+        cover: this.cover
       })
     }
   }

--- a/src/utils/popup.js
+++ b/src/utils/popup.js
@@ -1,4 +1,5 @@
 import { position as eventPosition } from './event.js'
+import { getScrollbarWidth } from './scroll.js'
 
 export function getAnchorPosition (el, offset) {
   let
@@ -42,11 +43,12 @@ export function getTargetPosition (el) {
   }
 }
 
-export function repositionIfNeeded (anchor, target, selfOrigin, anchorOrigin, targetPosition) {
+export function repositionIfNeeded (anchor, target, selfOrigin, anchorOrigin, targetPosition, cover) {
+  const margin = getScrollbarWidth()
   let { innerHeight, innerWidth } = window
   // don't go bellow scrollbars
-  innerHeight -= 20
-  innerWidth -= 20
+  innerHeight -= margin
+  innerWidth -= margin
 
   if (targetPosition.top < 0 || targetPosition.top + target.bottom > innerHeight) {
     if (selfOrigin.vertical === 'center') {
@@ -67,6 +69,9 @@ export function repositionIfNeeded (anchor, target, selfOrigin, anchorOrigin, ta
     if (selfOrigin.horizontal === 'middle') {
       targetPosition.left = anchor[selfOrigin.horizontal] > innerWidth / 2 ? innerWidth - target.right : 0
     }
+    else if (cover) {
+      targetPosition.left = targetPosition.left < 0 ? 0 : innerWidth - target.right
+    }
     else if (anchor[selfOrigin.horizontal] > innerWidth / 2) {
       const anchorY = Math.min(innerWidth, anchorOrigin.horizontal === 'middle' ? anchor.center : (anchorOrigin.horizontal === selfOrigin.horizontal ? anchor.right : anchor.left))
       targetPosition.maxWidth = Math.min(target.right, anchorY)
@@ -85,9 +90,10 @@ export function parseHorizTransformOrigin (pos) {
   return pos === 'middle' ? 'center' : pos
 }
 
-export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset, touchOffset}) {
+export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, maxHeight, event, anchorClick, touchPosition, offset, touchOffset, cover}) {
   let anchor
   el.style.maxHeight = maxHeight || '65vh'
+  el.style.maxWidth = '100vw'
 
   if (event && (!anchorClick || touchPosition)) {
     const {top, left} = eventPosition(event)
@@ -112,7 +118,7 @@ export function setPosition ({el, animate, anchorEl, anchorOrigin, selfOrigin, m
     left: anchor[anchorOrigin.horizontal] - target[selfOrigin.horizontal]
   }
 
-  targetPosition = repositionIfNeeded(anchor, target, selfOrigin, anchorOrigin, targetPosition)
+  targetPosition = repositionIfNeeded(anchor, target, selfOrigin, anchorOrigin, targetPosition, cover)
 
   el.style.top = Math.max(0, targetPosition.top) + 'px'
   el.style.left = Math.max(0, targetPosition.left) + 'px'


### PR DESCRIPTION
- QPopup - use scrollbar width for margin and make special case for cover
- QDatetimePicker Mat - allow to fit inside 290px container even if the windows is above md