### PR TITLE
fix(quasar+docs): QNotify - fix default actions handler and add details about defaults to documentation

### DIFF
--- a/docs/src/pages/quasar-plugins/notify.md
+++ b/docs/src/pages/quasar-plugins/notify.md
@@ -40,7 +40,7 @@ For a full list of options, check the API section.
 :::
 
 ### Setting Defaults from Code
-Similar to how you can define Notify defaults in the configuration you can also define defaults in code, using `setDefaults`
+Similar to how you can define Notify defaults in the configuration you can also define defaults in code, using `setDefaults` method. Create a boot file (`$ quasar new boot notify-defaults`):
 
 ``` js
 // outside of a Vue file, in a boot plugin

--- a/docs/src/pages/quasar-plugins/notify.md
+++ b/docs/src/pages/quasar-plugins/notify.md
@@ -6,6 +6,10 @@ Notify is a Quasar plugin that can display animated messages (floating above eve
 ## Installation
 <doc-installation plugins="Notify" :config="{ notify: 'Notify' }" />
 
+::: warning
+You cannot define `actions` with handlers as defaults. If you define `actions` in defaults all of them will close the notification. If you specify `actions` when creating the notification the **default ones will be ignored**. You cannot set default `onDismiss` handler.
+:::
+
 ## Usage
 ``` js
 // outside of a Vue file
@@ -33,6 +37,37 @@ If you define any actions, the notification will automatically be dismissed when
 
 ::: tip
 For a full list of options, check the API section.
+:::
+
+### Setting Defaults from Code
+Similar to how you can define Notify defaults in the configuration you can also define defaults in code, using `setDefaults`
+
+``` js
+// outside of a Vue file, in a boot plugin
+import { Notify } from 'quasar'
+
+Notify.setDefaults({
+  position: 'top-right',
+  timeout: 2500,
+  textColor: 'white',
+  actions: [{ icon: 'close', color: 'white' }]
+})
+
+// inside of a Vue file
+this.$q.setDefaults({
+  position: 'top-right',
+  timeout: 2500,
+  textColor: 'white',
+  actions: [{ icon: 'close', color: 'white' }]
+})
+```
+
+::: warning
+The defaults are not specific to a component, so changing them using `this.$q.setDefaults({...})` **will be global**.
+:::
+
+::: warning
+You cannot define `actions` with handlers as defaults. If you define `actions` in defaults all of them will close the notification. If you specify `actions` when creating the notification the **default ones will be ignored**. You cannot set default `onDismiss` handler.
 :::
 
 ### Programmatically Closing Alert

--- a/quasar/src/plugins/Notify.js
+++ b/quasar/src/plugins/Notify.js
@@ -92,6 +92,15 @@ const Notifications = {
           return action
         })
       }
+      else if (notif.actions) {
+        notif.actions = notif.actions.map(item => {
+          const action = clone(item)
+
+          action.handler = () => close()
+
+          return action
+        })
+      }
 
       if (typeof config.onDismiss === 'function') {
         notif.onDismiss = config.onDismiss


### PR DESCRIPTION
close #3722