### PR TITLE
Fix: #3478 Toggling hidden QDialog 'maximized' property locks scroll

### DIFF
--- a/quasar/src/components/dialog/QDialog.js
+++ b/quasar/src/components/dialog/QDialog.js
@@ -88,12 +88,14 @@ export default Vue.extend({
     },
 
     maximized (newV, oldV) {
-      this.__updateState(false, oldV)
-      if (this.value) this.__updateState(true, newV)
+      if (this.showing === true) {
+        this.__updateState(false, oldV)
+        this.__updateState(true, newV)
+      }
     },
 
     seamless (v) {
-      this.showing && this.__preventScroll(!v)
+      this.showing === true && this.__preventScroll(!v)
     }
   },
 

--- a/quasar/src/components/dialog/QDialog.js
+++ b/quasar/src/components/dialog/QDialog.js
@@ -89,7 +89,7 @@ export default Vue.extend({
 
     maximized (newV, oldV) {
       this.__updateState(false, oldV)
-      this.__updateState(true, newV)
+      if (this.value) this.__updateState(true, newV)
     },
 
     seamless (v) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Scroll lock now only applies when QDialog is visible so that `maximized` can be toggled in background depending on layout or screen size.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

#3478 [codepen](https://codepen.io/anon/pen/YgGMqe?editors=1010#0)