### PR TITLE
Props casting

### DIFF
--- a/docs/src/examples/QPagination/DirectionLinks.vue
+++ b/docs/src/examples/QPagination/DirectionLinks.vue
@@ -3,7 +3,7 @@
     <q-pagination
       v-model="current"
       :max="5"
-      :directionLinks="true"
+      :direction-links="true"
     >
     </q-pagination>
   </div>


### PR DESCRIPTION
https://vuejs.org/v2/guide/components-props.html#Prop-Casing-camelCase-vs-kebab-case
> HTML attribute names are case-insensitive, so browsers will interpret any uppercase characters as lowercase. That means when you’re using in-DOM templates, camelCased prop names need to use their kebab-cased

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Refactor

**Does this PR introduce a breaking change?** (check one)

- [x] No
