### PR TITLE
Allow 0 (Number) to be printed in QBtn label

### DIFF
--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -18,7 +18,7 @@ export default {
       return this.percentage !== void 0
     },
     isRectangleWithLabel () {
-      return this.label && this.isRectangle
+      return this.isRectangle && typeof this.label !== 'undefined' && this.label !== ''
     },
     width () {
       return `${between(this.percentage, 0, 100)}%`

--- a/src/components/btn/QBtn.js
+++ b/src/components/btn/QBtn.js
@@ -17,6 +17,9 @@ export default {
     hasPercentage () {
       return this.percentage !== void 0
     },
+    isRectangleWithLabel () {
+      return this.label && this.isRectangle
+    },
     width () {
       return `${between(this.percentage, 0, 100)}%`
     },
@@ -188,12 +191,12 @@ export default {
         : [
           this.icon
             ? h(QIcon, {
-              'class': { 'on-left': this.label && this.isRectangle },
+              'class': { 'on-left': this.isRectangleWithLabel },
               props: { name: this.icon }
             })
             : null,
 
-          this.label && this.isRectangle ? h('div', [ this.label ]) : null,
+          this.isRectangleWithLabel ? h('div', [ this.label ]) : null,
 
           this.$slots.default,
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
If you will to have an empty button when you have the Number 0, you need to do something like:
```
<q-btn :label="myVar ? myVar : null" />
-or-
<q-btn :label="myVar ? myVar : ''" />
```

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
Current code don't allow printing the Number 0.
This behaviour lead me to write code like this:
```
<q-btn :label="'' + myVar" />
-or-
<q-btn :label="myVar ? myVar : '0'" />
```
but seems less elegant then the change in the component.
If someone prefer old-style-empty they can do my same "hack" (see above).
What do you think?

**Other information:**