### PR TITLE
(fix) putting a QDate in a bigger QInput was doing a big popup for a QDate because of cover: true

### DIFF
--- a/quasar/src/components/popup-proxy/QPopupProxy.js
+++ b/quasar/src/components/popup-proxy/QPopupProxy.js
@@ -15,6 +15,18 @@ export default Vue.extend({
     breakpoint: {
       type: [String, Number],
       default: 450
+    },
+    cover: {
+      type: [Boolean],
+      default: true
+    },
+    self: {
+      type: [String],
+      default: ''
+    },
+    anchor: {
+      type: [String],
+      default: ''
     }
   },
 
@@ -95,7 +107,7 @@ export default Vue.extend({
       ['QDate', 'QTime', 'QCarousel', 'QColor'].includes(
         child[0].componentOptions.Ctor.sealedOptions.name
       )
-    ) ? { cover: true, maxHeight: '99vh' } : {}
+    ) ? { cover: this.cover, maxHeight: '99vh', self: this.self, anchor: this.anchor } : {}
 
     const data = {
       ref: 'popup',


### PR DESCRIPTION
Hello,

I just have a bug in a Web App.
When I put a QPopupProxy with a QDate in a QInput the QMenu will fill all the width of the input instead of just wrap the QDate.
Like that: 

```html
<q-input
    :value="formatDate(value, format)"
    v-bind="$props"
  >
    <q-popup-proxy>
      <q-date
        :value="formatDate(value, 'YYYY/MM/DD')"
        @input="setDate($event)"
      />
    </q-popup-proxy>
    <template v-slot:append>
      <q-icon
        name="event"
        class="cursor-pointer"
      />
    </template>
  </q-input>
```

![Screenshot_1](https://user-images.githubusercontent.com/6010926/57069236-52d3f580-6cd4-11e9-8e11-da616be3325c.png)
![Screenshot_2](https://user-images.githubusercontent.com/6010926/57069237-52d3f580-6cd4-11e9-8302-48f047ddc372.png)

So I added 3 props for QPopupProxy which are passed to the QMenu
They are:
- cover (default: true, like now)
- self
- anchor


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
