### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ I'm excited if you want to contribute to Quasar under any form (report bugs, wri
 
 ### Issue Reporting Guidelines
 
-**Please use the appropriate Github repo to report issues. See "Related Components" above.** For example, a bug related to CLI should be reported to the CLI repo, one related to build issues to Quasar Framework Templates repo and so on.
+**Please use the appropriate GitHub repo to report issues. See "Related Components" above.** For example, a bug related to CLI should be reported to the CLI repo, one related to build issues to Quasar Framework Templates repo and so on.
 
 - The issue list of the repository is **exclusively** for bug reports and feature requests. For anything else please use the [Community Forum](https://forum.quasar-framework.org).
 

--- a/cli/bin/quasar-create
+++ b/cli/bin/quasar-create
@@ -32,7 +32,7 @@ if (argv.help) {
     $ quasar create my-project --kit umd
       # installs an App project and installs the umd demo
     $ quasar create my-project --kit user/github-starter-kit
-      # installs an App project with a custom starter kit from Github
+      # installs an App project with a custom starter kit from GitHub
     $ quasar create my-project --kit ./starter-kit-folder
       # installs an App project using a starter kit located at ./starter-kit-folder
 
@@ -40,9 +40,9 @@ if (argv.help) {
     $ quasar create my-extension-project --kit app-extension
       # installs an App Extension project with the latest Quasar App Extension starter kit
     $ quasar create my-extension-project --kit user/github-extension-starter-kit
-      # installs an App Extension project with a custom starter kit from Github
+      # installs an App Extension project with a custom starter kit from GitHub
     $ quasar create my-extension-project --kit user/github-extension-starter-kit --branch dev
-      # installs an App Extension project with a custom starter kit from Github using the dev branch
+      # installs an App Extension project with a custom starter kit from GitHub using the dev branch
 
   Options
     --kit, -k      Use specific starter kit

--- a/docs/src/components/DocExample.vue
+++ b/docs/src/components/DocExample.vue
@@ -6,8 +6,8 @@ q-card.doc-example.q-my-lg(:class="classes", flat, bordered)
     q-space
 
     div.col-auto
-      q-btn(dense, flat, round, icon="fab fa-github", @click="openGithub")
-        q-tooltip View on Github
+      q-btn(dense, flat, round, icon="fab fa-github", @click="openGitHub")
+        q-tooltip View on GitHub
       q-btn.q-ml-sm(dense, flat, round, icon="fab fa-codepen", @click="$refs.codepen.open()")
         q-tooltip Edit in Codepen
       q-btn.q-ml-sm(dense, flat, round, icon="code", @click="expanded = !expanded")
@@ -148,7 +148,7 @@ export default {
       return parsed[1] || ''
     },
 
-    openGithub () {
+    openGitHub () {
       openURL(`https://github.com/quasarframework/quasar/tree/dev/docs/src/examples/${this.file}.vue`)
     }
   }

--- a/docs/src/components/DocPage.vue
+++ b/docs/src/components/DocPage.vue
@@ -47,7 +47,7 @@ q-page.doc-page
     q-separator
 
     .q-my-sm
-      | Caught a mistake? <doc-link :to="editHref">Suggest an edit on Github</doc-link>
+      | Caught a mistake? <doc-link :to="editHref">Suggest an edit on GitHub</doc-link>
 
     .doc-page-footer__icons.row.items-center
       a(href="https://github.com/quasarframework/quasar", target="_blank")

--- a/docs/src/components/HeaderMenu.vue
+++ b/docs/src/components/HeaderMenu.vue
@@ -34,7 +34,7 @@ div
       q-item(clickable, tag="a", href="https://github.com/quasarframework/quasar", target="_blank")
         q-item-section(avatar)
           q-icon(name="fab fa-github")
-        q-item-section Github
+        q-item-section GitHub
 
       q-item-label(header) Quick Tools
 

--- a/docs/src/examples/QItem/ExampleEmails.vue
+++ b/docs/src/examples/QItem/ExampleEmails.vue
@@ -56,19 +56,19 @@
         </q-item-section>
 
         <q-item-section top class="col-2 gt-sm">
-          <q-item-label class="q-mt-sm">Github</q-item-label>
+          <q-item-label class="q-mt-sm">GitHub</q-item-label>
         </q-item-section>
 
         <q-item-section top>
           <q-item-label lines="1">
             <span class="text-weight-medium">[quasarframework/quasar]</span>
-            <span class="text-grey-8"> - Github repository</span>
+            <span class="text-grey-8"> - GitHub repository</span>
           </q-item-label>
           <q-item-label caption lines="1">
             @rstoenescu in #3: > Generic type parameter for props
           </q-item-label>
           <q-item-label lines="1" class="q-mt-xs text-body2 text-weight-bold text-primary text-uppercase">
-            <span class="cursor-pointer">Open in Github</span>
+            <span class="cursor-pointer">Open in GitHub</span>
           </q-item-label>
         </q-item-section>
 
@@ -89,19 +89,19 @@
         </q-item-section>
 
         <q-item-section top class="col-2 gt-sm">
-          <q-item-label class="q-mt-sm">Github</q-item-label>
+          <q-item-label class="q-mt-sm">GitHub</q-item-label>
         </q-item-section>
 
         <q-item-section top>
           <q-item-label lines="1">
             <span class="text-weight-medium">[quasarframework/quasar]</span>
-            <span class="text-grey-8"> - Github repository</span>
+            <span class="text-grey-8"> - GitHub repository</span>
           </q-item-label>
           <q-item-label caption lines="1">
             @rstoenescu in #1: > The build system
           </q-item-label>
           <q-item-label lines="1" class="q-mt-xs text-body2 text-weight-bold text-primary text-uppercase">
-            <span class="cursor-pointer">Open in Github</span>
+            <span class="cursor-pointer">Open in GitHub</span>
           </q-item-label>
         </q-item-section>
 

--- a/docs/src/pages/options/quasar-icon-sets.md
+++ b/docs/src/pages/options/quasar-icon-sets.md
@@ -30,7 +30,7 @@ framework: {
 }
 ```
 
-For all available options, visit the [Github](https://github.com/quasarframework/quasar/tree/dev/quasar/icon-set) repository.
+For all available options, visit the [GitHub](https://github.com/quasarframework/quasar/tree/dev/quasar/icon-set) repository.
 
 #### Full Example
 Here is an example of including Ionicons & Fontawesome and telling Quasar to use Fontawesome for its components.

--- a/docs/src/pages/options/quasar-language-packs.md
+++ b/docs/src/pages/options/quasar-language-packs.md
@@ -13,7 +13,7 @@ It should be noted that what is described below is the internationalization of Q
 As mentioned above, some Quasar components have their own labels. When it comes to internationalization, one option is to configure labels through the label properties on each instance of Quasar components (like QTable). This is how you can customize the text to match the selected language. This however, takes time and adds unnecessary complexity to your website/app. **Instead**, you can use the Quasar Language Packs which have a number of standard label definitions translated for you, like "Cancel", "Clear", "Select", "Update", etc. No need to translate these again! And it comes out of the box.
 
 ::: tip
-For a complete list of available Quasar Languages, check [Quasar Languages on Github](https://github.com/quasarframework/quasar/tree/dev/quasar/lang).
+For a complete list of available Quasar Languages, check [Quasar Languages on GitHub](https://github.com/quasarframework/quasar/tree/dev/quasar/lang).
 <br><br>**If your desired language is not on that list**, then feel free to submit a PR to add it. It takes from 5 to 10 minutes at most. We kindly welcome any language!
 :::
 
@@ -148,7 +148,7 @@ Although the Quasar Language Packs **are designed only for Quasar components int
 {{ $q.lang.label.close }}
 ```
 
-Check a Quasar Language Pack on [Github](https://github.com/quasarframework/quasar/tree/dev/quasar/lang) to see the structure of `$q.lang`.
+Check a Quasar Language Pack on [GitHub](https://github.com/quasarframework/quasar/tree/dev/quasar/lang) to see the structure of `$q.lang`.
 
 ## Detecting Locale
 There's also a method to determine user locale which is supplied by Quasar out of the box:

--- a/docs/src/pages/quasar-cli/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli/developing-spa/deploying.md
@@ -178,4 +178,4 @@ Now you can build and deploy your application using:
 $ quasar build
 $ yarn deploy
 ```
-which will push the content of your build directory to your master branch on your Github Pages repository.
+which will push the content of your build directory to your master branch on your GitHub Pages repository.

--- a/docs/src/pages/security/dos-and-donts.md
+++ b/docs/src/pages/security/dos-and-donts.md
@@ -152,7 +152,7 @@ This is something that every team should have on their radar and put some though
  - **DO** require a review before merging to master
  - **DO** require 2FA for reviewers / code committers
  - **DO** require signed commits
- - **DO** take Github Security Warnings seriously
+ - **DO** take GitHub Security Warnings seriously
  - **DO** undertake deep code reviews
  - **DO** review critical third-party libraries, especially any working with real files
  - **DO** pin versions of critical libraries

--- a/docs/src/pages/security/report-a-vulnerability.md
+++ b/docs/src/pages/security/report-a-vulnerability.md
@@ -2,6 +2,6 @@
 title: Report a vulnerability
 ---
 
-If you have found a potential security threat, vulnerability or exploit in Quasar or one of its upstream dependencies, please **DON'T** create a pull-request, **DON'T** file an issue on Github, **DON'T** mention it on Discord and **DON'T** create a forum thread.
+If you have found a potential security threat, vulnerability or exploit in Quasar or one of its upstream dependencies, please **DON'T** create a pull-request, **DON'T** file an issue on GitHub, **DON'T** mention it on Discord and **DON'T** create a forum thread.
 
 **DO** reach out to the team by sending an email to [security@quasar-framework.org](mailto:security@quasar-framework.org) - we will investigate and work with you to triage this issue and help you to report it if appropriate. At the current time we do not have the financial ability to reward bounties, but in extreme cases will at our discretion consider a reward.

--- a/docs/src/pages/start/playground.md
+++ b/docs/src/pages/start/playground.md
@@ -2,7 +2,7 @@
 title: Quasar Playground
 ---
 
-You can fork and use these links for reporting issues on Github too. These links (obviously) use the Quasar UMD version.
+You can fork and use these links for reporting issues on GitHub too. These links (obviously) use the Quasar UMD version.
 
 | Supplier | URL |
 | --- | --- |

--- a/docs/src/pages/start/release-notes.md
+++ b/docs/src/pages/start/release-notes.md
@@ -2,6 +2,6 @@
 title: Release Notes
 ---
 
-Release notes (with changelog) for Quasar core packages (`quasar`, `@quasar/cli`, `@quasar/app`, `@quasar/extras`) are available on [Github](https://github.com/quasarframework/quasar/releases).
+Release notes (with changelog) for Quasar core packages (`quasar`, `@quasar/cli`, `@quasar/app`, `@quasar/extras`) are available on [GitHub](https://github.com/quasarframework/quasar/releases).
 
-For all other packages, visit the [Quasar Organization](https://github.com/quasarframework) Github page and look for the repository that you are interested in then click on its "Releases".
+For all other packages, visit the [Quasar Organization](https://github.com/quasarframework) GitHub page and look for the repository that you are interested in then click on its "Releases".

--- a/docs/src/pages/start/umd.md
+++ b/docs/src/pages/start/umd.md
@@ -109,7 +109,7 @@ Notice that as opposed to the Main Starter Kit, you don't need to import anythin
 However, the disadvantage is that you won't benefit from the top notch development experience provided by Quasar CLI -- which allows you to simultaneously develop and build SPA, PWA, SSR, Mobile and Electron Apps.
 
 ## JsFiddle / Codepen
-You can fork and use these links for reporting issues on Github too:
+You can fork and use these links for reporting issues on GitHub too:
 
 | Supplier | URL |
 | --- | --- |
@@ -213,7 +213,7 @@ Assuming you have already included the CDN link to your favorite Quasar Icon Set
 Quasar.iconSet.set(Quasar.iconSet.fontawesomeV5)
 ```
 
-The list of available [Quasar Icon Sets](/options/quasar-icon-sets) can be found on [Github](https://github.com/quasarframework/quasar/tree/dev/quasar/icon-set).
+The list of available [Quasar Icon Sets](/options/quasar-icon-sets) can be found on [GitHub](https://github.com/quasarframework/quasar/tree/dev/quasar/icon-set).
 
 ### Changing Quasar Language Pack
 Assuming you have already included the CDN link to your desired Quasar I18n Language (unless you want "en-us" language pack which is used by default), you can then tell Quasar to use it:
@@ -227,4 +227,4 @@ Quasar.lang.set(Quasar.lang.de)
 Quasar.lang.set(Quasar.lang.ptBr)
 ```
 
-The list of available languages can be found on [Github](https://github.com/quasarframework/quasar/tree/dev/quasar/lang). **If your desired language pack is not available yet, you can help by providing a PR.** We welcome any languages!
+The list of available languages can be found on [GitHub](https://github.com/quasarframework/quasar/tree/dev/quasar/lang). **If your desired language pack is not available yet, you can help by providing a PR.** We welcome any languages!

--- a/ui/README.md
+++ b/ui/README.md
@@ -113,7 +113,7 @@ I'm excited if you want to contribute to Quasar under any form (report bugs, wri
 
 ### Issue Reporting Guidelines
 
-**Please use the appropriate Github repo to report issues. See "Related Components" above.** For example, a bug related to CLI should be reported to the CLI repo, one related to build issues to Quasar Framework Templates repo and so on.
+**Please use the appropriate GitHub repo to report issues. See "Related Components" above.** For example, a bug related to CLI should be reported to the CLI repo, one related to build issues to Quasar Framework Templates repo and so on.
 
 - The issue list of the repository is **exclusively** for bug reports and feature requests. For anything else please use the [Community Forum](https://forum.quasar-framework.org).
 

--- a/ui/dev-umd/index.umd.html
+++ b/ui/dev-umd/index.umd.html
@@ -47,7 +47,7 @@
                 <q-icon name="code"></q-icon>
               </q-item-section>
               <q-item-section>
-                <q-item-label>Github</q-item-label>
+                <q-item-label>GitHub</q-item-label>
                 <q-item-label caption>github.com/quasarframework</q-item-label>
               </q-item-section>
             </q-item>

--- a/ui/dev/components/components/list-item.vue
+++ b/ui/dev/components/components/list-item.vue
@@ -669,20 +669,20 @@
 
           <q-item-section top class="col-2 gt-sm">
             <q-item-label class="q-mt-sm">
-              Github
+              GitHub
             </q-item-label>
           </q-item-section>
 
           <q-item-section top>
             <q-item-label lines="1">
               <span class="text-weight-medium">[quasarframework/quasar]</span>
-              <span class="text-grey-8"> - Github repository</span>
+              <span class="text-grey-8"> - GitHub repository</span>
             </q-item-label>
             <q-item-label caption lines="1">
               @rstoenescu in #3: > Generic type parameter for props
             </q-item-label>
             <div class="q-mt-xs text-body2 text-weight-bold text-primary text-uppercase">
-              <span class="cursor-pointer">Open in Github</span>
+              <span class="cursor-pointer">Open in GitHub</span>
             </div>
           </q-item-section>
 
@@ -704,20 +704,20 @@
 
           <q-item-section top class="col-2 gt-sm">
             <q-item-label class="q-mt-sm">
-              Github
+              GitHub
             </q-item-label>
           </q-item-section>
 
           <q-item-section top>
             <q-item-label lines="1">
               <span class="text-weight-medium">[quasarframework/quasar-cli]</span>
-              <span class="text-grey-8"> - Github repository</span>
+              <span class="text-grey-8"> - GitHub repository</span>
             </q-item-label>
             <q-item-label caption lines="1">
               @rstoenescu in #1: > The build system
             </q-item-label>
             <div class="q-mt-xs text-body2 text-weight-bold text-primary text-uppercase">
-              <span class="cursor-pointer">Open in Github</span>
+              <span class="cursor-pointer">Open in GitHub</span>
             </div>
           </q-item-section>
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Just a silly pet-peeve of mine -- it's officially capitalized as "GitHub", not "Github". It was already capitalized correctly in about half of its usages, this just fixes the remaining instances.