### PR TITLE
QEditor: fix link editor ENTER and ESC behavior

### DIFF
--- a/src/components/editor/editor-caret.js
+++ b/src/components/editor/editor-caret.js
@@ -206,8 +206,8 @@ export class Caret {
         if (!url.length) {
           return
         }
-        this.vm.editLinkUrl = urlRegex.test(url) ? url : `https://${url}`
-        document.execCommand('createLink', false, this.vm.editLinkUrl)
+        this.vm.editLinkUrl = urlRegex.test(url) ? url : ''
+        document.execCommand('createLink', false, this.vm.editLinkUrl === '' ? ' ' : this.vm.editLinkUrl)
       }
       else {
         this.vm.editLinkUrl = link

--- a/src/components/editor/editor-utils.js
+++ b/src/components/editor/editor-utils.js
@@ -237,9 +237,11 @@ export function getLinkEditor (h, vm) {
           keydown: event => {
             switch (getEventKey(event)) {
               case 13: // ENTER key
+                event.preventDefault()
                 return updateLink()
               case 27: // ESCAPE key
                 vm.caret.restore()
+                !vm.editLinkUrl && document.execCommand('unlink')
                 vm.editLinkUrl = null
                 break
             }


### PR DESCRIPTION
- start with empty URL if selected text is not a link
- if it wasn't a link then ESC removes link
- ENTER does not remove the selection

close #2602, close #2603