### PR TITLE
fix(json-api): Fixes issue with recursive mixins

### DIFF
--- a/quasar/build/build.api.js
+++ b/quasar/build/build.api.js
@@ -27,12 +27,10 @@ function getMixedInAPI (api, mainFile) {
 
     const content = require(mixinFile)
 
-    api = merge(
-      content.mixins !== void 0
-        ? getMixedInAPI(content, mixinFile)
-        : content,
-      api
-    )
+    api = merge(content, api)
+    if (content.mixins !== void 0) {
+      api = merge(getMixedInAPI(content, mixinFile), api)
+    }
   })
 
   const { mixins, ...finalApi } = api


### PR DESCRIPTION
When a mixin references another mixin, then the first mixin is not added to the json api. Only the last mixin makes it in.