### PR TITLE
QInput/QResizeObserver on Firefox: fix spinner and object keyboard navigation

### DIFF
--- a/src/components/observables/QResizeObservable.js
+++ b/src/components/observables/QResizeObservable.js
@@ -55,6 +55,7 @@ export default {
     return h('object', {
       style: this.style,
       attrs: {
+        tabindex: -1, // fix for Firefox
         type: 'text/html',
         data: this.url,
         'aria-hidden': true

--- a/src/css/core/helpers.styl
+++ b/src/css/core/helpers.styl
@@ -44,7 +44,7 @@
   overflow hidden !important
 
 .q-no-input-spinner
-  -moz-appearance textfield
+  -moz-appearance textfield !important
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button
     -webkit-appearance none


### PR DESCRIPTION
It looks like at least firefox adds tab navigation to <object>

close #2550
