### PR TITLE
Add a space before the colon and additional typos

### DIFF
--- a/quasar/lang/fr.js
+++ b/quasar/lang/fr.js
@@ -33,7 +33,7 @@ export default {
         ? rows + ' ' + (rows === 1 ? 'ligne sélectionnée' : 'lignes sélectionnées') + '.'
         : 'Aucune ligne sélectionnée.'
     },
-    recordsPerPage: 'Lignes par page:',
+    recordsPerPage: 'Lignes par page :',
     allRows: 'Tous',
     pagination: function (start, end, total) {
       return start + '-' + end + ' sur ' + total
@@ -86,6 +86,6 @@ export default {
   },
   tree: {
     noData: 'Aucun nœud à afficher',
-    noResults: 'Aucun nœud trouvée'
+    noResults: 'Aucun nœud trouvé'
   }
 }


### PR DESCRIPTION
As per French typography, a space is required before all two-signed punctuation (colon, semi-colon, exclamation and question marks). Everything else looks good, except 'Tous' for allRows that can be 'Tous', 'Tout' or 'Toutes' depending on the context. That said, if it indeed refers to the rows, it should be 'Toutes' if it means 'all the rows' or 'Tout' if it means everything. I don't want to make the change for that yet.
I also hope the œ in nœud is not a problem. If it is, oe (o followed by e) is equally as understandable.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
