### PR TITLE
fix(@quasar/app): quasar inspect: await compile()

### DIFF
--- a/app/bin/quasar-inspect
+++ b/app/bin/quasar-inspect
@@ -103,7 +103,7 @@ async function inspect () {
     process.exit(1)
   }
 
-  quasarConfig.compile()
+  await quasarConfig.compile()
 
   const util = require('util')
   let cfgEntries = getCfgEntries(quasarConfig.getWebpackConfig(), argv.mode)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**
https://github.com/quasarframework/quasar/commit/e4d7e5fda6390a2df02e0a6a0d704d8682a6acaf introduced async/await related changes that require the compilation to be awaited before logging the webpack config.

Related issue: https://github.com/quasarframework/quasar/issues/3704