### PR TITLE
fix(quasar): Trigger lazy validation rules on QSelect and controls without input

### DIFF
--- a/quasar/dev/components/form/input-validate.vue
+++ b/quasar/dev/components/form/input-validate.vue
@@ -54,6 +54,76 @@
         lazy-rules
       />
 
+      <q-select
+        v-bind="{[type]: true}"
+        v-model="stringSingle"
+        :options="stringOptions"
+        label="Single - Required, Lazy"
+        :rules="[
+          val => !!val || '* Required',
+        ]"
+        lazy-rules
+      />
+
+      <q-select
+        v-bind="{[type]: true}"
+        v-model="stringSingle"
+        :options="stringOptions"
+        use-input
+        label="Single - use-input - Required, Lazy"
+        :rules="[
+          val => !!val || '* Required',
+        ]"
+        lazy-rules
+      />
+
+      <q-field
+        class="q-textarea"
+        v-bind="{[type]: true}"
+        label="Slider - >= 10, Lazy"
+        :value="num"
+        :rules="[
+          val => val >= 10 || 'Select at least 10',
+        ]"
+        lazy-rules
+      >
+        <div class="q-field__native row items-center">
+          <q-slider
+            class="q-mt-xl"
+            v-model="num"
+            :min="0"
+            :max="50"
+            label-always
+          />
+        </div>
+      </q-field>
+
+      <q-field
+        class="q-textarea"
+        v-bind="{[type]: true}"
+        label="Knob - >= 10, Lazy"
+        :value="num"
+        :rules="[
+          val => val >= 10 || 'Select at least 10',
+        ]"
+        lazy-rules
+      >
+        <div class="q-field__native row items-center">
+          <q-knob
+            class="q-mt-md"
+            v-model="num"
+            color="black"
+            center-color="grey-8"
+            size="150px"
+            show-value
+            :min="0"
+            :max="50"
+          >
+            {{ num }}
+          </q-knob>
+        </div>
+      </q-field>
+
       <q-input
         ref="input3"
         v-bind="{[type]: true}"
@@ -223,7 +293,12 @@ export default {
       type: 'filled',
       modelExternal: '',
       error: false,
-      errorMessage: 'First error'
+      errorMessage: 'First error',
+      stringSingle: null,
+      stringOptions: [
+        'Google', 'Facebook', 'Twitter', 'Apple', 'Oracle'
+      ],
+      num: 0
     }
 
     for (let i = 1; i <= n; i++) {

--- a/quasar/src/components/input/QInput.js
+++ b/quasar/src/components/input/QInput.js
@@ -127,12 +127,14 @@ export default Vue.extend({
     __onFocus (e) {
       if (this.editable === true && this.focused === false) {
         this.focused = true
+        this.$listeners.focus !== void 0 && this.$emit('focus', e)
       }
     },
 
     __onBlur (e) {
       if (this.focused === true) {
         this.focused = false
+        this.$listeners.blur !== void 0 && this.$emit('blur', e)
       }
     },
 

--- a/quasar/src/components/input/QInput.js
+++ b/quasar/src/components/input/QInput.js
@@ -127,14 +127,12 @@ export default Vue.extend({
     __onFocus (e) {
       if (this.editable === true && this.focused === false) {
         this.focused = true
-        this.$emit('focus', e)
       }
     },
 
     __onBlur (e) {
       if (this.focused === true) {
         this.focused = false
-        this.$emit('blur', e)
       }
     },
 

--- a/quasar/src/mixins/validate.js
+++ b/quasar/src/mixins/validate.js
@@ -2,6 +2,8 @@ import { testPattern } from '../utils/patterns.js'
 
 export default {
   props: {
+    value: {},
+
     error: Boolean,
     errorMessage: String,
 
@@ -44,11 +46,11 @@ export default {
 
   mounted () {
     this.validateIndex = 0
-    this.$on('blur', this.__triggerValidation)
+    this.$el.addEventListener('focusout', this.__triggerValidation)
   },
 
   beforeDestroy () {
-    this.$off('blur', this.__triggerValidation)
+    this.$el.removeEventListener('focusout', this.__triggerValidation)
   },
 
   methods: {


### PR DESCRIPTION
close #3510

- remove redundant blur emit from QInput
- allow field to validate value standalone