### PR TITLE
fix(quasar): QSelect - make .q-select__input color obey field color; fix lefover q-popup--skip; fix timing for filter

### DIFF
--- a/quasar/dev/components/form/select-part-1.vue
+++ b/quasar/dev/components/form/select-part-1.vue
@@ -1,21 +1,21 @@
 <template>
   <div>
-    <div class="q-layout-padding q-gutter-y-md">
+    <div class="q-layout-padding q-gutter-y-md" :class="{ 'bg-grey-8 text-white': dark }">
       <div class="q-gutter-sm">
-        <q-radio v-model="type" val="filled" label="Filled" />
-        <q-radio v-model="type" val="outlined" label="Outlined" />
-        <q-radio v-model="type" val="standout" label="Standout" />
-        <q-radio v-model="type" val="standard" label="Standard" />
-        <q-radio v-model="type" val="borderless" label="Borderless" />
+        <q-radio :dark="dark" v-model="type" val="filled" label="Filled" />
+        <q-radio :dark="dark" v-model="type" val="outlined" label="Outlined" />
+        <q-radio :dark="dark" v-model="type" val="standout" label="Standout" />
+        <q-radio :dark="dark" v-model="type" val="standard" label="Standard" />
+        <q-radio :dark="dark" v-model="type" val="borderless" label="Borderless" />
       </div>
       <div>
-        <q-toggle v-model="readonly" label="Readonly" />
-        <q-toggle v-model="disable" label="Disable" />
-        <q-toggle v-model="dense" label="Dense" />
-        <q-toggle v-model="optionsDense" label="(Options) Dense" />
-        <q-toggle v-model="expandBesides" label="Expand besides" />
-        <q-toggle v-model="dark" label="Dark" />
-        <q-toggle v-model="optionsDark" label="(Options) Dark" />
+        <q-toggle :dark="dark" v-model="readonly" label="Readonly" />
+        <q-toggle :dark="dark" v-model="disable" label="Disable" />
+        <q-toggle :dark="dark" v-model="dense" label="Dense" />
+        <q-toggle :dark="dark" v-model="optionsDense" label="(Options) Dense" />
+        <q-toggle :dark="dark" v-model="expandBesides" label="Expand besides" />
+        <q-toggle :dark="dark" v-model="dark" label="Dark" />
+        <q-toggle :dark="dark" v-model="optionsDark" label="(Options) Dark" />
       </div>
 
       <div class="text-h6">String options</div>
@@ -58,7 +58,7 @@
 
       <div class="text-h6">
         Null model
-        <q-btn outline color="primary" label="Reset" @click="resetNull" />
+        <q-btn outline color="negative" label="Reset" @click="resetNull" />
       </div>
 
       <div>{{ stringNullSingle }}</div>
@@ -96,7 +96,7 @@
 
       <div class="text-h6">
         Model value not in options
-        <q-btn color="primary" outline label="Reset" @click="resetBogus" />
+        <q-btn color="negative" outline label="Reset" @click="resetBogus" />
       </div>
       <div>{{ bogusModel }}</div>
       <q-select

--- a/quasar/dev/components/form/select-part-2.vue
+++ b/quasar/dev/components/form/select-part-2.vue
@@ -1,171 +1,216 @@
 <template>
-  <div>
-    <div class="q-layout-padding q-gutter-y-md">
-      <div class="q-gutter-sm">
-        <q-radio v-model="type" val="filled" label="Filled" />
-        <q-radio v-model="type" val="outlined" label="Outlined" />
-        <q-radio v-model="type" val="standout" label="Standout" />
-        <q-radio v-model="type" val="standard" label="Standard" />
-        <q-radio v-model="type" val="borderless" label="Borderless" />
-      </div>
-      <div>
-        <q-toggle v-model="readonly" label="Readonly" />
-        <q-toggle v-model="disable" label="Disable" />
-        <q-toggle v-model="dense" label="Dense" />
-        <q-toggle v-model="expandBesides" label="Expand besides" />
-      </div>
-      <div class="q-mb-lg q-gutter-sm">
-        <q-btn label="Set Google" @click="setGoogle" color="primary" outline />
-        <q-btn label="Set Null" @click="setNull" color="primary" outline />
-      </div>
+  <q-layout view="lHh LpR fFf" :class="{ 'bg-grey-8 text-white': dark }">
+    <q-page-container>
+      <q-page padding>
+        <div class="q-gutter-y-md">
+          <div class="q-gutter-sm">
+            <q-radio :dark="dark" v-model="type" val="filled" label="Filled" />
+            <q-radio :dark="dark" v-model="type" val="outlined" label="Outlined" />
+            <q-radio :dark="dark" v-model="type" val="standout" label="Standout" />
+            <q-radio :dark="dark" v-model="type" val="standard" label="Standard" />
+            <q-radio :dark="dark" v-model="type" val="borderless" label="Borderless" />
+          </div>
+          <div>
+            <q-toggle :dark="dark" v-model="readonly" label="Readonly" />
+            <q-toggle :dark="dark" v-model="disable" label="Disable" />
+            <q-toggle :dark="dark" v-model="dense" label="Dense" />
+            <q-toggle :dark="dark" v-model="optionsDense" label="(Options) Dense" />
+            <q-toggle :dark="dark" v-model="expandBesides" label="Expand besides" />
+            <q-toggle :dark="dark" v-model="dark" label="Dark" />
+            <q-toggle :dark="dark" v-model="optionsDark" label="(Options) Dark" />
+          </div>
+          <div class="q-mb-lg q-gutter-sm">
+            <q-btn label="Set Google" @click="setGoogle" color="negative" outline />
+            <q-btn label="Set Null" @click="setNull" color="negative" outline />
+          </div>
 
