### PR TITLE
fix(QInput): Outlined border on autocomplete

### DIFF
--- a/quasar/src/components/field/field.styl
+++ b/quasar/src/components/field/field.styl
@@ -190,6 +190,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       &:before
         border 1px solid rgba(0,0,0,.24)
         transition border-color $field-transition
+        z-index 1
       &:hover:before
         border-color black
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Autocompleted forms in Chrome overlay the border

![Screenshot from 2019-04-02 12-50-43](https://user-images.githubusercontent.com/5211330/55422862-a541bb00-554a-11e9-8a08-09272536f06b.png)

This PR makes it like so

![Screenshot from 2019-04-02 12-51-26](https://user-images.githubusercontent.com/5211330/55422874-b4c10400-554a-11e9-9e1e-4197c8f8ae65.png)

