### PR TITLE
fix(@quasar/app): Stop overlay affecting visibility state #3381

### DIFF
--- a/quasar/src/components/layout/QDrawer.js
+++ b/quasar/src/components/layout/QDrawer.js
@@ -65,7 +65,7 @@ export default Vue.extend({
       largeScreenState = this.showIfAbove || (
         this.value !== void 0 ? this.value : true
       ),
-      showing = this.behavior !== 'mobile' && this.breakpoint < this.layout.width && !this.overlay
+      showing = this.behavior !== 'mobile' && this.breakpoint < this.layout.width
         ? largeScreenState
         : false
 
@@ -91,13 +91,11 @@ export default Vue.extend({
       }
 
       if (val) { // from lg to xs
-        if (!this.overlay) {
-          this.largeScreenState = this.showing
-        }
+        this.largeScreenState = this.showing
         // ensure we close it for small screen
         this.hide(false)
       }
-      else if (!this.overlay) { // from xs to lg
+      else { // from xs to lg
         this[this.largeScreenState ? 'show' : 'hide'](false)
       }
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

fix #3381 

I considered changing the docs to note this change but I figured it's such an edge case that it'd be self explanatory. If you set `overlay` on the drawer, it's going to overlay as the name implies.

Also worth noting I was considering not adding the PR for this as it now causes the mini drawer to overlap the content if the initial value is `true` but at least this way, it's up to the developer. It's not imposed on them that setting `overlay` means the drawer is hidden by default.

I've tested this vs old functionality and can't see any unintended side effects.