### PR TITLE
feat(docs): Added "related" to Flex and missing Mouse CSS definitions

### DIFF
--- a/docs/src/pages/layout/grid/introduction-to-flexbox.md
+++ b/docs/src/pages/layout/grid/introduction-to-flexbox.md
@@ -1,5 +1,8 @@
 ---
 title: Introduction to Flexbox
+related:
+  - /style/spacing
+  - /style/visibility
 ---
 
 Quasar provides lots of CSS classes to help you build your UI easily with the help of [Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Think of it like operating with rows and columns with many options at hand.

--- a/docs/src/pages/quasar-plugins/loading.md
+++ b/docs/src/pages/quasar-plugins/loading.md
@@ -6,6 +6,7 @@ related:
   - /vue-components/inner-loading
   - /vue-components/spinners
   - /quasar-plugins/loading-bar
+  - /vue-components/ajax-bar
 ---
 Loading is a feature that you can use to display an overlay with a spinner on top of your App's content to inform the user that a background operation is taking place. No need to add complex logic within your Pages for global background operations.
 

--- a/docs/src/pages/style/other-helper-classes.md
+++ b/docs/src/pages/style/other-helper-classes.md
@@ -15,6 +15,9 @@ The list below is not complete. Also check the other CSS documentation pages lik
 | `no-pointer-events` | DOM element does not become a target of mouse events - clicks, hover and so on |
 | `all-pointer-events` | The opposite of `no-pointer-events` |
 | `cursor-pointer` | Change mouse pointer on DOM element to look as if on a clickable link |
+| `cursor-not-allowed` | Change mouse pointer on DOM element to look as if action will not be carried out |
+| `cursor-inherit` | Change mouse pointer on DOM element to look as the same as parent option |
+| `cursor-none` | No mouse cursor is rendered |
 
 ## Size Related
 | Class Name | Description |

--- a/docs/src/pages/vue-components/ajax-bar.md
+++ b/docs/src/pages/vue-components/ajax-bar.md
@@ -1,6 +1,7 @@
 ---
 title: Ajax Bar
 related:
+  - /quasar-plugins/loading
   - /quasar-plugins/loading-bar
   - /quasar-cli/ajax-requests
 ---

--- a/quasar/src/components/dialog/QDialog.json
+++ b/quasar/src/components/dialog/QDialog.json
@@ -14,7 +14,7 @@
 
     "seamless": {
       "type": "Boolean",
-      "desc": "Put Dialog into seamless mode; Does not uses a backdrop so user is able to interact with the rest of the page too"
+      "desc": "Put Dialog into seamless mode; Does not use a backdrop so user is able to interact with the rest of the page too"
     },
 
     "maximized": {

--- a/quasar/src/plugins/AppVisibility.json
+++ b/quasar/src/plugins/AppVisibility.json
@@ -4,7 +4,7 @@
   "props": {
     "appVisible": {
       "type": "Boolean",
-      "desc": "Does the app has user focus? Or the app runs in the background / another tab has the user's attention",
+      "desc": "Does the app have user focus? Or the app runs in the background / another tab has the user's attention",
       "reactive": true
     }
   }

--- a/quasar/src/plugins/BottomSheet.json
+++ b/quasar/src/plugins/BottomSheet.json
@@ -66,7 +66,7 @@
             },
             "seamless": {
               "type": "Boolean",
-              "desc": "Put Bottom Sheet into seamless mode; Does not uses a backdrop so user is able to interact with the rest of the page too"
+              "desc": "Put Bottom Sheet into seamless mode; Does not use a backdrop so user is able to interact with the rest of the page too"
             },
             "persistent": {
               "type": "Boolean",


### PR DESCRIPTION
The related comes from legacy docs. I presume it was missed because "related" was not available when page was done.