### PR TITLE
input-text-color stylus variable 🖍

### DIFF
--- a/quasar/src/components/field/field.styl
+++ b/quasar/src/components/field/field.styl
@@ -104,7 +104,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     border none
     border-radius 0
     background none
-    color rgba(0,0,0,.87)
+    color $input-text-color
     outline 0
     padding 6px 0
 

--- a/quasar/src/css/variables.styl
+++ b/quasar/src/css/variables.styl
@@ -636,6 +636,7 @@ $tooltip-mobile-fontsize        ?= 14px
 $option-focus-transition        ?= .22s cubic-bezier(0,0,.2,1)
 
 $input-font-size                ?= 14px
+$input-text-color               ?= rgba(0,0,0,.87)
 $input-label-color              ?= rgba(0,0,0,.6)
 $input-autofill-color           ?= inherit
 


### PR DESCRIPTION
`input-label-color` was already available. I now require `input-text-color` 😄