### PR TITLE
[v1 docs] - Improves docs menu

### DIFF
--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -4,6 +4,25 @@ const gettingStarted = [
     path: 'pick-quasar-flavour'
   },
   {
+    name: 'Quasar Flavours',
+    opened: false,
+    openedPath: 'quasar-cli',
+    children: [
+      {
+        name: 'Quasar CLI',
+        path: 'quasar-cli'
+      },
+      {
+        name: 'UMD / Standalone',
+        path: 'umd'
+      },
+      {
+        name: 'Vue CLI Plugin',
+        path: 'vue-cli-plugin'
+      }
+    ]
+  },
+  {
     name: 'How to use Vue',
     path: 'how-to-use-vue'
   },
@@ -22,24 +41,6 @@ const gettingStarted = [
   {
     name: 'Contribution Guide',
     path: 'contribution-guide'
-  },
-  {
-    name: 'Quasar Flavours',
-    opened: true,
-    children: [
-      {
-        name: 'Quasar CLI',
-        path: 'quasar-cli'
-      },
-      {
-        name: 'UMD / Standalone',
-        path: 'umd'
-      },
-      {
-        name: 'Vue CLI Plugin',
-        path: 'vue-cli-plugin'
-      }
-    ]
   }
 ]
 
@@ -861,6 +862,12 @@ module.exports = [
     children: options
   },
   {
+    name: 'Quasar CLI',
+    icon: 'build',
+    path: 'quasar-cli',
+    children: cli
+  },
+  {
     name: 'Style & Identity',
     icon: 'style',
     path: 'style',
@@ -895,11 +902,5 @@ module.exports = [
     icon: 'healing',
     path: 'quasar-utils',
     children: utils
-  },
-  {
-    name: 'Quasar CLI',
-    icon: 'build',
-    path: 'quasar-cli',
-    children: cli
   }
 ]

--- a/docs/src/components/AppMenu.js
+++ b/docs/src/components/AppMenu.js
@@ -21,6 +21,7 @@ export default {
           'q-expansion-item',
           {
             staticClass: 'non-selectable',
+            class: `q-expansion-item--level${level}`,
             props: {
               label: menu.name,
               dense: level > 0,
@@ -36,7 +37,7 @@ export default {
             h,
             item,
             path + (item.path !== void 0 ? '/' + item.path : ''),
-            level > 0 ? level : level + 1
+            level + 1
           ))
         )
       }
@@ -45,16 +46,25 @@ export default {
         props: {
           to: path,
           dense: level > 0,
-          insetLevel: level
+          insetLevel: level <= 1 ? level : level - 1
         },
-        staticClass: 'app-menu-entry non-selectable'
+        staticClass: 'app-menu-entry non-selectable',
+        class: `q-item--level${level}`,
+        directives: [{
+          name: 'ripple'
+        }]
       }, [
         menu.icon !== void 0
           ? h('q-item-section', {
             props: { avatar: true }
           }, [ h('q-icon', { props: { name: menu.icon } }) ])
           : null,
-        h('q-item-section', [ menu.name ]),
+        level >= 2
+          ? h('div', { staticClass: 'spacer-div' })
+          : null,
+        h('q-item-section',
+          { class: `q-item-section--level${level}` },
+          [ menu.name ]),
         menu.badge !== void 0
           ? h('q-item-section', {
             props: { side: true }

--- a/docs/src/components/AppMenu.styl
+++ b/docs/src/components/AppMenu.styl
@@ -8,4 +8,36 @@
   .q-expansion-item--expanded > div > .q-item > .q-item__section--main
     color $primary
     font-weight 700
+  
+  .q-router-link--active
+    background-color $blue-1
+    pointer-events none !important
 
+  .q-expansion-item--level1 > div > .q-item > .q-item__section--main
+    padding-left 10px
+
+  .q-item-section--level1
+    padding-left 10px
+  
+  .q-item-section--level2
+    padding-left 10px
+
+  .q-item-section--level2 > div > .q-item > .q-item__section--main
+    padding-left 7px
+    border-left 3px solid $primary
+
+  .q-router-link--active .q-item-section--level1
+    padding-left 7px
+    border-left 3px solid $primary
+    
+
+  .q-router-link--active .q-item-section--level2
+    padding-left 7px
+    border-left 3px solid $primary
+  
+  .q-list--dense > .q-item, .q-item--dense
+    padding 6px 16px
+
+  .spacer-div
+    width 10px
+ 


### PR DESCRIPTION
1. CLI moved up to the top under "Quasar Options and Helpers" (as was mentioned would be better by a couple of users)
2. All levels are indented
3. The active menu item has a blue left border as an active link indicator and a light blue background
4. All menu items except the active one have a ripple effect

Scott

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
