### PR TITLE
Fix Timeline: Fix overlapping property "display: inline-flex;" styles from .material-icons

### DIFF
--- a/src/components/timeline/QTimelineEntry.js
+++ b/src/components/timeline/QTimelineEntry.js
@@ -63,7 +63,6 @@ export default {
       }, [
         this.icon
           ? h(QIcon, {
-            staticClass: 'row items-center justify-center',
             props: { name: this.icon }
           })
           : null

--- a/src/components/timeline/timeline.ios.styl
+++ b/src/components/timeline/timeline.ios.styl
@@ -58,6 +58,7 @@
 
 .q-timeline-dot .q-icon
   position absolute
+  display inline-flex
   top 0
   left 0
   right 0

--- a/src/components/timeline/timeline.mat.styl
+++ b/src/components/timeline/timeline.mat.styl
@@ -58,6 +58,7 @@
 
 .q-timeline-dot .q-icon
   position absolute
+  display inline-flex
   top 0
   left 0
   right 0


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
