### PR TITLE
Document QDate, QTime API

### DIFF
--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -49,7 +49,7 @@
     "first-day-of-week": {
       "type": "String or Number",
       "desc": "Sets the day of the week that is considered the first day (0 - Sunday, 1 - Monday, ...); This day will show in the left-most column of the calendar",
-      "default": "(based on configured Quasar i18n language),
+      "default": "(based on configured Quasar i18n language)",
       "examples": [
         "first-day-of-week=\"1\"",
         ":first-day-of-week=\"selectedFirstDayOfTheWeek\""

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -65,5 +65,12 @@
       "type": "Boolean",
       "desc": "Don’t display the header"
     }
+  },
+  
+  "events": {
+    "input": {
+      "extends": "input",
+      "type": "String"
+    }
   }
 }

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -2,6 +2,14 @@
   "mixins": [ "components/datetime/datetime-mixin" ],
 
   "props": {
+    "value": {
+      "extends": "value",
+      "desc": "Date of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
+      "examples": [
+        "v-model=\"2018/11/03\"",
+        "v-model=\"currentDate\""
+      ]
+    },
     "default-year-month": {
       "type": "String",
       "desc": "The default year and month to display.",

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -6,46 +6,50 @@
       "extends": "value",
       "desc": "Date of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
       "examples": [
-        "v-model=\"2018/11/03\"",
-        "v-model=\"currentDate\""
+        "v-model=\"myDate\""
       ]
     },
+
     "default-year-month": {
       "type": "String",
-      "desc": "The default year and month to display.",
+      "desc": "The default year and month to display (in YYYY/MM format) when model is unfilled (undefined or null)",
       "examples": [
         "1986/02"
       ]
     },
 
     "events": {
-      "type": "Array or function",
-      "desc": "A list of events to highlight on the calendar. Can be supplied as an array or a function that returns a boolean.",
+      "type": "Array or Function",
+      "desc": "A list of events to highlight on the calendar; If using a function, it receives the date as a String and must return a Boolean (matches or not)",
       "examples": [
         ":events=\"['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23']\"",
-        ":events=\"date => new Date(date).getDay() === 1\""
+        ":events=\"date => date[9] % 3 === 0\""
       ]
     },
 
     "event-color": {
-      "type": "String",
-      "desc": "Color name for a highlighted event from the Quasar Color Palette",
-      "examples": [ "primary", "teal-10" ]
+      "type": "String or Function",
+      "desc": "Color name (from the Quasar Color Palette); If using a function, it receives the date as a String and must return a String (color for the received date)",
+      "examples": [
+        "teal-10",
+        ":event-color=\"(date) => date[9] % 2 === 0 ? 'teal' : 'orange'\""
+      ]
     },
 
     "options": {
       "type": "Array or Function",
-      "desc": "Sets the days that are selectable. Supplied as an array of dates or a function. If using function, Date is passed to a function that must return a Boolean. (Function(date) => Boolean)",
+      "desc": "Optionally configure the days that are selectable; If using a function, it receives the date as a String and must return a Boolean (is date acceptable or not)",
       "examples": [
         ":options=\"['2018/11/05', '2018/11/12', '2018/11/19', '2018/11/26' ]\"",
-        ":options=\"date => new Date(date).getDay() === 1\""
+        ":options=\"date => date[9] % 3 === 0\"",
+        ":options=\"date => date >= '2018/11/03' && date <= '2018/11/15'\""
       ]
     },
 
     "first-day-of-week": {
       "type": "String or Number",
-      "desc": "Sets the day of the week that is considered the first day. This day will show in the left-most column of the calendar.",
-      "default": 0,
+      "desc": "Sets the day of the week that is considered the first day (0 - Sunday, 1 - Monday, ...); This day will show in the left-most column of the calendar",
+      "default": "(based on configured Quasar i18n language),
       "examples": [
         "first-day-of-week=\"1\"",
         ":first-day-of-week=\"selectedFirstDayOfTheWeek\""

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -1,0 +1,54 @@
+{
+  "mixins": [ "components/datetime/datetime-mixin" ],
+
+  "props": {
+    "default-year-month": {
+      "type": "String",
+      "desc": "The default year and month to display.",
+      "examples": [
+        "1986/02"
+      ]
+    },
+
+    "events": {
+      "type": "Array or function",
+      "desc": "A list of events to highlight on the calendar. Can be supplied as an array or a function that returns a boolean.",
+      "examples": [
+        ":events=\"['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23']\"",
+        ":events=\"date => new Date(date).getDay() === 1\""
+      ]
+    },
+
+    "event-color": {
+      "type": "String",
+      "desc": "Color name for a highlighted event from the Quasar Color Palette",
+      "examples": [ "primary", "teal-10" ]
+    },
+
+    "options": {
+      "type": "Array or function",
+      "desc": "",
+      "examples": []
+    },
+
+    "first-day-of-week": {
+      "type": "String or number",
+      "desc": "Sets the day of the week that is considered the first day. This day will show in the left-most column of the calendar.",
+      "default": 0,
+      "examples": [
+        "first-day-of-week=\"1\"",
+        ":first-day-of-week=\"selectedFirstDayOfTheWeek\""
+      ]
+    },
+
+    "today-btn": {
+      "type": "Boolean",
+      "desc": "Display a button that selects the current day"
+    },
+
+    "minimal": {
+      "type": "Boolean",
+      "desc": "Don’t display the header"
+    }
+  }
+}

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -26,13 +26,16 @@
     },
 
     "options": {
-      "type": "Array or function",
-      "desc": "",
-      "examples": []
+      "type": "Array or Function",
+      "desc": "Sets the days that are selectable. Supplied as an array of dates or a function. If using function, Date is passed to a function that must return a Boolean. (Function(date) => Boolean)",
+      "examples": [
+        ":options=\"['2018/11/05', '2018/11/12', '2018/11/19', '2018/11/26' ]\"",
+        ":options=\"date => new Date(date).getDay() === 1\""
+      ]
     },
 
     "first-day-of-week": {
-      "type": "String or number",
+      "type": "String or Number",
       "desc": "Sets the day of the week that is considered the first day. This day will show in the left-most column of the calendar.",
       "default": 0,
       "examples": [

--- a/quasar/src/components/datetime/QTime.json
+++ b/quasar/src/components/datetime/QTime.json
@@ -1,0 +1,52 @@
+{
+  "mixins": [ "components/datetime/datetime-mixin" ],
+
+  "props": {
+    "format24h": {
+      "type": "Boolean",
+      "desc": "Override default i18n setting. Use 24 hour time instead of AM/PM system, which is default."
+    },
+
+    "options": {
+      "type": "Function",
+      "desc": "Sets the hours, minutes and seconds to be selectable. Hour, minute, and second are passed to a function that must return a Boolean. (Function(hr, min, sec) => Boolean)",
+      "examples": [
+        ":options=\"(hr, min, sec) => hr <= 6\""
+      ]
+    },
+
+    "hour-options": {
+      "type": "Array",
+      "desc": "Specify the hours that are selectable",
+      "examples": [
+        ":hour-options=\"[12, 3, 6, 9]\""
+      ]
+    },
+
+    "minute-options": {
+      "type": "Array",
+      "desc": "Specify the minutes that are selectable",
+      "examples": [
+        ":minute-options=\"[0, 15, 30, 45]\""
+      ]
+    },
+
+    "second-options": {
+      "type": "Array",
+      "desc": "Specify the seconds that are selectable",
+      "examples": [
+        ":second-options=\"[0, 10, 20, 30, 40, 50]\""
+      ]
+    },
+
+    "with-seconds": {
+      "type": "Boolean",
+      "desc": "Allow the time to be set with seconds"
+    },
+
+    "now-btn": {
+      "type": "Boolean",
+      "desc": "Display a button that selects the current time"
+    }
+  }
+}

--- a/quasar/src/components/datetime/QTime.json
+++ b/quasar/src/components/datetime/QTime.json
@@ -13,12 +13,13 @@
 
     "format24h": {
       "type": "Boolean",
-      "desc": "Override default i18n setting. Use 24 hour time instead of AM/PM system, which is default."
+      "desc": "Forces 24 hour time display instead of AM/PM system",
+      "default": "(based on Quasar i18n language being used)"
     },
 
     "options": {
       "type": "Function",
-      "desc": "Sets the hours, minutes and seconds to be selectable. Hour, minute, and second are passed to a function that must return a Boolean. (Function(hr, min, sec) => Boolean)",
+      "desc": "Optionally configure what time is the user allowed to set; Overriden by 'hour-options', 'minute-options' and 'second-options' if those are set",
       "examples": [
         ":options=\"(hr, min, sec) => hr <= 6\""
       ]
@@ -26,15 +27,15 @@
 
     "hour-options": {
       "type": "Array",
-      "desc": "Specify the hours that are selectable",
+      "desc": "Optionally configure what hours is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
-        ":hour-options=\"[12, 3, 6, 9]\""
+        ":hour-options=\"[3, 6, 9]\""
       ]
     },
 
     "minute-options": {
       "type": "Array",
-      "desc": "Specify the minutes that are selectable",
+      "desc": "Optionally configure what minutes is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
         ":minute-options=\"[0, 15, 30, 45]\""
       ]
@@ -42,9 +43,9 @@
 
     "second-options": {
       "type": "Array",
-      "desc": "Specify the seconds that are selectable",
+      "desc": "Optionally configure what seconds is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
-        ":second-options=\"[0, 10, 20, 30, 40, 50]\""
+        ":second-options=\"[0, 7, 10, 23]\""
       ]
     },
 
@@ -56,6 +57,13 @@
     "now-btn": {
       "type": "Boolean",
       "desc": "Display a button that selects the current time"
+    }
+  },
+  
+  "events": {
+    "input": {
+      "extends": "input",
+      "type": "String"
     }
   }
 }

--- a/quasar/src/components/datetime/QTime.json
+++ b/quasar/src/components/datetime/QTime.json
@@ -2,6 +2,15 @@
   "mixins": [ "components/datetime/datetime-mixin" ],
 
   "props": {
+    "value": {
+      "extends": "value",
+      "desc": "Time of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
+      "examples": [
+        "v-model=\"10:56:33\"",
+        "v-model=\"currentTime\""
+      ]
+    },
+
     "format24h": {
       "type": "Boolean",
       "desc": "Override default i18n setting. Use 24 hour time instead of AM/PM system, which is default."

--- a/quasar/src/components/datetime/datetime-mixin.json
+++ b/quasar/src/components/datetime/datetime-mixin.json
@@ -1,0 +1,37 @@
+{
+  "props": {
+    "value": {
+      "type": "String or number",
+      "desc": "Datetime of the component. Must be castable to a Date; Either use this property (along with a listener for 'input' event) OR use v-model directive",
+      "examples": [
+        "v-model=\"2018/11/03\"",
+        "v-model=\"currentDate\""
+      ]
+    },
+
+    "landscape": {
+      "type": "Boolean",
+      "desc": "Display the component in landscape mode"
+    },
+
+    "color": {
+      "extends": "color"
+    },
+
+    "text-color": {
+      "extends": "text-color"
+    },
+
+    "dark": {
+      "extends": "dark"
+    },
+
+    "readonly": {
+      "extends": "readonly"
+    },
+
+    "disable": {
+      "extends": "disable"
+    }
+  }
+}

--- a/quasar/src/components/datetime/datetime-mixin.json
+++ b/quasar/src/components/datetime/datetime-mixin.json
@@ -1,13 +1,7 @@
 {
   "props": {
     "value": {
-      "type": "String or number",
-      "desc": "Date / time of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
-      "examples": [
-        "v-model=\"2018/11/03\"",
-        "v-model=\"10:56:03\"",
-        "v-model=\"currentDate\""
-      ]
+      "type": "String"
     },
 
     "landscape": {

--- a/quasar/src/components/datetime/datetime-mixin.json
+++ b/quasar/src/components/datetime/datetime-mixin.json
@@ -2,9 +2,10 @@
   "props": {
     "value": {
       "type": "String or number",
-      "desc": "Datetime of the component. Must be castable to a Date; Either use this property (along with a listener for 'input' event) OR use v-model directive",
+      "desc": "Date / time of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
       "examples": [
         "v-model=\"2018/11/03\"",
+        "v-model=\"10:56:03\"",
         "v-model=\"currentDate\""
       ]
     },


### PR DESCRIPTION
Take a closer look at the datetime-mixin.json file. I have the "value" prop documented there. It's not quite generic enough to match the usage in the components. For QDate it needs to be a date, whereas with QTime it needs to be a time. Can this be better documented in the mixin docs or should I break them out separately into the respective component docs?