### PR TITLE
fix(quasar): QDialog, QMenu and QPopupProxy fixes

### DIFF
--- a/quasar/dev/components/components/menu.vue
+++ b/quasar/dev/components/components/menu.vue
@@ -81,6 +81,22 @@
                   <q-item v-for="n in 5" :key="n" v-close-menu clickable>
                     <q-item-section>Menu Item {{ n }}</q-item-section>
                   </q-item>
+                  <q-item clickable>
+                    <q-item-section>Submenu Label</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu anchor="top right" self="top left">
+                      <q-list>
+                        <q-item v-for="n in 5" :key="n" v-close-menu clickable>
+                          <q-item-section>Menu Item {{ n }}</q-item-section>
+                        </q-item>
+                        <q-item clickable v-close-dialog>
+                          <q-item-section>Close dialog</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
                   <q-item clickable v-close-dialog>
                     <q-item-section>Close dialog</q-item-section>
                   </q-item>

--- a/quasar/dev/components/components/popup-proxy.vue
+++ b/quasar/dev/components/components/popup-proxy.vue
@@ -13,7 +13,9 @@
             <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
 
             <input v-model="text">
-            You have lost connection to the internet. This app is offline.
+            <div>Popup text.</div>
+
+            <q-btn slot="action" flat color="primary" label="close" v-close-dialog />
           </q-banner>
         </q-popup-proxy>
       </div>
@@ -26,9 +28,74 @@
             <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
 
             <input v-model="text">
-            You have lost connection to the internet. This app is offline.
+            <div>Popup text.</div>
+
+            <q-btn slot="action" flat color="primary" label="close" v-close-dialog />
           </q-banner>
         </q-popup-proxy>
+      </div>
+
+      <div class="q-mt-xl">
+        <q-btn @click="dialog = true" label="Dialog" />
+        <q-dialog v-model="dialog">
+          <q-card class="q-pa-xl">
+            <q-btn label="Popup proxy" color="primary" class="q-ma-md">
+              <q-popup-proxy>
+                <q-banner>
+                  <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
+
+                  <input v-model="text">
+                  <div>Popup text.</div>
+
+                  <q-btn slot="action" flat color="primary" label="Close popup" v-close-dialog />
+                </q-banner>
+              </q-popup-proxy>
+            </q-btn>
+            <q-btn label="Menu" color="primary" class="q-ma-md">
+              <q-menu>
+                <q-list>
+                  <q-item clickable>
+                    <q-item-section>
+                      Popup proxy
+                      <q-popup-proxy>
+                        <q-banner>
+                          <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
+
+                          <input v-model="text">
+                          <div>Popup text.</div>
+
+                          <q-btn slot="action" flat color="primary" label="Close popup" v-close-dialog />
+                        </q-banner>
+                      </q-popup-proxy>
+                    </q-item-section>
+                  </q-item>
+                  <q-item v-for="n in 5" :key="n" v-close-menu clickable>
+                    <q-item-section>Menu Item {{ n }}</q-item-section>
+                  </q-item>
+                  <q-item clickable>
+                    <q-item-section>Submenu Label</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu anchor="top right" self="top left">
+                      <q-list>
+                        <q-item v-for="n in 5" :key="n" v-close-menu clickable>
+                          <q-item-section>Menu Item {{ n }}</q-item-section>
+                        </q-item>
+                        <q-item clickable v-close-dialog>
+                          <q-item-section>Close dialog</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
+                  <q-item clickable v-close-dialog>
+                    <q-item-section>Close dialog</q-item-section>
+                  </q-item>
+                </q-list>
+              </q-menu>
+            </q-btn>
+          </q-card>
+        </q-dialog>
       </div>
 
       <div class="q-mt-xl">
@@ -80,7 +147,8 @@ export default {
       type: this.$q.screen.width < 600 ? 'dialog' : 'menu',
       input: '',
       date: '2018/11/03',
-      model: false
+      model: false,
+      dialog: false
     }
   },
 

--- a/quasar/src/components/dialog/QDialog.js
+++ b/quasar/src/components/dialog/QDialog.js
@@ -153,6 +153,10 @@ export default Vue.extend({
           }
         }
       })
+      this.__cleanupEscape = () => {
+        this.__cleanupEscape = void 0
+        EscapeKey.pop()
+      }
 
       this.__showPortal()
 
