### PR TITLE
Restore "hide-upload-button" option from 0.17

### DIFF
--- a/quasar/src/components/uploader/QUploaderBase.js
+++ b/quasar/src/components/uploader/QUploaderBase.js
@@ -26,6 +26,7 @@ export default {
     filter: Function,
     noThumbnails: Boolean,
     autoUpload: Boolean,
+    hideUploadButton: Boolean,
 
     disable: Boolean,
     readonly: Boolean
@@ -333,8 +334,8 @@ export default {
           ])
         ]),
 
-        this.__getBtn(h, this.editable, 'add', this.pickFiles),
-        this.__getBtn(h, this.editable && this.queuedFiles.length > 0, 'upload', this.upload),
+        this.__getBtn(h, this.editable && (this.multiple || this.queuedFiles.length == 0), 'add', this.pickFiles),
+        this.__getBtn(h, !this.hideUploadButton && this.editable && this.queuedFiles.length > 0, 'upload', this.upload),
         this.__getBtn(h, this.editable && this.isUploading, 'clear', this.abort)
       ])
     },

--- a/quasar/src/components/uploader/QUploaderBase.js
+++ b/quasar/src/components/uploader/QUploaderBase.js
@@ -334,7 +334,7 @@ export default {
           ])
         ]),
 
-        this.__getBtn(h, this.editable && (this.multiple || this.queuedFiles.length == 0), 'add', this.pickFiles),
+        this.__getBtn(h, this.editable && this.queuedFiles.length == 0, 'add', this.pickFiles),
         this.__getBtn(h, !this.hideUploadButton && this.editable && this.queuedFiles.length > 0, 'upload', this.upload),
         this.__getBtn(h, this.editable && this.isUploading, 'clear', this.abort)
       ])


### PR DESCRIPTION
When using the upload component within a larger form, it may be desirable to disallow file uploading directly from the component. 0.17 had this option. Currently 1.0-beta requires the entire header to be overwritten via scoped slot just to hide the `upload` button.

This update also hides the `add` button when the `multiple` option is not enabled and a file has already been selected. (Being unable to prevent the user from selecting multiple files, when the `multiple` option has not been enabled, might be considered a bug). This is also how 0.17 worked, although instead of hiding the `add` button, it kept it visible and changed the mouse pointer to `not allowed`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
