### PR TITLE
fix(quasar): Don't skip keys that have null value in $root.$options on fillInject 

### DIFF
--- a/quasar/src/mixins/portal.js
+++ b/quasar/src/mixins/portal.js
@@ -5,9 +5,9 @@ let inject
 
 function fillInject (root) {
   const
-    instance = new Vue(),
+    options = (new Vue()).$root.$options,
     skip = ['el', 'created', 'activated', 'deactivated', 'beforeMount', 'methods', 'mounted', 'render', 'mixins']
-      .concat(Object.keys(instance.$root.$options))
+      .concat(Object.keys(options).filter(key => options[key] !== null))
 
   inject = {}
 


### PR DESCRIPTION
close #3234