-      <q-select
-        v-bind="props"
-        v-model="simpleFilter"
-        label="Simple filter - lazy load options"
-        :options="simpleFilterOptions"
-        @filter="simpleFilterFn"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="simpleFilter"
+            label="Simple filter - lazy load options"
+            :options="simpleFilterOptions"
+            @filter="simpleFilterFn"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <q-select
-        v-bind="props"
-        v-model="simpleFilterInput"
-        use-input
-        input-debounce="0"
-        label="Simple filter - useInput"
-        :options="simpleFilterInputOptions"
-        @filter="simpleFilterInputFn"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="simpleFilterInput"
+            use-input
+            input-debounce="0"
+            label="Simple filter - useInput"
+            :options="simpleFilterInputOptions"
+            @filter="simpleFilterInputFn"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <q-select
-        v-bind="props"
-        v-model="createInput"
-        use-input
-        use-chips
-        multiple
-        input-debounce="0"
-        label="Multiple - Create new values (& filter)"
-        @new-value="createInputNewValue"
-        :options="createInputOptions"
-        @filter="createInputFn"
-      />
+          <q-select
+            v-bind="props"
+            v-model="createInput"
+            use-input
+            use-chips
+            multiple
+            input-debounce="0"
+            label="Multiple - Create new values (& filter)"
+            @new-value="createInputNewValue"
+            :options="createInputOptions"
+            @filter="createInputFn"
+          />
 
-      <q-select
-        v-bind="props"
-        v-model="createSingleInput"
-        use-input
-        use-chips
-        input-debounce="0"
-        label="Single - Create new values (& filter)"
-        @new-value="createInputNewValue"
-        :options="createInputOptions"
-        @filter="createInputFn"
-      />
+          <q-select
+            v-bind="props"
+            v-model="createSingleInput"
+            use-input
+            use-chips
+            input-debounce="0"
+            label="Single - Create new values (& filter)"
+            @new-value="createInputNewValue"
+            :options="createInputOptions"
+            @filter="createInputFn"
+          />
 
-      <q-select
-        v-bind="props"
-        v-model="createInput"
-        use-input
-        use-chips
-        multiple
-        input-debounce="0"
-        label="Multiple - Create new values (no filter)"
-        @new-value="createInputNewValue"
-      />
+          <q-select
+            v-bind="props"
+            v-model="createInput"
+            use-input
+            use-chips
+            multiple
+            input-debounce="0"
+            label="Multiple - Create new values (no filter)"
+            @new-value="createInputNewValue"
+          />
 
-      <q-select
-        v-bind="props"
-        v-model="createSingleInput"
-        use-input
-        use-chips
-        input-debounce="0"
-        label="Single - Create new values (no filter)"
-        @new-value="createInputNewValue"
-      />
+          <q-select
+            v-bind="props"
+            v-model="createSingleInput"
+            use-input
+            use-chips
+            input-debounce="0"
+            label="Single - Create new values (no filter)"
+            @new-value="createInputNewValue"
+          />
 
-      <q-select
-        v-bind="props"
-        v-model="simpleFilterInput"
-        use-input
-        input-debounce="0"
-        hide-selected
-        label="Simple filter - hide selected + useInput"
-        :options="simpleFilterInputOptions"
-        @filter="simpleFilterInputFn"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="simpleFilterInput"
+            use-input
+            input-debounce="0"
+            hide-selected
+            label="Simple filter - hide selected + useInput"
+            :options="simpleFilterInputOptions"
+            @filter="simpleFilterInputFn"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <q-select
-        v-bind="props"
-        v-model="minFilterInput"
-        use-input
-        input-debounce="0"
-        label="Simple filter - min 2 chars"
-        :options="minFilterInputOptions"
-        @filter="minFilterInputFn"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="minFilterInput"
+            use-input
+            input-debounce="0"
+            label="Simple filter - min 2 chars"
+            :options="minFilterInputOptions"
+            @filter="minFilterInputFn"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <q-select
-        v-bind="props"
-        v-model="chipFilterInput"
-        use-input
-        use-chips
-        input-debounce="0"
-        label="Simple filter - selected slot"
-        :options="chipFilterInputOptions"
-        @filter="chipFilterInputFn"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="chipFilterInput"
+            use-input
+            use-chips
+            input-debounce="0"
+            label="Simple filter - selected slot"
+            :options="chipFilterInputOptions"
+            @filter="chipFilterInputFn"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <q-select
-        v-bind="props"
-        v-model="delayedFilterInput"
-        use-input
-        use-chips
-        color="teal"
-        label="Delayed filter"
-        :options="delayedFilterInputOptions"
-        @filter="delayedFilterInputFn"
-        @filter-abort="delayedAbort"
-      >
-        <q-item slot="no-option">
-          <q-item-section class="text-grey">
-            No results
-          </q-item-section>
-        </q-item>
-      </q-select>
+          <q-select
+            v-bind="props"
+            v-model="delayedFilterInput"
+            use-input
+            use-chips
+            color="teal"
+            label="Delayed filter"
+            :options="delayedFilterInputOptions"
+            @filter="delayedFilterInputFn"
+            @filter-abort="delayedAbort"
+          >
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
 
