### PR TITLE
transition bug fix for slide transitions 📲

### DIFF
--- a/quasar/src/css/core/transitions.styl
+++ b/quasar/src/css/core/transitions.styl
@@ -30,25 +30,25 @@ $transition-easing = cubic-bezier(0.215, 0.61, 0.355, 1) // easeOutCubic
   &--slide-right
     &-enter
       transform translate3d(-100%, 0, 0)
-    &-leave-active
+    &-leave-to
       transform translate3d(100%, 0, 0)
 
   &--slide-left
     &-enter
       transform translate3d(100%, 0, 0)
-    &-leave-active
+    &-leave-to
       transform translate3d(-100%, 0, 0)
 
   &--slide-up
     &-enter
       transform translate3d(0, 100%, 0)
-    &-leave-active
+    &-leave-to
       transform translate3d(0, -100%, 0)
 
   &--slide-down
     &-enter
       transform translate3d(0, -100%, 0)
-    &-leave-active
+    &-leave-to
       transform translate3d(0, 100%, 0)
 
 


### PR DESCRIPTION
**Motivation:**

All transitions use `-leave-to` for the end positioning, and `-leave-active` for adding `transition transform .3s`.
Only the slide transitions had **no change on `-leave-to`** and **both** the `transition transform .3s` _and_ the end position translate on the `-leave-active` class. This makes it hit or miss sometimes applying 0ms transition where the dialog would just disappear instantly.

This is especially a problem when using mobile view on chrome dev tools. The window disappears instantly every time.
See this video: (watch frame by frame to see it disappearing instantly)
https://www.dropbox.com/s/sgim9eyx9pt52np/no-transition-on-slide-down.mov?dl=0
From this code pen:
https://codepen.io/mesqueeb/pen/RObxYN?&editable=true&editors=101

I'm not 100% sure this bug fix will solve the problem 100% but either way, I think using `-leave-to` and `-leave-active` is better streamlined like all other transitions on that stylus page. Because currently it's only the swipe transitions that don't use `-leave-to` at all...

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs]

