### PR TITLE
clearable icon: close-cirle  (suggestion)

### DIFF
--- a/quasar/icon-set/ionicons-v4.js
+++ b/quasar/icon-set/ionicons-v4.js
@@ -81,7 +81,7 @@ export default {
     activeIcon: 'ion-close'
   },
   field: {
-    clear: 'ion-close'
+    clear: 'ion-close-circle'
   },
   pagination: {
     first: 'ion-skip-backward',


### PR DESCRIPTION
Just a preference suggestion:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/3253920/55283966-26148180-53a8-11e9-8b78-0299dab42900.png">

I feel like the circle one is a better option.