### PR TITLE
[v1] Flex: revert to using padding for gutter gap, apply min/max limits to cols

### DIFF
--- a/quasar/src/css/core/flex.styl
+++ b/quasar/src/css/core/flex.styl
@@ -11,14 +11,14 @@ fg($name, $size)
   @media (min-width $size)
     {fe('.col<name>', $name, $noProcNotZero)}
       &, &-auto, &-grow
+        min-width 0
+        max-width 100%
+        min-height 0
+        max-height 100%
         .row > &, .flex > &
           width auto
-          min-width 0
-          max-width 100%
         .column > &, .flex > &
           height auto
-          min-height 0
-          max-height 100%
       &
         flex 10**4 1 0%
       &-auto
@@ -130,11 +130,11 @@ for $name, $size in $flex-gutter
     &-x-{$name}
       margin-left (- $size)
       > *
-        margin-left $size
+        padding-left $size
     &-y-{$name}
       margin-top (- $size)
       > *
-        margin-top $size
+        padding-top $size
     &-{$name}
       @extends .q-gutter-x-{$name}, .q-gutter-y-{$name}
       > *

--- a/quasar/src/css/flex-addon.styl
+++ b/quasar/src/css/flex-addon.styl
@@ -167,11 +167,11 @@ fg($name, $size)
         &x-{$gname}
           margin-left (- $gsize)
           > *
-            margin-left $gsize
+            padding-left $gsize
         &y-{$gname}
           margin-top (- $gsize)
           > *
-            margin-top $gsize
+            padding-top $gsize
         &{$gname}
           @extends .q-gutter{$name}-x-{$gname}, .q-gutter{$name}-y-{$gname}
           > *


### PR DESCRIPTION
- fixes `.row.q-gutter-sm.bg-red>.col-6.bg-green*2{gigi}`