### PR TITLE
(feat): Dialog Plugin prop to turn Enter key into Ok in all dialog types. #3801

### DIFF
--- a/docs/src/pages/quasar-plugins/dialog.md
+++ b/docs/src/pages/quasar-plugins/dialog.md
@@ -24,6 +24,8 @@ In order to create #1, the prompting input form, you have the `prompt` property 
 
 In order to create #2, the options selection form, you have the `options` property within the `opts` object.
 
+I'ts also possible to make the ENTER key a confirmation button setting the prop `enterConfirm` to true.
+
 ## Installation
 <doc-installation plugins="Dialog" />
 

--- a/quasar/dev/components/global/dialog-plugin.vue
+++ b/quasar/dev/components/global/dialog-plugin.vue
@@ -69,6 +69,7 @@ export default {
           push: true,
           color: 'negative'
         },
+        enterConfirm: true,
         persistent: true
       }).onOk(() => {
         console.log('>>>> OK')

--- a/quasar/src/components/dialog/DialogPlugin.js
+++ b/quasar/src/components/dialog/DialogPlugin.js
@@ -35,6 +35,10 @@ export default Vue.extend({
     },
 
     stackButtons: Boolean,
+    enterConfirm: {
+      type: Boolean,
+      default: false
+    },
     color: {
       type: String,
       default: 'primary'
@@ -112,13 +116,7 @@ export default Vue.extend({
             autofocus: true
           },
           on: {
-            input: v => { this.prompt.model = v },
-            keyup: evt => {
-              // if ENTER key
-              if (evt.keyCode === 13) {
-                this.onOk()
-              }
-            }
+            input: v => { this.prompt.model = v }
           }
         })
       ]
@@ -230,6 +228,11 @@ export default Vue.extend({
       },
 
       on: {
+        keyup: evt => {
+          if (evt.keyCode === 13 && this.enterConfirm) {
+            this.onOk()
+          }
+        },
         hide: () => {
           this.cancelled === true && this.$emit('cancel')
           this.$emit('hide')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:
Option to choose the ENTER key as an option for the click on Ok in the Dialog Plugin. The prop `enterConfirm` is set to default `false`, but if turned to `true` will enable this feature.

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
