### PR TITLE
fix(quasar): Fixes the QColor (color picker) jitter issues with Firefox

### DIFF
--- a/quasar/src/components/color/color.styl
+++ b/quasar/src/components/color/color.styl
@@ -2,6 +2,7 @@
   overflow hidden
   background white
   max-width 350px
+  min-width 240px
   vertical-align top
 
   border-radius $generic-border-radius


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When QColor is in a QMenu (or QPopupProxy) a fix is to add css styling for a min-width. Since this is not reasonable to ask of users, I added a "min-width: 280px;" to the ".q-color-picker" class. 280px looks like the minimum the QColor should be in order to function without jitters.

