### PR TITLE
feat(app): add extendJsonFile function to InstallAPI

### DIFF
--- a/app/lib/app-extension/InstallAPI.js
+++ b/app/lib/app-extension/InstallAPI.js
@@ -91,24 +91,23 @@ module.exports = class InstallAPI {
   }
 
   /**
-   * Extend a JSON file with new props.
+   * Extend a JSON file with new props (deep merge).
    * If specifying existing props, it will override them.
    *
-   * @param {string} file
-   * @param {object} newData
+   * @param {string} file (relative path to app root folder)
+   * @param {object} newData (Object to merge in)
    */
   extendJsonFile (file, newData) {
     if (newData !== void 0 && Object(newData) === newData && Object.keys(newData).length > 0) {
       const
         filePath = appPaths.resolve.app(file),
-        pkg = merge(fs.existsSync(filePath) ? require(filePath): {}, newData)
+        data = merge(fs.existsSync(filePath) ? require(filePath) : {}, newData)
 
       fs.writeFileSync(
         appPaths.resolve.app(file),
-        JSON.stringify(pkg, null, 2),
+        JSON.stringify(data, null, 2),
         'utf-8'
       )
-
     }
   }
 

--- a/app/lib/app-extension/InstallAPI.js
+++ b/app/lib/app-extension/InstallAPI.js
@@ -91,6 +91,28 @@ module.exports = class InstallAPI {
   }
 
   /**
+   * Extend a JSON file with new props.
+   * If specifying existing props, it will override them.
+   *
+   * @param {string} file
+   * @param {object} newData
+   */
+  extendJsonFile (file, newData) {
+    if (newData !== void 0 && Object(newData) === newData && Object.keys(newData).length > 0) {
+      const
+        filePath = appPaths.resolve.app(file),
+        pkg = merge(fs.existsSync(filePath) ? require(filePath): {}, newData)
+
+      fs.writeFileSync(
+        appPaths.resolve.app(file),
+        JSON.stringify(pkg, null, 2),
+        'utf-8'
+      )
+
+    }
+  }
+
+  /**
    * Render a folder from extension templates into devland.
    * Needs a relative path to extension's /install.js script.
    *


### PR DESCRIPTION
Adds an `extendJsonFile` function to the app extension install API. Works exactly like `extendPackageJson`, but writes to a custom file.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

