### PR TITLE
Ensure QDate with default-year-month initializes correctly when inside QInput type="text" 

### DIFF
--- a/quasar/src/components/datetime/QDate.js
+++ b/quasar/src/components/datetime/QDate.js
@@ -622,7 +622,7 @@ export default Vue.extend({
         date.year = this.innerModel.year
       }
       if (date.month === void 0) {
-        date.month = this.innerModel.month
+        date.month = parseInt(this.innerModel.month)
       }
       if (date.day === void 0) {
         date.day = Math.min(this.innerModel.day, this.daysInMonth)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When QDate contains a default-year-month property and is inside a QInput type="text", the initial selection will default to December due to innerModel.month being a two digit string which is padded additionally when __updateValue is called, resulting in a value such as '001' (for January).

The only change is a parsing of the innerModel.month value when creating the date.month object which is then padded, converted to a date string and emitted. Perhaps the parsing can be moved inside of an if statement which checks whether or not the value is a string instead of parsing all values by default.