### PR TITLE
Allow for float cookie expiration times, thus enabling setting sub-day expiration values

### DIFF
--- a/quasar/src/plugins/Cookies.js
+++ b/quasar/src/plugins/Cookies.js
@@ -39,7 +39,7 @@ function set (key, val, opts = {}, ssr) {
   let expire, expireValue
 
   if (opts.expires !== void 0) {
-    expireValue = parseInt(opts.expires, 10)
+    expireValue = parseFloat(opts.expires)
 
     if (isNaN(expireValue)) {
       expire = opts.expires


### PR DESCRIPTION
Right now you have to specify an integer as the cookie's expiration option.
Allowing for floats (usually sub-unitary values) would allow setting a cookie to expire in a shorter amount of time than the current minimum of 1 day.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
