### PR TITLE
fix(quasar): Hide resize handler for QInput on mobile

### DIFF
--- a/quasar/src/components/input/input.styl
+++ b/quasar/src/components/input/input.styl
@@ -16,11 +16,8 @@
     padding-top 17px
     min-height 52px
 
-    .q-field--readonly&
-      pointer-events auto
-
-    .disabled&
-      resize none
+  &.q-field--readonly .q-field__native
+    pointer-events auto
 
   &.q-field--labeled
     .q-field__control-container
@@ -47,3 +44,8 @@
       .q-field__native
         min-height 24px
         padding-top 2px
+
+body.mobile .q-textarea
+.q-textarea.disabled
+  .q-field__native
+    resize none

--- a/quasar/src/components/input/input.styl
+++ b/quasar/src/components/input/input.styl
@@ -45,7 +45,7 @@
         min-height 24px
         padding-top 2px
 
-body.mobile .q-textarea
+body.mobile .q-textarea,
 .q-textarea.disabled
   .q-field__native
     resize none


### PR DESCRIPTION
close #3239