### PR TITLE
feat(docs): QSelect (Filter) example warning

### DIFF
--- a/docs/src/examples/QSelect/Filter.vue
+++ b/docs/src/examples/QSelect/Filter.vue
@@ -13,7 +13,7 @@
 <script>
 const options = ['Google', 'Facebook', 'Twitter']
 export default {
-  name: 'Filter',
+  name: 'Filtered',
   data () {
     return {
       selected: null,

--- a/docs/src/examples/QSelect/Filter.vue
+++ b/docs/src/examples/QSelect/Filter.vue
@@ -13,7 +13,6 @@
 <script>
 const options = ['Google', 'Facebook', 'Twitter']
 export default {
-  name: 'Filtered',
   data () {
     return {
       selected: null,


### PR DESCRIPTION
Vue complains on ComponentNameCheck that 'Do not use built-in or reserved HTML elements as component'