### PR TITLE
Scroll to the position shown in the buttons before reassigning the position

### DIFF
--- a/docs/src/examples/QScrollArea/ScrollPosition.vue
+++ b/docs/src/examples/QScrollArea/ScrollPosition.vue
@@ -22,13 +22,13 @@ export default {
   }),
   methods: {
     scroll () {
-      this.position = Math.floor(Math.random() * 1001) * 20
       this.$refs.scrollArea.setScrollPosition(this.position)
+      this.position = Math.floor(Math.random() * 1001) * 20
     },
 
     animateScroll () {
-      this.position = Math.floor(Math.random() * 1001) * 20
       this.$refs.scrollArea.setScrollPosition(this.position, 300)
+      this.position = Math.floor(Math.random() * 1001) * 20
     }
   }
 }


### PR DESCRIPTION
At the moment, the "Scroll to ${position}px" and "Animate to ${position}px" buttons don't actually scroll or animate to that position, but rather assign a new random number to the position and then scroll or animate to that new position.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

n/a