### PR TITLE
feat: add variable to control the shrinking percentage of the heading

### DIFF
--- a/src/css/core.variables.styl
+++ b/src/css/core.variables.styl
@@ -147,6 +147,8 @@ $headings ?= {
   }
 }
 
+$headings-shrink-percentage ?= 0.6
+
 $h-tags ?= {
   h1: $headings.display-4,
   h2: $headings.display-3,

--- a/src/css/core/typography.styl
+++ b/src/css/core/typography.styl
@@ -19,7 +19,7 @@ for $heading, $value in $h-tags
     if $value.letter-spacing
       letter-spacing: $value.letter-spacing
     @media screen and (max-width $breakpoint-sm)
-      font-size: ($value.size * .6)
+      font-size: ($value.size * $headings-shrink-percentage)
 
 for $heading, $value in $headings
   .q-{$heading}-opacity


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

not yet, first waiting if this is oke, then im going to document it and afterwards we can merge them both.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

So your building and designing your application. And most of the time we (at our company) don't shrink the size of the headings that much (or not at all). The default setting of [0.6 is now harcoded](https://github.com/quasarframework/quasar/blob/dev/src/css/core/typography.styl#L22) . At the moment a developer can't overwrite such a thing. It would be nice if we give the developers a way to customize that.

I created this feature to make the shrinking on smaller screens adjustable.

please give permission to do this or give some directions. After that i do the rest of the testing and updating the docs.
