### PR TITLE
Add links between QButtonDropdown and QSelect 🔗

### DIFF
--- a/docs/src/pages/vue-components/button-dropdown.md
+++ b/docs/src/pages/vue-components/button-dropdown.md
@@ -6,6 +6,8 @@ related:
 ---
 QBtnDropdown is a very convenient dropdown button. Goes very well with [QList](/vue-components/lists-and-list-items) as dropdown content, but it's by no means limited to it.
 
+In case you are looking for a dropdown "input" instead of "button" use [Select](/vue-components/select) instead.
+
 ## Installation
 <doc-installation components="QBtnDropdown" />
 

--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -4,6 +4,8 @@ title: Select
 
 The QSelect component has two types of selection: single or multiple. This component opens up a Popover for the selection list and action. A filter can also be used for longer lists.
 
+In case you are looking for a dropdown "button" instead of "input" use [Button Dropdown](/vue-components/button-dropdown) instead.
+
 ## Installation
 <doc-installation components="QSelect"/>
 


### PR DESCRIPTION
I just added a link to QSelect on QButton and the other way around.

### Motivation
Some people (like me) might find one component or the other with a keyword like "dropdown" and do not know where to look for the other.

#4016 