### PR TITLE
feat(cli): Notify user when @quasar/cli is out of date

### DIFF
--- a/cli/bin/quasar
+++ b/cli/bin/quasar
@@ -2,6 +2,20 @@
 
 require('../lib/node-version-check')
 
+const updateNotifier = require('update-notifier')
+const pkg = require('../package.json')
+ 
+// checks for available update and returns an instance
+const notifier = updateNotifier({
+  pkg,
+  updateCheckInterval: 1000 * 60 * 60 * 24 // no more than once a day
+})
+ 
+// notify with global
+notifier.notify({
+  isGlobal: true
+})
+ 
 const
   path = require('path'),
   resolveFrom = require('resolve-from')

--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,7 @@
     "route-cache": "0.4.4",
     "selfsigned": "1.10.4",
     "tildify": "1.2.0",
+    "update-notifier": "^2.5.0",
     "user-home": "2.0.0",
     "validate-npm-package-name": "3.0.0"
   },


### PR DESCRIPTION
This update will notify the user when @quasar/cli is out of date.
The notification has been set to no more than once a day.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The notification always happens at the end of the current execution.

![image](https://user-images.githubusercontent.com/10262924/55823275-9f098c80-5abe-11e9-895f-47b426548146.png)
