### PR TITLE
fix(quasar): Add a click modifier to TouchPan

### DIFF
--- a/quasar/src/components/color/QColor.js
+++ b/quasar/src/components/color/QColor.js
@@ -309,13 +309,11 @@ export default Vue.extend({
           staticClass: 'q-color-picker__spectrum non-selectable relative-position cursor-pointer',
           style: this.spectrumStyle,
           class: { readonly: !this.editable },
-          on: this.editable
-            ? { click: this.__spectrumClick }
-            : null,
           directives: this.editable
             ? [{
               name: 'touch-pan',
               modifiers: {
+                click: true,
                 mightPrevent: true
               },
               value: this.__spectrumPan
@@ -805,17 +803,6 @@ export default Vue.extend({
       this.__onSpectrumChange(
         evt.position.left,
         evt.position.top
-      )
-    },
-
-    __spectrumClick (evt) {
-      if (this.spectrumDragging) {
-        return
-      }
-      this.__onSpectrumChange(
-        evt.pageX - window.pageXOffset,
-        evt.pageY - window.pageYOffset,
-        true
       )
     }
   }

--- a/quasar/src/components/datetime/QTime.js
+++ b/quasar/src/components/datetime/QTime.js
@@ -215,9 +215,8 @@ export default Vue.extend({
           dist: dist * 0.7
         }
         this.dragCache = null
-        this.__updateClock(event.evt)
       }
-      else if (event.isFinal) {
+      if (event.isFinal) {
         this.__updateClock(event.evt)
         this.dragging = false
 
@@ -408,6 +407,7 @@ export default Vue.extend({
                 name: 'touch-pan',
                 value: this.__drag,
                 modifiers: {
+                  click: true,
                   stop: true,
                   prevent: true
                 }

--- a/quasar/src/components/knob/QKnob.js
+++ b/quasar/src/components/knob/QKnob.js
@@ -211,6 +211,7 @@ export default Vue.extend({
         name: 'touch-pan',
         value: this.__pan,
         modifiers: {
+          click: true,
           prevent: true,
           stop: true
         }

--- a/quasar/src/directives/TouchPan.js
+++ b/quasar/src/directives/TouchPan.js
@@ -79,6 +79,7 @@ export default {
       mouse = binding.modifiers.noMouse !== true,
       stopPropagation = binding.modifiers.stop,
       preventDefault = binding.modifiers.prevent,
+      triggerOnClick = binding.modifiers.click && mouse === true,
       evtOpts = preventDefault || binding.modifiers.mightPrevent ? null : listenOpts.passive
 
     let ctx = {
@@ -96,7 +97,7 @@ export default {
       mouseEnd (evt) {
         document.removeEventListener('mousemove', ctx.move, evtOpts)
         document.removeEventListener('mouseup', ctx.mouseEnd, evtOpts)
-        ctx.end(evt)
+        ctx.end(evt, triggerOnClick)
       },
 
       start (evt, mouseEvent) {
@@ -161,9 +162,9 @@ export default {
         ctx.move(evt)
       },
 
-      end (evt) {
+      end (evt, triggerOnClick) {
         el.classList.remove('q-touch')
-        if (ctx.event.abort || !ctx.event.detected || ctx.event.isFirst) {
+        if (ctx.event.abort || !ctx.event.detected || (ctx.event.isFirst && triggerOnClick !== true)) {
           return
         }
 

--- a/quasar/src/directives/TouchPan.json
+++ b/quasar/src/directives/TouchPan.json
@@ -122,6 +122,11 @@
       "desc": "Disregard mouse events and handle only touch events"
     },
 
+    "click": {
+      "type": "Boolean",
+      "desc": "Trigger also on mouse click without pan - active only if 'noMouse' is not specified"
+    },
+
     "horizontal": {
       "type": "Boolean",
       "desc": "Catch horizontal movement; If 'horizontal' or 'vertical' are not specified, then both directions are considered by default"


### PR DESCRIPTION
On desktop QTime and QKnob do not respond to click without a drag.
QColor can be simplified to not listen for click.