### PR TITLE
[Feature] Added defaultView prop to QDate

### DIFF
--- a/docs/src/examples/QDate/DefaultView.vue
+++ b/docs/src/examples/QDate/DefaultView.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="q-pa-md">
+    <q-date
+      v-model="date"
+      default-view="Years"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      date: null
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -34,6 +34,10 @@ QDate requires a default year + month when model is unfilled (like `null`, `void
 
 <doc-example title="Default year month" file="QDate/DefaultYearMonth" />
 
+The default view can be changed.
+
+<doc-example title="Default view" file="QDate/DefaultView" />
+
 The first day of the week is applied depending on the [Quasar Language Pack](/options/quasar-language-packs) that you've set, but you can also force it, like in the example below.
 
 <doc-example title="First day of week" file="QDate/FirstDayOfWeek" />

--- a/quasar/dev/components/form/date.vue
+++ b/quasar/dev/components/form/date.vue
@@ -116,6 +116,25 @@
       </div>
 
       <div class="text-h6">
+        Default view
+      </div>
+      <div class="q-gutter-md column">
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          default-view="Years"
+        />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          default-view="Months"
+        />
+      </div>
+
+      <div class="text-h6">
         Negative years: {{ dateNeg }}
       </div>
       <div class="q-gutter-md column">

--- a/quasar/src/components/datetime/QDate.js
+++ b/quasar/src/components/datetime/QDate.js
@@ -26,12 +26,17 @@ export default Vue.extend({
 
     firstDayOfWeek: [String, Number],
     todayBtn: Boolean,
-    minimal: Boolean
+    minimal: Boolean,
+    defaultView: {
+      type: String,
+      default: 'Calendar',
+      validator: v => ['Calendar', 'Years', 'Months'].indexOf(v) !== -1
+    }
   },
 
   data () {
     return {
-      view: 'Calendar',
+      view: this.defaultView,
       monthDirection: 'left',
       yearDirection: 'left',
       innerModel: this.__getInnerModel(this.value)

--- a/quasar/src/components/datetime/QDate.js
+++ b/quasar/src/components/datetime/QDate.js
@@ -30,7 +30,7 @@ export default Vue.extend({
     defaultView: {
       type: String,
       default: 'Calendar',
-      validator: v => ['Calendar', 'Years', 'Months'].indexOf(v) !== -1
+      validator: v => ['Calendar', 'Years', 'Months'].includes(v)
     }
   },
 

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -24,12 +24,9 @@
 
     "default-view": {
       "type": "String",
-      "desc": "The view which will be opened by default",
+      "desc": "The view which will be displayed by default",
       "default": "Calendar",
-      "examples": [
-        "default-view=\"Years\"",
-        "default-view=\"Months\""
-      ]
+      "values": [ "Calendar", "Months", "Years" ]
     },
 
     "events": {

--- a/quasar/src/components/datetime/QDate.json
+++ b/quasar/src/components/datetime/QDate.json
@@ -22,6 +22,16 @@
       ]
     },
 
+    "default-view": {
+      "type": "String",
+      "desc": "The view which will be opened by default",
+      "default": "Calendar",
+      "examples": [
+        "default-view=\"Years\"",
+        "default-view=\"Months\""
+      ]
+    },
+
     "events": {
       "type": [ "Array", "Function" ],
       "desc": "A list of events to highlight on the calendar; If using a function, it receives the date as a String and must return a Boolean (matches or not)",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

Similar to the prop that was available in v0.17. When selecting a birth date it is easy to forget to change the year after selecting a day and month. For that reason, it is better to start with selecting the year.

I could not get the docs to run locally so I was not able to check them (exports is read-only error...). But the functionality in npm run dev works fine.
