### PR TITLE
feat(docs) components API props grouped by category

### DIFF
--- a/docs/src/components/ApiRows.js
+++ b/docs/src/components/ApiRows.js
@@ -49,6 +49,7 @@ export default {
 
   props: {
     which: String,
+    apiKey: String,
     api: Object
   },
 
@@ -438,7 +439,7 @@ export default {
   },
 
   render (h) {
-    const api = this.api[this.which]
+    const api = this.api[this.apiKey || this.which]
 
     const content = Object.keys(api).length !== 0
       ? this[this.which](h, api)

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -54,7 +54,9 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
                 q-scroll-area.api-container
                   ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
-      ApiRows(:which="tab", :api="filteredApi", v-else)
+      template(v-else)
+        q-scroll-area.api-container
+          ApiRows(:which="tab", :api="filteredApi")
 </template>
 
 <script>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -37,8 +37,8 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
   q-tab-panels(v-model="currentTab", animated)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
-        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]" disable style="height: 600px")
-          template(v-slot:before)
+        div.row(style="height: 600px")
+          div.col-xs-6.col-sm-4.col-md-2.col-xl-1
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(
                 v-for="category in apiTabs(tab)"
@@ -47,7 +47,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
                 :label="category"
               )
                 q-badge(color="primary" v-if="apiCount(tab, category)") {{ apiCount(tab, category) }}
-          template(v-slot:after)
+          div.col
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
                 ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
@@ -100,9 +100,6 @@ export default {
         props: null
       },
       aggregationModel: {},
-      splitterModel: {
-        props: 20
-      },
       filter: '',
       filteredApi: {}
     }

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -146,6 +146,21 @@ export default {
               api[tab][group] = filterApi(this.api[tab][group])
             }
           }
+
+          if (this.currentTab === tab) {
+            let apiWithResultsCount = 0,
+              lastFoundApiWithResults = null
+            for (let group in this.api[tab]) {
+              if (Object.keys(api[tab][group]).length > 0) {
+                apiWithResultsCount++
+                lastFoundApiWithResults = group
+              }
+            }
+
+            if (apiWithResultsCount === 1) {
+              this.currentInnerTab[tab] = lastFoundApiWithResults
+            }
+          }
         }
         else {
           api[tab] = filterApi(this.api[tab])

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -41,14 +41,14 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
           template(v-slot:before)
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(
-                v-for="(_, category) in api[tab]"
+                v-for="category in apiTabs(tab)"
                 :key="`api-inner-tab-${category}`"
                 :name="category"
                 :label="category"
               )
           template(v-slot:after)
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
-              q-tab-panel(v-for="(_, category) in api[tab]", :name="category", :key="category", class="q-pa-none")
+              q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
                 ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
       ApiRows(:which="tab", :api="filteredApi", v-else)
 </template>
@@ -189,6 +189,10 @@ export default {
         this.filter = ''
       }
       this.$refs.input.focus()
+    },
+
+    apiTabs (tab) {
+      return Object.keys(this.filteredApi[tab]).sort()
     }
   },
 

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -38,15 +38,17 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
         div.row(style="height: 600px")
-          div.col-xs-6.col-sm-4.col-md-2.col-xl-1
+          div.col-auto
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(
                 v-for="category in apiTabs(tab)"
                 :key="`api-inner-tab-${category}`"
+                class="inner-tab"
                 :name="category"
-                :label="category"
               )
-                q-badge(color="primary" v-if="apiCount(tab, category)") {{ apiCount(tab, category) }}
+                div.q-tab__label
+                  q-badge(color="primary" v-if="apiCount(tab, category)") {{ formattedApiCount(tab, category) }}
+                  span.q-ml-xs {{ category }}
           div.col
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
@@ -57,6 +59,8 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
 <script>
 import ApiRows from './ApiRows.js'
 import CardTitle from './CardTitle.vue'
