### PR TITLE
feat(QPullToRefresh): limit pull distance

### DIFF
--- a/quasar/src/components/pull-to-refresh/QPullToRefresh.js
+++ b/quasar/src/components/pull-to-refresh/QPullToRefresh.js
@@ -11,7 +11,8 @@ import slot from '../../utils/slot.js'
 
 const
   PULLER_HEIGHT = 40,
-  OFFSET_TOP = 20
+  OFFSET_TOP = 20,
+  MAX_PULL_DISTANCE = 140
 
 export default Vue.extend({
   name: 'QPullToRefresh',
@@ -111,6 +112,9 @@ export default Vue.extend({
       prevent(event.evt)
 
       const distance = Math.max(0, event.distance.y)
+      if (distance > MAX_PULL_DISTANCE) {
+        return
+      }
       this.pullPosition = distance - PULLER_HEIGHT
       this.pullRatio = between(distance / (OFFSET_TOP + PULLER_HEIGHT), 0, 1)
 

--- a/quasar/src/components/pull-to-refresh/QPullToRefresh.js
+++ b/quasar/src/components/pull-to-refresh/QPullToRefresh.js
@@ -11,8 +11,7 @@ import slot from '../../utils/slot.js'
 
 const
   PULLER_HEIGHT = 40,
-  OFFSET_TOP = 20,
-  MAX_PULL_DISTANCE = 140
+  OFFSET_TOP = 20
 
 export default Vue.extend({
   name: 'QPullToRefresh',
@@ -111,10 +110,7 @@ export default Vue.extend({
 
       prevent(event.evt)
 
-      const distance = Math.max(0, event.distance.y)
-      if (distance > MAX_PULL_DISTANCE) {
-        return
-      }
+      const distance = Math.min(140, Math.max(0, event.distance.y))
       this.pullPosition = distance - PULLER_HEIGHT
       this.pullRatio = between(distance / (OFFSET_TOP + PULLER_HEIGHT), 0, 1)
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Usually, pull to refresh animation is limited to a specific height distance, which is implemented on this PR. This prevents the refresh indicator being pulled until the end of the screen height.