### PR TITLE
[BUG] Fix __pad on QDateTimeMixin

### DIFF
--- a/quasar/dev/components/form/date.vue
+++ b/quasar/dev/components/form/date.vue
@@ -32,6 +32,9 @@
         Null/Undefined model
         <q-btn outline color="primary" size="sm" label="Reset" @click="nullDate = null" />
       </div>
+
+      <div>{{ nullDate }}</div>
+
       <div class="q-gutter-md column">
         <q-date
           v-model="nullDate"
@@ -51,6 +54,9 @@
       <div class="text-h6">
         Colored
       </div>
+
+      <div>{{ date }}</div>
+
       <div class="q-gutter-md column">
         <q-date
           v-model="date"
@@ -71,6 +77,9 @@
       <div class="text-h6">
         Events
       </div>
+
+      <div>{{ date }}</div>
+
       <div class="q-gutter-md column">
         <q-date
           v-model="date"
@@ -92,6 +101,9 @@
       <div class="text-h6">
         Limited options
       </div>
+
+      <div>{{ date }}</div>
+
       <div class="q-gutter-md column">
         <q-date
           v-model="date"

--- a/quasar/src/components/datetime/datetime-mixin.js
+++ b/quasar/src/components/datetime/datetime-mixin.js
@@ -41,7 +41,7 @@ export default {
 
   methods: {
     __pad (unit) {
-      return (unit < 10 ? '0' : '') + unit
+      return (unit < 10 && typeof unit === 'string' ? '0' : '') + unit
     },
 
     __padYear (unit) {

--- a/quasar/src/components/datetime/datetime-mixin.js
+++ b/quasar/src/components/datetime/datetime-mixin.js
@@ -42,7 +42,7 @@ export default {
   methods: {
     __pad (unit) {
       if (unit < 10) {
-        return (unit.includes('0') ? '' : '0') + unit
+        return (typeof unit === 'string' && unit.startsWith('0') ? '' : '0') + unit
       }
       return unit
     },

--- a/quasar/src/components/datetime/datetime-mixin.js
+++ b/quasar/src/components/datetime/datetime-mixin.js
@@ -41,7 +41,10 @@ export default {
 
   methods: {
     __pad (unit) {
-      return (unit < 10 && typeof unit === 'string' ? '0' : '') + unit
+      if (unit < 10) {
+        return (unit.includes('0') ? '' : '0') + unit
+      }
+      return unit
     },
 
     __padYear (unit) {


### PR DESCRIPTION
The __pad function on QDateTimeMixin was bugged and when the user pass a defaultYearMonth with leading zero, it will emit the month with two zeroes.

Example -> https://jsfiddle.net/ymqwja27/

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
