### PR TITLE
Add passive option to scroll-blocking events, fix: #2730

### DIFF
--- a/src/directives/touch-hold.js
+++ b/src/directives/touch-hold.js
@@ -1,4 +1,4 @@
-import { position, leftClick } from '../utils/event.js'
+import { position, leftClick, listenOpts } from '../utils/event.js'
 
 function updateBinding (el, binding) {
   const ctx = el.__qtouchhold
@@ -63,8 +63,8 @@ export default {
     if (mouse) {
       el.addEventListener('mousedown', ctx.mouseStart)
     }
-    el.addEventListener('touchstart', ctx.start)
-    el.addEventListener('touchmove', ctx.abort)
+    el.addEventListener('touchstart', ctx.start, listenOpts.passive)
+    el.addEventListener('touchmove', ctx.abort, listenOpts.passive)
     el.addEventListener('touchend', ctx.abort)
   },
   update (el, binding) {

--- a/src/directives/touch-swipe.js
+++ b/src/directives/touch-swipe.js
@@ -1,4 +1,4 @@
-import { position, leftClick } from '../utils/event.js'
+import { position, leftClick, listenOpts } from '../utils/event.js'
 
 function getDirection (mod) {
   let dir = {}
@@ -161,8 +161,8 @@ export default {
       el.addEventListener('mousedown', ctx.mouseStart)
     }
 
-    el.addEventListener('touchstart', ctx.start)
-    el.addEventListener('touchmove', ctx.move)
+    el.addEventListener('touchstart', ctx.start, listenOpts.passive)
+    el.addEventListener('touchmove', ctx.move, listenOpts.passive)
     el.addEventListener('touchend', ctx.end)
   },
   update (el, binding) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR solves an issue in which certain browsers will show warnings related to scroll-blocking event listeners by adding a passive option. The option makes use of an existing quasar util to check browser compatibility. 

Solves #2730 