### PR TITLE
fix(quasar): Don't use on-right on QBtn icon when label is not present

### DIFF
--- a/quasar/src/components/btn/QBtn.js
+++ b/quasar/src/components/btn/QBtn.js
@@ -120,7 +120,7 @@ export default Vue.extend({
     if (this.iconRight !== void 0 && this.isRound === false) {
       inner.push(
         h(QIcon, {
-          props: { name: this.iconRight, right: this.stack === false }
+          props: { name: this.iconRight, right: this.stack === false && this.hasLabel === true }
         })
       )
     }


### PR DESCRIPTION
ref #3683