### PR TITLE
feat(quasar): Fix QStepper contractable class and disabled dot on dark

### DIFF
--- a/docs/src/examples/QStepper/Contracted.vue
+++ b/docs/src/examples/QStepper/Contracted.vue
@@ -3,7 +3,7 @@
     <q-stepper
       v-model="step"
       ref="stepper"
-      :contractable="$q.screen.lt.md"
+      :contracted="$q.screen.lt.md"
       color="primary"
       animated
     >

--- a/docs/src/pages/vue-components/stepper.md
+++ b/docs/src/pages/vue-components/stepper.md
@@ -31,7 +31,7 @@ process, like in a [wizard](https://en.wikipedia.org/wiki/Wizard_(software)).
 
 For the example below, in order for you to see the effect, resize browser window to be smaller than 1024px then bigger.
 
-<doc-example title="Contractable" file="QStepper/Contractable" />
+<doc-example title="Contracted" file="QStepper/Contracted" />
 
 ### Style
 

--- a/quasar/dev/components/components/stepper.vue
+++ b/quasar/dev/components/components/stepper.vue
@@ -4,7 +4,7 @@
       <q-toggle label="Vertical" v-model="vertical" />
       <q-toggle label="Animated" v-model="animated" />
       <q-toggle label="Alternative Labels" v-model="alt" />
-      <q-toggle label="Contractable" v-model="contractable" />
+      <q-toggle label="Contracted lt-md" v-model="contractable" />
       <q-toggle label="Header Navigation" v-model="headerNav" />
       <q-toggle label="Use 'header-nav' on steps" v-model="headerNavStep" />
       <q-toggle label="Flat" v-model="flat" />
@@ -27,7 +27,7 @@
         ref="stepper"
         v-model="step"
         :alternative-labels="alt"
-        :contractable="contractable"
+        :contracted="contractable && !vertical && $q.screen.lt.md"
       >
         <q-step :name="1" :done="useDone && step > 1" :header-nav="headerNavStep ? step > 1 : true" title="Ad style" icon="map" :caption="caption ? 'Some caption' : null">
           <div v-for="n in 10" :key="'1.'+n">{{ n }} Step 1</div>

--- a/quasar/src/components/stepper/QStepper.js
+++ b/quasar/src/components/stepper/QStepper.js
@@ -22,7 +22,7 @@ export default Vue.extend({
     vertical: Boolean,
     alternativeLabels: Boolean,
     headerNav: Boolean,
-    contractable: Boolean,
+    contracted: Boolean,
 
     inactiveColor: String,
     inactiveIcon: String,
@@ -40,7 +40,7 @@ export default Vue.extend({
         [`q-stepper--${this.vertical ? 'vertical' : 'horizontal'}`]: true,
         'q-stepper--flat no-shadow': this.flat || this.dark,
         'q-stepper--bordered': this.bordered || (this.dark && !this.flat),
-        'q-stepper--contractable': this.contractable,
+        'q-stepper--contracted': this.contracted,
         'q-stepper--dark': this.dark
       }
     }

--- a/quasar/src/components/stepper/QStepper.json
+++ b/quasar/src/components/stepper/QStepper.json
@@ -29,7 +29,7 @@
       "desc": "Allow navigation through the header"
     },
 
-    "contractable": {
+    "contracted": {
       "type": "Boolean",
       "desc": "Hide header labels on narrow windows"
     },

--- a/quasar/src/components/stepper/stepper.styl
+++ b/quasar/src/components/stepper/stepper.styl
@@ -176,18 +176,29 @@
     .q-stepper__tab
       &--disabled
         color $separator-dark-color
+        .q-stepper__dot
+          background $separator-dark-color
         .q-stepper__label
           color rgba(255, 255, 255, .54)
 
-  &--contractable
+  &--contracted
     .q-stepper__header
       min-height 72px
-    .q-stepper__tab
-      padding 24px 0
-      &:first-child
-        padding-left 24px
-      &:last-child
-        padding-right 24px
+      &--alternative-labels
+        .q-stepper__tab
+          min-height 72px
+          &:first-child
+            align-items flex-start
+          &:last-child
+            align-items flex-end
+      .q-stepper__tab
+        padding 24px 0
+        &:first-child
+          .q-stepper__dot
+            transform translate3d(24px, 0, 0)
+        &:last-child
+          .q-stepper__dot
+            transform translate3d(-24px, 0, 0)
     .q-stepper__tab:not(:last-child)
       .q-stepper__dot:after
         display block !important


### PR DESCRIPTION
- contractable works now as default gt-sm
- works the same lt-md no matter if alternative labels or not