### PR TITLE
Show QRadio instead of QCheckbox on QTable single select mode

### DIFF
--- a/quasar/src/components/table/table-body.js
+++ b/quasar/src/components/table/table-body.js
@@ -1,4 +1,5 @@
 import QCheckbox from '../checkbox/QCheckbox.js'
+import QRadio from '../radio/QRadio.js'
 
 export default {
   methods: {
@@ -46,7 +47,7 @@ export default {
 
           if (this.hasSelectionMode) {
             child.unshift(h('td', { staticClass: 'q-table--col-auto-width' }, [
-              h(QCheckbox, {
+              h(this.singleSelection ? QRadio : QCheckbox, {
                 props: {
                   value: selected,
                   color: this.color,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

JSFiddle:
https://jsfiddle.net/tomers/7gu065yg/272/

There is no visible distinction in QTable rows between single and multiple selection modes. the only difference is the added QCheckbox in the the header.

On my system, QCheckbox looks square, as expected, and the differences between QCheckbox and QRadio are visible, thus this fix is more visible than in JSFiddle, where QCheckbox looks round, similar to QRadio.