### PR TITLE
fix(quasar): Only register portalParentId for QMenu

### DIFF
--- a/quasar/dev/components/components/menu.vue
+++ b/quasar/dev/components/components/menu.vue
@@ -71,6 +71,21 @@
             This Popover content won't be shown because of "disable"
           </q-menu>
         </q-btn>
+
+        <q-btn @click="dialog = true" label="Dialog" />
+        <q-dialog v-model="dialog">
+          <q-card class="q-pa-xl">
+            <q-btn label="Menu" color="primary">
+              <q-menu>
+                <q-list>
+                  <q-item v-for="n in 5" :key="n" v-close-menu clickable>
+                    <q-item-section>Menu Item {{ n }}</q-item-section>
+                  </q-item>
+                </q-list>
+              </q-menu>
+            </q-btn>
+          </q-card>
+        </q-dialog>
       </div>
 
       <div class="q-gutter-md q-my-md">
@@ -434,7 +449,9 @@ export default {
       vIfTest: true,
       touchPosition: true,
       contextMenu: true,
-      targetEl: '#target-img-1'
+      targetEl: '#target-img-1',
+
+      dialog: false
     }
   },
   computed: {

--- a/quasar/src/components/menu/QMenu.js
+++ b/quasar/src/components/menu/QMenu.js
@@ -220,6 +220,10 @@ export default Vue.extend({
           }] : null
         }, slot(this, 'default')) : null
       ])
+    },
+
+    __registerParentPortalId (vm, id) {
+      vm.menuPortalParentId = id
     }
   }
 })

--- a/quasar/src/components/menu/menu-tree.js
+++ b/quasar/src/components/menu/menu-tree.js
@@ -34,17 +34,17 @@ export const MenuTreeMixin = {
     __registerTree () {
       tree[this.portalId] = true
 
-      if (this.$root.portalParentId === void 0) {
+      if (this.$root.menuPortalParentId === void 0) {
         rootHide[this.portalId] = this.hide
         return
       }
 
-      if (tree[this.$root.portalParentId] !== true) {
-        bus.$emit('hide', tree[this.$root.portalParentId])
+      if (tree[this.$root.menuPortalParentId] !== true) {
+        bus.$emit('hide', tree[this.$root.menuPortalParentId])
       }
 
       bus.$on('hide', this.__processEvent)
-      tree[this.$root.portalParentId] = this.portalId
+      tree[this.$root.menuPortalParentId] = this.portalId
     },
 
     __unregisterTree () {
@@ -55,7 +55,7 @@ export const MenuTreeMixin = {
 
       delete rootHide[this.portalId]
 
-      if (this.$root.portalParentId !== void 0) {
+      if (this.$root.menuPortalParentId !== void 0) {
         bus.$off('hide', this.__processEvent)
       }
 

--- a/quasar/src/directives/CloseMenu.js
+++ b/quasar/src/directives/CloseMenu.js
@@ -8,7 +8,7 @@ export default {
       enabled: value !== false,
 
       handler: () => {
-        ctx.enabled !== false && closeRootMenu(vnode.componentInstance.$root.portalParentId)
+        ctx.enabled !== false && closeRootMenu(vnode.componentInstance.$root.menuPortalParentId)
       },
 
       handlerKey: ev => {

--- a/quasar/src/mixins/portal.js
+++ b/quasar/src/mixins/portal.js
@@ -50,7 +50,9 @@ export default {
   },
 
   beforeMount () {
-    const id = this.portalId
+    const
+      id = this.portalId,
+      registerPortalParentId = this.__registerParentPortalId
 
     if (inject === void 0) {
       fillInject(this.$root.$options)
@@ -65,7 +67,7 @@ export default {
       directives: this.$options.directives,
 
       created () {
-        this.portalParentId = id
+        registerPortalParentId !== void 0 && registerPortalParentId(this, id)
       },
 
       methods: {


### PR DESCRIPTION
can be later extended to register other roots
close #3520