### PR TITLE
fix[#2815 ] animScrollTo - set final scroll position if no time left for the animation

### DIFF
--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -24,6 +24,9 @@ export function getHorizontalScrollPosition (scrollTarget) {
 
 export function animScrollTo (el, to, duration) {
   if (duration <= 0) {
+    if (el.scrollTop !== to) {
+      setScroll(el, to)
+    }
     return
   }
 

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -23,18 +23,19 @@ export function getHorizontalScrollPosition (scrollTarget) {
 }
 
 export function animScrollTo (el, to, duration) {
+  const pos = getScrollPosition(el)
+
   if (duration <= 0) {
-    if (el.scrollTop !== to) {
+    if (pos !== to) {
       setScroll(el, to)
     }
     return
   }
 
-  const pos = getScrollPosition(el)
-
   requestAnimationFrame(() => {
-    setScroll(el, pos + (to - pos) / Math.max(16, duration) * 16)
-    if (el.scrollTop !== to) {
+    const newPos = pos + (to - pos) / Math.max(16, duration) * 16
+    setScroll(el, newPos)
+    if (newPos !== to) {
       animScrollTo(el, to, duration - 16)
     }
   })


### PR DESCRIPTION
fixes #2815 by setting desired scroll position directly if there is no time left for the animation 

This is just a quick  fix, though. Ideally, this method should be reimplemented to be framerate-independent (there is framerate hardcoded, now).