### PR TITLE
Update upgrade-guide.md

### DIFF
--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -1321,7 +1321,6 @@ Replace `:handler` with `@load`.
 
 |Legacy|v1|
 |-|-|
-|`blur()`||
 |`clear()`||
 |`select()`||
 |`togglePass()`||


### PR DESCRIPTION
QInput: `blur()` method not deprecated.