### PR TITLE
QChip: add zIndex for floating chip

### DIFF
--- a/dev/components/components/chip.vue
+++ b/dev/components/components/chip.vue
@@ -101,6 +101,15 @@
         <q-btn round dense color="dark" icon="announcement">
           <q-chip floating color="red">1</q-chip>
         </q-btn>
+        &nbsp;&nbsp;
+        <q-btn-group>
+          <q-btn label="Button" icon="announcement" color="secondary">
+            <q-chip floating color="red">22</q-chip>
+          </q-btn>
+          <q-btn label="Button" icon="announcement" color="primary">
+            <q-chip floating color="red">22</q-chip>
+          </q-btn>
+        </q-btn-group>
       </div>
 
       <p class="caption">Advanced Label Chips</p>

--- a/src/components/chip/chip.ios.styl
+++ b/src/components/chip/chip.ios.styl
@@ -46,6 +46,7 @@
   top -.3em
   right -.3em
   pointer-events none
+  z-index 1
 
 .q-chip-tag
   position relative

--- a/src/components/chip/chip.mat.styl
+++ b/src/components/chip/chip.mat.styl
@@ -46,6 +46,7 @@
   top -.3em
   right -.3em
   pointer-events none
+  z-index 1
 
 .q-chip-tag
   position relative


### PR DESCRIPTION
Fixes floating chips in QBtnGroup.

close #2621