### PR TITLE
Make input-label-color a variable 🖍

### DIFF
--- a/quasar/src/components/field/field.styl
+++ b/quasar/src/components/field/field.styl
@@ -115,7 +115,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     left 0
     right 0
     top 18px
-    color rgba(0,0,0,.6)
+    color $input-label-color
     font-size 16px
     line-height 20px
     font-weight 400

--- a/quasar/src/css/variables.styl
+++ b/quasar/src/css/variables.styl
@@ -635,3 +635,5 @@ $tooltip-mobile-padding         ?= 8px 16px
 $tooltip-mobile-fontsize        ?= 14px
 
 $option-focus-transition        ?= .22s cubic-bezier(0,0,.2,1) 0ms
+
+$input-label-color              ?= rgba(0,0,0,.6)


### PR DESCRIPTION
### Motivation:
There's currently no way to change the color of the label of Q-Input. And the docs advice to not target inner element CSS classes.

That's why I'd like to have it available as a stylus variable so I can change it in my `quasar.variables` file. 😊

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

