### PR TITLE
fix(QDrawer): QDrawer with overlay and value(true) will now be opened at render

### DIFF
--- a/ui/src/components/layout/QDrawer.js
+++ b/ui/src/components/layout/QDrawer.js
@@ -65,7 +65,7 @@ export default Vue.extend({
       largeScreenState = this.showIfAbove === true || (
         this.value !== void 0 ? this.value : true
       ),
-      showing = this.behavior !== 'mobile' && this.breakpoint < this.layout.width && this.overlay === false
+      showing = this.behavior !== 'mobile' && this.breakpoint < this.layout.width
         ? largeScreenState
         : false
 


### PR DESCRIPTION
Today, I realized that our QDrawer was in mode 'Open by default' but was closed.

I then did tests and realized that it was because of the overlay mode.

So I have to look at the QDrawer code and modify it for it to work.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
