### PR TITLE
added vuelidate and input group touch support in validate.js mixin

### DIFF
--- a/quasar/src/mixins/validate.js
+++ b/quasar/src/mixins/validate.js
@@ -9,7 +9,8 @@ export default {
     noErrorIcon: Boolean,
 
     rules: Array,
-    lazyRules: Boolean
+    lazyRules: Boolean,
+    instantRules: Boolean,
   },
 
   data () {
@@ -52,6 +53,7 @@ export default {
   mounted () {
     this.validateIndex = 0
     this.focused === void 0 && this.$el.addEventListener('focusout', this.__triggerValidation)
+    this.instantRules && this.__triggerValidation()
   },
 
   beforeDestroy () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Because vuelidate relies on external properties that don't get sent into a QInput component, if you use the `:rules` method of validation messages then any fields which have not been focused cannot have any errors shown without focusing them or using a `ref` to initiate the `validate()` function, 

for example

https://jsfiddle.net/mjs9z2fu/1/

I'm running this at the moment