### PR TITLE
Allow password to be shown by default

### DIFF
--- a/src/components/input/QInput.js
+++ b/src/components/input/QInput.js
@@ -30,11 +30,11 @@ export default {
     step: Number,
     upperCase: Boolean,
     lowerCase: Boolean,
-    showPassword: Boolean
+    initialShowPassword: Boolean
   },
   data () {
     return {
-      showPass: this.showPassword,
+      showPass: this.initialShowPassword,
       showNumber: true,
       model: this.value,
       watcher: null,
@@ -359,7 +359,7 @@ export default {
     [].concat(this.$slots.before).concat([
       this.isTextarea ? this.__getTextarea(h) : this.__getInput(h),
 
-      (!this.disable && this.isPassword && !this.noPassToggle && (this.length || this.showPassword) && h(QIcon, {
+      (!this.disable && this.isPassword && !this.noPassToggle && (this.initialShowPassword || this.length) && h(QIcon, {
         slot: 'after',
         staticClass: 'q-if-control',
         props: {

--- a/src/components/input/QInput.js
+++ b/src/components/input/QInput.js
@@ -29,11 +29,12 @@ export default {
     decimals: Number,
     step: Number,
     upperCase: Boolean,
-    lowerCase: Boolean
+    lowerCase: Boolean,
+    showPassword: Boolean
   },
   data () {
     return {
-      showPass: false,
+      showPass: this.showPassword,
       showNumber: true,
       model: this.value,
       watcher: null,
@@ -358,7 +359,7 @@ export default {
     [].concat(this.$slots.before).concat([
       this.isTextarea ? this.__getTextarea(h) : this.__getInput(h),
 
-      (!this.disable && this.isPassword && !this.noPassToggle && this.length && h(QIcon, {
+      (!this.disable && this.isPassword && !this.noPassToggle && (this.length || this.showPassword) && h(QIcon, {
         slot: 'after',
         staticClass: 'q-if-control',
         props: {


### PR DESCRIPTION
Usage `<q-input v-model="user.password" type="password" show-password float-label="Password" />`
this change will allow a password field and show/hide icon to be visible by default.

This might be good for an admin panel where you have to make a user account and send that user the credentials.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
