### PR TITLE
Use consistent q-scroll-area

### DIFF
--- a/src/components/scroll-area/QScrollArea.js
+++ b/src/components/scroll-area/QScrollArea.js
@@ -165,7 +165,7 @@ export default {
     }
 
     return h('div', {
-      staticClass: 'q-scrollarea relative-position',
+      staticClass: 'q-scroll-area relative-position',
       on: {
         mouseenter: () => { this.hover = true },
         mouseleave: () => { this.hover = false }


### PR DESCRIPTION
The `QScrollArea` component creates a `div` with class `q-scrollarea` on desktop, but `q-scroll-area` on mobile. As a result, CSS styles targeted at one or the other will be inconsistent between devices. See demo [here](https://codepen.io/anon/pen/EOJvYM). 

This fix is important because `QScrollArea` is one of the few components that must have a custom style, namely the height, so I'm probably not the only one that needs my Stylus selectors to be `.q-scrollarea, .q-scroll-area`. This PR uses `q-scroll-area` which is consistent with the component name. The `q-scrollarea-thumb` class is not affected to avoid a breaking change. 

This PR could invalidate some styles targeted at `q-scrollarea`. To avoid that we can add a redundant `q-scrollarea` class to the divs. 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Can avoid the breaking change by keeping the redundant `q-scrollarea` class on both desktop and mobile.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) - this is more consistent with the docs, which use `q-scroll-area` as the component name.
