### PR TITLE
[v1] QDate + QTime: enhance model string parsing

### DIFF
--- a/quasar/dev/components/form/date.vue
+++ b/quasar/dev/components/form/date.vue
@@ -108,6 +108,27 @@
         />
       </div>
 
+      <div class="text-h6">Negative years: {{ dateNeg }}</div>
+      <div class="q-gutter-md">
+        <q-date
+          v-model="dateNeg"
+          v-bind="props"
+          :style="style"
+        />
+
+        <q-input :dark="dark" filled v-model="dateNeg">
+          <q-icon slot="append" name="event" class="cursor-pointer">
+            <q-popup-proxy>
+              <q-date
+                v-model="dateNeg"
+                v-bind="props"
+                :style="style"
+              />
+            </q-popup-proxy>
+          </q-icon>
+        </q-input>
+      </div>
+
       <div class="text-h6">Input: {{ input }}</div>
       <div class="q-gutter-md">
         <q-input :dark="dark" filled v-model="input" mask="date" :rules="['date']">
@@ -139,6 +160,7 @@ export default {
       todayBtn: false,
 
       date: '2018/11/03',
+      dateNeg: '-13/11/03',
       events: ['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23'],
       options: ['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23'],
 

--- a/quasar/src/components/datetime/QTime.js
+++ b/quasar/src/components/datetime/QTime.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 import QBtn from '../btn/QBtn.js'
 import TouchPan from '../../directives/TouchPan.js'
 
-import { testPattern } from '../../utils/patterns.js'
+import { splitTime } from '../../utils/date.js'
 import { position } from '../../utils/event.js'
 import { isDeepEqual } from '../../utils/is.js'
 import DateTimeMixin from './datetime-mixin.js'
@@ -34,8 +34,20 @@ export default Vue.extend({
 
   data () {
     const model = this.__getNumberModel(this.value)
+
+    let view = 'Hour'
+
+    if (model.hour !== null) {
+      if (model.minute === null) {
+        view = 'Minute'
+      }
+      else if (this.withSeconds && model.second === null) {
+        view = 'Second'
+      }
+    }
+
     return {
-      view: 'Hour',
+      view,
       isAM: model.hour === null || model.hour < 12,
       innerModel: model
     }
@@ -48,7 +60,7 @@ export default Vue.extend({
       if (isDeepEqual(model, this.innerModel) === false) {
         this.innerModel = model
 
-        if (this.innerModel.hour === null) {
+        if (model.hour === null) {
           this.view = 'Hour'
         }
         else {
@@ -77,7 +89,7 @@ export default Vue.extend({
           : (
             this.computedFormat24h === true
               ? this.__pad(time.hour)
-              : (
+              : String(
                 this.isAM === true
                   ? (time.hour === 0 ? 12 : time.hour)
                   : (time.hour > 12 ? time.hour - 12 : time.hour)
@@ -452,11 +464,7 @@ export default Vue.extend({
     },
 
     __getNumberModel (v) {
-      if (
-        v === void 0 || v === null || v === '' ||
-        typeof v !== 'string' ||
-        testPattern.timeOrFulltime(v) === false
-      ) {
+      if (v === void 0 || v === null || v === '' || typeof v !== 'string') {
         return {
           hour: null,
           minute: null,
@@ -464,18 +472,7 @@ export default Vue.extend({
         }
       }
 
-      const val = v.split(':')
-      return {
-        hour: val[0] !== void 0
-          ? parseInt(val[0], 10)
-          : null,
-        minute: val[1] !== void 0
-          ? parseInt(val[1], 10)
-          : null,
-        second: val[2] === void 0
-          ? null
-          : parseInt(val[2], 10)
-      }
+      return splitTime(v)
     },
 
     __setHour (hour) {
@@ -531,6 +528,7 @@ export default Vue.extend({
     __verifyAndUpdate () {
       if (this.hourInSelection !== void 0 && this.hourInSelection(this.innerModel.hour) !== true) {
         this.innerModel = this.__getNumberModel(void 0)
+        this.isAM = this.innerModel.hour === null || this.innerModel.hour < 12
         this.view = 'Hour'
         return
       }
@@ -548,6 +546,10 @@ export default Vue.extend({
         return
       }
 
+      if (this.innerModel.hour === null || this.innerModel.minute === null || (this.withSeconds === true && this.innerModel.second === null)) {
+        return
+      }
+
       this.__updateValue({})
     },
 
@@ -557,9 +559,9 @@ export default Vue.extend({
           ...this.innerModel,
           ...obj
         },
-        val = this.__pad(Math.min(time.hour, 23)) + ':' +
-          this.__pad(Math.min(time.minute, 59)) +
-          (this.withSeconds ? ':' + this.__pad(Math.min(time.second, 59)) : '')
+        val = this.__pad(time.hour % 24) + ':' +
+          this.__pad(time.minute % 60) +
+          (this.withSeconds ? ':' + this.__pad(time.second % 60) : '')
 
       if (val !== this.value) {
         this.$emit('input', val)
@@ -575,5 +577,9 @@ export default Vue.extend({
       this.__getHeader(h),
       this.__getClock(h)
     ])
+  },
+
+  beforeDestroy () {
+    this.__verifyAndUpdate()
   }
 })

--- a/quasar/src/components/datetime/datetime-mixin.js
+++ b/quasar/src/components/datetime/datetime-mixin.js
@@ -42,6 +42,13 @@ export default {
   methods: {
     __pad (unit) {
       return (unit < 10 ? '0' : '') + unit
+    },
+
+    __padYear (unit) {
+      if (unit < 0 || unit > 9999) {
+        return '' + unit
+      }
+      return ('000' + unit).slice(-4)
     }
   }
 }

--- a/quasar/src/utils/date.js
+++ b/quasar/src/utils/date.js
@@ -55,6 +55,53 @@ export function isValid (date) {
   return isNaN(t) === false
 }
 
+export function splitDate (date) {
+  let
+    value = date,
+    [year, month, day] = value.split('/')
+      .concat([null, null, null])
+      .slice(0, 3)
+      .map(d => parseInt(d, 10))
+      .map(d => isNaN(d) === true ? null : d)
+
+  if (day < 1 || day > (new Date(year, month, 0)).getDate()) {
+    day = null
+  }
+
+  if (month > 12 || month === 0) {
+    month = month % 12 || 12
+  }
+
+  if (year === null || month === null || day === null) {
+    value = null
+
+    if (year !== null && month === null) {
+      month = 1
+    }
+  }
+
+  return {
+    year,
+    month,
+    day,
+    value
+  }
+}
+
+export function splitTime (time) {
+  let [hour, minute, second] = time.split(':')
+    .concat([null, null, null])
+    .slice(0, 3)
+    .map(d => parseInt(d, 10))
+    .map(d => isNaN(d) === true ? null : d)
+
+  return {
+    hour: hour === null ? null : hour % 24,
+    minute: minute === null ? null : minute % 60,
+    second: second === null ? null : second % 60
+  }
+}
+
 export function buildDate (mod, utc) {
   return adjustDate(new Date(), mod, utc)
 }
@@ -544,6 +591,8 @@ export function clone (value) {
 
 export default {
   isValid,
+  splitDate,
+  splitTime,
   buildDate,
   getDayOfWeek,
   getWeekOfYear,


### PR DESCRIPTION
QDate:
- work with negative year (more than -13 - see title)
- formats positive years < 1000 to 4 chars so it works with mask
- parses incomplete date strings (2018/03, 2018/03/8, 18/3/5)
- wraps months > 12
- invalidates wrong days (> last day in month)
- if model is valid but missing digits it is updated on close (2018/03/3 => 2018/03/03)

QTime:
- selects the first view that is not filled (12: => minutes)
- fixes computedFormat24h (was sometimes string sometimes number)
- does not update on invalid model
- if model is valid but missing digits it is updated on close (12/03/3 => 12/03/03)
- wraps around hour, minute, second