### PR TITLE
[v1] QSelect: use color for selected options, use dark for options list

### DIFF
--- a/quasar/dev/components/form/select-part-1.vue
+++ b/quasar/dev/components/form/select-part-1.vue
@@ -13,6 +13,8 @@
         <q-toggle v-model="disable" label="Disable" />
         <q-toggle v-model="dense" label="Dense" />
         <q-toggle v-model="expandBesides" label="Expand besides" />
+        <q-toggle v-model="dark" label="Dark" />
+        <q-checkbox toggle-indeterminate v-model="darkOptions" label="Dark Options" />
       </div>
 
       <div class="text-h6">String options</div>
@@ -23,6 +25,7 @@
         v-model="stringSingle"
         :options="stringOptions"
         label="Single"
+        color="red"
       />
 
       <div>{{ stringMultiple }}</div>
@@ -32,6 +35,7 @@
         :options="stringOptions"
         label="Multiple"
         multiple
+        color="green"
       />
 
       <div class="text-h6">Object options</div>
@@ -317,6 +321,8 @@ export default {
 
     return {
       type: 'filled',
+      dark: false,
+      darkOptions: void 0,
       readonly: false,
       disable: false,
       dense: false,
@@ -418,6 +424,8 @@ export default {
     props () {
       return {
         [this.type]: true,
+        dark: this.dark,
+        darkOptions: this.darkOptions,
         readonly: this.readonly,
         disable: this.disable,
         dense: this.dense,

--- a/quasar/src/components/list/list.styl
+++ b/quasar/src/components/list/list.styl
@@ -61,7 +61,7 @@
     color $primary
     .q-item__section--avatar
       &, & .q-icon
-        color $primary
+        color inherit
 
 .q-item__section--main
   & + &

--- a/quasar/src/components/select/QSelect.js
+++ b/quasar/src/components/select/QSelect.js
@@ -45,6 +45,10 @@ export default Vue.extend({
     counter: Boolean,
     maxValues: [Number, String],
     denseOptions: Boolean,
+    darkOptions: {
+      type: Boolean,
+      default: null
+    },
 
     useInput: Boolean,
     useChips: Boolean,
@@ -137,6 +141,10 @@ export default Vue.extend({
       }
     },
 
+    computedDark () {
+      return this.darkOptions !== null ? this.darkOptions : this.dark
+    },
+
     optionScope () {
       return this.options.slice(0, this.optionsToShow).map((opt, i) => {
         const disable = this.__isDisabled(opt)
@@ -148,7 +156,8 @@ export default Vue.extend({
           focused: false,
           disable,
           tabindex: -1,
-          dense: this.denseOptions
+          dense: this.denseOptions,
+          dark: this.computedDark
         }
 
         if (disable !== true) {
@@ -525,6 +534,7 @@ export default Vue.extend({
     __getOptions (h) {
       const fn = this.$scopedSlots.option || (scope => h(QItem, {
         key: scope.index,
+        class: scope.selected === true && this.color !== void 0 ? `text-${this.color}` : void 0,
         props: scope.itemProps,
         on: scope.itemEvents
       }, [
@@ -553,6 +563,7 @@ export default Vue.extend({
           ? h('div', {
             ref: 'menu',
             staticClass: 'q-local-menu scroll',
+            class: this.computedDark === true ? 'bg-grey-10' : void 0,
             on: {
               click: stopAndPrevent,
               '&scroll': this.__onMenuScroll
@@ -573,6 +584,7 @@ export default Vue.extend({
           : null,
 
         h(QIcon, {
+          staticClass: 'cursor-pointer',
           props: { name: this.dropdownArrowIcon }
         })
       ]


### PR DESCRIPTION
Add boolean darkOptions prop (default null).
If it's not set then uses dark prop from the control to set dark mode of options list.