-      <div style="height: 400px">Scroll on purpose</div>
-    </div>
-  </div>
+          <q-select
+            v-bind="props"
+            v-model="delayedFilterInput"
+            use-input
+            use-chips
+            color="teal"
+            label="Delayed filter with loading slot"
+            :options="delayedFilterInputOptions"
+            @filter="delayedFilterInputFn"
+            @filter-abort="delayedAbort"
+          >
+            <template #loading>
+              Click for menu
+              <q-menu fit>
+                <div class="q-pa-md text-center">
+                  Menu
+                </div>
+              </q-menu>
+            </template>
+            <q-item slot="no-option">
+              <q-item-section class="text-grey">
+                No results
+              </q-item-section>
+            </q-item>
+          </q-select>
+
+          <div style="height: 400px">Scroll on purpose</div>
+        </div>
+        <q-page-sticky expand position="bottom" :class="dark ? 'bg-blue-8 text-white' : 'bg-yellow'">
+          <q-select
+            class="full-width"
+            v-bind="props"
+            v-model="simpleFilterInput"
+            use-input
+            input-debounce="0"
+            label="Type 'aa' to have no option, then delete one 'a'"
+            :options="simpleFilterInputOptions"
+            @filter="simpleFilterInputFn"
+          />
+        </q-page-sticky>
+      </q-page>
+    </q-page-container>
+  </q-layout>
 </template>
 
 <script>
@@ -180,6 +225,9 @@ export default {
       readonly: false,
       disable: false,
       dense: false,
+      dark: false,
+      optionsDark: false,
+      optionsDense: false,
       expandBesides: false,
 
       simpleFilter: null,
@@ -366,6 +414,9 @@ export default {
         readonly: this.readonly,
         disable: this.disable,
         dense: this.dense,
+        dark: this.dark,
+        optionsDense: this.optionsDense,
+        optionsDark: this.optionsDark,
         expandBesides: this.expandBesides
       }
     }

--- a/quasar/src/components/field/QField.js
+++ b/quasar/src/components/field/QField.js
@@ -146,7 +146,7 @@ export default Vue.extend({
 
         this.__getInnerAppend !== void 0
           ? h('div', {
-            staticClass: 'q-field__append q-field__marginal row no-wrap items-center q-popup--skip',
+            staticClass: 'q-field__append q-field__marginal row no-wrap items-center q-anchor--skip',
             key: 'inner-append'
           }, this.__getInnerAppend(h))
           : null,

--- a/quasar/src/components/field/field.styl
+++ b/quasar/src/components/field/field.styl
@@ -240,7 +240,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     .q-field__control:hover:before
       border-color white
 
-    .q-field__native, .q-field__prefix, .q-field__suffix
+    .q-field__native, .q-field__prefix, .q-field__suffix, .q-select__input
       color white
 
     &:not(.q-field--focused) .q-field__label, .q-field__marginal, .q-field__bottom
@@ -269,7 +269,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       .q-field__control
         box-shadow $shadow-2
         background black
-      .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__prepend, .q-field__append
+      .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__prepend, .q-field__append, .q-select__input
         color white
 
     &.q-field--readonly
@@ -286,7 +286,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       &.q-field--focused
         .q-field__control
           background white
-        .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__prepend, .q-field__append
+        .q-field__native, .q-field__prefix, .q-field__suffix, .q-field__prepend, .q-field__append, .q-select__input
           color black
       &.q-field--readonly
         .q-field__control:before

--- a/quasar/src/components/select/QSelect.js
+++ b/quasar/src/components/select/QSelect.js
@@ -648,9 +648,11 @@ export default Vue.extend({
         val,
         fn => {
           if (this.focused === true && this.filterId === filterId) {
-            this.loading = false
-            this.menu = true
             typeof fn === 'function' && fn()
+            this.$nextTick(() => {
+              this.loading = false
+              this.menu = true
+            })
           }
         },
         () => {


### PR DESCRIPTION
- color (reproduced with QSelect dark with input)
- q-popup--skip - added test in dev
- filter timing:
  - this.menu is set in the same tick when fn() is called
  - in the next tick the options are updated, but QSelect has for one tick the old ones with menu open (reproduced by filtering to see no option and then clearing filter - it must not have no-option slot)