### PR TITLE
Restart work upon reset

### DIFF
--- a/quasar/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/quasar/src/components/infinite-scroll/QInfiniteScroll.js
@@ -70,7 +70,7 @@ export default Vue.extend({
 
     reset () {
       this.index = 0
-      this.working = true
+      this.resume()
     },
 
     resume () {

--- a/quasar/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/quasar/src/components/infinite-scroll/QInfiniteScroll.js
@@ -70,6 +70,7 @@ export default Vue.extend({
 
     reset () {
       this.index = 0
+      this.working = true
     },
 
     resume () {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

When the `reset` method is called, I can only assume that it's because the content of the scrollable area was emptied and that we want to make a fresh new start on loading new content. But if `working` had been set to `false` previously (because all the old content was loaded for example), nothing will happen on the new content (the scripts blocks at line 40). So the `restart` call should make sure that the component is ready to work again.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)