### PR TITLE
fix(QInput): [v1] Float label overlaps with browsers autocomplete #3338

### DIFF
--- a/quasar/src/components/field/field.styl
+++ b/quasar/src/components/field/field.styl
@@ -120,7 +120,8 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     transform-origin left top
     transition transform $field-transition, color $field-transition
 
-  &--float .q-field__label,
+  &--float .q-field__label
+    transform translate3d(0, -50%, 0) scale3d(.75, .75, .75)
   .q-field__native:-webkit-autofill + .q-field__label
     transform translate3d(0, -50%, 0) scale3d(.75, .75, .75)
 


### PR DESCRIPTION
Browser specific selectors should be in separate rules