### PR TITLE
When electron open links using the default browser 

### DIFF
--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -13,7 +13,7 @@ import { openURL } from 'quasar'
 openURL('http://...')
 ```
 
-It will take care of the quirks involved when running under Cordova or on a browser, including notifying the user he/she has to acknowledge opening popups.
+It will take care of the quirks involved when running under Cordova or on a browser, including notifying the user he/she has to acknowledge opening popups. For electron, it will open links in the users default browser. 
 
 ::: tip
 If you want to open the telephone dialer in a Cordova app, don't use `openURL()`. Instead you should directly use `<a href="tel:123456789">` tags or `<QBtn type="a" href="tel:123456789">`

--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -13,7 +13,7 @@ import { openURL } from 'quasar'
 openURL('http://...')
 ```
 
-It will take care of the quirks involved when running under Cordova or on a browser, including notifying the user he/she has to acknowledge opening popups. For electron, it will open links in the users default browser. 
+It will take care of the quirks involved when running under Cordova, Electron or on a browser, including notifying the user he/she has to acknowledge opening popups. 
 
 ::: tip
 If you want to open the telephone dialer in a Cordova app, don't use `openURL()`. Instead you should directly use `<a href="tel:123456789">` tags or `<QBtn type="a" href="tel:123456789">`

--- a/quasar/src/utils/open-url.js
+++ b/quasar/src/utils/open-url.js
@@ -14,7 +14,7 @@ export default (url, reject) => {
       })
     }
   }
-  else if (Platform.is.electron === true) {
+  else if (Vue.prototype.$q.electron !== void 0) {
     return Vue.prototype.$q.electron.shell.openExternal(url)
   }
 

--- a/quasar/src/utils/open-url.js
+++ b/quasar/src/utils/open-url.js
@@ -1,4 +1,5 @@
 import Platform from '../plugins/Platform.js'
+import Vue from 'vue'
 
 export default (url, reject) => {
   let open = window.open
@@ -12,6 +13,9 @@ export default (url, reject) => {
         openExternal: true
       })
     }
+  }
+  else if (Platform.is.electron === true) {
+    return Vue.prototype.$q.electron.shell.openExternal(url)
   }
 
   let win = open(url, '_blank')


### PR DESCRIPTION
Previously it would open in another electron session which isn't what a user would expect.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I've assumed it's safe to use `Vue.prototype.$q.electron` without any further checks as I believe this is always available when `Platform.is.electron === true`.