### PR TITLE
Remove sym dependency

### DIFF
--- a/build/script.test-umd.js
+++ b/build/script.test-umd.js
@@ -1,7 +1,6 @@
 const
   fs = require('fs'),
   { resolve } = require('path'),
-  sym = require('sym'),
   opn = require('opn')
 
 const
@@ -14,7 +13,7 @@ if (!fs.existsSync(src)) {
 }
 
 if (!fs.existsSync(dest)) {
-  sym(src, dest, 'dir')
+  fs.symlinkSync(src, dest, 'dir')
 }
 
 opn(

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "stylint": "^1.5.9",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "sym": "0.0.4",
     "uglify-es": "^3.3.9",
     "url-loader": "^1.0.1",
     "vue": "^2.5.17",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
Fix npm audit
**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The sym dependency gives the following audit error:
```
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ semver                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.3.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ sym [dev]                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ sym > update-notifier > semver                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/31                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 moderate severity vulnerability in 19675 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```
I runned a git grep and I found only one place where it's used. I replaced it with fs equivalent call:

https://nodejs.org/api/fs.html#fs_fs_symlinksync_target_path_type

I tested it on Linux:

```
[francesco@hp-pavillion quasar]$ node --version
v8.11.4
[francesco@hp-pavillion quasar]$ npm -version
6.4.1
[francesco@hp-pavillion quasar]$ uname -a
Linux hp-pavillion 4.18.7-arch1-1-ARCH #1 SMP PREEMPT Sun Sep 9 11:27:58 UTC 2018 x86_64 GNU/Linux
```

