### PR TITLE
fix(Loading): guard vm on destroy

### DIFF
--- a/quasar/src/plugins/Loading.js
+++ b/quasar/src/plugins/Loading.js
@@ -105,10 +105,12 @@ export default {
     else {
       vm.isActive = false
       vm.$on('destroy', () => {
-        vm.$destroy()
-        document.body.classList.remove('q-body--loading')
-        vm.$el.remove()
-        vm = null
+        if (vm !== null) {
+          vm.$destroy()
+          document.body.classList.remove('q-body--loading')
+          vm.$el.remove()
+          vm = null
+        }
         this.isActive = false
       })
     }


### PR DESCRIPTION
When using Loading from multiple preFetch (in hierarchical route components) it happens to be already destroyed