### PR TITLE
[v1] [WIP] API grouping by category

### DIFF
--- a/docs/src/components/ApiRows.js
+++ b/docs/src/components/ApiRows.js
@@ -49,6 +49,7 @@ export default {
 
   props: {
     which: String,
+    apiKey: String,
     api: Object
   },
 
@@ -438,7 +439,7 @@ export default {
   },
 
   render (h) {
-    const api = this.api[this.which]
+    const api = this.api[this.apiKey || this.which]
 
     const content = Object.keys(api).length !== 0
       ? this[this.which](h, api)

--- a/quasar/build/build.api.js
+++ b/quasar/build/build.api.js
@@ -42,28 +42,28 @@ const topSections = {
 
 const objectTypes = {
   Boolean: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples', 'category' ],
     required: [ 'desc' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isArray: [ 'examples' ]
   },
 
   String: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Number: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Object: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     recursive: [ 'definition' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
@@ -72,7 +72,7 @@ const objectTypes = {
   },
 
   Array: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isObject: [ 'definition' ],
@@ -80,7 +80,7 @@ const objectTypes = {
   },
 
   Promise: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isObject: [ 'definition' ],
@@ -88,7 +88,7 @@ const objectTypes = {
   },
 
   Function: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'params', 'returns', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'params', 'returns', 'examples', 'category' ],
     required: [ 'desc', 'params', 'returns' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isObject: [ 'params', 'returns' ],
@@ -97,7 +97,7 @@ const objectTypes = {
   },
 
   MultipleTypes: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'params', 'returns', 'examples' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'params', 'returns', 'examples', 'category' ],
     required: [ 'desc', 'examples' ],
     isBoolean: [ 'required', 'reactive', 'sync' ],
     isObject: [ 'definition', 'params', 'returns' ],

--- a/quasar/src/api.extends.json
+++ b/quasar/src/api.extends.json
@@ -2,40 +2,47 @@
   "props": {
     "readonly": {
       "type": "Boolean",
-      "desc": "Put component in readonly mode"
+      "desc": "Put component in readonly mode",
+      "category": "behavior"
     },
 
     "disable": {
       "type": "Boolean",
-      "desc": "Put component in disabled mode"
+      "desc": "Put component in disabled mode",
+      "category": "behavior"
     },
 
     "color": {
       "type": "String",
       "desc": "Color name for component from the Quasar Color Palette",
-      "examples": [ "primary", "teal-10" ]
+      "examples": [ "primary", "teal-10" ],
+      "category": "style"
     },
 
     "text-color": {
       "type": "String",
       "desc": "Overrides text color (if needed); color name from the Quasar Color Palette",
-      "examples": [ "primary", "teal-10" ]
+      "examples": [ "primary", "teal-10" ],
+      "category": "style"
     },
 
     "dense": {
       "type": "Boolean",
-      "desc": "Dense mode; occupies less space"
+      "desc": "Dense mode; occupies less space",
+      "category": "style"
     },
 
     "size": {
       "type": "String",
       "desc": "Size in CSS units, including unit name",
-      "examples": [ "16px", "2rem" ]
+      "examples": [ "16px", "2rem" ],
+      "category": "style"
     },
 
     "dark": {
       "type": "Boolean",
-      "desc": "Notify the component that the background is a dark color"
+      "desc": "Notify the component that the background is a dark color",
+      "category": "style"
     },
 
     "icon": {
@@ -46,39 +53,46 @@
         "ion-add",
         "img:https://cdn.quasar-framework.org/logo/svg/quasar-logo.svg",
         "img:statics/path/to/some_image.png"
-      ]
+      ],
+      "category": "content"
     },
 
     "flat": {
       "type": "Boolean",
-      "desc": "Applies a 'flat' design (no default shadow)"
+      "desc": "Applies a 'flat' design (no default shadow)",
+      "category": "style"
     },
 
     "bordered": {
       "type": "Boolean",
-      "desc": "Applies a default border to the component"
+      "desc": "Applies a default border to the component",
+      "category": "style"
     },
 
     "square": {
       "type": "Boolean",
-      "desc": "Removes border-radius so borders are squared"
+      "desc": "Removes border-radius so borders are squared",
+      "category": "style"
     },
 
     "rounded": {
       "type": "Boolean",
-      "desc": "Applies a small standard border-radius for a squared shape of the component"
+      "desc": "Applies a small standard border-radius for a squared shape of the component",
+      "category": "style"
     },
 
     "tabindex": {
       "type": [ "Number", "String" ],
       "desc": "Tabindex HTML attribute value",
-      "examples": [ "0", "100" ]
+      "examples": [ "0", "100" ],
+      "category": "behavior"
     },
 
     "transition": {
       "type": "String",
       "desc": "One of Quasar's embedded transitions",
-      "examples": [ "fade", "slide-down" ]
+      "examples": [ "fade", "slide-down" ],
+      "category": "behavior"
     },
 
     "value": {
@@ -88,7 +102,8 @@
     "sanitize": {
       "type": "Boolean",
       "default": "false",
-      "desc": "Force use of textContent instead of innerHTML to render text; Use it when the text might be unsafe (from user input)"
+      "desc": "Force use of textContent instead of innerHTML to render text; Use it when the text might be unsafe (from user input)",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/avatar/QAvatar.json
+++ b/quasar/src/components/avatar/QAvatar.json
@@ -11,7 +11,8 @@
     "font-size": {
       "type": "String",
       "desc": "The size in CSS units, including unit name, of the content (icon, text)",
-      "examples": [ "18px", "2rem" ]
+      "examples": [ "18px", "2rem" ],
+      "category": "style"
     },
 
     "color": {

--- a/quasar/src/components/breadcrumbs/QBreadcrumbsEl.json
+++ b/quasar/src/components/breadcrumbs/QBreadcrumbsEl.json
@@ -9,7 +9,8 @@
     "label": {
       "type": "String",
       "desc": "The label text for the breadcrumb",
-      "examples": ["Home", "Index"]
+      "examples": ["Home", "Index"],
+      "category": "content"
     },
 
     "icon": {

--- a/quasar/src/components/btn/__btn-mixin.json
+++ b/quasar/src/components/btn/__btn-mixin.json
@@ -11,7 +11,8 @@
       ],
       "examples": [
         ":type=\"a\" href=\"http://some-site.net\" target=\"__blank\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "to": {
@@ -20,18 +21,21 @@
       "examples": [
         "/home/dashboard",
         ":to=\"{ name: 'my-route-name' }\""
-      ]
+      ],
+      "category": "router"
     },
 
     "replace": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'replace' property"
+      "desc": "Equivalent to Vue Router <router-link> 'replace' property",
+      "category": "router"
     },
 
     "label":{
       "type": [ "String", "Number" ],
       "desc": "The text that will be shown on the button",
-      "examples": [ "Button Label" ]
+      "examples": [ "Button Label" ],
+      "category": "content"
     },
 
     "icon": {
@@ -44,53 +48,63 @@
 
     "round": {
       "type": "Boolean",
-      "desc": "Makes a circle shaped button"
+      "desc": "Makes a circle shaped button",
+      "category": "style"
     },
 
     "outline": {
       "type": "Boolean",
-      "desc": "Use 'outline' design"
+      "desc": "Use 'outline' design",
+      "category": "style"
     },
 
     "flat": {
       "type": "Boolean",
-      "desc": "Use 'flat' design"
+      "desc": "Use 'flat' design",
+      "category": "style"
     },
 
     "unelevated": {
       "type": "Boolean",
-      "desc": "Remove shadow"
+      "desc": "Remove shadow",
+      "category": "style"
     },
 
     "rounded": {
       "type": "Boolean",
-      "desc": "Applies a more prominent border-radius for a squared shape button"
+      "desc": "Applies a more prominent border-radius for a squared shape button",
+      "category": "style"
     },
 
     "push": {
       "type": "Boolean",
-      "desc": "Use 'push' design"
+      "desc": "Use 'push' design",
+      "category": "style"
     },
 
     "glossy": {
       "type": "Boolean",
-      "desc": "Applies a glossy effect"
+      "desc": "Applies a glossy effect",
+      "category": "style"
     },
 
     "size": {
       "type": "String",
       "desc": "Button size name or a CSS unit including unit name",
-      "examples": [ "xs", "sm", "md", "lg", "xl", "25px", "2rem" ]
+      "examples": [ "xs", "sm", "md", "lg", "xl", "25px", "2rem" ],
+      "category": "style"
     },
 
     "fab": {
       "type": "Boolean",
-      "desc": "Makes button size and shape to fit a Floating Action Button"
+      "desc": "Makes button size and shape to fit a Floating Action Button",
+      "category": "style"
     },
 
     "fab-mini": {
       "type": "Boolean",
-      "desc": "Makes button size and shape to fit a small Floating Action Button"
+      "desc": "Makes button size and shape to fit a small Floating Action Button",
+      "category": "style"
     },
 
     "color": {
@@ -103,12 +117,14 @@
 
     "no-caps": {
       "type": "Boolean",
-      "desc": "Avoid turning label text into caps (which happens by default)"
+      "desc": "Avoid turning label text into caps (which happens by default)",
+      "category": "content"
     },
 
     "no-wrap": {
       "type": "Boolean",
-      "desc": "Avoid label text wrapping"
+      "desc": "Avoid label text wrapping",
+      "category": "content"
     },
 
     "dense": {
@@ -123,22 +139,26 @@
       "type": "String",
       "desc": "Label or content alignment",
       "default": "center",
-      "values": [ "left", "right", "center", "around", "between" ]
+      "values": [ "left", "right", "center", "around", "between" ],
+      "category": "content"
     },
 
     "stack": {
       "type": "Boolean",
-      "desc": "Stack icon and label vertically instead of on same line (like it is by default)"
+      "desc": "Stack icon and label vertically instead of on same line (like it is by default)",
+      "category": "content"
     },
 
     "stretch": {
       "type": "Boolean",
-      "desc": "When used on flexbox parent, button will stretch to parent's height"
+      "desc": "When used on flexbox parent, button will stretch to parent's height",
+      "category": "behavior"
     },
 
     "loading": {
       "type": "Boolean",
-      "desc": "Put button into loading state (displays a QSpinner -- can be overriden by using a 'loading' slot)"
+      "desc": "Put button into loading state (displays a QSpinner -- can be overriden by using a 'loading' slot)",
+      "category": "behavior"
     },
 
     "disable": {

--- a/quasar/src/components/datetime/QTime.json
+++ b/quasar/src/components/datetime/QTime.json
@@ -17,7 +17,8 @@
     "format24h": {
       "type": "Boolean",
       "desc": "Forces 24 hour time display instead of AM/PM system",
-      "default": "(based on Quasar lang language being used)"
+      "default": "(based on Quasar lang language being used)",
+      "category": "content"
     },
 
     "options": {
@@ -43,7 +44,8 @@
       "returns": null,
       "examples": [
         ":options=\"(hr, min, sec) => hr <= 6\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "hour-options": {
@@ -51,7 +53,8 @@
       "desc": "Optionally configure what hours is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
         ":hour-options=\"[3, 6, 9]\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "minute-options": {
@@ -59,7 +62,8 @@
       "desc": "Optionally configure what minutes is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
         ":minute-options=\"[0, 15, 30, 45]\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "second-options": {
@@ -67,17 +71,20 @@
       "desc": "Optionally configure what seconds is the user allowed to set; Overrides 'options' prop if that is also set",
       "examples": [
         ":second-options=\"[0, 7, 10, 23]\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "with-seconds": {
       "type": "Boolean",
-      "desc": "Allow the time to be set with seconds"
+      "desc": "Allow the time to be set with seconds",
+      "category": "behavior"
     },
 
     "now-btn": {
       "type": "Boolean",
-      "desc": "Display a button that selects the current time"
+      "desc": "Display a button that selects the current time",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/datetime/datetime-mixin.json
+++ b/quasar/src/components/datetime/datetime-mixin.json
@@ -6,7 +6,8 @@
 
     "landscape": {
       "type": "Boolean",
-      "desc": "Display the component in landscape mode"
+      "desc": "Display the component in landscape mode",
+      "category": "style"
     },
 
     "color": {

--- a/quasar/src/components/dialog/QDialog.json
+++ b/quasar/src/components/dialog/QDialog.json
@@ -4,47 +4,56 @@
   "props": {
     "persistent": {
       "type": "Boolean",
-      "desc": "User cannot dismiss Dialog if clicking outside of it or hitting ESC key; Also, an app route change won't dismiss it"
+      "desc": "User cannot dismiss Dialog if clicking outside of it or hitting ESC key; Also, an app route change won't dismiss it",
+      "category": "behavior"
     },
 
     "no-esc-dismiss": {
       "type": "Boolean",
-      "desc": "User cannot dismiss Dialog by hitting ESC key; No need to set it if 'persistent' prop is also set"
+      "desc": "User cannot dismiss Dialog by hitting ESC key; No need to set it if 'persistent' prop is also set",
+      "category": "behavior"
     },
 
     "no-backdrop-dismiss": {
       "type": "Boolean",
-      "desc": "User cannot dismiss Dialog by clicking outside of it; No need to set it if 'persistent' prop is also set"
+      "desc": "User cannot dismiss Dialog by clicking outside of it; No need to set it if 'persistent' prop is also set",
+      "category": "behavior"
     },
 
     "no-route-dismiss": {
       "type": "Boolean",
-      "desc": "Changing route app won't dismiss Dialog; No need to set it if 'persistent' prop is also set"
+      "desc": "Changing route app won't dismiss Dialog; No need to set it if 'persistent' prop is also set",
+      "category": "behavior"
     },
 
     "auto-close": {
       "type": "Boolean",
-      "desc": "Any click/tap inside of the dialog will close it"
+      "desc": "Any click/tap inside of the dialog will close it",
+      "category": "behavior"
     },
 
     "seamless": {
       "type": "Boolean",
-      "desc": "Put Dialog into seamless mode; Does not use a backdrop so user is able to interact with the rest of the page too"
+      "desc": "Put Dialog into seamless mode; Does not use a backdrop so user is able to interact with the rest of the page too",
+      "category": "behavior"
     },
 
     "maximized": {
       "type": "Boolean",
-      "desc": "Put Dialog into maximized mode"
+      "desc": "Put Dialog into maximized mode",
+      "category": "behavior"
     },
 
     "full-width": {
       "type": "Boolean",
-      "desc": "Dialog will try to render with same width as the window"
+      "desc": "Dialog will try to render with same width as the window",
+      "category": "behavior"
     },
 
     "full-height": {
       "type": "Boolean",
-      "desc": "Dialog will try to render with same height as the window"
+      "desc": "Dialog will try to render with same height as the window",
+      "category": "behavior"
     },
 
     "position": {
@@ -52,7 +61,8 @@
       "desc": "",
       "default": "standard",
       "values": [ "standard", "top", "right", "bottom", "left" ],
-      "examples": [ "top", "right" ]
+      "examples": [ "top", "right" ],
+      "category": "behavior"
     },
 
     "transition-show": {
@@ -67,7 +77,8 @@
 
     "no-refocus": {
       "type": "Boolean",
-      "desc": "(Accessibility) When Dialog gets hidden, do not refocus on the DOM element that previously had focus"
+      "desc": "(Accessibility) When Dialog gets hidden, do not refocus on the DOM element that previously had focus",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/fab/QFab.json
+++ b/quasar/src/components/fab/QFab.json
@@ -7,7 +7,8 @@
 
   "props": {
     "value": {
-      "desc": "Controls state of fab actions (showing/hidden); Works best with v-model directive, otherwise use along listening to 'input' event"
+      "desc": "Controls state of fab actions (showing/hidden); Works best with v-model directive, otherwise use along listening to 'input' event",
+      "category": "behavior"
     },
 
     "icon": {
@@ -23,27 +24,32 @@
       "desc": "Direction to expand Fab Actions to",
       "default": "right",
       "values": [ "up", "right", "down", "left" ],
-      "examples": [ "bottom" ]
+      "examples": [ "bottom" ],
+      "category": "behavior"
     },
 
     "persistent": {
       "type": "Boolean",
-      "desc": "By default, Fab Actions are hidden when user navigates to another route and this prop disables this behavior"
+      "desc": "By default, Fab Actions are hidden when user navigates to another route and this prop disables this behavior",
+      "category": "behavior"
     },
 
     "outline": {
       "type": "Boolean",
-      "desc": "Use 'outline' design for Fab button"
+      "desc": "Use 'outline' design for Fab button",
+      "category": "style"
     },
 
     "push": {
       "type": "Boolean",
-      "desc": "Use 'push' design for Fab button"
+      "desc": "Use 'push' design for Fab button",
+      "category": "style"
     },
 
     "flat": {
       "type": "Boolean",
-      "desc": "Use 'flat' design for Fab button"
+      "desc": "Use 'flat' design for Fab button",
+      "category": "style"
     },
 
     "color": {
@@ -56,7 +62,8 @@
 
     "glossy": {
       "type": "Boolean",
-      "desc": "Apply the glossy effect over the button"
+      "desc": "Apply the glossy effect over the button",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/field/__QField.json
+++ b/quasar/src/components/field/__QField.json
@@ -5,35 +5,41 @@
     "label": {
       "type": "String",
       "desc": "A text label that will “float” up above the input field, once the field gets focus",
-      "examples": [ "Username" ]
+      "examples": [ "Username" ],
+      "category": "content"
     },
 
     "stack-label": {
       "type": "Boolean",
-      "desc": "Label will be always shown above the field regardless of field content (if any)"
+      "desc": "Label will be always shown above the field regardless of field content (if any)",
+      "category": "content"
     },
 
     "hint": {
       "type": "String",
       "desc": "Helper (hint) text which gets placed below your wrapped form component",
-      "examples": [ "Fill in between 3 and 12 characters" ]
+      "examples": [ "Fill in between 3 and 12 characters" ],
+      "category": "content"
     },
 
     "hide-hint": {
       "type": "Boolean",
-      "desc": "Hide the helper (hint) text when field doesn't has focus"
+      "desc": "Hide the helper (hint) text when field doesn't has focus",
+      "category": "content"
     },
 
     "prefix": {
       "type": "String",
       "desc": "Prefix",
-      "examples": [ "$" ]
+      "examples": [ "$" ],
+      "category": "content"
     },
 
     "suffix": {
       "type": "String",
       "desc": "Suffix",
-      "examples": [ "@gmail.com" ]
+      "examples": [ "@gmail.com" ],
+      "category": "content"
     },
 
     "color": {
@@ -50,47 +56,56 @@
 
     "loading": {
       "type": "Boolean",
-      "desc": "Signals the user a process is in progress by displaying a spinner; Spinner can be customized by using the 'loading' slot."
+      "desc": "Signals the user a process is in progress by displaying a spinner; Spinner can be customized by using the 'loading' slot.",
+      "category": "behavior"
     },
 
     "clearable": {
       "type": "Boolean",
-      "desc": "Appends clearable icon when a value (not undefined or null) is set; When clicked, model becomes null"
+      "desc": "Appends clearable icon when a value (not undefined or null) is set; When clicked, model becomes null",
+      "category": "content"
     },
 
     "clear-icon": {
       "type": "Boolean",
-      "desc": "Custom icon to use for the clear button when using along with 'clearable' prop"
+      "desc": "Custom icon to use for the clear button when using along with 'clearable' prop",
+      "category": "content"
     },
 
     "filled": {
       "type": "Boolean",
-      "desc": "Use 'filled' design for the field"
+      "desc": "Use 'filled' design for the field",
+      "category": "style"
     },
 
     "outlined": {
       "type": "Boolean",
-      "desc": "Use 'outlined' design for the field"
+      "desc": "Use 'outlined' design for the field",
+      "category": "style"
     },
 
     "borderless": {
       "type": "Boolean",
-      "desc": "Use 'borderless' design for the field"
+      "desc": "Use 'borderless' design for the field",
+      "category": "style"
     },
 
     "standout": {
       "type": "Boolean",
-      "desc": "Use 'standout' design for the field"
+      "desc": "Use 'standout' design for the field",
+      "category": "style"
     },
 
     "bottom-slots": {
       "type": "Boolean",
-      "desc": "Enables bottom slots ('error', 'hint', 'counter')"
+      "desc": "Enables bottom slots ('error', 'hint', 'counter')",
+      "category": "content"
     },
 
     "counter": {
       "type": "Boolean",
-      "desc": "Show an automatic counter on bottom right"
+      "desc": "Show an automatic counter on bottom right",
+      "category": "content"
     },
 
     "rounded": {
@@ -99,7 +114,8 @@
 
     "square": {
       "type": "Boolean",
-      "desc": "Remove border-radius so borders are squared; Overrides 'rounded' prop"
+      "desc": "Remove border-radius so borders are squared; Overrides 'rounded' prop",
+      "category": "style"
     },
 
     "dense": {
@@ -108,7 +124,8 @@
 
     "items-aligned": {
       "type": "Boolean",
-      "desc": "Align content to match QItem"
+      "desc": "Align content to match QItem",
+      "category": "content"
     },
 
     "disable": {

--- a/quasar/src/components/form/QForm.json
+++ b/quasar/src/components/form/QForm.json
@@ -3,7 +3,8 @@
     "autofocus": {
       "type": "Boolean",
       "desc": "Focus first field on initial component render",
-      "default": true
+      "default": true,
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/inner-loading/QInnerLoading.json
+++ b/quasar/src/components/inner-loading/QInnerLoading.json
@@ -6,7 +6,8 @@
   "props": {
     "showing": {
       "type": "Boolean",
-      "desc": "State - loading or not"
+      "desc": "State - loading or not",
+      "category": "behavior"
     },
 
     "color": {
@@ -16,7 +17,8 @@
     "size": {
       "extends": "size",
       "desc": "Size in CSS units, including unit name, for Spinner (unless using the default slot)",
-      "default": "42px"
+      "default": "42px",
+      "category": "style"
     },
 
     "transition-show": {

--- a/quasar/src/components/knob/QKnob.json
+++ b/quasar/src/components/knob/QKnob.json
@@ -3,26 +3,30 @@
     "value": {
       "type": "Number",
       "desc": "Any number to indicate the given value of the knob. Either use this property (along with a listener for 'input' event) OR use the v-model directive",
-      "examples": [ "v-model=\"myValue\"" ]
+      "examples": [ "v-model=\"myValue\"" ],
+      "category": "behavior"
     },
 
     "min": {
       "type": "Number",
       "desc": "The minimum value that the model (the knob value) should start at",
-      "examples": [ "20", "5" ]
+      "examples": [ "20", "5" ],
+      "category": "behavior"
     },
 
     "max": {
       "type": "Number",
       "desc": "The maximimum value that the model (the knob value) should go to",
-      "examples": [ "100", "50" ]
+      "examples": [ "100", "50" ],
+      "category": "behavior"
     },
 
     "step": {
       "type": "Number",
       "default": "1",
       "desc": "A number representing steps in the value of the model, while adjusting the knob",
-      "examples": [ "1", "5" ]
+      "examples": [ "1", "5" ],
+      "category": "behavior"
     },
 
     "color": {
@@ -31,12 +35,14 @@
 
     "center-color": {
       "extends": "color",
-      "desc": "Color name for the center part of the component from the Quasar Color Palette"
+      "desc": "Color name for the center part of the component from the Quasar Color Palette",
+      "category": "style"
     },
 
     "track-color": {
       "extends": "color",
-      "desc": "Color name for the track of the component from the Quasar Color Palette"
+      "desc": "Color name for the track of the component from the Quasar Color Palette",
+      "category": "style"
     },
 
     "size": {
@@ -47,26 +53,30 @@
       "type": "String",
       "desc": "Size of text in CSS units, including unit name. Suggestion: use 'em' units to sync with component size",
       "default": "0.25em",
-      "examples": [ "1em", "16px", "2rem" ]
+      "examples": [ "1em", "16px", "2rem" ],
+      "category": "style"
     },
 
     "thickness": {
       "type": "Number",
       "default": 0.2,
       "desc": "Thickness of progress arc as a ratio (0.0 < x < 1.0) of component size",
-      "examples": [ 1, 0.3 ]
+      "examples": [ 1, 0.3 ],
+      "category": "style"
     },
 
     "angle": {
       "type": "Number",
       "desc": "Angle to rotate progress arc by",
       "default": 0,
-      "examples": [ 0, 40, 90 ]
+      "examples": [ 0, 40, 90 ],
+      "category": "style"
     },
 
     "show-value": {
       "type": "Boolean",
-      "desc": "Enables the default slot and uses it (if available), otherwise it displays the 'value' prop as text; Make sure the text has enough space to be displayed inside the component"
+      "desc": "Enables the default slot and uses it (if available), otherwise it displays the 'value' prop as text; Make sure the text has enough space to be displayed inside the component",
+      "category": "behavior|content"
     },
 
     "tabindex": {

--- a/quasar/src/components/layout/QPage.json
+++ b/quasar/src/components/layout/QPage.json
@@ -6,7 +6,8 @@
   "props": {
     "padding": {
       "type": "Boolean",
-      "desc": "Applies a default responsive page padding"
+      "desc": "Applies a default responsive page padding",
+      "category": "content"
     },
 
     "style-fn": {
@@ -25,7 +26,8 @@
         "__exemption": [ "examples" ]
       },
       "default": "(see source code)",
-      "examples": [ "(see source code)" ]
+      "examples": [ "(see source code)" ],
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/layout/QPageSticky.json
+++ b/quasar/src/components/layout/QPageSticky.json
@@ -9,18 +9,21 @@
         "bottom-right", "bottom-left",
         "top", "right", "bottom", "left"
       ],
-      "examples": [ "top-right" ]
+      "examples": [ "top-right" ],
+      "category": "content"
     },
 
     "offset": {
       "type": "Array",
       "desc": "An array of two numbers to offset the component horizontally and vertically in pixels",
-      "examples": [ "[8, 8]", "[5, 10]" ]
+      "examples": [ "[8, 8]", "[5, 10]" ],
+      "category": "content"
     },
 
     "expand": {
       "type": "Boolean",
-      "desc": "By default the component shrinks to content's size; By using this prop you make the component fully expand horizontally or vertically, based on 'position' prop"
+      "desc": "By default the component shrinks to content's size; By using this prop you make the component fully expand horizontally or vertically, based on 'position' prop",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/linear-progress/QLinearProgress.json
+++ b/quasar/src/components/linear-progress/QLinearProgress.json
@@ -8,13 +8,15 @@
       "type": "Number",
       "desc": "Progress value (0.0 < x < 1.0)",
       "default": 0,
-      "examples": [ ":value=\"0.28\"" ]
+      "examples": [ ":value=\"0.28\"" ],
+      "category": "behavior"
     },
 
     "buffer": {
       "type": "Number",
       "desc": "Optional buffer value (0.0 < x < 1.0)",
-      "examples": [ ":buffer=\"0.78\"" ]
+      "examples": [ ":buffer=\"0.78\"" ],
+      "category": "behavior"
     },
 
     "color": {
@@ -23,7 +25,8 @@
 
     "track-color": {
       "extends": "color",
-      "desc": "Color name for component's track from the Quasar Color Palette"
+      "desc": "Color name for component's track from the Quasar Color Palette",
+      "category": "style"
     },
 
     "dark": {
@@ -32,22 +35,26 @@
 
     "reverse":  {
       "type": "Boolean",
-      "desc": "Reverse direction of progress"
+      "desc": "Reverse direction of progress",
+      "category": "behavior"
     },
 
     "stripe": {
       "type": "Boolean",
-      "desc":  "Draw stripes; For determinate state only (for performance reasons)"
+      "desc":  "Draw stripes; For determinate state only (for performance reasons)",
+      "category": "behavior"
     },
 
     "indeterminate": {
       "type": "Boolean",
-      "desc": "Put component into indeterminate mode"
+      "desc": "Put component into indeterminate mode",
+      "category": "behavior"
     },
 
     "query": {
       "type": "Boolean",
-      "desc": "Put component into query mode"
+      "desc": "Put component into query mode",
+      "category": "behavior"
     },
 
     "rounded": {

--- a/quasar/src/components/list/QItem.json
+++ b/quasar/src/components/list/QItem.json
@@ -8,7 +8,8 @@
   "props": {
     "active": {
       "type": "Boolean",
-      "desc": "Put item into 'active' state"
+      "desc": "Put item into 'active' state",
+      "category": "behavior"
     },
 
     "dark": {
@@ -17,7 +18,8 @@
 
     "clickable": {
       "type": "Boolean",
-      "desc": "Is QItem clickable? If it's the case, then it will add hover effects and emit 'click' events"
+      "desc": "Is QItem clickable? If it's the case, then it will add hover effects and emit 'click' events",
+      "category": "behavior"
     },
 
     "dense": {
@@ -27,7 +29,8 @@
     "inset-level": {
       "type": "Number",
       "desc": "Apply an inset; Useful when avatar/left side is missing but you want to align content with other items that do have a left side, or when you're building a menu",
-      "examples": [ ":inset-level=\"1\"" ]
+      "examples": [ ":inset-level=\"1\"" ],
+      "category": "content"
     },
 
     "tabindex": {
@@ -38,17 +41,20 @@
       "type": "String",
       "desc": "HTML tag to render; Suggestion: use 'label' when encapsulating a QCheckbox/QRadio/QToggle so that when user clicks/taps on the whole item it will trigger a model change for the mentioned components",
       "default": "div",
-      "examples": [ "a", "label" ]
+      "examples": [ "a", "label" ],
+      "category": "content"
     },
 
     "manual-focus": {
       "type": "Boolean",
-      "desc": "Put item into a manual focus state; Enables 'focused' prop which will determine if item is focused or not, rather than relying on native hover/focus states"
+      "desc": "Put item into a manual focus state; Enables 'focused' prop which will determine if item is focused or not, rather than relying on native hover/focus states",
+      "category": "behavior"
     },
 
     "focused": {
       "type": "Boolean",
-      "desc": "Determines focus state, ONLY if 'manual-focus' is enabled / set to true"
+      "desc": "Determines focus state, ONLY if 'manual-focus' is enabled / set to true",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/list/QItemLabel.json
+++ b/quasar/src/components/list/QItemLabel.json
@@ -6,28 +6,33 @@
   "props": {
     "overline": {
       "type": "Boolean",
-      "desc": "Renders an overline label"
+      "desc": "Renders an overline label",
+      "category": "content"
     },
 
     "caption": {
       "type": "Boolean",
-      "desc": "Renders a caption label"
+      "desc": "Renders a caption label",
+      "category": "content"
     },
 
     "header": {
       "type": "Boolean",
-      "desc": "Renders a header label"
+      "desc": "Renders a header label",
+      "category": "content"
     },
 
     "inset": {
       "type": "Boolean",
-      "desc": "Applies an inset to the label"
+      "desc": "Applies an inset to the label",
+      "category": "content"
     },
 
     "lines": {
       "type": [ "Number", "String" ],
       "desc": "Apply ellipsis when there's not enough space to render on the specified number of lines; If more than one line specified, then it will only work on webkit browsers because it uses the '-webkit-line-clamp' CSS property!",
-      "examples": [ "1", "3", ":lines=\"2\"" ]
+      "examples": [ "1", "3", ":lines=\"2\"" ],
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/list/QItemSection.json
+++ b/quasar/src/components/list/QItemSection.json
@@ -6,27 +6,32 @@
   "props": {
     "avatar": {
       "type": "Boolean",
-      "desc": "Render an avatar item side (does not needs 'side' prop to be set)"
+      "desc": "Render an avatar item side (does not needs 'side' prop to be set)",
+      "category": "content"
     },
 
     "thumbnail": {
       "type": "Boolean",
-      "desc": "Render a thumbnail item side (does not needs 'side' prop to be set)"
+      "desc": "Render a thumbnail item side (does not needs 'side' prop to be set)",
+      "category": "content"
     },
 
     "side": {
       "type": "Boolean",
-      "desc": "Renders as a side of the item"
+      "desc": "Renders as a side of the item",
+      "category": "content"
     },
 
     "top": {
       "type": "Boolean",
-      "desc": "Align content to top (useful for multi-line items)"
+      "desc": "Align content to top (useful for multi-line items)",
+      "category": "content"
     },
 
     "no-wrap": {
       "type": "Boolean",
-      "desc": "Do not wrap text (useful for item's main content)"
+      "desc": "Do not wrap text (useful for item's main content)",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/list/QList.json
+++ b/quasar/src/components/list/QList.json
@@ -14,7 +14,8 @@
 
     "separator": {
       "type": "Boolean",
-      "desc": "Applies a separator between contained items"
+      "desc": "Applies a separator between contained items",
+      "category": "content"
     },
 
     "dark": {
@@ -23,7 +24,8 @@
 
     "padding": {
       "type": "Boolean",
-      "desc": "Applies a material design-like padding on top and bottom"
+      "desc": "Applies a material design-like padding on top and bottom",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/list/QSlideItem.json
+++ b/quasar/src/components/list/QSlideItem.json
@@ -2,12 +2,14 @@
   "props": {
     "left-color": {
       "extends": "color",
-      "desc": "Color name for left-side background from the Quasar Color Palette"
+      "desc": "Color name for left-side background from the Quasar Color Palette",
+      "category": "style"
     },
 
     "right-color": {
       "extends": "color",
-      "desc": "Color name for right-side background from the Quasar Color Palette"
+      "desc": "Color name for right-side background from the Quasar Color Palette",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/menu/QMenu.json
+++ b/quasar/src/components/menu/QMenu.json
@@ -8,12 +8,14 @@
   "props": {
     "fit": {
       "type": "Boolean",
-      "desc": "Allows the menu to match at least the full width of its target"
+      "desc": "Allows the menu to match at least the full width of its target",
+      "category": "behavior"
     },
 
     "cover": {
       "type": "Boolean",
-      "desc": "Allows the menu to cover its target. When used, the 'self' and 'fit' props are no longer effective"
+      "desc": "Allows the menu to cover its target. When used, the 'self' and 'fit' props are no longer effective",
+      "category": "behavior"
     },
 
     "anchor": {
@@ -24,7 +26,8 @@
         "center left", "center middle", "center right",
         "bottom left", "bottom middle", "bottom right"
       ],
-      "examples": [ "top left", "bottom right" ]
+      "examples": [ "top left", "bottom right" ],
+      "category": "position"
     },
 
     "self": {
@@ -35,58 +38,69 @@
         "center left", "center middle", "center right",
         "bottom left", "bottom middle", "bottom right"
       ],
-      "examples": [ "top left", "bottom right" ]
+      "examples": [ "top left", "bottom right" ],
+      "category": "position"
     },
 
     "offset": {
       "type": "Array",
       "desc": "An array of two numbers to offset the menu horizontally and vertically in pixels",
-      "examples": [ "[8, 8]", "[5, 10]" ]
+      "examples": [ "[8, 8]", "[5, 10]" ],
+      "category": "position"
     },
 
     "no-parent-event":{
       "type": "Boolean",
-      "desc": "Skips attaching events to the target DOM element (that trigger the menu to get shown)"
+      "desc": "Skips attaching events to the target DOM element (that trigger the menu to get shown)",
+      "category": "behavior"
     },
 
     "touch-position": {
       "type": "Boolean",
-      "desc": "Allows for the target position to be set by the mouse position, when the target of the menu is either clicked or touched"
+      "desc": "Allows for the target position to be set by the mouse position, when the target of the menu is either clicked or touched",
+      "category": "position"
     },
 
     "persistent": {
       "type": "Boolean",
-      "desc": "Allows the menu to not be dismissed by a click/tap outside of the menu or by hitting the ESC key"
+      "desc": "Allows the menu to not be dismissed by a click/tap outside of the menu or by hitting the ESC key",
+      "category": "behavior"
     },
 
     "auto-close": {
       "type": "Boolean",
-      "desc": "Allows any click/tap in the menu to close it; Useful instead of attaching events to each menu item that should close the menu on click/tap"
+      "desc": "Allows any click/tap in the menu to close it; Useful instead of attaching events to each menu item that should close the menu on click/tap",
+      "category": "behavior"
     },
 
     "no-refocus": {
       "type": "Boolean",
-      "desc": "(Accessibility) When Menu gets hidden, do not refocus on the DOM element that previously had focus"
+      "desc": "(Accessibility) When Menu gets hidden, do not refocus on the DOM element that previously had focus",
+      "category": "behavior"
     },
 
     "max-height": {
       "extends": "size",
-      "desc": "The maximimum height of the menu; Size in CSS units, including unit name"
+      "desc": "The maximimum height of the menu; Size in CSS units, including unit name",
+      "category": "style"
     },
 
     "max-width": {
       "extends": "size",
-      "desc": "The maximimum width of the menu; Size in CSS units, including unit name"
+      "desc": "The maximimum width of the menu; Size in CSS units, including unit name",
+      "category": "style"
     },
 
     "transition-show": {
       "extends": "transition",
-      "default": "fade"
+      "default": "fade",
+      "category": "style"
     },
 
     "transition-hide": {
       "extends": "transition",
-      "default": "fade"
+      "default": "fade",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/no-ssr/QNoSsr.json
+++ b/quasar/src/components/no-ssr/QNoSsr.json
@@ -4,13 +4,15 @@
       "type": "String",
       "desc": "HTML tag to render",
       "default": "div",
-      "examples": [ "span", "blockquote" ]
+      "examples": [ "span", "blockquote" ],
+      "category": "content"
     },
 
     "placeholder": {
       "type": "String",
       "desc": "Text to display on server-side render (unless using 'placeholder' slot)",
-      "examples": [ "This is server-side only" ]
+      "examples": [ "This is server-side only" ],
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/observer/QResizeObserver.json
+++ b/quasar/src/components/observer/QResizeObserver.json
@@ -4,7 +4,8 @@
       "type": [ "String", "Number" ],
       "desc": "Debounce amount (in milliseconds)",
       "default": 100,
-      "examples": [ "0", "530" ]
+      "examples": [ "0", "530" ],
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/observer/QScrollObserver.json
+++ b/quasar/src/components/observer/QScrollObserver.json
@@ -3,12 +3,14 @@
     "debounce": {
       "type": [ "String", "Number" ],
       "desc": "Debounce amount (in milliseconds)",
-      "examples": [ "0", "530" ]
+      "examples": [ "0", "530" ],
+      "category": "behavior"
     },
 
     "horizontal": {
       "type": "Boolean",
-      "desc": "Register for horizontal scroll instead of vertical (which is default)"
+      "desc": "Register for horizontal scroll instead of vertical (which is default)",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/option-group/QOptionGroup.json
+++ b/quasar/src/components/option-group/QOptionGroup.json
@@ -11,7 +11,8 @@
       "desc": "Array of objects with value and label props. The binary components will be created according to this array",
       "examples": [
         ":options=\"[ { label: 'Option 1', value: 'op1' }, { label: 'Option 2', value: 'op2' }, { label: 'Option 3', value: 'op3' } ]\""
-      ]
+      ],
+      "category": "content"
     },
 
     "type": {
@@ -19,7 +20,8 @@
       "desc": "The type of input component to be used",
       "values": [ "radio", "checkbox", "toggle" ],
       "default": "radio",
-      "examples": [ "checkbox" ]
+      "examples": [ "checkbox" ],
+      "category": "content"
     },
 
     "color": {
@@ -28,7 +30,8 @@
 
     "keep-color": {
       "type": "Boolean",
-      "desc": "Should the color (if specified any) be kept when input components are unticked?"
+      "desc": "Should the color (if specified any) be kept when input components are unticked?",
+      "category": "behavior"
     },
 
     "dark": {
@@ -41,12 +44,14 @@
 
     "left-label":  {
       "type": "Boolean",
-      "desc": "Label (if any specified) should be displayed on the left side of the input components"
+      "desc": "Label (if any specified) should be displayed on the left side of the input components",
+      "category": "content"
     },
 
     "inline": {
       "type": "Boolean",
-      "desc": "Show input components as inline-block rather than each having their own row"
+      "desc": "Show input components as inline-block rather than each having their own row",
+      "category": "content"
     },
 
     "disable": {

--- a/quasar/src/components/page-scroller/QPageScroller.json
+++ b/quasar/src/components/page-scroller/QPageScroller.json
@@ -10,18 +10,21 @@
       "type": "Number",
       "desc": "Scroll offset (in pixels) from which point the component is shown on page",
       "default": 1000,
-      "examples": [ 550 ]
+      "examples": [ 550 ],
+      "category": "behavior"
     },
 
     "duration": {
       "type": "Number",
       "desc": "Duration (in milliseconds) of the scrolling until it reaches its target",
       "default": 300,
-      "examples": [ 500 ]
+      "examples": [ 500 ],
+      "category": "behavior"
     },
 
     "offset": {
-      "default": [18, 18]
+      "default": [18, 18],
+      "category": "behavior"
     }
   }
 }

--- a/quasar/src/components/pagination/QPagination.json
+++ b/quasar/src/components/pagination/QPagination.json
@@ -38,7 +38,8 @@
     "size": {
       "type": "String",
       "desc": "Button size in CSS units, including unit name",
-      "examples": [ "20px" ]
+      "examples": [ "20px" ],
+      "category": "content"
     },
 
     "disable": {
@@ -47,34 +48,40 @@
 
     "input": {
       "type": "Boolean",
-      "desc": "Use an input instead of buttons"
+      "desc": "Use an input instead of buttons",
+      "category": "content"
     },
 
     "boundary-links": {
       "type": "Boolean",
-      "desc": "Show boundary button links"
+      "desc": "Show boundary button links",
+      "category": "content"
     },
 
     "boundary-numbers": {
       "type": "Boolean",
-      "desc": "Always show first and last page buttons (if not using 'input')"
+      "desc": "Always show first and last page buttons (if not using 'input')",
+      "category": "content"
     },
 
     "direction-links": {
       "type": "Boolean",
-      "desc": "Show direction buttons"
+      "desc": "Show direction buttons",
+      "category": "content"
     },
 
     "ellipses": {
       "type": "Boolean",
-      "desc": "Show ellipses (...) when pages are available"
+      "desc": "Show ellipses (...) when pages are available",
+      "category": "content"
     },
 
     "max-pages": {
       "type": "Number",
       "default": 0,
       "desc": "Maximum number of page links to display at a time; 0 means Infinite",
-      "examples": [ 5 ]
+      "examples": [ 5 ],
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/parallax/QParallax.json
+++ b/quasar/src/components/parallax/QParallax.json
@@ -11,20 +11,23 @@
         "(statics folder) statics/img/something.png",
         "(relative path format) :src=\"require('./my_img.jpg')\"",
         "(URL) https://some-site.net/some-img.jpg"
-      ]
+      ],
+      "category": "content"
     },
 
     "height": {
       "type": "Number",
       "desc": "Height of component (in pixels)",
       "default": 500,
-      "examples": [ ":height=\"1000\"" ]
+      "examples": [ ":height=\"1000\"" ],
+      "category": "style"
     },
 
     "speed": {
       "type": "Number",
       "desc": "Speed of parallax effect (0.0 < x < 1.0)",
-      "examples": [ ":speed=\"0.24\"" ]
+      "examples": [ ":speed=\"0.24\"" ],
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/popup-edit/QPopupEdit.json
+++ b/quasar/src/components/popup-edit/QPopupEdit.json
@@ -9,29 +9,34 @@
     "title": {
       "type": "String",
       "desc": "Optional title (unless 'title' slot is used)",
-      "examples": [ "Calories" ]
+      "examples": [ "Calories" ],
+      "category": "content"
     },
 
     "buttons": {
       "type": "Boolean",
-      "desc": "Show Set and Cancel buttons"
+      "desc": "Show Set and Cancel buttons",
+      "category": "content"
     },
 
     "label-set": {
       "type": "String",
       "desc": "Override Set button label",
-      "examples": [ "OK" ]
+      "examples": [ "OK" ],
+      "category": "content"
     },
 
     "label-cancel": {
       "type": "String",
       "desc": "Override Cancel button label",
-      "examples": [ "Cancel" ]
+      "examples": [ "Cancel" ],
+      "category": "content"
     },
 
     "persistent": {
       "type": "Boolean",
-      "desc": "Avoid Popup closing by hitting ESC key or by clicking/tapping outside of the Popup"
+      "desc": "Avoid Popup closing by hitting ESC key or by clicking/tapping outside of the Popup",
+      "category": "behavior"
     },
 
     "color": {
@@ -55,7 +60,8 @@
       },
       "examples": [
         ":validate=\"myValidation\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "disable": {

--- a/quasar/src/components/popup-proxy/QPopupProxy.json
+++ b/quasar/src/components/popup-proxy/QPopupProxy.json
@@ -4,14 +4,16 @@
   "props": {
     "value": {
       "type": "Boolean",
-      "desc": "Defines the state of the component (shown/hidden); Either use this property (along with a listener for 'input' event) OR use v-model directive"
+      "desc": "Defines the state of the component (shown/hidden); Either use this property (along with a listener for 'input' event) OR use v-model directive",
+      "category": "behavior"
     },
 
     "breakpoint": {
       "type": [ "Number", "String" ],
       "desc": "Breakpoint (in pixels) of window width from where a Menu will get to be used instead of a Dialog",
       "default": 450,
-      "examples": [ 992, ":breakpoint=\"1024\"" ]
+      "examples": [ 992, ":breakpoint=\"1024\"" ],
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/pull-to-refresh/QPullToRefresh.json
+++ b/quasar/src/components/pull-to-refresh/QPullToRefresh.json
@@ -6,12 +6,14 @@
 
     "icon": {
       "extends": "icon",
-      "desc": "Icon to display when refreshing the content"
+      "desc": "Icon to display when refreshing the content",
+      "category": "content"
     },
 
     "no-mouse": {
       "type": "Boolean",
-      "desc": "Don't listen for mouse events"
+      "desc": "Don't listen for mouse events",
+      "category": "behavior"
     },
 
     "disable": {

--- a/quasar/src/components/radio/QRadio.json
+++ b/quasar/src/components/radio/QRadio.json
@@ -11,18 +11,21 @@
       "type": [ "Number", "String" ],
       "required": true,
       "desc": "The actual value of the option with which model value is changed",
-      "examples": [ "opt1", 50 ]
+      "examples": [ "opt1", 50 ],
+      "category": "behavior"
     },
 
     "label": {
       "type": "String",
       "desc": "Label to display along the radio control (or use the default slot instead of this prop)",
-      "examples": [ "label=\"Option 1\"" ]
+      "examples": [ "label=\"Option 1\"" ],
+      "category": "content"
     },
 
     "left-label": {
       "type": "Boolean",
-      "desc": "Label (if any specified) should be displayed on the left side of the checkbox"
+      "desc": "Label (if any specified) should be displayed on the left side of the checkbox",
+      "category": "content"
     },
 
     "color": {
@@ -31,7 +34,8 @@
 
     "keep-color": {
       "type": "Boolean",
-      "desc": "Should the color (if specified any) be kept when checkbox is unticked?"
+      "desc": "Should the color (if specified any) be kept when checkbox is unticked?",
+      "category": "behavior"
     },
 
     "dark": {

--- a/quasar/src/components/range/QRange.json
+++ b/quasar/src/components/range/QRange.json
@@ -15,38 +15,44 @@
           "examples": [ 12 ]
         }
       },
-      "examples": [ "v-model=\"positionModel\"" ]
+      "examples": [ "v-model=\"positionModel\"" ],
+      "category": "behavior"
     },
 
     "min": {
       "type": "Number",
       "desc": "Minimum value of the model",
       "default": 0,
-      "examples": [ ":min=\"0\"" ]
+      "examples": [ ":min=\"0\"" ],
+      "category": "behavior"
     },
 
     "max": {
       "type": "Number",
       "desc": "Maximum value of the model",
       "default": 100,
-      "examples": [ ":max=\"100\"" ]
+      "examples": [ ":max=\"100\"" ],
+      "category": "behavior"
     },
 
     "step": {
       "type": "Number",
       "desc": "Specify step amount between valid values (> 0.0); When step equals to 0 it defines infinite granularity",
       "default": 1,
-      "examples": [ ":step=\"1\"" ]
+      "examples": [ ":step=\"1\"" ],
+      "category": "behavior"
     },
 
     "drag-range": {
       "type": "Boolean",
-      "desc": "User can drag range instead of just the two thumbs"
+      "desc": "User can drag range instead of just the two thumbs",
+      "category": "behavior"
     },
 
     "drag-range-only": {
       "type": "Boolean",
-      "desc": "User can drag only the range instead and NOT the two thumbs"
+      "desc": "User can drag only the range instead and NOT the two thumbs",
+      "category": "behavior"
     },
 
     "color": {
@@ -55,22 +61,26 @@
 
     "label": {
       "type": "Boolean",
-      "desc": "Popup labels (for left and right thumbs) when user clicks/taps on the slider thumb and moves it"
+      "desc": "Popup labels (for left and right thumbs) when user clicks/taps on the slider thumb and moves it",
+      "category": "content"
     },
 
     "label-color": {
       "extends": "color",
-      "desc": "Color name for labels background from the Quasar Color Palette; Applies to both labels, unless specific label color props are used"
+      "desc": "Color name for labels background from the Quasar Color Palette; Applies to both labels, unless specific label color props are used",
+      "category": "content"
     },
 
     "left-label-color": {
       "extends": "color",
-      "desc": "Color name for left label background from the Quasar Color Palette"
+      "desc": "Color name for left label background from the Quasar Color Palette",
+      "category": "content"
     },
 
     "right-label-color": {
       "extends": "color",
-      "desc": "Color name for right label background from the Quasar Color Palette"
+      "desc": "Color name for right label background from the Quasar Color Palette",
+      "category": "content"
     },
 
     "left-label-value": {
@@ -78,7 +88,8 @@
       "desc": "Override default label for min value",
       "examples": [
         ":left-label-value=\"model.min + 'px'\""
-      ]
+      ],
+      "category": "content"
     },
 
     "right-label-value": {
@@ -86,22 +97,26 @@
       "desc": "Override default label for max value",
       "examples": [
         ":right-label-value=\"model.max + 'px'\""
-      ]
+      ],
+      "category": "content"
     },
 
     "label-always": {
       "type": "Boolean",
-      "desc": "Always display the labels"
+      "desc": "Always display the labels",
+      "category": "content|behavior"
     },
 
     "markers": {
       "type": "Boolean",
-      "desc": "Display markers on the track, one for each possible value for the model"
+      "desc": "Display markers on the track, one for each possible value for the model",
+      "category": "content|behavior"
     },
 
     "snap": {
       "type": "Boolean",
-      "desc": "Snap thumbs on valid values, rather than sliding freely; Suggestion: use with 'step' prop"
+      "desc": "Snap thumbs on valid values, rather than sliding freely; Suggestion: use with 'step' prop",
+      "category": "behavior"
     },
 
     "dark": {

--- a/quasar/src/components/rating/QRating.json
+++ b/quasar/src/components/rating/QRating.json
@@ -14,7 +14,8 @@
       "type": [ "Number", "String" ],
       "desc": "Number of icons to display",
       "default": 5,
-      "examples": [ "3", ":max=\"5\"" ]
+      "examples": [ "3", ":max=\"5\"" ],
+      "category": "content"
     },
 
     "icon": {
@@ -31,7 +32,8 @@
 
     "no-reset": {
       "type": "Boolean",
-      "desc": "When used, disables default behavior of clicking/tapping on icon which represents current model value to reset model to 0"
+      "desc": "When used, disables default behavior of clicking/tapping on icon which represents current model value to reset model to 0",
+      "category": "behavior"
     },
 
     "readonly": {

--- a/quasar/src/components/scroll-area/QScrollArea.json
+++ b/quasar/src/components/scroll-area/QScrollArea.json
@@ -3,31 +3,36 @@
     "thumb-style": {
       "type": "Object",
       "desc": "Object with CSS properties and values for styling the thumb of custom scrollbar",
-      "examples": [ ":thumb-style=\"{ right: '4px', borderRadius: '5px', background: 'red', width: '10px', opacity: 1 }\"" ]
+      "examples": [ ":thumb-style=\"{ right: '4px', borderRadius: '5px', background: 'red', width: '10px', opacity: 1 }\"" ],
+      "category": "style"
     },
 
     "content-style": {
       "type": "Object",
       "desc": "Object with CSS properties and values for styling the container of QScrollArea",
-      "examples": [ ":content-style=\"{ backgroundColor: '#C0C0C0' }\"" ]
+      "examples": [ ":content-style=\"{ backgroundColor: '#C0C0C0' }\"" ],
+      "category": "style"
     },
 
     "content-active-style": {
       "type": "Object",
       "desc": "Object with CSS properties and values for styling the container of QScrollArea when scroll area becomes active (is mouse hovered)",
-      "examples": [ ":content-active-style=\"{ backgroundColor: 'white' }\"" ]
+      "examples": [ ":content-active-style=\"{ backgroundColor: 'white' }\"" ],
+      "category": "style"
     },
 
     "delay": {
       "type": [ "Number", "String" ],
       "desc": "When content changes, the scrollbar appears; this delay defines the amount of time (in milliseconds) before scrollbars dissapear again (if component is not hovered)",
       "default": 1000,
-      "examples": [ 500, ":delay=\"550\"" ]
+      "examples": [ 500, ":delay=\"550\"" ],
+      "category": "behavior"
     },
 
     "horizontal": {
       "type": "Boolean",
-      "desc": "Register for horizontal scroll instead of vertical (which is default)"
+      "desc": "Register for horizontal scroll instead of vertical (which is default)",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/select/QSelect.json
+++ b/quasar/src/components/select/QSelect.json
@@ -6,23 +6,27 @@
       "type": [ "Number", "String", "Array" ],
       "desc": "Model of the component; Must be Array if using 'multiple' prop; Either use this property (along with a listener for 'input' event) OR use v-model directive",
       "required": true,
-      "examples": [ "v-model=\"myModel\"" ]
+      "examples": [ "v-model=\"myModel\"" ],
+      "category": "selection|behavior"
     },
 
     "multiple": {
       "type": "Boolean",
-      "desc": "Allow multiple selection; Model must be Array"
+      "desc": "Allow multiple selection; Model must be Array",
+      "category": "selection"
     },
 
     "display-value": {
       "type": [ "Number", "String" ],
       "desc": "Override default selection string, if not using 'selected' slot/scoped slot and if not using 'use-chips' prop",
-      "examples": [ "Options: x, y, z"]
+      "examples": [ "Options: x, y, z"],
+      "category": "selection"
     },
 
     "display-value-sanitize": {
       "extends": "sanitize",
-      "desc": "Force use of textContent instead of innerHTML to render selected option(s); Use it when the selected option(s) might be unsafe (from user input); Does NOT apply when using 'selected' or 'selected-item' slots!"
+      "desc": "Force use of textContent instead of innerHTML to render selected option(s); Use it when the selected option(s) might be unsafe (from user input); Does NOT apply when using 'selected' or 'selected-item' slots!",
+      "category": "selection"
     },
 
     "options": {
@@ -32,7 +36,8 @@
       "examples": [
         ":options=\"[ 'BMW', 'Samsung Phone' ]\"",
         ":options=\"[ { label: 'BMW', value: 'car' }, { label: 'Samsung Phone', value: 'phone' } ]\""
-      ]
+      ],
+      "category": "options"
     },
 
     "option-value": {
@@ -42,7 +47,8 @@
       "examples": [
         "option-value=\"modelNumber\"",
         ":option-value=\"(item) => item.modelNumber\""
-      ]
+      ],
+      "category": "options"
     },
 
     "option-label": {
@@ -52,7 +58,8 @@
       "examples": [
         "option-label=\"itemName\"",
         ":option-label=\"(item) => item.itemName\""
-      ]
+      ],
+      "category": "options"
     },
 
     "option-disable": {
@@ -62,17 +69,20 @@
       "examples": [
         "option-disable=\"cannotSelect\"",
         ":option-disable=\"(item) => item.cannotSelect\""
-      ]
+      ],
+      "category": "options"
     },
 
     "hide-selected": {
       "type": "Boolean",
-      "desc": "Hides selection; Use the underlying input tag to hold the label (instead of showing it to the right of the input) of the selected option; Only works for non 'multiple' Selects"
+      "desc": "Hides selection; Use the underlying input tag to hold the label (instead of showing it to the right of the input) of the selected option; Only works for non 'multiple' Selects",
+      "category": "options"
     },
 
     "hide-dropdown-icon": {
       "type": "Boolean",
-      "desc": "Hides dropdown icon"
+      "desc": "Hides dropdown icon",
+      "category": "content"
     },
 
     "dropdown-icon": {
@@ -82,83 +92,98 @@
     "max-values": {
       "type": [ "Number", "String" ],
       "desc": "Allow a maximum number of selections that the user can do",
-      "examples": [ "5" ]
+      "examples": [ "5" ],
+      "category": "selection"
     },
 
     "options-dense": {
       "extends": "dense",
-      "desc": "Dense mode for options list; occupies less space"
+      "desc": "Dense mode for options list; occupies less space",
+      "category": "options|style"
     },
 
     "options-dark": {
       "type": "Boolean",
-      "desc": "Options menu will be colored with a dark color"
+      "desc": "Options menu will be colored with a dark color",
+      "category": "options|style"
     },
 
     "options-selected-class": {
       "type": "String",
       "desc": "CSS class name for options that are active/selected",
-      "examples": [ "text-orange" ]
+      "examples": [ "text-orange" ],
+      "category": "options|selection|style"
     },
 
     "options-cover": {
       "type": "Boolean",
-      "desc": "Expanded menu will cover the component"
+      "desc": "Expanded menu will cover the component",
+      "category": "options|style"
     },
 
     "options-sanitize": {
       "extends": "sanitize",
-      "desc": "Force use of textContent instead of innerHTML to render options; Use it when the options might be unsafe (from user input); Does NOT applies when using 'option' slot!"
+      "desc": "Force use of textContent instead of innerHTML to render options; Use it when the options might be unsafe (from user input); Does NOT applies when using 'option' slot!",
+      "category": "options"
     },
 
     "use-input": {
       "type": "Boolean",
-      "desc": "Use an input tag where users can type"
+      "desc": "Use an input tag where users can type",
+      "category": "content"
     },
 
     "use-chips": {
       "type": "Boolean",
-      "desc": "Use QChip to show what is currently selected"
+      "desc": "Use QChip to show what is currently selected",
+      "category": "selection"
     },
 
     "new-value-mode": {
       "type": "String",
       "desc": "Enables creation of new values and defines behavior when a new value is added: 'add' means it adds the value (even if possible duplicate), 'add-unique' adds only unique values, and 'toggle' adds or removes the value (based on if it exists or not already); When using this prop then listening for @new-value becomes optional (only to override the behavior defined by 'new-value-mode')",
-      "values": [ "add", "add-unique", "toggle" ]
+      "values": [ "add", "add-unique", "toggle" ],
+      "category": "behavior"
     },
 
     "map-options": {
       "type": "Boolean",
-      "desc": "Try to map labels of model from 'options' Array; has a small performance penalty"
+      "desc": "Try to map labels of model from 'options' Array; has a small performance penalty",
+      "category": "options|behavior"
     },
 
     "emit-value": {
       "type": "Boolean",
-      "desc": "Update model with the value of the selected option instead of the whole option"
+      "desc": "Update model with the value of the selected option instead of the whole option",
+      "category": "selection|behavior"
     },
 
     "input-debounce": {
       "type": [ "Number", "String" ],
       "desc": "Debounce the input model update with an amount of milliseconds",
       "default": 500,
-      "examples": [ 650 ]
+      "examples": [ 650 ],
+      "category": "behavior"
     },
 
     "autofocus": {
       "type": "Boolean",
-      "desc": "Focus component on initial render"
+      "desc": "Focus component on initial render",
+      "category": "behavior"
     },
 
     "transition-show": {
       "extends": "transition",
       "desc": "Transition when showing the menu; One of Quasar's embedded transitions; Works only if \"cover-options\" is not used",
-      "default": "fade"
+      "default": "fade",
+      "category": "style"
     },
 
     "transition-hide": {
       "extends": "transition",
       "desc": "Transition when hiding the menu; One of Quasar's embedded transitions; Works only if \"cover-options\" is not used",
-      "default": "fade"
+      "default": "fade",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/separator/QSeparator.json
+++ b/quasar/src/components/separator/QSeparator.json
@@ -6,18 +6,21 @@
 
     "spaced": {
       "type": "Boolean",
-      "desc": "If set to true, the top and bottom margins will be set to 8px"
+      "desc": "If set to true, the top and bottom margins will be set to 8px",
+      "category": "style"
     },
 
     "inset": {
       "type": [ "Boolean", "String" ],
       "desc": "if set to true, the left and right margins will be set to 16px. If set to item, the left and right margins will be set to 72px. If set to item-thumbnail, the left margin is set to 116px and right margin is set to 0px",
-      "examples": [ "item", "item-thumbnail" ]
+      "examples": [ "item", "item-thumbnail" ],
+      "category": "style"
     },
 
     "vertical": {
       "type": "Boolean",
-      "desc": "If set to true, the separator will be vertical."
+      "desc": "If set to true, the separator will be vertical.",
+      "category": "behavior"
     },
 
     "color": {

--- a/quasar/src/components/slide-transition/QSlideTransition.json
+++ b/quasar/src/components/slide-transition/QSlideTransition.json
@@ -2,14 +2,16 @@
   "props": {
     "appear": {
       "type": "Boolean",
-      "desc": "If set to true, the transition will be applied on the initial render."
+      "desc": "If set to true, the transition will be applied on the initial render.",
+      "category": "behavior"
     },
 
     "duration": {
       "type": "Number",
       "desc": "Duration (in milliseconds) enabling animated scroll.",
       "default": 300,
-      "examples": [ 500, ":duration=\"500\"" ]
+      "examples": [ 500, ":duration=\"500\"" ],
+      "category": "behavior"
     }
   },
   

--- a/quasar/src/components/slider/QSlider.json
+++ b/quasar/src/components/slider/QSlider.json
@@ -3,28 +3,32 @@
     "value": {
       "type": "Number",
       "desc": "Model of the component (must be between min/max); Either use this property (along with a listener for 'input' event) OR use v-model directive",
-      "examples": [ "v-model=\"positionModel\"" ]
+      "examples": [ "v-model=\"positionModel\"" ],
+      "category": "behavior"
     },
 
     "min": {
       "type": "Number",
       "desc": "Minimum value of the model",
       "default": 0,
-      "examples": [ ":min=\"0\"" ]
+      "examples": [ ":min=\"0\"" ],
+      "category": "behavior"
     },
 
     "max": {
       "type": "Number",
       "desc": "Maximum value of the model",
       "default": 100,
-      "examples": [ ":max=\"100\"" ]
+      "examples": [ ":max=\"100\"" ],
+      "category": "behavior"
     },
 
     "step": {
       "type": "Number",
       "desc": "Specify step amount between valid values (> 0.0); When step equals to 0 it defines infinite granularity",
       "default": 1,
-      "examples": [ ":step=\"1\"" ]
+      "examples": [ ":step=\"1\"" ],
+      "category": "behavior"
     },
 
     "color": {
@@ -33,11 +37,13 @@
 
     "label": {
       "type": "Boolean",
-      "desc": "Popup a label when user clicks/taps on the slider thumb and moves it"
+      "desc": "Popup a label when user clicks/taps on the slider thumb and moves it",
+      "category": "content"
     },
 
     "label-color": {
-      "extends": "color"
+      "extends": "color",
+      "category": "content"
     },
 
     "label-value": {
@@ -45,22 +51,26 @@
       "desc": "Override default label value",
       "examples": [
         ":label-value=\"model + 'px'\""
-      ]
+      ],
+      "category": "content"
     },
 
     "label-always": {
       "type": "Boolean",
-      "desc": "Always display the label"
+      "desc": "Always display the label",
+      "category": "content"
     },
 
     "markers": {
       "type": "Boolean",
-      "desc": "Display markers on the track, one for each possible value for the model"
+      "desc": "Display markers on the track, one for each possible value for the model",
+      "category": "content"
     },
 
     "snap": {
       "type": "Boolean",
-      "desc": "Snap on valid values, rather than sliding freely; Suggestion: use with 'step' prop"
+      "desc": "Snap on valid values, rather than sliding freely; Suggestion: use with 'step' prop",
+      "category": "behavior"
     },
 
     "dark": {

--- a/quasar/src/components/spinner/QSpinner.json
+++ b/quasar/src/components/spinner/QSpinner.json
@@ -16,7 +16,8 @@
       "type": "Number",
       "desc": "Override value to use for stroke-width",
       "default": 5,
-      "examples": [ "2", "5" ]
+      "examples": [ "2", "5" ],
+      "category": "style"
     }
   }
 }

--- a/quasar/src/components/splitter/QSplitter.json
+++ b/quasar/src/components/splitter/QSplitter.json
@@ -7,19 +7,22 @@
     "value": {
       "type": "Number",
       "desc": "Model of the component defining the split ratio percent (0.0 < x < 100.0) between panes; Either use this property (along with a listener for 'input' event) OR use v-model directive",
-      "examples": [ "v-model=\"ratio\"" ]
+      "examples": [ "v-model=\"ratio\"" ],
+      "category": "behavior"
     },
 
     "horizontal": {
       "type": "Boolean",
-      "desc": "Allows the splitter to split its two panes horizontally, instead of vertically"
+      "desc": "Allows the splitter to split its two panes horizontally, instead of vertically",
+      "category": "behavior"
     },
 
     "limits": {
       "type": "Array",
       "desc": "An array of two values representing a ratio of minimum and maximum split area of the two panes (0.0 < x < 100.0)",
       "default": "[10, 90]",
-      "examples": [ ":limits=\"[30, 70]\"" ]
+      "examples": [ ":limits=\"[30, 70]\"" ],
+      "category": "behavior"
     },
 
     "disable": {
@@ -32,7 +35,8 @@
       "examples": [
         "bg-deep-orange",
         ":before-class=\"{ 'my-special-class': <condition> }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "after-class": {
@@ -41,7 +45,8 @@
       "examples": [
         "bg-deep-orange",
         ":after-class=\"{ 'my-special-class': <condition> }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "separator-class": {
@@ -50,7 +55,8 @@
       "examples": [
         "bg-deep-orange",
         ":separator-class=\"{ 'my-special-class': <condition> }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "separator-style": {
@@ -59,12 +65,14 @@
       "examples": [
         "background-color: #ff0000",
         ":separator-style=\"{ backgroundColor: '#ff0000' }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "dark": {
       "type": "Boolean",
-      "desc": "Applies a default lighter color on the separator; To be used when background is darker; Avoid using when you are overriding through separator-class or separator-style props"
+      "desc": "Applies a default lighter color on the separator; To be used when background is darker; Avoid using when you are overriding through separator-class or separator-style props",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/stepper/QStep.json
+++ b/quasar/src/components/stepper/QStep.json
@@ -20,7 +20,8 @@
       "required": true,
       "examples": [
         "Ad Groups", "Payment"
-      ]
+      ],
+      "category": "content"
     },
 
     "caption": {
@@ -28,7 +29,8 @@
       "desc": "Step’s additional information that appears beneath the title",
       "examples": [
         "Create an account", "Payment details"
-      ]
+      ],
+      "category": "content"
     },
 
     "done-icon": {
@@ -58,17 +60,20 @@
     "header-nav": {
       "type": "Boolean",
       "default": true,
-      "desc": "Allow navigation through the header"
+      "desc": "Allow navigation through the header",
+      "category": "behavior"
     },
 
     "done": {
       "type": "Boolean",
-      "desc": "Mark the step as 'done'"
+      "desc": "Mark the step as 'done'",
+      "category": "behavior"
     },
 
     "error": {
       "type": "Boolean",
-      "desc": "Mark the step as having an error"
+      "desc": "Mark the step as having an error",
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/stepper/QStepper.json
+++ b/quasar/src/components/stepper/QStepper.json
@@ -20,22 +20,26 @@
 
     "vertical": {
       "type": "Boolean",
-      "desc": "Put Stepper in vertical mode (instead of horizontal by default)"
+      "desc": "Put Stepper in vertical mode (instead of horizontal by default)",
+      "category": "behavior"
     },
 
     "alternative-labels": {
       "type": "Boolean",
-      "desc": "Use alternative labels (applies only to horizontal stepper)"
+      "desc": "Use alternative labels (applies only to horizontal stepper)",
+      "category": "content"
     },
 
     "header-nav": {
       "type": "Boolean",
-      "desc": "Allow navigation through the header"
+      "desc": "Allow navigation through the header",
+      "category": "content"
     },
 
     "contracted": {
       "type": "Boolean",
-      "desc": "Hide header labels on narrow windows"
+      "desc": "Hide header labels on narrow windows",
+      "category": "content"
     },
 
     "inactive-icon": {

--- a/quasar/src/components/table/QMarkupTable.json
+++ b/quasar/src/components/table/QMarkupTable.json
@@ -25,12 +25,14 @@
       "desc": "Use a separator/border between rows, columns or all cells",
       "default": "horizontal",
       "values": [ "horizontal", "vertical", "cell", "none" ],
-      "examples": [ "cell" ]
+      "examples": [ "cell" ],
+      "category": "content"
     },
 
     "wrap-cells": {
       "type": "Boolean",
-      "desc": "Wrap text within table cells"
+      "desc": "Wrap text within table cells",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/table/QTable.json
+++ b/quasar/src/components/table/QTable.json
@@ -22,12 +22,14 @@
 
     "grid": {
       "type": "Boolean",
-      "desc": "Display data as a grid instead of the default table"
+      "desc": "Display data as a grid instead of the default table",
+      "category": "behavior"
     },
 
     "dense": {
       "extends": "dense",
-      "desc": "Dense mode; Connect with $q.screen for responsive behavior"
+      "desc": "Dense mode; Connect with $q.screen for responsive behavior",
+      "category": "style"
     },
 
     "columns": {
@@ -47,23 +49,27 @@
 
     "loading": {
       "type": "Boolean",
-      "desc": "Put Table into 'loading' state; Notify the user something is happening behind the covers"
+      "desc": "Put Table into 'loading' state; Notify the user something is happening behind the covers",
+      "category": "behavior"
     },
 
     "title": {
       "type": "String",
       "desc": "Table title",
-      "examples": [ "Device list" ]
+      "examples": [ "Device list" ],
+      "category": "content"
     },
 
     "hide-header": {
       "type": "Boolean",
-      "desc": "Hide table header layer"
+      "desc": "Hide table header layer",
+      "category": "content"
     },
 
     "hide-bottom": {
       "type": "Boolean",
-      "desc": "Hide table bottom layer"
+      "desc": "Hide table bottom layer",
+      "category": "content"
     },
 
     "dark": {
@@ -83,35 +89,41 @@
       "desc": "Use a separator/border between rows, columns or all cells",
       "default": "horizontal",
       "values": [ "horizontal", "vertical", "cell", "none" ],
-      "examples": [ "cell" ]
+      "examples": [ "cell" ],
+      "category": "content"
     },
 
     "wrap-cells": {
       "type": "Boolean",
-      "desc": "Wrap text within table cells"
+      "desc": "Wrap text within table cells",
+      "category": "content"
     },
 
     "binary-state-sort": {
       "type": "Boolean",
-      "desc": "Skip the third state (unsorted) when user toggles column sort direction"
+      "desc": "Skip the third state (unsorted) when user toggles column sort direction",
+      "category": "behavior"
     },
 
     "no-data-label": {
       "type": "String",
       "desc": "Override default text to display when no data is available",
-      "examples": [ "No devices available" ]
+      "examples": [ "No devices available" ],
+      "category": "content"
     },
 
     "no-results-label": {
       "type": "String",
       "desc": "Override default text to display when user filters the table and no matched results are found",
-      "examples": [ "No matched records" ]
+      "examples": [ "No matched records" ],
+      "category": "content"
     },
 
     "loading-label": {
       "type": "String",
       "desc": "Override default text to display when table is in loading state (see 'loading' prop)",
-      "examples": [ "Loading devices..." ]
+      "examples": [ "Loading devices..." ],
+      "category": "content"
     },
 
     "selected-rows-label": {
@@ -129,13 +141,15 @@
         "desc": "Label to display",
         "examples": [ "5 rows are selected" ]
       },
-      "examples": [ ":selected-rows-label=\"getSelectedString\"" ]
+      "examples": [ ":selected-rows-label=\"getSelectedString\"" ],
+      "category": "content"
     },
 
     "rows-per-page-label": {
       "type": "String",
       "desc": "Text to override default rows per page label at bottom of table",
-      "examples": [ "Records per page:" ]
+      "examples": [ "Records per page:" ],
+      "category": "pagination"
     },
 
     "pagination-label": {
@@ -163,7 +177,8 @@
         "desc": "Label to display",
         "examples": [ "1-10 of 132" ]
       },
-      "examples": [ ":rows-per-page=\"getPaginationLabel\"" ]
+      "examples": [ ":rows-per-page=\"getPaginationLabel\"" ],
+      "category": "pagination"
     },
 
     "table-style": {
@@ -172,7 +187,8 @@
       "examples": [
         "background-color: #ff0000",
         ":table-style=\"{ backgroundColor: '#ff0000' }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "table-class": {
@@ -181,13 +197,15 @@
       "examples": [
         "my-special-class",
         ":table-class=\"{ 'my-special-class': [Boolean condition] }\""
-      ]
+      ],
+      "category": "style"
     },
 
     "filter": {
       "type": [ "String", "Object" ],
       "desc": "String/Object to filter table with; When using an Object it requires 'filter-method' to also be specified since it will be a custom filtering",
-      "examples": [ ":filter=\"myFilterInput\"" ]
+      "examples": [ ":filter=\"myFilterInput\"" ],
+      "category": "behavior"
     },
 
     "filter-method": {
@@ -241,7 +259,8 @@
       "default": "(see source code)",
       "examples": [
         "(see source code)"
-      ]
+      ],
+      "category": "behavior"
     },
 
     "pagination": {
@@ -276,7 +295,8 @@
       },
       "examples": [
         ":pagination.sync=\"myPagination\""
-      ]
+      ],
+      "category": "pagination"
     },
 
     "rows-per-page-options": {
@@ -285,7 +305,8 @@
       "default": "[3, 5, 7, 10, 15, 20, 25, 50, 0]",
       "examples": [
         ":rows-per-page-options=\"[10, 20]\""
-      ]
+      ],
+      "category": "pagination"
     },
 
     "selection": {
@@ -293,7 +314,8 @@
       "desc": "Selection type",
       "default": "none",
       "values": [ "single", "multiple", "none" ],
-      "examples": [ "multiple" ]
+      "examples": [ "multiple" ],
+      "category": "behavior"
     },
 
     "selected": {
@@ -303,7 +325,8 @@
       "default": "[]",
       "examples": [
         ":selected.sync=\"selection\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "sort-method": {
@@ -333,7 +356,8 @@
       "default": "(see source code)",
       "examples": [
         "(see source code)"
-      ]
+      ],
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/table/QTd.json
+++ b/quasar/src/components/table/QTd.json
@@ -8,7 +8,8 @@
 
     "auto-width": {
       "type": "Boolean",
-      "desc": "Tries to shrink column width size; Useful for columns with a checkbox/radio/toggle"
+      "desc": "Tries to shrink column width size; Useful for columns with a checkbox/radio/toggle",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/table/QTh.json
+++ b/quasar/src/components/table/QTh.json
@@ -8,7 +8,8 @@
 
     "auto-width": {
       "type": "Boolean",
-      "desc": "Tries to shrink header column width size; Useful for columns with a checkbox/radio/toggle"
+      "desc": "Tries to shrink header column width size; Useful for columns with a checkbox/radio/toggle",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/tabs/QRouteTab.json
+++ b/quasar/src/components/tabs/QRouteTab.json
@@ -3,7 +3,8 @@
   
   "props": {
     "to": {
-      "required": true
+      "required": true,
+      "category": "behavior"
     }
   }
 }

--- a/quasar/src/components/tabs/QTab.json
+++ b/quasar/src/components/tabs/QTab.json
@@ -13,7 +13,8 @@
     "label": {
       "type": [ "Number", "String" ],
       "desc": "A number or string to label the tab",
-      "examples": [ "Home" ]
+      "examples": [ "Home" ],
+      "category": "content"
     },
 
     "alert": {
@@ -22,7 +23,8 @@
       "examples": [
         "alert",
         "alert=\"purple\""
-      ]
+      ],
+      "category": "content"
     },
 
     "name": {
@@ -36,7 +38,8 @@
 
     "no-caps": {
       "type": "Boolean",
-      "desc": "Turns off capitalizing all letters within the tab (which is the default)"
+      "desc": "Turns off capitalizing all letters within the tab (which is the default)",
+      "category": "content"
     },
 
     "tabindex": {

--- a/quasar/src/components/tabs/QTabs.json
+++ b/quasar/src/components/tabs/QTabs.json
@@ -12,7 +12,8 @@
 
     "vertical": {
       "type": "Boolean",
-      "desc": "Use vertical design (tabs one on top of each other rather than one next to the other horizontally)"
+      "desc": "Use vertical design (tabs one on top of each other rather than one next to the other horizontally)",
+      "category": "style"
     },
 
     "align": {
@@ -20,66 +21,78 @@
       "desc": "Horizontal alignment the tabs within the tabs container",
       "default": "center",
       "values": [ "left", "center", "right", "justify" ],
-      "examples": [ "right" ]
+      "examples": [ "right" ],
+      "category": "style"
     },
 
     "breakpoint": {
       "type": [ "Number", "String" ],
       "desc": "Breakpoint (in pixels) of tabs container width at which the tabs automatically turn to a justify alignment",
       "default": 600,
-      "examples": [ ":breakpoint=\"500\"" ]
+      "examples": [ ":breakpoint=\"500\"" ],
+      "category": "behavior"
     },
 
     "active-color": {
       "extends": "color",
-      "desc": "The color to be attributed to the text of the active tab"
+      "desc": "The color to be attributed to the text of the active tab",
+      "category": "style"
     },
 
     "active-bg-color": {
       "extends": "color",
-      "desc": "The color to be attributed to the background of the active tab"
+      "desc": "The color to be attributed to the background of the active tab",
+      "category": "style"
     },
 
     "indicator-color": {
       "extends": "color",
-      "desc": "The color to be attributed to the indicator (the underline) of the active tab"
+      "desc": "The color to be attributed to the indicator (the underline) of the active tab",
+      "category": "style"
     },
 
     "left-icon": {
       "type": "String",
       "desc": "The name of an icon to replace the default arrow used to scroll through the tabs to the left, when the tabs extend past the width of the tabs container",
-      "examples": [ "arrow_left" ]
+      "examples": [ "arrow_left" ],
+      "category": "content"
     },
 
     "right-icon": {
       "type": "String",
       "desc": "The name of an icon to replace the default arrow used to scroll through the tabs to the right, when the tabs extend past the width of the tabs container",
-      "examples": [ "arrow_right" ]
+      "examples": [ "arrow_right" ],
+      "category": "content"
     },
 
     "shrink": {
       "type": "Boolean",
-      "desc": "By default, QTabs is set to grow to the available space; However, you can reverse that with this prop; Useful (and required) when placing the component in a QToolbar"
+      "desc": "By default, QTabs is set to grow to the available space; However, you can reverse that with this prop; Useful (and required) when placing the component in a QToolbar",
+      "category": "behavior"
     },
 
     "switch-indicator": {
       "type": "Boolean",
-      "desc": "Switches the indicator position (on left of tab for vertical mode or above the tab for default horizontal mode)"
+      "desc": "Switches the indicator position (on left of tab for vertical mode or above the tab for default horizontal mode)",
+      "category": "content"
     },
 
     "narrow-indicator": {
       "type": "Boolean",
-      "desc": "Allows the indicator to be the same width as the tab's content (text or icon), instead of the whole width of the tab"
+      "desc": "Allows the indicator to be the same width as the tab's content (text or icon), instead of the whole width of the tab",
+      "category": "content"
     },
 
     "inline-label": {
       "type": "Boolean",
-      "desc": "Allows the text to be inline with the icon, should one be used"
+      "desc": "Allows the text to be inline with the icon, should one be used",
+      "category": "content"
     },
 
     "no-caps": {
       "type": "Boolean",
-      "desc": "Turns off capitalizing all letters within the tab (which is the default)"
+      "desc": "Turns off capitalizing all letters within the tab (which is the default)",
+      "category": "content"
     },
 
     "dense": {

--- a/quasar/src/components/timeline/QTimeline.json
+++ b/quasar/src/components/timeline/QTimeline.json
@@ -12,14 +12,16 @@
       "type": "String",
       "desc": "Side to place the timeline entries in dense and comfortable layout; For loose layout it gets overriden by QTimelineEntry side prop",
       "default": "right",
-      "values": [ "left", "right" ]
+      "values": [ "left", "right" ],
+      "category": "content"
     },
 
     "layout": {
       "type": "String",
       "desc": "Layout of the timeline. Dense keeps content and labels on one side. Comfortable keeps content on one side and labels on the opposite side. Loose puts content on both sides.",
       "default": "large",
-      "values": [ "dense", "comfortable", "loose" ]
+      "values": [ "dense", "comfortable", "loose" ],
+      "category": "style"
     },
 
     "dark": {

--- a/quasar/src/components/timeline/QTimelineEntry.json
+++ b/quasar/src/components/timeline/QTimelineEntry.json
@@ -6,21 +6,24 @@
   "props": {
     "heading": {
       "type": "Boolean",
-      "desc": "Defines a heading timeline item"
+      "desc": "Defines a heading timeline item",
+      "category": "content"
     },
 
     "tag": {
       "type": "String",
       "desc": "Tag to use, if of type 'heading' only",
       "default": "h3",
-      "examples": [ "h1" ]
+      "examples": [ "h1" ],
+      "category": "content"
     },
 
     "side": {
       "type": "String",
       "desc": "Side to place the timeline entry; Works only if QTimeline layout is loose.",
       "default": "right",
-      "values": [ "left", "right" ]
+      "values": [ "left", "right" ],
+      "category": "content"
     },
 
     "icon": {
@@ -34,13 +37,15 @@
     "title": {
       "type": "String",
       "desc": "Title of timeline entry",
-      "examples": [ "December party" ]
+      "examples": [ "December party" ],
+      "category": "content"
     },
 
     "subtitle": {
       "type": "String",
       "desc": "Subtitle of timeline entry",
-      "examples": [ "All invited" ]
+      "examples": [ "All invited" ],
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/toggle/QToggle.json
+++ b/quasar/src/components/toggle/QToggle.json
@@ -9,13 +9,15 @@
     "checked-icon": {
       "type": "String",
       "desc": "The icon to be used when the toggle is on",
-      "examples": [ "visibility" ]      
+      "examples": [ "visibility" ],
+      "category": "content"
     },
 
     "unchecked-icon": {
       "type": "String",
       "desc": "The icon to be used when the toggle is off",
-      "examples": [ "visibility_off" ]
+      "examples": [ "visibility_off" ],
+      "category": "content"
     }
   }
 }

--- a/quasar/src/components/toolbar/QToolbar.json
+++ b/quasar/src/components/toolbar/QToolbar.json
@@ -6,7 +6,8 @@
   "props": {
     "inset": {
       "type": "Boolean",
-      "desc": "Apply an inset to content (useful for subsequent toolbars)"
+      "desc": "Apply an inset to content (useful for subsequent toolbars)",
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/toolbar/QToolbarTitle.json
+++ b/quasar/src/components/toolbar/QToolbarTitle.json
@@ -6,7 +6,8 @@
   "props": {
     "shrink": {
       "type": "Boolean",
-      "desc": "By default, QToolbarTitle is set to grow to the available space. However, you can reverse that with this prop"
+      "desc": "By default, QToolbarTitle is set to grow to the available space. However, you can reverse that with this prop",
+      "category": "style"
     }
   },
 

--- a/quasar/src/components/tooltip/QTooltip.json
+++ b/quasar/src/components/tooltip/QTooltip.json
@@ -4,12 +4,14 @@
   "props": {
     "max-height": {
       "extends": "size",
-      "desc": "The maximimum height of the Tooltip; Size in CSS units, including unit name"
+      "desc": "The maximimum height of the Tooltip; Size in CSS units, including unit name",
+      "category": "style"
     },
 
     "max-width": {
       "extends": "size",
-      "desc": "The maximimum width of the Tooltip; Size in CSS units, including unit name"
+      "desc": "The maximimum width of the Tooltip; Size in CSS units, including unit name",
+      "category": "style"
     },
 
     "transition-show": {
@@ -30,7 +32,8 @@
         "center left", "center middle", "center right",
         "bottom left", "bottom middle", "bottom right"
       ],
-      "examples": [ "top left", "bottom right" ]
+      "examples": [ "top left", "bottom right" ],
+      "category": "behavior"
     },
 
     "self": {
@@ -41,14 +44,16 @@
         "center left", "center middle", "center right",
         "bottom left", "bottom middle", "bottom right"
       ],
-      "examples": [ "top left", "bottom right" ]
+      "examples": [ "top left", "bottom right" ],
+      "category": "style"
     },
 
     "offset": {
       "type": "Array",
       "desc": "An array of two numbers to offset the Tooltip horizontally and vertically in pixels",
       "default": "[14, 14]",
-      "examples": [ "[8, 8]", "[5, 10]" ]
+      "examples": [ "[8, 8]", "[5, 10]" ],
+      "category": "style"
     },
 
     "target": {
@@ -59,14 +64,16 @@
       "examples": [
         ":target=\"false\"",
         "target=\".my-parent\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "delay": {
       "type": "Number",
       "desc": "Configure Tooltip to appear with delay",
       "default": 0,
-      "examples": [ ":delay=\"550\"" ]
+      "examples": [ ":delay=\"550\"" ],
+      "category": "behavior"
     }
   },
 

--- a/quasar/src/components/tree/QTree.json
+++ b/quasar/src/components/tree/QTree.json
@@ -4,21 +4,24 @@
       "type": "Array",
       "desc": "The array of nodes that designates the tree structure",
       "required": true,
-      "examples": [ "[ {...}, {...} ]" ]
+      "examples": [ "[ {...}, {...} ]" ],
+      "category": "content"
     },
 
     "node-key": {
       "type": "String",
       "desc": "The property name of each node object that holds a unique node id",
       "required": true,
-      "examples": [ "key", "id" ]
+      "examples": [ "key", "id" ],
+      "category": "content"
     },
 
     "label-key": {
       "type": "String",
       "desc": "The property name of each node object that holds the label of the node",
       "default": "label",
-      "examples": [ "name", "description" ]
+      "examples": [ "name", "description" ],
+      "category": "content"
     },
 
     "color": {
@@ -27,7 +30,8 @@
 
     "control-color": {
       "extends": "color",
-      "desc": "Color name for controls (like checkboxes) from the Quasar Color Palette"
+      "desc": "Color name for controls (like checkboxes) from the Quasar Color Palette",
+      "category": "style"
     },
 
     "text-color": {
@@ -36,7 +40,8 @@
 
     "selected-color": {
       "extends": "color",
-      "desc": "Color name for selected nodes (from the Quasar Color Palette)"
+      "desc": "Color name for selected nodes (from the Quasar Color Palette)",
+      "category": "style"
     },
 
     "dark": {
@@ -51,44 +56,51 @@
       "type": "String",
       "desc": "The type of strategy to use for the selection of the nodes",
       "default": "none",
-      "values": [ "none", "strict", "leaf", "leaf-filtered" ]
+      "values": [ "none", "strict", "leaf", "leaf-filtered" ],
+      "category": "behavior"
     },
 
     "ticked": {
       "type": "Array",
       "desc": "Keys of nodes that are ticked",
       "sync": true,
-      "examples": [ ":ticked.sync=\"tickedKeys\"" ]
+      "examples": [ ":ticked.sync=\"tickedKeys\"" ],
+      "category": "content"
     },
 
     "expanded": {
       "type": "Array",
       "desc": "Keys of nodes that are expanded",
       "sync": true,
-      "examples": [ ":expanded.sync=\"expandedKeys\"" ]
+      "examples": [ ":expanded.sync=\"expandedKeys\"" ],
+      "category": "content"
     },
 
     "selected": {
       "type": "Any",
       "desc": "Key of node currently selected",
       "sync": true,
-      "examples": [ ":selected.sync=\"selectedKey\"" ]
+      "examples": [ ":selected.sync=\"selectedKey\"" ],
+      "category": "content"
     },
 
     "default-expand-all": {
       "type": "Boolean",
-      "desc": "Allow the tree to have all its branches expanded, when first rendered"
+      "desc": "Allow the tree to have all its branches expanded, when first rendered",
+      "category": "behavior"
     },
 
     "accordion": {
       "type": "Boolean",
-      "desc": "Allows the tree to be set in accordion mode"
+      "desc": "Allows the tree to be set in accordion mode",
+      "category": "behavior"
     },
 
     "filter": {
       "type": "String",
       "desc": "The text value to be used for filtering nodes",
-      "examples": [ ":filter=\"searchText\"" ]
+      "examples": [ ":filter=\"searchText\"" ],
+      "category": "behavior"
     },
 
     "filter-method": {
@@ -110,26 +122,30 @@
       "returns": {
         "type": "Boolean",
         "desc": "Matches or not"
-      }
+      },
+      "category": "behavior"
     },
 
     "duration": {
       "type": "Number",
       "desc": "Toggle animation duration (in milliseconds)",
       "default": 300,
-      "examples": [ ":duration=\"500\"" ]
+      "examples": [ ":duration=\"500\"" ],
+      "category": "style"
     },
 
     "no-nodes-label": {
       "type": "String",
       "desc": "Override default such label for when no nodes are available",
-      "examples": [ "No nodes to show!" ]
+      "examples": [ "No nodes to show!" ],
+      "category": "content"
     },
 
     "no-results-label": {
       "type": "String",
       "desc": "Override default such label for when no nodes are available due to filtering",
-      "examples": [ "No results" ]
+      "examples": [ "No results" ],
+      "category": "content"
     }
   },
 

--- a/quasar/src/components/uploader/QUploader.json
+++ b/quasar/src/components/uploader/QUploader.json
@@ -3,7 +3,8 @@
     "label": {
       "type": "String",
       "desc": "Label for the uploader",
-      "examples": [ "Upload photo here" ]
+      "examples": [ "Upload photo here" ],
+      "category": "content"
     },
 
     "color": {
@@ -32,7 +33,8 @@
 
     "multiple": {
       "type": "Boolean",
-      "desc": "Allow multiple file uploads"
+      "desc": "Allow multiple file uploads",
+      "category": "behavior"
     },
 
     "accept": {
@@ -40,19 +42,22 @@
       "desc": "Comma separated list of unique file type specifiers. Maps to 'accept' attribute of native input type=file element",
       "examples": [
         ".jpg, .pdf, image/*", "image/jpeg, .pdf"
-      ]
+      ],
+      "category": "behavior"
     },
 
     "max-file-size": {
       "type": "Number",
       "desc": "Maximum size of individual file in bytes",
-      "examples": [ 1024, 1048576 ]
+      "examples": [ 1024, 1048576 ],
+      "category": "behavior"
     },
 
     "max-total-size": {
       "type": "Number",
       "desc": "Maximum size of all files combined in bytes",
-      "examples": [ 1024, 1048576 ]
+      "examples": [ 1024, 1048576 ],
+      "category": "behavior"
     },
 
     "filter": {
@@ -70,17 +75,20 @@
         "desc": "Filtered files to be added to queue",
         "__exemption": [ "examples" ]
       },
-      "examples": [ ":filter=\"files => files.filter(file => file.size === 1024)\"" ]
+      "examples": [ ":filter=\"files => files.filter(file => file.size === 1024)\"" ],
+      "category": "behavior"
     },
 
     "no-thumbnails": {
       "type": "Boolean",
-      "desc": "Don't display thumbnails for image files"
+      "desc": "Don't display thumbnails for image files",
+      "category": "content"
     },
 
     "auto-upload": {
       "type": "Boolean",
-      "desc": "Upload files immediately when added"
+      "desc": "Upload files immediately when added",
+      "category": "behavior"
     },
 
     "disable": {
@@ -105,13 +113,15 @@
         "type": [ "Object", "Promise" ],
         "desc": "Optional configuration for the upload process; You can override QUploader props in this Object (url, method, headers, fields, fieldName, withCredentials, sendRaw); Props of these Object can also be Functions with the form of (file[s]) => value",
         "__exemption": [ "examples" ]
-      }
+      },
+      "category": "behavior"
     },
 
     "url": {
       "type": [ "String", "Function" ],
       "desc": "URL or path to the server which handles the upload. Takes String or factory function, which returns String. Function is called right before upload",
-      "examples": ["https://example.com/path", "files => `https://example.com?count=${files.length}`"]
+      "examples": ["https://example.com/path", "files => `https://example.com?count=${files.length}`"],
+      "category": "behavior"
     },
 
     "method": {
@@ -119,7 +129,8 @@
       "default": "POST",
       "desc": "HTTP method to use for upload; Takes String or factory function which returns a String; Function is called right before upload",
       "values": [ "POST", "PUT" ],
-      "examples": [ "POST", ":method=\"files => files.length > 10 ? 'POST' : 'PUT'\"" ]
+      "examples": [ "POST", ":method=\"files => files.length > 10 ? 'POST' : 'PUT'\"" ],
+      "category": "behavior"
     },
 
     "field-name": {
@@ -129,7 +140,8 @@
       "examples": [
         "backgroundFile",
         ":field-name=\"(file) => 'background' + file.name\""
-      ]
+      ],
+      "category": "behavior"
     },
 
     "headers": {
@@ -153,7 +165,8 @@
         "[{name: 'Content-Type', value: 'application/json'}, {name: 'Accept', value: 'application/json'}]",
         "() => [{name: 'X-Custom-Timestamp', value: Date.now()}]",
         "files => [{name: 'X-Custom-Count', value: files.length}]"
-      ]
+      ],
+      "category": "behavior"
     },
 
     "fields": {
@@ -177,25 +190,29 @@
         "[{name: 'my-field', value: 'my-value'}]",
         "() => [{name: 'my-field', value: 'my-value'}]",
         "files => [{name: 'my-field', value: 'my-value' + files.length}]"
-      ]
+      ],
+      "category": "behavior"
     },
 
     "with-credentials": {
       "type": [ "Boolean", "Function" ],
       "desc": "Sets withCredentials to true on the XHR that manages the upload; Takes boolean or factory function for Boolean; Function is called right before upload",
-      "examples": [ "with-credentials", ":with-credentials=\"files => ...\"" ]
+      "examples": [ "with-credentials", ":with-credentials=\"files => ...\"" ],
+      "category": "behavior"
     },
 
     "send-raw": {
       "type": [ "Boolean", "Function" ],
       "desc": "Send raw files without wrapping into a Form(); Takes boolean or factory function for Boolean; Function is called right before upload",
-      "examples": [ "send-raw", ":send-raw=\"files => ...\"" ]
+      "examples": [ "send-raw", ":send-raw=\"files => ...\"" ],
+      "category": "behavior"
     },
 
     "batch": {
       "type": [ "Boolean", "Function" ],
       "desc": "Upload files in batch (in one XHR request); Takes boolean or factory function for Boolean; Function is called right before upload",
-      "examples": [ "files => files.length > 10" ]
+      "examples": [ "files => files.length > 10" ],
+      "category": "behavior"
     }
   },
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I am making this WIP PR to discuss with the maintainers the viability of this feature, and how to address it properly if we decide its a good one. 

Some components have a lot of props e.g. QSelect. Grouping the props by categories such as style, behavior, content, options can make them easier to understand and locate. My approach for it is a new key on API JSON definition, **category**, which is parsed by the DocApi component. The grouped by props is displayed as follows:

![image](https://user-images.githubusercontent.com/20051258/55289340-ee9fd800-539b-11e9-8e88-18806e3bdc04.png)

Some points to consider:

- Its hard to have consistency through categories. In one API JSON I can put "value" on "behavior" or "general", and that can be confusing for devs.
- It creates another variable to maintain.
- It is hard to validate this PR (make sure all props are on the correct category).

Please let me know if I can help with this feature or if I should close it. Thank you.

