### PR TITLE
QEditor Cleanup (with doc revision)

### DIFF
--- a/docs/src/examples/QEditor/ToolbarSlot.vue
+++ b/docs/src/examples/QEditor/ToolbarSlot.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="q-pa-md q-gutter-sm">
+    <q-editor
+      v-model="editor"
+      ref="editor"
+      toolbar-text-color="white"
+      toolbar-toggle-color="yellow-8"
+      toolbar-flat
+      toolbar-bg="primary"
+      :toolbar="[
+        ['token'],
+        ['bold', 'italic', 'underline'],
+        [{
+          label: $q.lang.editor.formatting,
+          icon: $q.icon.editor.formatting,
+          list: 'no-icons',
+          options: ['p', 'h3', 'h4', 'h5', 'h6', 'code']
+        }]
+      ]"
+    >
+      <q-btn-dropdown
+        dense no-caps
+        ref="token"
+        no-wrap
+        slot="token"
+        color="white"
+        text-color="primary"
+        label="Token"
+        size="sm"
+      >
+        <q-list>
+          <q-item tag="label" clickable @click="add('email')">
+            <q-item-section side>
+              <q-icon name="mail" />
+            </q-item-section>
+            <q-item-section>Email</q-item-section>
+          </q-item>
+          <q-item tag="label" clickable @click="add('title')">
+            <q-item-section side>
+              <q-icon name="title" />
+            </q-item-section>
+            <q-item-section>Title</q-item-section>
+          </q-item>
+        </q-list>
+      </q-btn-dropdown>
+    </q-editor>
+  </div>
+</template>
+<script>
+export default {
+  data () {
+    return {
+      editor: 'Customize it.'
+    }
+  },
+  methods: {
+    add (name) {
+      const edit = this.$refs.editor
+      this.$refs.token.hide()
+      edit.caret.restore()
+      edit.runCmd('insertHTML', `&nbsp;<div class="editor_token row inline items-center" contenteditable="false">&nbsp;<span>${name}</span>&nbsp;<i class="q-icon material-icons cursor-pointer" onclick="this.parentNode.parentNode.removeChild(this.parentNode)">close</i></div>&nbsp;`)
+      edit.focus()
+    }
+  }
+}
+</script>
+<style lang="stylus">
+  .editor_token
+    background rgba(0, 0, 0, .6)
+    color white
+    padding 3px
+    &, .q-icon
+      border-radius 3px
+    .q-icon
+      background rgba(0, 0, 0, .2)
+</style>

--- a/docs/src/pages/vue-components/editor.md
+++ b/docs/src/pages/vue-components/editor.md
@@ -39,6 +39,8 @@ The following is an example that adds custom definitions. In such cases, make su
 
 <doc-example title="Custom Style" file="QEditor/Custom" />
 
+<doc-example title="Using Toolbar Slots" file="QEditor/ToolbarSlot" />
+
 ## Dropdowns
 
 ### Types of dropdowns

--- a/quasar/dev/components/form/editor.vue
+++ b/quasar/dev/components/form/editor.vue
@@ -24,6 +24,7 @@
     >
       <q-btn
         slot="custom_btn"
+        size="sm"
         dense
         color="secondary"
         icon="import_contacts"
@@ -137,8 +138,8 @@
         gogu: {tip: 'Custom', icon: 'account_balance', handler: vm => vm.runCmd('print')}
       }"
     >
-      <q-btn dense color="yellow" slot="custom_btn">Wow</q-btn>
-      <q-btn-dropdown dense no-caps ref="token" no-wrap slot="token" color="green" label="Token">
+      <q-btn dense color="yellow" slot="custom_btn" size="sm">Wow</q-btn>
+      <q-btn-dropdown dense no-caps ref="token" no-wrap slot="token" color="green" label="Token" size="sm">
         <q-list>
           <q-item tag="label" clickable @click="add('email')">
             <q-item-section side>

--- a/quasar/src/components/editor/QEditor.js
+++ b/quasar/src/components/editor/QEditor.js
@@ -81,7 +81,8 @@ export default Vue.extend({
         rounded: this.toolbarRounded,
         dense: true,
         color: this.toolbarColor,
-        disable: !this.editable
+        disable: !this.editable,
+        size: 'sm'
       }
     },
 
@@ -159,6 +160,8 @@ export default Vue.extend({
               type: 'dropdown',
               icon: token.icon,
               label: token.label,
+              size: 'sm',
+              dense: true,
               fixedLabel: token.fixedLabel,
               fixedIcon: token.fixedIcon,
               highlight: token.highlight,

--- a/quasar/src/components/editor/editor-utils.js
+++ b/quasar/src/components/editor/editor-utils.js
@@ -46,7 +46,8 @@ function getBtn (h, vm, btn, clickHandler, active = false) {
       color: toggled ? btn.toggleColor || vm.toolbarToggleColor : btn.color || vm.toolbarColor,
       textColor: toggled && (vm.toolbarFlat || vm.toolbarOutline) ? null : btn.textColor || vm.toolbarTextColor,
       label: btn.label,
-      disable: btn.disable ? (typeof btn.disable === 'function' ? btn.disable(vm) : true) : false
+      disable: btn.disable ? (typeof btn.disable === 'function' ? btn.disable(vm) : true) : false,
+      size: 'sm'
     }),
     on: events
   }, child)
@@ -83,7 +84,9 @@ function getDropdown (h, vm, btn) {
         {
           props: vm.buttonProps,
           staticClass: 'relative-position q-editor-toolbar-padding',
-          style: { borderRadius: '0' }
+          style: { borderRadius: '0' },
+          size: 'sm',
+          dense: true
         },
         Items
       )
@@ -113,7 +116,7 @@ function getDropdown (h, vm, btn) {
       return h(
         QItem,
         {
-          props: { active, activeClass, clickable: true, disable: disable },
+          props: { active, activeClass, clickable: true, disable: disable, dense: true },
           on: {
             click (e) {
               closeDropdown()

--- a/quasar/src/components/editor/editor.styl
+++ b/quasar/src/components/editor/editor.styl
@@ -26,7 +26,7 @@
 .q-editor-toolbar
   border-bottom $editor-border
   background $grey-4
-  min-height 37px
+  min-height 32px
   .q-btn-group
     box-shadow none
   .q-btn-group + .q-btn-group


### PR DESCRIPTION
- dense and smaller (even dropdown lists)
- added example with button slot to 1.0 docs
- fixed quasar/dev QEditor example to match

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
