### PR TITLE
QBtn, VRipple: fixes for IE

### DIFF
--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -33,8 +33,9 @@ export default Vue.extend({
     click (e) {
       if (e.defaultPrevented) { return }
 
-      if (document.activeElement !== this.$el) {
+      if (document.activeElement !== this.$el || (e instanceof PointerEvent && !e.screenX && !e.screenY)) {
         stopAndPrevent(e)
+        e.preventRipple = true
         this.$el.focus()
         return
       }

--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -6,7 +6,7 @@ function showRipple (evt, el, ctx) {
   }
 
   let { center, color } = ctx.modifiers
-  center = center || evt.detail <= 0 // comes from keyboard event
+  center = center || evt instanceof KeyboardEvent // comes from keyboard event
 
   const
     node = document.createElement('span'),
@@ -75,13 +75,13 @@ export default {
       modifiers: {},
 
       click (evt) {
-        if (ctx.enabled) {
+        if (ctx.enabled && !evt.preventRipple) {
           showRipple(evt, el, ctx)
         }
       },
 
       keyup (evt) {
-        if (ctx.enabled && !evt.defaultPrevented && evt.keyCode === 13) {
+        if (ctx.enabled && !evt.preventRipple && evt.keyCode === 13) {
           showRipple(evt, el, ctx)
         }
       }

--- a/src/ie-compat/ie.styl
+++ b/src/ie-compat/ie.styl
@@ -39,21 +39,12 @@ ie_style = @block
       display table
 
   /* QBtn */
+  .q-btn__content
+    position relative
+    flex-basis auto
+    pointer-events none
   a.q-btn:not(.q-btn--round)
     height 0px
-  .q-btn
-    .q-btn__content
-      flex-basis auto
-    &:active
-    &.active
-      .q-btn__content
-        margin -1px 1px 1px -1px
-      &.q-btn--push
-        .q-btn__content
-          margin 1px 1px -1px -1px
-        &.disabled
-          .q-btn__content
-            margin -1px 1px 1px -1px
   .q-btn-group > .q-btn.q-btn--push:not(.disabled)
     &:active .q-btn__content
     &.active .q-btn__content


### PR DESCRIPTION
- in IE enter in form element first focuses the submit button and then emits a fake click pointer event
- use a preventRipple property in event
- adjust styles for QBtn in IE