### PR TITLE
QForm validation and focusing fixes

### DIFF
--- a/quasar/dev/components/form/form.vue
+++ b/quasar/dev/components/form/form.vue
@@ -7,6 +7,7 @@
 
     <q-toggle v-model="show" label="Show form" />
     <q-toggle v-model="autofocus" label="Autofocus" />
+    <q-option-group class="q-mb-lg" inline v-model="autofocusEl" dense="dense" :options="autofocusEls" />
 
     <q-form
       v-if="show"
@@ -18,7 +19,7 @@
       @validation-error="onValidationError"
       class="q-gutter-md"
     >
-      <input v-model="native">
+      <input v-model="native" :autofocus="autofocusEl === 0">
 
       <q-input
         ref="name"
@@ -28,6 +29,7 @@
         hint="Name and surname"
         lazy-rules
         :rules="[ val => val && val.length > 0 || 'Please type something']"
+        :autofocus="autofocusEl === 1"
       />
 
       <q-input
@@ -41,6 +43,7 @@
           val => val !== null && val !== '' || 'Please type your age',
           val => val > 0 && val < 100 || 'Please type a real age'
         ]"
+        :autofocus="autofocusEl === 2"
       />
 
       <q-input
@@ -52,7 +55,7 @@
         ]"
       />
 
-      <q-toggle v-model="accept" label="I accept the license and terms" />
+      <q-toggle v-model="accept" label="I accept the license and terms" :autofocus="autofocusEl === 3" />
 
       <div>
         <q-btn label="Submit" type="submit" color="primary" />
@@ -74,7 +77,14 @@ export default {
       accept: false,
 
       show: true,
-      autofocus: true
+      autofocus: true,
+      autofocusEls: [
+        { value: 0, label: 'Native input' },
+        { value: 1, label: 'Name' },
+        { value: 2, label: 'Age' },
+        { value: 3, label: 'Toggle' }
+      ],
+      autofocusEl: 1
     }
   },
 

--- a/quasar/src/components/field/QField.js
+++ b/quasar/src/components/field/QField.js
@@ -46,7 +46,9 @@ export default Vue.extend({
     clearIcon: String,
 
     disable: Boolean,
-    readonly: Boolean
+    readonly: Boolean,
+
+    autofocus: Boolean
   },
 
   data () {
@@ -245,7 +247,8 @@ export default Vue.extend({
             ref: 'target',
             staticClass: 'q-field__native row',
             attrs: this.$attrs.tabindex !== void 0 ? {
-              tabindex: this.$attrs.tabindex
+              tabindex: this.$attrs.tabindex,
+              autofocus: this.autofocus
             } : void 0
           }, this.$scopedSlots.control())
         )
@@ -392,5 +395,9 @@ export default Vue.extend({
         focusin: this.__onControlFocusin,
         focusout: this.__onControlFocusout
       }
+  },
+
+  mounted () {
+    this.autofocus === true && this.$nextTick(this.focus)
   }
 })

--- a/quasar/src/components/field/__QField.json
+++ b/quasar/src/components/field/__QField.json
@@ -117,6 +117,11 @@
 
     "readonly": {
       "extends": "readonly"
+    },
+
+    "autofocus": {
+      "type": "Boolean",
+      "desc": "Focus field on initial component render"
     }
   },
 

--- a/quasar/src/components/input/QInput.js
+++ b/quasar/src/components/input/QInput.js
@@ -23,7 +23,6 @@ export default Vue.extend({
 
     maxlength: [Number, String],
     autogrow: Boolean, // makes a textarea
-    autofocus: Boolean,
 
     inputClass: [Array, String, Object],
     inputStyle: [Array, String, Object]
@@ -137,6 +136,7 @@ export default Vue.extend({
 
       const attrs = {
         tabindex: 0,
+        autofocus: this.autofocus,
         rows: this.type === 'textarea' ? 6 : void 0,
         ...this.$attrs,
         'aria-label': this.label,
@@ -174,7 +174,6 @@ export default Vue.extend({
   mounted () {
     // textarea only
     this.autogrow === true && this.__adjustHeight()
-    this.autofocus === true && this.$nextTick(this.focus)
   },
 
   beforeDestroy () {

--- a/quasar/src/components/input/QInput.json
+++ b/quasar/src/components/input/QInput.json
@@ -43,11 +43,6 @@
       "desc": "Make field autogrow along with its content (uses a textarea)"
     },
 
-    "autofocus": {
-      "type": "Boolean",
-      "desc": "Focus field on initial component render"
-    },
-
     "input-class": {
       "type": [ "Array", "String", "Object" ],
       "desc": "Class definitions to be attributed to the underlying input tag",

--- a/quasar/src/components/select/QSelect.js
+++ b/quasar/src/components/select/QSelect.js
@@ -69,9 +69,7 @@ export default Vue.extend({
     inputDebounce: {
       type: [Number, String],
       default: 500
-    },
-
-    autofocus: Boolean
+    }
   },
 
   data () {
@@ -598,6 +596,7 @@ export default Vue.extend({
           ref: 'target',
           attrs: {
             tabindex: 0,
+            autofocus: this.autofocus,
             ...this.$attrs
           },
           on: {
@@ -679,6 +678,7 @@ export default Vue.extend({
         domProps: { value: this.inputValue },
         attrs: {
           tabindex: 0,
+          autofocus: this.autofocus,
           ...this.$attrs,
           disabled: this.editable !== true
         },
@@ -851,10 +851,6 @@ export default Vue.extend({
         this.optionsCover === true && this.noOptions !== true && this.useInput !== true
       )
     }
-  },
-
-  mounted () {
-    this.autofocus === true && this.$nextTick(this.focus)
   },
 
   beforeDestroy () {

--- a/quasar/src/components/select/QSelect.json
+++ b/quasar/src/components/select/QSelect.json
@@ -144,11 +144,6 @@
       "examples": [ 650 ]
     },
 
-    "autofocus": {
-      "type": "Boolean",
-      "desc": "Focus component on initial render"
-    },
-
     "transition-show": {
       "extends": "transition",
       "desc": "Transition when showing the menu; One of Quasar's embedded transitions; Works only if \"cover-options\" is not used",


### PR DESCRIPTION
- moved autofocus to QField (from QInput, QSelect)
- on QForm reset autofocus (if set)
- on QForm submit focus first element with error - **should we check for autofocus here?**
- on QForm reset first emit event and then reset validation in next tick (to allow user to reset/change the values before reset)