### PR TITLE
fix #3815: scroll bar is always displayed when the tab overflows

### DIFF
--- a/quasar/src/components/tabs/QTabs.js
+++ b/quasar/src/components/tabs/QTabs.js
@@ -212,10 +212,9 @@ export default Vue.extend({
     },
 
     __updateContainer ({ width, height }) {
-      const offset = this.scrollable === true ? (this.extraOffset ? this.extraOffset : 0) : 0
       const scroll = this.vertical === true
-        ? this.$refs.content.scrollHeight - offset > height
-        : this.$refs.content.scrollWidth - offset > width
+        ? this.$refs.content.scrollHeight > height
+        : this.$refs.content.scrollWidth > width
 
       if (this.scrollable !== scroll) {
         this.scrollable = scroll

--- a/quasar/src/components/tabs/QTabs.js
+++ b/quasar/src/components/tabs/QTabs.js
@@ -212,7 +212,7 @@ export default Vue.extend({
     },
 
     __updateContainer ({ width, height }) {
-      const offset = this.scrollable === true ? this.extraOffset : 0
+      const offset = this.scrollable === true ? (this.extraOffset ? this.extraOffset : 0) : 0
       const scroll = this.vertical === true
         ? this.$refs.content.scrollHeight - offset > height
         : this.$refs.content.scrollWidth - offset > width


### PR DESCRIPTION
Variable this.extraOffset is not always defined, that fails the scroll condition after

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I'm not sure why `this.extraOffset` is not defined there. It is not defined in the scope of QTabs. 
Maybe someone of quasar Team Members can answer if it is needed there.?
