### PR TITLE
#2530 allow overriding QSelect options QPopover behavior.

### DIFF
--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -38,8 +38,8 @@ export default {
     displayValue: String,
     popupMaxHeight: String,
     popupCover: {
-    	type: Boolean,
-    	default: true
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/src/components/select/QSelect.js
+++ b/src/components/select/QSelect.js
@@ -36,7 +36,11 @@ export default {
     chipsColor: String,
     chipsBgColor: String,
     displayValue: String,
-    popupMaxHeight: String
+    popupMaxHeight: String,
+    popupCover: {
+    	type: Boolean,
+    	default: true
+    }
   },
   data () {
     return {
@@ -351,7 +355,7 @@ export default {
       staticClass: 'column no-wrap',
       'class': this.dark ? 'bg-dark' : null,
       props: {
-        cover: true,
+        cover: this.popupCover,
         keepOnScreen: true,
         disable: !this.editable,
         anchorClick: false,


### PR DESCRIPTION
This PR is about allowing the Options QPopover of the select to be positionned above the QSelect and not over the QSelect.

This PR solve the issue  :
https://github.com/quasarframework/quasar/issues/2530
this help **making Quasar QSelect behavior back to the behavior it has in Quasar v0.16**. 
As the new behavior is considered unpleasant by our customers as it not allow to close the QPopover by click/touch on the QSelect (clicking outside may lead to unwanted focus on other elements).

It introduce a new prop on the QSelect. If this prop is unused, the behavior stay the same as before. So the should be no Impact.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
