### PR TITLE
#3394 | Fix for icon only mini mode edge case

### DIFF
--- a/quasar/src/components/layout/layout.styl
+++ b/quasar/src/components/layout/layout.styl
@@ -97,7 +97,7 @@ $layout-transition = all .12s ease-in
       padding-left 0
       padding-right 0
       min-width 0
-    .q-item__label, .q-item__section--main, .q-item__section--side:last-child
+    .q-item__label, .q-item__section--main, .q-item__section--side:nth-child(n+3)
       display none
   &--mini
     .q-mini-drawer-hide, .q-expansion-item__content

--- a/quasar/src/components/layout/layout.styl
+++ b/quasar/src/components/layout/layout.styl
@@ -97,7 +97,7 @@ $layout-transition = all .12s ease-in
       padding-left 0
       padding-right 0
       min-width 0
-    .q-item__label, .q-item__section--main, .q-item__section--side:nth-child(n+3)
+    .q-item__label, .q-item__section--main, .q-item__section--side ~ .q-item__section--side
       display none
   &--mini
     .q-mini-drawer-hide, .q-expansion-item__content


### PR DESCRIPTION
The nth-child(n+3) will hide everything from the 3rd element on so you still get the focus helper element and the very first <q-section> but the next element and all following elements will be hidden on mini mode

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
