### PR TITLE
fix typo in docs

### DIFF
--- a/docs/src/pages/vue-directives/close-menu.md
+++ b/docs/src/pages/vue-directives/close-menu.md
@@ -4,7 +4,7 @@ related:
   - /vue-components/menu
 ---
 
-This directive is a helper when dealing with [QMenu](/vue-components/menu) component. When attached to a DOM element or component then that component will close the Dialog when clicked/tapped.
+This directive is a helper when dealing with [QMenu](/vue-components/menu) component. When attached to a DOM element or component then that component will close the Menu when clicked/tapped.
 
 ## Installation
 <doc-installation directives="CloseMenu" />


### PR DESCRIPTION
fix typo due to copy/paste QCloseDialog directive page to QCloseMenu