### PR TITLE
fix: [QDateTime] bad layout from am/pm format

### DIFF
--- a/src/components/datetime/datetime.mat.styl
+++ b/src/components/datetime/datetime.mat.styl
@@ -23,6 +23,9 @@
   > div
     color white
     width 100%
+.modal-content, .q-popover
+  > .q-datetime > .q-datetime-header
+    min-width 175px
 
 .q-datetime-weekdaystring
   font-size .8rem


### PR DESCRIPTION
close #2671 QDatetimePicker Mat: enforce min-width in modal and popover