### PR TITLE
Update QInput.js

### DIFF
--- a/src/components/input/QInput.js
+++ b/src/components/input/QInput.js
@@ -208,6 +208,13 @@ export default {
               }
             })
           }
+          else if(this.model === "") {
+            this.model = this.computedClearValue
+            this.$emit('input', this.computedClearValue)
+            this.$nextTick(() => {
+              this.$emit('change', this.computedClearValue)
+            })
+          }
           return
         }
         this.isNumberError = false


### PR DESCRIPTION
When erasing the last digit the quasar does not emit the input. Because the model is "".

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
