### PR TITLE
fix(quasar): Guard QDate's __pad functions for strings

### DIFF
--- a/quasar/src/components/datetime/datetime-mixin.js
+++ b/quasar/src/components/datetime/datetime-mixin.js
@@ -40,11 +40,13 @@ export default {
   },
 
   methods: {
-    __pad (unit) {
+    __pad (text) {
+      const unit = parseInt(text, 10)
       return (unit < 10 ? '0' : '') + unit
     },
 
-    __padYear (unit) {
+    __padYear (text) {
+      const unit = parseInt(text, 10)
       if (unit < 0 || unit > 9999) {
         return '' + unit
       }


### PR DESCRIPTION
close #3348
