### PR TITLE
Explain `emit-value` , `map-options` for upgraders

### DIFF
--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -1840,7 +1840,7 @@ Replace `:handler` with `@load`.
 
 - Type of `stack-label` was changed from `string` to `boolean`
 - Type of `display-value` was changed from `string` to `string|number`
-- When the option list is an array of objects (as opposed to simple strings or numbers), upgraders may want to turn on the `emit-value` and `map-options` flags to preserve the behavior of previous versions. 1.0 defaults to emitting the entire object, not just the `value` property, upon selection. Also, during initialization, if the model is a simple value, 1.0 will display it exactly, and not attempt to find the associated `label` property among the option list. 
+- When the option list is an array of objects (as opposed to simple strings or numbers), upgraders may want to turn on the `emit-value` and `map-options` flags to preserve the behavior of previous versions. 1.0 defaults to emitting the entire object, not just the `value` property, upon selection.
 
 <div class="row">
   <div class="inline-block q-pa-md">

--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -1840,6 +1840,7 @@ Replace `:handler` with `@load`.
 
 - Type of `stack-label` was changed from `string` to `boolean`
 - Type of `display-value` was changed from `string` to `string|number`
+- When the option list is an array of objects (as opposed to simple strings or numbers), upgraders may want to turn on the `emit-value` and `map-options` flags to preserve the behavior of previous versions. 1.0 defaults to emitting the entire object, not just the `value` property, upon selection. Also, during initialization, if the model is a simple value, 1.0 will display it exactly, and not attempt to find the associated `label` property among the option list. 
 
 <div class="row">
   <div class="inline-block q-pa-md">


### PR DESCRIPTION
QSelect acts very differently in 1.0 when option lists are comprised of objects. This guide should be much clearer for upgraders what options are needed to be turned on to preserve prior functionality, reducing the pain of having to figure things out independently, and allowing upgrades to "just work".

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: update to Upgrade Guide for QSelect

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
