### PR TITLE
QBtn API - add missing `click` event

### DIFF
--- a/quasar/src/components/btn/QBtn.json
+++ b/quasar/src/components/btn/QBtn.json
@@ -14,6 +14,12 @@
     }
   },
 
+  "events": {
+    "click": {
+      "extends": "click"
+    }
+  },
+
   "slots": {
     "default": {
       "desc": "Use for custom content, instead of relying on 'icon' and 'label' props"


### PR DESCRIPTION
This one got me absolutely furious, because I thought I had a mistake in my diffing algorithm 😄 