### PR TITLE
[v1] QSelect fixes

### DIFF
--- a/dev/components/form/select-part-1.vue
+++ b/dev/components/form/select-part-1.vue
@@ -123,7 +123,9 @@
           :active="scope.selected"
           :focused="scope.focused"
           :disable="scope.opt.disable"
-          @click="scope.toggleOption(scope.opt)"
+          @click="scope.toggleOption(scope.opt, scope.index)"
+          @mouseenter.native="scope.setOptionIndex(scope.index)"
+          tabindex="-1"
         >
           <q-item-section avatar>
             <q-icon :name="scope.opt.icon" />
@@ -151,7 +153,9 @@
           :active="scope.selected"
           :focused="scope.focused"
           :disable="scope.opt.disable"
-          @click="scope.toggleOption(scope.opt)"
+          @click="scope.toggleOption(scope.opt, scope.index)"
+          @mouseenter.native="scope.setOptionIndex(scope.index)"
+          tabindex="-1"
         >
           <q-item-section avatar>
             <q-icon :name="scope.opt.icon" />
@@ -180,6 +184,8 @@
           @remove="scope.removeValue(scope.opt)"
           color="white"
           text-color="primary"
+          :tabindex="scope.control.targetFocused === true && scope.control.menu === false && this.readonly !== true && this.disable !== true ? 0 : -1"
+          :disable="this.readonly === true || this.disable === true"
         >
           <q-avatar color="primary" text-color="white" :icon="scope.opt.icon" />
           <span v-html="scope.opt.label" />
@@ -221,6 +227,8 @@
           removable
           @remove="scope.removeValue(scope.opt)"
           text-color="teal"
+          :tabindex="scope.control.targetFocused === true && scope.control.menu === false && this.readonly !== true && this.disable !== true ? 0 : -1"
+          :disable="this.readonly === true || this.disable === true"
         >
           <span v-html="scope.opt.label" />
         </q-chip>

--- a/src/components/field/QField.js
+++ b/src/components/field/QField.js
@@ -204,13 +204,21 @@ export default Vue.extend({
           staticClass: 'q-field__counter'
         }, this.$slots.counter || [ this.computedCounter ]) : null
       ])
-    }
+    },
+
+    __onFocusout () { },
+
+    __onFocusin () { }
   },
 
   render (h) {
     return h('div', {
       staticClass: 'q-field row no-wrap items-start',
-      class: this.classes
+      class: this.classes,
+      on: {
+        focusout: this.__onFocusout,
+        focusin: this.__onFocusin
+      }
     }, [
       this.$slots.before !== void 0 ? h('div', {
         staticClass: 'q-field__before q-field__marginal row no-wrap items-center'


### PR DESCRIPTION
- don't navigate on options with tab
- mouseenter on list item => set optionIndex for kbd
- fix enter not toggling option (multiple) after mouse click on option
- kbd navigation on chips (enable when control focused and menu closed)
- create new - if the cursor is in list and then you filter more so there is no list then you cannot add
- hide selected - set value after selecting the already selected item
- focus fixes (if you navigate through chips with menu open => keep focus, but if you navigate with menu closed => lose focus)