### PR TITLE
suggestion on history.js

### DIFF
--- a/quasar/src/history.js
+++ b/quasar/src/history.js
@@ -24,6 +24,10 @@ export default {
 
     document.addEventListener('deviceready', () => {
       document.addEventListener('backbutton', () => {
+        if($q.customBackButtonAction !== 'undefined' && $q.customBackButtonAction === true) {
+          $q.customBackButtonAction = false
+          return
+        }
         if (this.__history.length) {
           this.__history.pop().handler()
         }


### PR DESCRIPTION
Sometime, in some condition is very very useful ignore default backbutton behavior.
So, when I use a backbutton listener in my app code I must be able to stop default back button behavior.
In my custom listener I could simple use this.$q.customBackButtonAction = true

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ X ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