+import { format } from 'quasar'
+const { pad } = format
 
 const groupBy = (list, groupKey, defaultGroupKeyValue) => {
   const res = {}
@@ -212,6 +216,26 @@ export default {
 
     apiCount (tab, category) {
       return Object.keys(this.filteredApi[tab][category]).length
+    },
+
+    formattedApiCount (tab, category) {
+      return pad(this.apiCount(tab, category), (this.currentTabMaxCategoryPropCount + '').length)
+    }
+  },
+
+  computed: {
+    currentTabMaxCategoryPropCount () {
+      const calculateFn = () => {
+        let max = -1
+        for (let category in this.filteredApi[this.currentTab]) {
+          let count = this.apiCount(this.currentTab, category)
+          if (count > max) {
+            max = count
+          }
+        }
+        return max
+      }
+      return this.aggregationModel[this.currentTab] ? calculateFn() : 0
     }
   },
 
@@ -232,7 +256,9 @@ export default {
 .doc-api .q-tab
   height 40px
 
-.doc-api .q-badge
-  margin-left: 2px;
-  margin-bottom: 16px;
+.dosc-api .q-badge
+  position absolute
+
+.doc-api .inner-tab
+  justify-content left
 </style>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -37,7 +37,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
   q-tab-panels(v-model="currentTab", animated)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
-        q-splitter(v-model="splitterModel[tab]")
+        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]")
           template(v-slot:before)
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -157,10 +157,12 @@ export default {
 
   methods: {
     parseJson (name, { type, behavior, ...api }) {
-      for (let apiGroup of ['props']) {
-        api[apiGroup] = groupBy(api[apiGroup], 'category', 'general')
-        this.currentInnerTab[apiGroup] = Object.keys(api[apiGroup])[0]
-        this.aggregationModel[apiGroup] = true
+      if (type === 'component') {
+        for (let apiGroup of ['props']) {
+          api[apiGroup] = groupBy(api[apiGroup], 'category', 'general')
+          this.currentInnerTab[apiGroup] = Object.keys(api[apiGroup])[0]
+          this.aggregationModel[apiGroup] = true
+        }
       }
       this.api = api
       this.filteredApi = api

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -46,7 +46,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
                 :name="category"
                 :label="category"
               )
-                q-badge(color="primary" floating v-if="apiCount(tab, category)") {{ apiCount(tab, category) }}
+                q-badge(color="primary" v-if="apiCount(tab, category)") {{ apiCount(tab, category) }}
           template(v-slot:after)
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
@@ -101,7 +101,7 @@ export default {
       },
       aggregationModel: {},
       splitterModel: {
-        props: 15
+        props: 20
       },
       filter: '',
       filteredApi: {}
@@ -236,5 +236,6 @@ export default {
   height 40px
 
 .doc-api .q-badge
-  right: -20px
+  margin-left: 2px;
+  margin-bottom: 16px;
 </style>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -37,7 +37,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
   q-tab-panels(v-model="currentTab", animated)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
-        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]" style="height: 600px")
+        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]" disable style="height: 600px")
           template(v-slot:before)
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -256,9 +256,6 @@ export default {
 .doc-api .q-tab
   height 40px
 
-.dosc-api .q-badge
-  position absolute
-
 .doc-api .inner-tab
   justify-content left
 </style>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -37,7 +37,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
   q-tab-panels(v-model="currentTab", animated)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
-        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]")
+        q-splitter(v-model="splitterModel[tab]" :limits="[20, 20]" style="height: 600px")
           template(v-slot:before)
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -37,7 +37,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
   q-tab-panels(v-model="currentTab", animated)
     q-tab-panel(v-for="tab in tabs", :name="tab", :key="tab" class="q-pa-none")
       template(v-if="aggregationModel[tab]")
-        div.row(style="height: 600px")
+        div.row.api-container
           div.col-auto
             q-tabs(v-model="currentInnerTab[tab]", indicator-color="primary", align="left", :breakpoint="0", dense, vertical)
               q-tab(
@@ -52,7 +52,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
           div.col
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
-                q-scroll-area(style="height: 600px")
+                q-scroll-area.api-container
                   ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
       ApiRows(:which="tab", :api="filteredApi", v-else)
 </template>
@@ -259,4 +259,7 @@ export default {
 
 .doc-api .inner-tab
   justify-content left
+
+.doc-api .api-container
+  height: 600px
 </style>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -52,7 +52,8 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
           div.col
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
-                ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
+                q-scroll-area(style="height: 600px")
+                  ApiRows(:which="tab", :apiKey="category", :api="filteredApi[tab]")
       ApiRows(:which="tab", :api="filteredApi", v-else)
 </template>
 

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -46,6 +46,7 @@ q-card.doc-api.q-my-lg(v-if="ready", flat, bordered)
                 :name="category"
                 :label="category"
               )
+                q-badge(color="primary" floating v-if="apiCount(tab, category)") {{ apiCount(tab, category) }}
           template(v-slot:after)
             q-tab-panels(v-model="currentInnerTab[tab]", animated)
               q-tab-panel(v-for="category in apiTabs(tab)", :name="category", :key="category", class="q-pa-none")
@@ -195,6 +196,10 @@ export default {
 
     apiTabs (tab) {
       return Object.keys(this.filteredApi[tab]).sort()
+    },
+
+    apiCount (tab, category) {
+      return Object.keys(this.filteredApi[tab][category]).length
     }
   },
 
@@ -214,4 +219,7 @@ export default {
 <style lang="stylus">
 .doc-api .q-tab
   height 40px
+
+.doc-api .q-badge
+  right: -20px
 </style>

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -161,7 +161,7 @@ export default {
       if (type === 'component') {
         for (let apiGroup of ['props']) {
           api[apiGroup] = groupBy(api[apiGroup], 'category', 'general')
-          this.currentInnerTab[apiGroup] = Object.keys(api[apiGroup])[0]
+          this.currentInnerTab[apiGroup] = this.apiTabs(apiGroup, api)[0]
           this.aggregationModel[apiGroup] = true
         }
       }
@@ -194,8 +194,8 @@ export default {
       this.$refs.input.focus()
     },
 
-    apiTabs (tab) {
-      return Object.keys(this.filteredApi[tab]).sort()
+    apiTabs (tab, api) {
+      return Object.keys((api || this.filteredApi)[tab]).sort()
     },
 
     apiCount (tab, category) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR is related to #3813. 
The new API "category" field is now used to group component props, which are rendered with vertical QTabs. 
The categories are sorted alphabetically.
Each tab contains a QBadge indicating the number of related props.
When the user filters the API, if only one category contains found props, the current tab is changed to that.

Please let me know if there's something I should implement or change.

![2019-04-06_846x787_screenshot](https://user-images.githubusercontent.com/20051258/55669655-682e3f00-5850-11e9-9423-7bcd8b78fa09.png)
