### PR TITLE
fix(docs): Fixing markdown tables to fit content

### DIFF
--- a/docs/build/md-plugin-table.js
+++ b/docs/build/md-plugin-table.js
@@ -8,6 +8,7 @@ module.exports = function (md) {
 
     token.tag = 'q-markup-table'
     token.attrSet(':wrap-cells', 'true')
+    token.attrSet('style', 'width: fit-content; max-width: 100%;')
 
     return self.renderToken(tokens, idx, options)
   }


### PR DESCRIPTION
Default width of 100% makes tables with 2 columns look horrible. A better compomise if to use "width: fit-content" so the table is only as wide as the data. "max-width: 100%" is used to keep current width should data make the rows greater than 100%. This is especially needed for the "Upgrade guide".