@@ -190,7 +194,7 @@ export default Vue.extend({
       clearTimeout(this.timer)
       clearTimeout(this.shakeTimeout)
 
-      EscapeKey.pop()
+      this.__cleanupEscape !== void 0 && this.__cleanupEscape()
 
       if (hiding === true || this.showing === true) {
         this.__updateState(false, this.maximized)

--- a/quasar/src/components/menu/ClickOutside.js
+++ b/quasar/src/components/menu/ClickOutside.js
@@ -29,6 +29,9 @@ export default {
             if (parent.classList.contains('q-menu')) {
               return
             }
+            if (parent.classList.contains('q-dialog') && parent.previousSibling === el) {
+              return
+            }
           }
         }
 

--- a/quasar/src/components/menu/QMenu.js
+++ b/quasar/src/components/menu/QMenu.js
@@ -106,6 +106,10 @@ export default Vue.extend({
         this.$emit('escape-key')
         this.hide()
       })
+      this.__cleanupEscape = () => {
+        this.__cleanupEscape = void 0
+        EscapeKey.pop()
+      }
 
       this.__showPortal()
       this.__registerTree()
@@ -148,7 +152,7 @@ export default Vue.extend({
       clearTimeout(this.timer)
       this.absoluteOffset = void 0
 
-      EscapeKey.pop()
+      this.__cleanupEscape !== void 0 && this.__cleanupEscape()
       this.__unregisterTree()
 
       if (this.unwatch !== void 0) {
@@ -222,8 +226,17 @@ export default Vue.extend({
       ])
     },
 
-    __registerParentPortalId (vm, id) {
+    __registerPortalParent (vm, id) {
+      const root = this.$root
+
       vm.menuPortalParentId = id
+
+      if (this.noParentEvent === true) {
+        vm.menuPortalParentDialog = vm
+      }
+      else {
+        vm.menuPortalParentDialog = root.menuPortalParentId === void 0 && root.__qPortalClose !== void 0 ? root : root.menuPortalParentDialog
+      }
     }
   }
 })

--- a/quasar/src/components/menu/menu.styl
+++ b/quasar/src/components/menu/menu.styl
@@ -6,14 +6,15 @@
   overflow-x hidden
   outline 0
   max-height 65vh
-  z-index $z-menu
 
 .q-menu
+  z-index $z-fullscreen
   position fixed !important
   display inline-block
   max-width $menu-max-width
 
 .q-local-menu
+  z-index $z-menu
   cursor default
   position absolute
   color initial

--- a/quasar/src/directives/CloseDialog.js
+++ b/quasar/src/directives/CloseDialog.js
@@ -6,10 +6,15 @@ export default {
       enabled: value !== false,
 
       handler: ev => {
-        const vm = vnode.componentInstance.$root
+        if (ctx.enabled !== false) {
+          const vm = vnode.componentInstance.$root
 
-        if (ctx.enabled !== false && vm.__qPortalClose !== void 0) {
-          vm.__qPortalClose(ev)
+          if (vm.menuPortalParentDialog !== void 0 && vm.menuPortalParentDialog.__qPortalClose !== void 0) {
+            vm.menuPortalParentDialog.__qPortalClose(ev)
+          }
+          else if (vm.__qPortalClose !== void 0) {
+            vm.__qPortalClose(ev)
+          }
         }
       },
 

--- a/quasar/src/mixins/portal.js
+++ b/quasar/src/mixins/portal.js
@@ -52,7 +52,7 @@ export default {
   beforeMount () {
     const
       id = this.portalId,
-      registerPortalParentId = this.__registerParentPortalId
+      registerPortalParent = this.__registerPortalParent
 
     if (inject === void 0) {
       fillInject(this.$root.$options)
@@ -67,7 +67,7 @@ export default {
       directives: this.$options.directives,
 
       created () {
-        registerPortalParentId !== void 0 && registerPortalParentId(this, id)
+        registerPortalParent !== void 0 && registerPortalParent(this, id)
       },
 
       methods: {


### PR DESCRIPTION
- fix EscapeKey.pop triggered multiple times
- make ClickOutside aware of dialogs opened from menu
- allow dialog to be visible above menu (respect order in dom)
- make VCloseDialog aware of QProxyPopup - it closes the popup

close #3589