### PR TITLE
QDialog: emit show after focusing the element in dialog

### DIFF
--- a/src/components/dialog/QDialog.js
+++ b/src/components/dialog/QDialog.js
@@ -94,9 +94,8 @@ export default {
           this.$emit('input', val)
         },
         show: () => {
-          this.$emit('show')
-
           if (!this.$q.platform.is.desktop) {
+            this.$emit('show')
             return
           }
 
@@ -109,6 +108,7 @@ export default {
 
             if (node.length) {
               node[0].focus()
+              this.$emit('show')
               return
             }
           }
@@ -117,6 +117,7 @@ export default {
           if (node.length) {
             node[node.length - 1].focus()
           }
+          this.$emit('show')
         },
         hide: () => {
           this.$emit('hide')


### PR DESCRIPTION
Allows simpler focusing of another elements in `@show` in userland.
Without this change you need to delay the focus to the next tick.

ref #2583
