### PR TITLE
[v1] DateTimePicker: change time display in header

### DIFF
--- a/src/components/datetime/QDatetimePicker.js
+++ b/src/components/datetime/QDatetimePicker.js
@@ -586,7 +586,7 @@ export default Vue.extend({
         ]))
         const content = [
           h('span', {
-            staticClass: 'col',
+            staticClass: 'col-auto',
             style: { textAlign: 'right' }
           }, [
             h('span', {
@@ -623,7 +623,7 @@ export default Vue.extend({
           h('span', { style: 'opacity:0.6;' }, [ ':' ]),
 
           h('span', {
-            staticClass: 'col row no-wrap items-center',
+            staticClass: 'col-auto row no-wrap items-center',
             style: { textAlign: 'left' }
           }, [
             h('span', {

--- a/src/components/datetime/datetime.styl
+++ b/src/components/datetime/datetime.styl
@@ -24,6 +24,10 @@
     color white
     width 100%
 
+.modal-content, .q-popover
+  > .q-datetime > .q-datetime-header
+    min-width 175px
+
 .q-datetime-weekdaystring
   font-size .8rem
   background rgba(0, 0, 0, .1)
@@ -61,7 +65,6 @@
     opacity 1
 
 .q-datetime-clockstring
-  min-width 210px
   font-size 2.7rem
   direction: ltr /* rtl:ignore */
 


### PR DESCRIPTION
Centers the whole string instead of centering on the colon between hour and minute

from #2684