### PR TITLE
DateTime: no clear icon when empty

### DIFF
--- a/src/components/datetime/QDatetime.js
+++ b/src/components/datetime/QDatetime.js
@@ -81,7 +81,7 @@ export default {
       return this.clearValue === void 0 ? this.defaultValue : this.clearValue
     },
     isClearable () {
-      return this.editable && this.clearable && !isSameDate(this.computedClearValue, this.value)
+      return this.editable && this.clearable && this.value && !isSameDate(this.computedClearValue, this.value)
     },
     modalBtnColor () {
       return process.env.THEME === 'mat'


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The clear icon is shown when the datetime input is empty, but it shouldn't.