### PR TITLE
quasar-cli/build-commands

### DIFF
--- a/docs/src/pages/quasar-cli/developing-mobile-apps/build-commands.vue
+++ b/docs/src/pages/quasar-cli/developing-mobile-apps/build-commands.vue
@@ -1,74 +1,79 @@
 <template lang="pug">
 doc-page(
-  title="Sample Page"
+  title="Mobile App Build Commands"
 )
-  div Introduction - <doc-token>token</doc-token>
+
   div
-    | Introduction - another paragraph.
-    doc-link(to="https://github.com/quasarframework/quasar") External link
-    | . Continuation...
-    doc-link(to="/sponsors-and-backers") Internal link
-    | ...
+    doc-link(to="/guide/quasar-cli.html") Quasar CLI
+    | makes it incredibly simple to develop or build the final distributables from your source code.
 
-  doc-section.h1(title="Header 1")
-  div Bla bla bla
+  div Before we dive in, make sure you got the Cordova CLI installed.
+    code-markup(lang="bash")
+      | $ yarn global add cordova
+      | # or:
+      | $ npm install -g cordova
 
-  doc-section.h2(title="Header 2")
-  div Bla bla bla
+  doc-section.h2(title="Developing")
 
-  doc-section.h3(title="Header 3")
-  div Bla bla bla
+  div
+    code-markup(lang="bash")
+      | $ quasar dev -m cordova -T [ios|android]
+      |
+      | # ..or the longer form:
+      | $ quasar dev --mode cordova -T [ios|android]
+      |
+      | # with a specific Quasar theme, for iOS platform:
+      | $ quasar dev -m cordova -T ios -t ios
+      |
+      | # with a specific Quasar theme, for Android platform:
+      | $ quasar dev -m cordova -T android -t mat
+      |
+      | # using a specific emulator (--emulator, -e)
+      | $ quasar dev -m cordova -T ios -e iPhone-7
 
-  div Warning sample
-  doc-warning
-    div Quasar is awesome
   doc-warning(title="IMPORTANT")
-    div Quasar is awesome
+    div You can develop with any Quasar theme, regardless of the platform you are building on (Android, IOS, ...).
 
-  div Table sample
-  q-markup-table.q-mb-lg
-    thead
-      tr
-        th.text-left Property
-        th.text-left Type
-        th.text-left Description
-    tbody
-      tr
-        td color
-        td String
-        td The color the QInput should have. The default is primary.
-      tr
-        td inverted
-        td Boolean
-        td Set to true, to color field&rsquo;s background set by the color prop.
+  div In order for you to be able to develop on a device emulator or directly on a phone (with Hot Module Reload included), Quasar CLI follows these steps:
+    ol
+      li Detects your machine's external IP address. If there are multiple such IPs detected, then it asks you to choose one. If you'll be using a mobile phone to develop then choose the IP address of your machine that's pingable from the phone/tablet.
+      li It starts up a development server on your machine.
+      li It temporarily changes the `<content/>` tag in `/src-cordova/config.xml` to point to the IP previously detected. This allows the app to connect to the development server.
+      li It defers to Cordova CLI to build a native app with the temporarily changed config.xml.
+      li Cordova CLI checks if a mobile phone / tablet is connected to your development machine. If it is, it installs the development app on it. If none is found, then it boots up an emulator and runs the development app.
+      li Finally, it reverts the temporary changes made to `/src-cordova/config.xml`.
 
-  div Code markup
-  code-markup(lang="bash")
-    | $ quasar dev -m ssr
-    | # some comment
-    | $ quasar build
+  doc-warning(title="IMPORTANT")
+    div If developing on a mobile phone/tablet, it is very important that the external IP address of your build machine is accessible from the phone/tablet, otherwise you'll get a development app with white screen only. Also check your machine's firewall to allow connections to the development chosen port.
 
-  doc-section.h1(title="Installation")
-  InstallationCard(
-    components="QBtn"
-    :plugins="['Meta', 'Cookies']"
-    directives="Ripple"
-    :config="{ notify: 'Notify' }"
-  )
+  doc-section.h2(title="Building for Production")
+  div
+    code-markup(lang="bash")
+      | $ quasar build -m cordova -T [ios|android]
+      |
+      | # ..or the longer form:
+      | $ quasar build --mode cordova -T [ios|android]
+      |
+      | # with a specific Quasar theme, for iOS platform:
+      | $ quasar build -m cordova -T ios -t ios
+      |
+      | # with a specific Quasar theme, for Android platform:
+      | $ quasar build -m cordova -T android -t mat
 
-  doc-section.h1(title="Usage")
-  code-example(title="Standard", file="QBtn/Standard")
+  doc-warning(title="IMPORTANT")
+    div You can build with any Quasar theme, regardless of the platform you are targeting (Android, IOS, ...).
 
-  doc-section.h1(title="API")
-  ApiCard(file="QUploader")
+  div These commands parse and build your `/src` folder then overwrite `/src-cordova/www` then defer to Cordova CLI to trigger the actual native app creation.
+
+  div You may ask yourself. So where's the .apk or .app? Watch the terminal console to see where it puts it.
 </template>
 
 <script>
 export default {
-  name: 'NamePage',
+  name: 'BuildCommands',
 
   meta: {
-    title: 'Name'
+    title: 'BuildCommands'
   }
 }
 </script>


### PR DESCRIPTION
quasar v1
page: quasar-cli/build-commands

I'm not sure if this is correct like I wrote it:
```
<script>
export default {
  name: 'BuildCommands',

  meta: {
    title: 'BuildCommands'
  }
}
</script>
```