### PR TITLE
fix(quasar): QSelect maxValues fix #3698

### DIFF
--- a/quasar/src/components/select/QSelect.js
+++ b/quasar/src/components/select/QSelect.js
@@ -260,6 +260,10 @@ export default Vue.extend({
       }
 
       const model = [].concat(this.value)
+      
+      if (this.maxValues !== void 0 && model.length >= this.maxValues) {
+        return
+      }
 
       this.$emit('add', { index: model.length, value: val })
       model.push(val)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**

As described in https://github.com/quasarframework/quasar/issues/3698, QSelect does not always work as intended. While it works with the multiselect as shown in the [docs](https://v1.quasar-framework.org/vue-components/select#Example--Multiple-selection%2C-counter-and-max-values), (there is a maxValues check in the [toggleOption()](https://github.com/quasarframework/quasar/blob/24871dfd55738b414130092ee979a9fe4f7200b6/quasar/src/components/select/QSelect.js#L312)), the same check does not happen when add() is used to update the model.