### PR TITLE
feat(QTimelineEntry): Allow titles slots for Timeline Entries

### DIFF
--- a/src/components/timeline/QTimelineEntry.js
+++ b/src/components/timeline/QTimelineEntry.js
@@ -53,10 +53,11 @@ export default {
       staticClass: `q-timeline-entry`,
       'class': this.classes
     }, [
-      h('div', { staticClass: 'q-timeline-subtitle' }, [
-        h('span', this.subtitle)
-      ]),
-
+      this.$slots.subtitle
+        ? this.$slots.subtitle
+        : h('div', { staticClass: 'q-timeline-subtitle' }, [
+          h('span', this.subtitle)
+        ]),
       h('div', {
         staticClass: 'q-timeline-dot',
         'class': this.colorClass
@@ -73,7 +74,9 @@ export default {
         'div',
         { staticClass: 'q-timeline-content' },
         [
-          h('h6', { staticClass: 'q-timeline-title' }, [ this.title ])
+          this.$slots.title
+            ? this.$slots.title
+            : h('h6', { staticClass: 'q-timeline-title' }, [ this.title ])
         ].concat(this.$slots.default)
       )
     ])

--- a/src/components/timeline/QTimelineEntry.js
+++ b/src/components/timeline/QTimelineEntry.js
@@ -53,11 +53,9 @@ export default {
       staticClass: `q-timeline-entry`,
       'class': this.classes
     }, [
-      this.$slots.subtitle
-        ? this.$slots.subtitle
-        : h('div', { staticClass: 'q-timeline-subtitle' }, [
-          h('span', this.subtitle)
-        ]),
+      this.$slots.subtitle || h('div', { staticClass: 'q-timeline-subtitle' }, [
+        h('span', this.subtitle)
+      ]),
       h('div', {
         staticClass: 'q-timeline-dot',
         'class': this.colorClass
@@ -73,11 +71,9 @@ export default {
       h(
         'div',
         { staticClass: 'q-timeline-content' },
-        [
-          this.$slots.title
-            ? this.$slots.title
-            : h('h6', { staticClass: 'q-timeline-title' }, [ this.title ])
-        ].concat(this.$slots.default)
+        (this.$slots.title || [
+          h('h6', { staticClass: 'q-timeline-title' }, [ this.title ])
+        ]).concat(this.$slots.default)
       )
     ])
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**


I would like to allow to add icons, buttons and other elements to the title and subtitle of a Timeline Entry.  In order to allow any kind of customization and retain current behaviour as default. I came with a feature which allows to indicate those via slots.
Thank U