### PR TITLE
fix: #3735 [v1][QExpansionItem] value prop is ignored when input event is fired

### DIFF
--- a/quasar/dev/components/components/list-expansion-item.vue
+++ b/quasar/dev/components/components/list-expansion-item.vue
@@ -645,6 +645,31 @@
           4. Gigi
         </q-item-section>
       </q-item>
+
+      <p class="caption">
+        Input handler test
+      </p>
+      <div>
+        <div class="q-pa-md">
+          <q-toggle v-model="modelExpanded" label="Expanded" class="q-mb-md" />
+          <div>
+            model value: {{ modelExpanded }}
+          </div>
+          <q-expansion-item
+            :value="modelExpanded"
+            icon="perm_identity"
+            label="Account settings"
+            caption="John Doe"
+            @input="handleModelExpandedToggle"
+          >
+            <q-card>
+              <q-card-section>
+                {{ lorem }}
+              </q-card-section>
+            </q-card>
+          </q-expansion-item>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -655,7 +680,8 @@ export default {
     return {
       open: true,
       counter: 0,
-      lorem: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore, nemo minus dolore facere saepe molestias, fugiat officia aspernatur expedita pariatur, accusantium hic exercitationem perspiciatis voluptate possimus nobis temporibus ipsa officiis!'
+      lorem: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempore, nemo minus dolore facere saepe molestias, fugiat officia aspernatur expedita pariatur, accusantium hic exercitationem perspiciatis voluptate possimus nobis temporibus ipsa officiis!',
+      modelExpanded: true
     }
   },
   methods: {
@@ -683,6 +709,10 @@ export default {
     },
     onKeyup (which) {
       console.log('onKeyup', which)
+    },
+    handleModelExpandedToggle (newState) {
+      // do not change modelExpanded
+      console.log(`handleModelExpandedToggle model state: ${newState}`)
     }
   }
 }

--- a/quasar/src/components/list/QExpansionItem.js
+++ b/quasar/src/components/list/QExpansionItem.js
@@ -87,7 +87,7 @@ export default Vue.extend({
 
   methods: {
     __onHeaderClick (e) {
-      this.hasRouterLink !== true && this.toggle(e)
+      this.hasRouterLink !== true && this.toggle(e, false)
       this.$emit('click', e)
     },
 

--- a/quasar/src/mixins/model-toggle.js
+++ b/quasar/src/mixins/model-toggle.js
@@ -25,11 +25,11 @@ export default {
   },
 
   methods: {
-    toggle (evt) {
-      this[this.showing === true ? 'hide' : 'show'](evt)
+    toggle (evt, triggerModelChange = true) {
+      this[this.showing === true ? 'hide' : 'show'](evt, triggerModelChange)
     },
 
-    show (evt) {
+    show (evt, triggerModelChange = true) {
       if (this.disable === true || this.showing === true) {
         return
       }
@@ -37,9 +37,15 @@ export default {
         return
       }
 
-      this.$emit('before-show', evt)
-      this.showing = true
-      this.$emit('input', true)
+      if (triggerModelChange) {
+        this.$emit('before-show', evt)
+        this.showing = true
+        this.$emit('input', true)
+      }
+      else {
+        this.$emit('input', true)
+        return
+      }
 
       if (this.$options.modelToggle !== void 0 && this.$options.modelToggle.history === true) {
         this.__historyEntry = {
@@ -56,14 +62,20 @@ export default {
       }
     },
 
-    hide (evt) {
+    hide (evt, triggerModelChange = true) {
       if (this.disable === true || this.showing === false) {
         return
       }
 
-      this.$emit('before-hide', evt)
-      this.showing = false
-      this.value !== false && this.$emit('input', false)
+      if (triggerModelChange) {
+        this.$emit('before-hide', evt)
+        this.showing = false
+        this.value !== false && this.$emit('input', false)
+      }
+      else {
+        this.value !== false && this.$emit('input', false)
+        return
+      }
 
       this.__removeHistory()
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Additional parameter `triggerModelChange` added to model-toggle mixin. If `true` - the property `showing` is instantly updated, otherwise only `input` event triggered. By default set to true (previous behaviour).