### PR TITLE
QPopupEdit, QPopover, QModal: fixes related to 'escape-key'

### DIFF
--- a/src/components/modal/QModal.js
+++ b/src/components/modal/QModal.js
@@ -189,8 +189,8 @@ export default {
           this.__shake()
         }
         else {
+          this.$emit('escape-key')
           this.hide().then(() => {
-            this.$emit('escape-key')
             this.$emit('dismiss')
           })
         }

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -113,7 +113,12 @@ export default {
         this.__refocusTarget = (this.anchorClick && this.anchorEl) || document.activeElement
       }
       document.body.appendChild(this.$el)
-      EscapeKey.register(() => { !this.persistent && this.hide() })
+      EscapeKey.register(() => {
+        if (!this.persistent) {
+          this.$emit('escape-key')
+          this.hide()
+        }
+      })
       this.scrollTarget = getScrollTarget(this.anchorEl)
       this.scrollTarget.addEventListener('scroll', this.__updatePosition, listenOpts.passive)
       if (this.scrollTarget !== window) {

--- a/src/components/popover/QPopover.js
+++ b/src/components/popover/QPopover.js
@@ -114,10 +114,8 @@ export default {
       }
       document.body.appendChild(this.$el)
       EscapeKey.register(() => {
-        if (!this.persistent) {
-          this.$emit('escape-key')
-          this.hide()
-        }
+        this.$emit('escape-key')
+        this.hide()
       })
       this.scrollTarget = getScrollTarget(this.anchorEl)
       this.scrollTarget.addEventListener('scroll', this.__updatePosition, listenOpts.passive)

--- a/src/components/popup-edit/QPopupEdit.js
+++ b/src/components/popup-edit/QPopupEdit.js
@@ -106,11 +106,16 @@ export default {
       },
       on: {
         show: () => {
-          const input = this.$el.querySelector('.q-input-target, input')
+          const input = this.$el.querySelector('.q-input-target:not(.q-input-shadow)') || this.$el.querySelector('input') || this.$el.querySelector('textarea')
           input && input.focus()
           this.$emit('show')
           this.initialValue = clone(this.value)
           this.validated = false
+        },
+        'escape-key': () => {
+          this.validated = true
+          this.$emit('cancel', this.value, this.initialValue)
+          this.$emit('input', this.initialValue)
         },
         hide: () => {
           if (this.validated) { return }


### PR DESCRIPTION
- QModal: emit 'escape-key' before hide
- QPopover:  emit 'escape-key' before hide
- QPopupEdit:
  - fix focus for textarea (querySelector on multiple selectors returns the first one in dom that matches)
  - listen for 'escape-key' and emit cancel

QPopupEdit - expected behavior:
- if it has buttons:
  - cancel btn => cancel and close
  - set btn => if verify than change and close else do not close
  - ESC key => cancel and close
  - ENTER key => if verify then change and close else do not close
  - click outside => if persistent then do not close else if verify then change and close else cancel and close

- if it has no buttons
  - ESC key => cancel and close
  - ENTER key => if verify then change and close else cancel and close
  - click outside=> if persistent then do not close else if verify then change and close else cancel and close

close #2577