### PR TITLE
Button icon should now get padding when there is no label, if there is a slot

### DIFF
--- a/quasar/dev/components/components/button.vue
+++ b/quasar/dev/components/components/button.vue
@@ -338,6 +338,9 @@
       </div>
       <div class="q-gutter-sm">
         <q-btn :type="tag" color="primary" icon="mail" label="On Left" />
+        <q-btn :type="tag" color="white" text-color="black" icon="mail">
+          On left, slot instead of label
+        </q-btn>
         <q-btn :type="tag" color="secondary" icon-right="mail" label="On Right" />
       </div>
 

--- a/quasar/src/components/btn/QBtn.js
+++ b/quasar/src/components/btn/QBtn.js
@@ -21,6 +21,9 @@ export default Vue.extend({
   computed: {
     hasLabel () {
       return this.label !== void 0 && this.label !== null && this.label !== ''
+    },
+    hasSlotContent () {
+      return this.$slots && this.$slots.default && this.$slots.default.length > 0
     }
   },
 
@@ -112,7 +115,7 @@ export default Vue.extend({
     if (this.icon !== void 0) {
       inner.unshift(
         h(QIcon, {
-          props: { name: this.icon, left: this.stack === false && this.hasLabel === true }
+          props: { name: this.icon, left: this.stack === false && (this.hasLabel === true || this.hasSlotContent) }
         })
       )
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Description**
Currently, the `q-icon` in the `q-btn` component will only get the `on-left` class if a `label` property is present. In my application (and I am sure many others), the slot is used for the label, rather than this prop, which means that there is no spacing between the icon and the content.

This PR changes that so that if _either_ the `label` prop __**or**_ a slot is present, the icon receives `on-left`.

**Before:**
![Screenshot 2019-03-28 at 15 53 20](https://user-images.githubusercontent.com/393605/55172757-730f1280-5172-11e9-800c-ccd05287cf6b.png)

**After**
![Screenshot 2019-03-28 at 15 59 10](https://user-images.githubusercontent.com/393605/55172786-802c0180-5172-11e9-8c02-ffb13c8a55da.png)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)