### PR TITLE
Update quasar-config.js

### DIFF
--- a/app/lib/quasar-config.js
+++ b/app/lib/quasar-config.js
@@ -610,11 +610,13 @@ class QuasarConfig {
     }
 
     if (this.ctx.dev) {
-      const host = cfg.devServer.host === '0.0.0.0'
-        ? 'localhost'
-        : cfg.devServer.host
-      const urlPath = `${cfg.build.vueRouterMode === 'hash' ? (cfg.build.htmlFilename !== 'index.html' ? cfg.build.htmlFilename : '') : ''}`
-      cfg.build.APP_URL = `http${cfg.devServer.https ? 's' : ''}://${host}:${cfg.devServer.port}/${urlPath}`
+      if (!cfg.build.APP_URL) {
+        const host = cfg.devServer.host === '0.0.0.0'
+          ? 'localhost'
+          : cfg.devServer.host
+        const urlPath = `${cfg.build.vueRouterMode === 'hash' ? (cfg.build.htmlFilename !== 'index.html' ? cfg.build.htmlFilename : '') : ''}`
+        cfg.build.APP_URL = `http${cfg.devServer.https ? 's' : ''}://${host}:${cfg.devServer.port}/${urlPath}`
+      }
     }
     else if (this.ctx.mode.cordova) {
       cfg.build.APP_URL = 'index.html'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

This allows setting *APP_URL* manually instead of relying on the script to figure it out for you. this is useful in local environments while testing features that require a valid SSL cert.

My use case is geolocation. As-is Cordova's geolocation won't work in Android because chrome will block the request saying the origin is not allowed. The only way around that is to serve over SSL and have a valid cert. I can fix that issue with ngrok but I need to inject the proper url.

In order to use this, just set *APP_URL* in your the `build` section of your `quasar.conf.js`

