### PR TITLE
feat(QBanner): Add avatar-right slot

### DIFF
--- a/docs/src/examples/QBanner/Basic.vue
+++ b/docs/src/examples/QBanner/Basic.vue
@@ -18,6 +18,29 @@
       </template>
     </q-banner>
 
+    <q-banner class="bg-grey-3">
+      <template v-slot:avatar-right>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      You have lost connection to the internet. This app is offline.
+      <template v-slot:action>
+        <q-btn flat color="primary" label="Turn on Wifi" />
+      </template>
+    </q-banner>
+
+    <q-banner class="bg-grey-3">
+      <template v-slot:avatar>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      <template v-slot:avatar-right>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      <center>You have lost connection to the internet. This app is offline.</center>
+      <template v-slot:action>
+        <q-btn flat color="primary" label="Turn on Wifi" />
+      </template>
+    </q-banner>
+
     <q-banner inline-actions class="text-white bg-red">
       You have lost connection to the internet. This app is offline.
       <template v-slot:action>

--- a/docs/src/examples/QBanner/Dense.vue
+++ b/docs/src/examples/QBanner/Dense.vue
@@ -18,6 +18,29 @@
       </template>
     </q-banner>
 
+    <q-banner dense class="bg-grey-3">
+      <template v-slot:avatar-right>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      You have lost connection to the internet. This app is offline.
+      <template v-slot:action>
+        <q-btn flat color="primary" label="Turn on Wifi" />
+      </template>
+    </q-banner>
+
+    <q-banner dense class="bg-grey-3">
+      <template v-slot:avatar>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      <template v-slot:avatar-right>
+        <q-icon name="signal_wifi_off" color="primary" />
+      </template>
+      <center>You have lost connection to the internet. This app is offline.</center>
+      <template v-slot:action>
+        <q-btn flat color="primary" label="Turn on Wifi" />
+      </template>
+    </q-banner>
+
     <q-banner dense inline-actions class="text-white bg-red">
       You have lost connection to the internet. This app is offline.
       <template v-slot:action>

--- a/quasar/dev/components/components/banner.vue
+++ b/quasar/dev/components/components/banner.vue
@@ -14,6 +14,27 @@
       </q-banner>
 
       <q-banner :dense="dense" class="q-my-md">
+        <q-icon slot="avatar-right" name="signal_wifi_off" color="primary" />
+
+        <q-input v-model="text" />
+        You have lost connection to the internet. This app is offline.
+
+        <q-btn slot="action" flat color="primary" label="Turn ON Wifi" />
+        <q-btn slot="action" flat color="primary" label="Dismiss" />
+      </q-banner>
+
+      <q-banner :dense="dense" class="q-my-md">
+        <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
+        <q-icon slot="avatar-right" name="signal_wifi_off" color="primary" />
+
+        <q-input v-model="text" />
+        You have lost connection to the internet. This app is offline.
+
+        <q-btn slot="action" flat color="primary" label="Turn ON Wifi" />
+        <q-btn slot="action" flat color="primary" label="Dismiss" />
+      </q-banner>
+
+      <q-banner :dense="dense" class="q-my-md">
         <q-avatar slot="avatar" icon="signal_wifi_off" color="primary" text-color="white" />
 
         You have lost connection to the internet. This app is offline.

--- a/quasar/src/components/banner/QBanner.js
+++ b/quasar/src/components/banner/QBanner.js
@@ -13,6 +13,8 @@ export default Vue.extend({
 
   render (h) {
     const actions = slot(this, 'action')
+    const avatar = slot(this, 'avatar')
+    const avatarRight = slot(this, 'avatar-right')
 
     return h('div', {
       staticClass: 'q-banner row items-center',
@@ -24,21 +26,29 @@ export default Vue.extend({
       on: this.$listeners
     }, [
 
-      h('div', {
-        staticClass: 'q-banner__avatar col-auto row items-center'
-      }, slot(this, 'avatar')),
+      avatar !== void 0
+        ? h('div', {
+          staticClass: 'q-banner__avatar col-auto row items-center'
+        }, slot(this, 'avatar'))
+        : null,
 
       h('div', {
-        staticClass: 'q-banner__content col text-body2'
+        staticClass: 'q-banner__content text-body2',
+        class: avatarRight !== void 0 ? 'col' : 'col-auto'
       }, slot(this, 'default')),
+
+      avatarRight !== void 0
+        ? h('div', {
+          staticClass: 'q-banner__avatar-right col-auto row items-center'
+        }, avatarRight)
+        : null,
 
       actions !== void 0
         ? h('div', {
           staticClass: 'q-banner__actions row items-center justify-end',
-          class: this.inlineActions ? 'col-auto' : 'col-all'
+          class: this.inlineActions ? 'col' : 'col-all'
         }, actions)
         : null
-
     ])
   }
 })

--- a/quasar/src/components/banner/QBanner.json
+++ b/quasar/src/components/banner/QBanner.json
@@ -27,6 +27,10 @@
       "desc": "Slot for displaying an avatar (suggestions: QIcon, QAvatar)"
     },
 
+    "avatar-right": {
+      "desc": "Slot for displaying an avatar on the right (suggestions: QIcon, QAvatar)"
+    },
+
     "action": {
       "desc": "Slot for Banner action (suggestions: QBtn)"
     }

--- a/quasar/src/components/banner/banner.styl
+++ b/quasar/src/components/banner/banner.styl
@@ -16,6 +16,17 @@
   &__avatar:not(:empty) + &__content
     padding-left 16px
 
+  &__avatar-right
+    min-width 1px !important
+    right 0
+    > .q-avatar
+      font-size 46px
+    > .q-icon
+      font-size 40px
+
+  &__avatar-right:not(:empty) + &__content
+    padding-right 16px
+
   &__actions
     &.col-auto
       padding-left 16px
@@ -32,6 +43,11 @@
       > .q-avatar, > .q-icon
         font-size 28px
     .q-banner__avatar:not(:empty) + .q-banner__content
+      padding-left 8px
+    .q-banner__avatar-right
+      > .q-avatar, > .q-icon
+        font-size 28px
+    .q-banner__avatar-right:not(:empty) + .q-banner__content
       padding-left 8px
     .q-banner__actions
       &.col-auto


### PR DESCRIPTION
The avatar-right slot can be use for icons that can be clicked to do an action (similar to avatar on the left). This is also more agreeable for RTL societies.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

![QBanner-avatar-right](https://user-images.githubusercontent.com/10262924/55662295-3a54e600-57cf-11e9-9ffe-4fcdf5166d15.png)
![QBanner-avatar-right-dense](https://user-images.githubusercontent.com/10262924/55662296-3a54e600-57cf-11e9-86bb-e5e6c96864d0.png)
