### PR TITLE
fix(quasar): QTabs - clean previously registered buffer when current route has changed

### DIFF
--- a/quasar/dev/components/components/tabs.vue
+++ b/quasar/dev/components/components/tabs.vue
@@ -194,6 +194,26 @@
         <q-route-tab name="tabs/c" to="/components/tabs/c" exact label="/tabs/c" />
       </q-tabs>
 
+      <div class="row q-gutter-xs justify-stretch">
+        <div class="col-12 col-sm-6 col-md">
+          <q-btn class="fit" size="sm" color="secondary" :to="{ name: 'ta', params: { id: 1 }}" replace label="t/1/a" />
+        </div>
+        <div class="col-12 col-sm-6 col-md">
+          <q-btn class="fit" size="sm" color="secondary" :to="{ name: 'tb', params: { id: 1 }}" replace label="t/1/b" />
+        </div>
+        <div class="col-12 col-sm-6 col-md">
+          <q-btn class="fit" size="sm" color="secondary" :to="{ name: 'ta', params: { id: 2 }}" replace label="t/2/a" />
+        </div>
+        <div class="col-12 col-sm-6 col-md">
+          <q-btn class="fit" size="sm" color="secondary" :to="{ name: 'tb', params: { id: 2 }}" replace label="t/2/b" />
+        </div>
+      </div>
+      <q-tabs :dense="dense" class="test q-mt-sm">
+        <q-route-tab to="/components/tabs/t" exact label="t" />
+        <q-route-tab v-if="$route.params.id" :to="{ name: 'ta', params: $route.params }" exact :label="`t/${ $route.params.id }/a`" />
+        <q-route-tab v-if="$route.params.id" :to="{ name: 'tb', params: $route.params }" exact :label="`t/${ $route.params.id }/b`" />
+      </q-tabs>
+
       <h4>Tabs content (animated, swipeable)</h4>
       <q-option-group
         type="radio"

--- a/quasar/dev/router.js
+++ b/quasar/dev/router.js
@@ -44,7 +44,14 @@ let routes = [
       { path: 'a/b' },
       { path: 'b' },
       { path: 'b/a' },
-      { path: 'c' }
+      { path: 'c' },
+      {
+        path: 't',
+        children: [
+          { path: ':id/a', name: 'ta' },
+          { path: ':id/b', name: 'tb' }
+        ]
+      }
     ]
   },
   {

--- a/quasar/src/components/tabs/QTabs.js
+++ b/quasar/src/components/tabs/QTabs.js
@@ -127,6 +127,12 @@ export default Vue.extend({
     },
 
     __activateRoute (params) {
+      if (this.bufferRoute !== this.$route && this.buffer.length > 0) {
+        clearTimeout(this.bufferTimer)
+        this.buffer.length = 0
+      }
+      this.bufferRoute = this.$route
+
       const
         { name, selectable, exact, selected, priority } = params,
         first = !this.buffer.length,


### PR DESCRIPTION
- prevents the selection of previously active tabs when the current route changes very fast