### PR TITLE
QSelect: Make expand-besides default to true

### DIFF
--- a/quasar/src/components/select/QSelect.js
+++ b/quasar/src/components/select/QSelect.js
@@ -60,7 +60,10 @@ export default Vue.extend({
       default: 500
     },
 
-    expandBesides: Boolean,
+    expandBesides: {
+      type: Boolean,
+      default: true
+    },
     autofocus: Boolean
   },
 

--- a/quasar/src/components/select/QSelect.json
+++ b/quasar/src/components/select/QSelect.json
@@ -125,7 +125,8 @@
 
     "expand-besides": {
       "type": "Boolean",
-      "desc": "Expand the menu on top or bottom of the component, so it won't cover it"
+      "desc": "Expand the menu on top or bottom of the component, so it won't cover it",
+      "default": true
     },
 
     "autofocus": {


### PR DESCRIPTION
Why?
- it's native behaviour
- it's logical and intuitive
- you can click on the header to close the popover
   - right now, if you don't want to select or you select multiple values, you need to click outside to close the popover
- you can see list of all selected items easily (useful for long lists)
- My guess is that it will be more desired than the opposite