### PR TITLE
fix(quasar+docs): Fix QDrawer mini animation and small tweaks in docs

### DIFF
--- a/docs/src/examples/grid/ChildrenStyling.vue
+++ b/docs/src/examples/grid/ChildrenStyling.vue
@@ -24,18 +24,18 @@
 
     <q-separator class="q-my-md" />
 
-    <p>.q-col-gutter with styling on children</p>
+    <p>.q-col-gutter with direct QBtn children</p>
     <div class="bg-red-4 clearfix q-mt-lg">
-      <div class="row q-col-gutter-xl">
+      <div class="row q-col-gutter-lg">
         <q-btn class="semi-transparent col-4" color="primary" label="Button" v-for="n in 7" :key="`md-${n}`" />
       </div>
     </div>
 
     <q-separator class="q-my-md" />
 
-    <p>.q-col-gutter with styling on the element inside children</p>
+    <p>.q-col-gutter with QBtn inside children</p>
     <div class="bg-red-4 clearfix">
-      <div class="row q-col-gutter-xl">
+      <div class="row q-col-gutter-lg">
         <div class="col-4" v-for="n in 7" :key="n">
           <q-btn class="full-width" color="primary" label="Button" />
         </div>

--- a/docs/src/pages/style/spacing.md
+++ b/docs/src/pages/style/spacing.md
@@ -25,8 +25,6 @@ S - size
       md (medium),
       lg (large),
       xl (extra large)
-
-q-my-form - applies the default vertical margins for form controls, according to material specification.
 ```
 
 ## Examples
@@ -46,7 +44,6 @@ When enabled (through `quasar.conf > framework > cssAddon: true`) it provides br
 
 ```
 .q-(p|m)(t|r|b|l|a|x|y)-<bp>-(none|auto|xs|sm|md|lg|xl)
-.q-my-<bp>-form
 ```
 
 Examples: `q-pa-xs-md q-pa-sm-sm q-px-md-lg q-py-md-md`

--- a/quasar/src/components/layout/QDrawer.js
+++ b/quasar/src/components/layout/QDrawer.js
@@ -162,6 +162,14 @@ export default Vue.extend({
 
     mini () {
       if (this.value) {
+        if (this.$el !== void 0) {
+          this.$el.classList.add('q-drawer--mini-animate')
+          setTimeout(() => {
+            if (this.$el !== void 0) {
+              this.$el.classList.remove('q-drawer--mini-animate')
+            }
+          }, 150)
+        }
         this.layout.__animate()
       }
     }

--- a/quasar/src/components/layout/layout.styl
+++ b/quasar/src/components/layout/layout.styl
@@ -89,7 +89,7 @@ $layout-transition = all .12s ease-in
       &:after
         left 10px
 
-  body:not(.q-body--layout-animate) &--mini
+  &-container:not(&--mini-animate) &--mini
     padding 0 !important
     .q-item, .q-item__section
       text-align center
@@ -102,7 +102,7 @@ $layout-transition = all .12s ease-in
   &--mini
     .q-mini-drawer-hide, .q-expansion-item__content
       display none
-  .q-body--layout-animate &__content
+  &--mini-animate &__content
     overflow-x hidden
     white-space nowrap
   &--standard


### PR DESCRIPTION
The mini animation in drawer was based on body animation class, so if anything else was animated the drawer was affected.

Visible in docs, in drawer page - watch docs right menu when hovering over and out of a demo with mini menu on mouse over.