### PR TITLE
Update card.mat.styl

### DIFF
--- a/src/components/card/card.mat.styl
+++ b/src/components/card/card.mat.styl
@@ -45,8 +45,8 @@
   .q-btn
     padding 0 8px
 .q-card-actions-horiz
-  .q-btn + .q-btn
-    margin-left 8px
+  .q-btn:not(:last-child)
+    margin-right 8px
 .q-card-actions-vert
   .q-btn + .q-btn
     margin-top 4px


### PR DESCRIPTION
If buttons in action area of the card not fitted in one line, they placed on new line and before this button add left margin. This behavior see on first example on Card page on mobile view (button "RESERVE"). This change removes left margin and add right margin on not last button.
