### PR TITLE
Add support for iOS 11 ~ 11.1

### DIFF
--- a/quasar/src/components/layout/layout.styl
+++ b/quasar/src/components/layout/layout.styl
@@ -138,11 +138,13 @@ body.q-ios-statusbar-x
   .q-layout .q-header > .q-tabs:nth-child(2) .q-tabs-head
   .q-layout .q-drawer--top-padding,
   .modal:not(.minimized) .q-header > .q-toolbar:nth-child(1)
+    padding-top constant(safe-area-inset-top)
     padding-top env(safe-area-inset-top)
   .q-layout .q-footer > .q-toolbar:last-child,
   .q-layout .q-footer > .q-tabs:last-child .q-tabs-head
   .q-layout .q-drawer--top-padding,
   .modal:not(.minimized) .q-footer > .q-toolbar:last-child
+    padding-bottom constant(safe-area-inset-bottom)
     padding-bottom env(safe-area-inset-bottom)
     min-height ($toolbar-min-height + $ios-statusbar-height)
 

--- a/quasar/src/plugins/notify.styl
+++ b/quasar/src/plugins/notify.styl
@@ -16,8 +16,10 @@
 
 body.q-ios-statusbar-x .q-notifications__list
   &--center, &--top
+    top constant(safe-area-inset-top)
     top env(safe-area-inset-top)
   &--center, &--bottom
+    bottom constant(safe-area-inset-bottom)
     bottom env(safe-area-inset-bottom)
 
 .q-notification


### PR DESCRIPTION
because `env` is only usable on 11.2 and beyond.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
