### PR TITLE
feat(app/extensions): strip "quasar-app-extension-" when installing

### DIFF
--- a/app/lib/app-extension/Extension.js
+++ b/app/lib/app-extension/Extension.js
@@ -1,10 +1,11 @@
-const logger = require('../helpers/logger'),
+const
+  logger = require('../helpers/logger'),
   log = logger('app:extension'),
   warn = logger('app:extension', 'red'),
   appPaths = require('../app-paths')
 
 module.exports = class Extension {
-  constructor(name) {
+  constructor (name) {
     if (name.charAt(0) === '@') {
       const slashIndex = name.indexOf('/')
       if (slashIndex === -1) {
@@ -12,34 +13,34 @@ module.exports = class Extension {
         process.exit(1)
       }
 
-      this.packageFullName =
-        name.substring(0, slashIndex + 1) +
+      this.packageFullName = name.substring(0, slashIndex + 1) +
         'quasar-app-extension-' +
         name.substring(slashIndex + 1)
 
-      this.packageName =
-        '@' + this.__stripVersion(this.packageFullName.substring(1))
+      this.packageName = '@' + this.__stripVersion(this.packageFullName.substring(1))
       this.extId = '@' + this.__stripVersion(name.substring(1))
-    } else {
+    }
+    else {
       this.packageFullName = 'quasar-app-extension-' + name
       this.packageName = this.__stripVersion('quasar-app-extension-' + name)
       this.extId = this.__stripVersion(name)
     }
   }
 
-  isInstalled() {
+  isInstalled () {
     try {
       require.resolve(this.packageName, {
-        paths: [appPaths.appDir]
+        paths: [ appPaths.appDir ]
       })
-    } catch (e) {
+    }
+    catch (e) {
       return false
     }
 
     return true
   }
 
-  async install(skipPkgInstall) {
+  async install (skipPkgInstall) {
     if (/quasar-app-extension-/.test(this.extId)) {
       this.extId = this.extId.replace('quasar-app-extension-', '')
       log(
@@ -55,14 +56,12 @@ module.exports = class Extension {
     // verify if already installed
     if (skipPkgInstall !== true && this.isInstalled()) {
       const inquirer = require('inquirer')
-      const answer = await inquirer.prompt([
-        {
-          name: 'reinstall',
-          type: 'confirm',
-          message: `Already installed. Reinstall?`,
-          default: false
-        }
-      ])
+      const answer = await inquirer.prompt([{
+        name: 'reinstall',
+        type: 'confirm',
+        message: `Already installed. Reinstall?`,
+        default: false
+      }])
 
       if (!answer.reinstall) {
         return
@@ -91,7 +90,7 @@ module.exports = class Extension {
     }
   }
 
-  async uninstall(skipPkgUninstall) {
+  async uninstall (skipPkgUninstall) {
     log(`Uninstalling "${this.extId}" App Extension`)
     log()
 
@@ -122,7 +121,7 @@ module.exports = class Extension {
     }
   }
 
-  async run(ctx) {
+  async run (ctx) {
     if (!this.isInstalled()) {
       warn(`⚠️  Quasar App Extension "${this.extId}" is missing...`)
       process.exit(1)
@@ -144,13 +143,15 @@ module.exports = class Extension {
     return api.__getHooks()
   }
 
-  __stripVersion(packageFullName) {
+  __stripVersion (packageFullName) {
     const index = packageFullName.indexOf('@')
 
-    return index > -1 ? packageFullName.substring(0, index) : packageFullName
+    return index > -1
+      ? packageFullName.substring(0, index)
+      : packageFullName
   }
 
-  async __getPrompts() {
+  async __getPrompts () {
     const questions = this.__getScript('prompts')
 
     if (!questions) {
@@ -164,11 +165,13 @@ module.exports = class Extension {
     return prompts
   }
 
-  __installPackage() {
-    const spawn = require('../helpers/spawn'),
+  __installPackage () {
+    const
+      spawn = require('../helpers/spawn'),
       nodePackager = require('../helpers/node-packager'),
-      cmdParam =
-        nodePackager === 'npm' ? ['install', '--save-dev'] : ['add', '--dev']
+      cmdParam = nodePackager === 'npm'
+        ? ['install', '--save-dev']
+        : ['add', '--dev']
 
     log(`Retrieving "${this.packageFullName}"...`)
     spawn.sync(
@@ -179,11 +182,13 @@ module.exports = class Extension {
     )
   }
 
-  __uninstallPackage() {
-    const spawn = require('../helpers/spawn'),
+  __uninstallPackage () {
+    const
+      spawn = require('../helpers/spawn'),
       nodePackager = require('../helpers/node-packager'),
-      cmdParam =
-        nodePackager === 'npm' ? ['uninstall', '--save-dev'] : ['remove']
+      cmdParam = nodePackager === 'npm'
+        ? ['uninstall', '--save-dev']
+        : ['remove']
 
     log(`Uninstalling "${this.packageName}"...`)
     spawn.sync(
@@ -194,20 +199,17 @@ module.exports = class Extension {
     )
   }
 
-  __getScript(scriptName, fatal) {
+  __getScript (scriptName, fatal) {
     let script
 
     try {
       script = require.resolve(this.packageName + '/' + scriptName, {
-        paths: [appPaths.appDir]
+        paths: [ appPaths.appDir ]
       })
-    } catch (e) {
+    }
+    catch (e) {
       if (fatal) {
-        warn(
-          `⚠️  App Extension "${
-            this.extId
-          }" has missing ${scriptName} script...`
-        )
+        warn(`⚠️  App Extension "${this.extId}" has missing ${scriptName} script...`)
         process.exit(1)
       }
 
@@ -217,7 +219,7 @@ module.exports = class Extension {
     return require(script)
   }
 
-  async __runInstallScript(prompts) {
+  async __runInstallScript (prompts) {
     const script = this.__getScript('install')
 
     if (!script) {
@@ -236,20 +238,26 @@ module.exports = class Extension {
     await script(api)
 
     if (api.__needsNodeModulesUpdate) {
-      const spawn = require('../helpers/spawn'),
+      const
+        spawn = require('../helpers/spawn'),
         nodePackager = require('../helpers/node-packager'),
-        cmdParam = nodePackager === 'npm' ? ['install'] : []
+        cmdParam = nodePackager === 'npm'
+          ? ['install']
+          : []
 
       log(`Updating dependencies...`)
-      spawn.sync(nodePackager, cmdParam, appPaths.appDir, () =>
-        warn(`⚠️  Failed to update dependencies`)
+      spawn.sync(
+        nodePackager,
+        cmdParam,
+        appPaths.appDir,
+        () => warn(`⚠️  Failed to update dependencies`)
       )
     }
 
     return api.__getHooks()
   }
 
-  async __runUninstallScript(prompts) {
+  async __runUninstallScript (prompts) {
     const script = this.__getScript('uninstall')
 
     if (!script) {

--- a/app/lib/app-extension/Extension.js
+++ b/app/lib/app-extension/Extension.js
@@ -1,11 +1,10 @@
-const
-  logger = require('../helpers/logger'),
+const logger = require('../helpers/logger'),
   log = logger('app:extension'),
   warn = logger('app:extension', 'red'),
   appPaths = require('../app-paths')
 
 module.exports = class Extension {
-  constructor (name) {
+  constructor(name) {
     if (name.charAt(0) === '@') {
       const slashIndex = name.indexOf('/')
       if (slashIndex === -1) {
@@ -13,46 +12,57 @@ module.exports = class Extension {
         process.exit(1)
       }
 
-      this.packageFullName = name.substring(0, slashIndex + 1) +
+      this.packageFullName =
+        name.substring(0, slashIndex + 1) +
         'quasar-app-extension-' +
         name.substring(slashIndex + 1)
 
-      this.packageName = '@' + this.__stripVersion(this.packageFullName.substring(1))
+      this.packageName =
+        '@' + this.__stripVersion(this.packageFullName.substring(1))
       this.extId = '@' + this.__stripVersion(name.substring(1))
-    }
-    else {
+    } else {
       this.packageFullName = 'quasar-app-extension-' + name
       this.packageName = this.__stripVersion('quasar-app-extension-' + name)
       this.extId = this.__stripVersion(name)
     }
   }
 
-  isInstalled () {
+  isInstalled() {
     try {
       require.resolve(this.packageName, {
-        paths: [ appPaths.appDir ]
+        paths: [appPaths.appDir]
       })
-    }
-    catch (e) {
+    } catch (e) {
       return false
     }
 
     return true
   }
 
-  async install (skipPkgInstall) {
+  async install(skipPkgInstall) {
+    if (/quasar-app-extension-/.test(this.extId)) {
+      this.extId = this.extId.replace('quasar-app-extension-', '')
+      log(
+        `When using an extension, "quasar-app-extension-" is added automatically. Just run "quasar ext --add ${
+          this.extId
+        }"`
+      )
+    }
+
     log(`Installing "${this.extId}" Quasar App Extension`)
     log()
 
     // verify if already installed
     if (skipPkgInstall !== true && this.isInstalled()) {
       const inquirer = require('inquirer')
-      const answer = await inquirer.prompt([{
-        name: 'reinstall',
-        type: 'confirm',
-        message: `Already installed. Reinstall?`,
-        default: false
-      }])
+      const answer = await inquirer.prompt([
+        {
+          name: 'reinstall',
+          type: 'confirm',
+          message: `Already installed. Reinstall?`,
+          default: false
+        }
+      ])
 
       if (!answer.reinstall) {
         return
@@ -81,7 +91,7 @@ module.exports = class Extension {
     }
   }
 
-  async uninstall (skipPkgUninstall) {
+  async uninstall(skipPkgUninstall) {
     log(`Uninstalling "${this.extId}" App Extension`)
     log()
 
@@ -112,7 +122,7 @@ module.exports = class Extension {
     }
   }
 
-  async run (ctx) {
+  async run(ctx) {
     if (!this.isInstalled()) {
       warn(`⚠️  Quasar App Extension "${this.extId}" is missing...`)
       process.exit(1)
@@ -134,15 +144,13 @@ module.exports = class Extension {
     return api.__getHooks()
   }
 
-  __stripVersion (packageFullName) {
+  __stripVersion(packageFullName) {
     const index = packageFullName.indexOf('@')
 
-    return index > -1
-      ? packageFullName.substring(0, index)
-      : packageFullName
+    return index > -1 ? packageFullName.substring(0, index) : packageFullName
   }
 
-  async __getPrompts () {
+  async __getPrompts() {
     const questions = this.__getScript('prompts')
 
     if (!questions) {
@@ -156,13 +164,11 @@ module.exports = class Extension {
     return prompts
   }
 
-  __installPackage () {
-    const
-      spawn = require('../helpers/spawn'),
+  __installPackage() {
+    const spawn = require('../helpers/spawn'),
       nodePackager = require('../helpers/node-packager'),
-      cmdParam = nodePackager === 'npm'
-        ? ['install', '--save-dev']
-        : ['add', '--dev']
+      cmdParam =
+        nodePackager === 'npm' ? ['install', '--save-dev'] : ['add', '--dev']
 
     log(`Retrieving "${this.packageFullName}"...`)
     spawn.sync(
@@ -173,13 +179,11 @@ module.exports = class Extension {
     )
   }
 
-  __uninstallPackage () {
-    const
-      spawn = require('../helpers/spawn'),
+  __uninstallPackage() {
+    const spawn = require('../helpers/spawn'),
       nodePackager = require('../helpers/node-packager'),
-      cmdParam = nodePackager === 'npm'
-        ? ['uninstall', '--save-dev']
-        : ['remove']
+      cmdParam =
+        nodePackager === 'npm' ? ['uninstall', '--save-dev'] : ['remove']
 
     log(`Uninstalling "${this.packageName}"...`)
     spawn.sync(
@@ -190,17 +194,20 @@ module.exports = class Extension {
     )
   }
 
-  __getScript (scriptName, fatal) {
+  __getScript(scriptName, fatal) {
     let script
 
     try {
       script = require.resolve(this.packageName + '/' + scriptName, {
-        paths: [ appPaths.appDir ]
+        paths: [appPaths.appDir]
       })
-    }
-    catch (e) {
+    } catch (e) {
       if (fatal) {
-        warn(`⚠️  App Extension "${this.extId}" has missing ${scriptName} script...`)
+        warn(
+          `⚠️  App Extension "${
+            this.extId
+          }" has missing ${scriptName} script...`
+        )
         process.exit(1)
       }
 
@@ -210,7 +217,7 @@ module.exports = class Extension {
     return require(script)
   }
 
-  async __runInstallScript (prompts) {
+  async __runInstallScript(prompts) {
     const script = this.__getScript('install')
 
     if (!script) {
@@ -229,26 +236,20 @@ module.exports = class Extension {
     await script(api)
 
     if (api.__needsNodeModulesUpdate) {
-      const
-        spawn = require('../helpers/spawn'),
+      const spawn = require('../helpers/spawn'),
         nodePackager = require('../helpers/node-packager'),
-        cmdParam = nodePackager === 'npm'
-          ? ['install']
-          : []
+        cmdParam = nodePackager === 'npm' ? ['install'] : []
 
       log(`Updating dependencies...`)
-      spawn.sync(
-        nodePackager,
-        cmdParam,
-        appPaths.appDir,
-        () => warn(`⚠️  Failed to update dependencies`)
+      spawn.sync(nodePackager, cmdParam, appPaths.appDir, () =>
+        warn(`⚠️  Failed to update dependencies`)
       )
     }
 
     return api.__getHooks()
   }
 
-  async __runUninstallScript (prompts) {
+  async __runUninstallScript(prompts) {
     const script = this.__getScript('uninstall')
 
     if (!script) {


### PR DESCRIPTION
Since `quasar-app-extension-` is added automatically when installing/using extensions, if you run `quasar ext --add quasar-app-extension-*`, you will run into issues. This PR will strip `quasar-app-extension-` and provide a helpful message on install.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)