### PR TITLE
Add default callback function to openUrl

### DIFF
--- a/src/utils/open-url.js
+++ b/src/utils/open-url.js
@@ -1,6 +1,6 @@
 import Platform from '../plugins/platform.js'
 
-export default (url, reject) => {
+export default (url, reject = () => {}) => {
   if (Platform.is.cordova && navigator && navigator.app) {
     return navigator.app.loadUrl(url, {
       openExternal: true

--- a/src/utils/open-url.js
+++ b/src/utils/open-url.js
@@ -1,6 +1,6 @@
 import Platform from '../plugins/platform.js'
 
-export default (url, reject = () => {}) => {
+export default (url, reject) => {
   if (Platform.is.cordova && navigator && navigator.app) {
     return navigator.app.loadUrl(url, {
       openExternal: true
@@ -14,6 +14,6 @@ export default (url, reject = () => {}) => {
     return win
   }
   else {
-    reject()
+    reject && reject()
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In the documentation for [openUrl](https://quasar-framework.org/components/other-utils.html), it doesn't include the reject function inside the `openUrl` function, if `window.open(url, '_blank')` returns null, it will call `reject` function which will be undefined since it was not added to parameter (or doesn't have default value)
