### PR TITLE
[Docs] Add `glossy` examples and mentions to Toolbar + Header/Footer pages

### DIFF
--- a/docs/src/examples/QHeader/Glossy.vue
+++ b/docs/src/examples/QHeader/Glossy.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="q-pa-md">
+    <q-layout view="lHh lpr lFf" container style="height: 400px" class="shadow-2 rounded-borders">
+      <q-header elevated>
+        <q-toolbar class="glossy">
+          <q-btn flat round dense icon="menu" class="q-mr-sm" />
+          <q-avatar>
+            <img src="https://cdn.quasar-framework.org/img/quasar-logo.png">
+          </q-avatar>
+
+          <q-toolbar-title>Quasar Framework</q-toolbar-title>
+
+          <q-btn flat round dense icon="whatshot" />
+        </q-toolbar>
+      </q-header>
+
+      <q-footer elevated>
+        <q-toolbar class="glossy">
+          <q-toolbar-title>Footer</q-toolbar-title>
+        </q-toolbar>
+      </q-footer>
+
+      <q-page-container>
+        <q-page class="q-pa-md">
+          <p v-for="n in 15" :key="n">
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugit nihil praesentium molestias a adipisci,
+            dolore vitae odit, quidem consequatur optio voluptates asperiores pariatur eos numquam rerum delectus
+            commodi perferendis voluptate?
+          </p>
+        </q-page>
+      </q-page-container>
+    </q-layout>
+  </div>
+</template>

--- a/docs/src/examples/QToolbar/Glossy.vue
+++ b/docs/src/examples/QToolbar/Glossy.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="q-pa-md">
+    <q-toolbar class="bg-primary glossy text-white">
+      <q-btn flat round dense icon="menu" class="q-mr-sm" />
+      <q-avatar>
+        <img src="https://cdn.quasar-framework.org/img/quasar-logo.png">
+      </q-avatar>
+
+      <q-toolbar-title>Quasar Framework</q-toolbar-title>
+
+      <q-btn flat round dense icon="whatshot" />
+    </q-toolbar>
+  </div>
+</template>

--- a/docs/src/pages/layout/header-and-footer.md
+++ b/docs/src/pages/layout/header-and-footer.md
@@ -28,6 +28,10 @@ Since the header and footer needs a layout and QLayout by default manages the en
 
 <doc-example title="Basic" file="QHeader/Basic" />
 
+You can use `glossy` class on toolbars in header and footer.
+
+<doc-example title="Glossy" file="QHeader/Glossy" />
+
 ### Various content
 
 <doc-example title="Playing with QToolbar" file="QHeader/Extended" />

--- a/docs/src/pages/vue-components/toolbar.md
+++ b/docs/src/pages/vue-components/toolbar.md
@@ -19,6 +19,10 @@ QToolbar is a component usually part of Layout Header and Footer, but it can be 
 
 <doc-example title="With Avatar" file="QToolbar/Avatar" />
 
+You can use the `glossy` class to make the toolbar glossy.
+
+<doc-example title="Glossy" file="QToolbar/Glossy" />
+
 <doc-example title="Grouped vertically" file="QToolbar/GroupedVertically" />
 
 <doc-example title="Grouped horizontally" file="QToolbar/GroupedHorizontally" />


### PR DESCRIPTION
fix for `glossy` not showing up anything in search.

Glossy stuff is not so significant on itself, but since it was explicit feature in 0.* versions, people might be looking for it, so I added examples for toolbar and header/footer page (Just copied basic examples and added glossy class).