### PR TITLE
fix(typescript): Corrections in type definitions

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -39,9 +39,8 @@ function convertTypeVal (type, def) {
       const defs = getPropDefinitions(def.definition)
       return defs && defs.length > 0 ? `{\n        ${getPropDefinitions(def.definition).join('\n        ')} }` : 'any'
     }
-    else {
-      return 'any'
-    }
+
+    return 'any'
   }
 
   return t
@@ -55,22 +54,21 @@ function getTypeVal (def) {
 
 function getPropDefinition (key, propDef) {
   const propName = toCamelCase(key)
+
   if (!propName.startsWith('...')) {
     const propType = getTypeVal(propDef)
-
     return `${propName}${!propDef.required ? '?' : ''} : ${propType}`
   }
-  return undefined
 }
 
 function getPropDefinitions (propDefs) {
   const defs = []
+
   for (const key in propDefs) {
     const def = getPropDefinition(key, propDefs[key])
-    if (def) {
-      defs.push(def)
-    }
+    def && defs.push(def)
   }
+
   return defs
 }
 

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -35,9 +35,13 @@ function convertTypeVal (type, def) {
   }
 
   if (t === 'Object') {
-    return def.definition
-      ? `{\n        ${getPropDefinitions(def.definition).join('\n        ')} }`
-      : 'any'
+    if (def.definition) {
+      const defs = getPropDefinitions(def.definition)
+      return defs && defs.length > 0 ? `{\n        ${getPropDefinitions(def.definition).join('\n        ')} }` : 'any'
+    }
+    else {
+      return 'any'
+    }
   }
 
   return t
@@ -45,21 +49,27 @@ function convertTypeVal (type, def) {
 
 function getTypeVal (def) {
   return Array.isArray(def.type)
-    ? def.type.map(convertTypeVal).join(' | ')
+    ? def.type.map(type => convertTypeVal(type, def)).join(' | ')
     : convertTypeVal(def.type, def)
 }
 
 function getPropDefinition (key, propDef) {
   const propName = toCamelCase(key)
-  const propType = getTypeVal(propDef)
+  if (!propName.startsWith('...')) {
+    const propType = getTypeVal(propDef)
 
-  return `${propName}${!propDef.required ? '?' : ''} : ${propType}`
+    return `${propName}${!propDef.required ? '?' : ''} : ${propType}`
+  }
+  return undefined
 }
 
 function getPropDefinitions (propDefs) {
   const defs = []
   for (const key in propDefs) {
-    defs.push(getPropDefinition(key, propDefs[key]))
+    const def = getPropDefinition(key, propDefs[key])
+    if (def) {
+      defs.push(def)
+    }
   }
   return defs
 }

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -78,7 +78,7 @@
       "desc": "Creates a notification; Same as calling $q.notify(...)",
       "params": {
         "opts": {
-          "type": "Object",
+          "type": ["Object", "String"],
           "desc": "For syntax, check quasar.conf options parameters",
           "definition": {
             "color": {

--- a/ui/src/plugins/Screen.json
+++ b/ui/src/plugins/Screen.json
@@ -6,46 +6,39 @@
       "type": "Number",
       "desc": "Screen width (in pixels)",
       "reactive": true,
-      "examples": [ 452 ],
-      "required": true
+      "examples": [ 452 ]
     },
 
     "height": {
       "type": "Number",
       "desc": "Screen height (in pixels)",
       "reactive": true,
-      "examples": [ 721 ],
-      "required": true
+      "examples": [ 721 ]
     },
 
     "sizes": {
       "type": "Object",
-      "desc": "Breakpoints (in pixels)",
-      "required": true,
+      "desc": "Breakpoints (in pixels)"
       "definition": {
         "sm": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 600 ],
-          "required": true
+          "examples": [ 600 ]
         },
         "md": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1024 ],
-          "required": true
+          "examples": [ 1024 ]
         },
         "lg": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1440 ],
-          "required": true
+          "examples": [ 1440 ]
         },
         "xl": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1920 ],
-          "required": true
+          "examples": [ 1920 ]
         }
       },
       "reactive": true,
@@ -57,28 +50,23 @@
     "lt": {
       "type": "Object",
       "desc": "Tells if current screen width is lower than breakpoint-name",
-      "required": true,
       "reactive": true,
       "definition": {
         "sm": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
-          "required": true
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
         },
         "md": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
-          "required": true
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
         },
         "lg": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
-          "required": true
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
         },
         "xl": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
-          "required": true
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
         }
       },
       "examples": [
@@ -88,29 +76,24 @@
 
     "gt": {
       "type": "Object",
-      "desc": "Tells if current screen width is greater than breakpoint-name",
-      "required": true,
+      "desc": "Tells if current screen width is greater than breakpoint-name"
       "reactive": true,
       "definition": {
         "xs": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?",
-          "required": true
+          "desc": "Is current screen width greater than this breakpoint's max limit?"
         },
         "sm": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?",
-          "required": true
+          "desc": "Is current screen width greater than this breakpoint's max limit?"
         },
         "md": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?",
-          "required": true
+          "desc": "Is current screen width greater than this breakpoint's max limit?"
         },
         "lg": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?",
-          "required": true
+          "desc": "Is current screen width greater than this breakpoint's max limit?"
         }
       },
       "examples": [
@@ -121,36 +104,31 @@
     "xs": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'xs' breakpoint",
-      "reactive": true,
-      "required": true
+      "reactive": true
     },
 
     "sm": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'sm' breakpoint",
-      "reactive": true,
-      "required": true
+      "reactive": true
     },
 
     "md": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'md' breakpoint",
-      "reactive": true,
-      "required": true
+      "reactive": true
     },
 
     "lg": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'lg' breakpoint",
-      "reactive": true,
-      "required": true
+      "reactive": true
     },
 
     "xl": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'xl' breakpoint",
-      "reactive": true,
-      "required": true
+      "reactive": true
     }
   },
 

--- a/ui/src/plugins/Screen.json
+++ b/ui/src/plugins/Screen.json
@@ -18,7 +18,7 @@
 
     "sizes": {
       "type": "Object",
-      "desc": "Breakpoints (in pixels)"
+      "desc": "Breakpoints (in pixels)",
       "definition": {
         "sm": {
           "type": "Number",
@@ -76,7 +76,7 @@
 
     "gt": {
       "type": "Object",
-      "desc": "Tells if current screen width is greater than breakpoint-name"
+      "desc": "Tells if current screen width is greater than breakpoint-name",
       "reactive": true,
       "definition": {
         "xs": {

--- a/ui/src/plugins/Screen.json
+++ b/ui/src/plugins/Screen.json
@@ -6,39 +6,46 @@
       "type": "Number",
       "desc": "Screen width (in pixels)",
       "reactive": true,
-      "examples": [ 452 ]
+      "examples": [ 452 ],
+      "required": true
     },
 
     "height": {
       "type": "Number",
       "desc": "Screen height (in pixels)",
       "reactive": true,
-      "examples": [ 721 ]
+      "examples": [ 721 ],
+      "required": true
     },
 
     "sizes": {
       "type": "Object",
       "desc": "Breakpoints (in pixels)",
+      "required": true,
       "definition": {
         "sm": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 600 ]
+          "examples": [ 600 ],
+          "required": true
         },
         "md": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1024 ]
+          "examples": [ 1024 ],
+          "required": true
         },
         "lg": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1440 ]
+          "examples": [ 1440 ],
+          "required": true
         },
         "xl": {
           "type": "Number",
           "desc": "Breakpoint width size",
-          "examples": [ 1920 ]
+          "examples": [ 1920 ],
+          "required": true
         }
       },
       "reactive": true,
@@ -50,23 +57,28 @@
     "lt": {
       "type": "Object",
       "desc": "Tells if current screen width is lower than breakpoint-name",
+      "required": true,
       "reactive": true,
       "definition": {
         "sm": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
+          "required": true
         },
         "md": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
+          "required": true
         },
         "lg": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
+          "required": true
         },
         "xl": {
           "type": "Boolean",
-          "desc": "Is current screen width lower than this breakpoint's lowest limit?"
+          "desc": "Is current screen width lower than this breakpoint's lowest limit?",
+          "required": true
         }
       },
       "examples": [
@@ -77,23 +89,28 @@
     "gt": {
       "type": "Object",
       "desc": "Tells if current screen width is greater than breakpoint-name",
+      "required": true,
       "reactive": true,
       "definition": {
         "xs": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?"
+          "desc": "Is current screen width greater than this breakpoint's max limit?",
+          "required": true
         },
         "sm": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?"
+          "desc": "Is current screen width greater than this breakpoint's max limit?",
+          "required": true
         },
         "md": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?"
+          "desc": "Is current screen width greater than this breakpoint's max limit?",
+          "required": true
         },
         "lg": {
           "type": "Boolean",
-          "desc": "Is current screen width greater than this breakpoint's max limit?"
+          "desc": "Is current screen width greater than this breakpoint's max limit?",
+          "required": true
         }
       },
       "examples": [
@@ -104,31 +121,36 @@
     "xs": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'xs' breakpoint",
-      "reactive": true
+      "reactive": true,
+      "required": true
     },
 
     "sm": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'sm' breakpoint",
-      "reactive": true
+      "reactive": true,
+      "required": true
     },
 
     "md": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'md' breakpoint",
-      "reactive": true
+      "reactive": true,
+      "required": true
     },
 
     "lg": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'lg' breakpoint",
-      "reactive": true
+      "reactive": true,
+      "required": true
     },
 
     "xl": {
       "type": "Boolean",
       "desc": "Current screen width fits exactly 'xl' breakpoint",
-      "reactive": true
+      "reactive": true,
+      "required": true
     }
   },
 


### PR DESCRIPTION
Fix bugs in type definitions:
* QNotify, missing string parameter option for the Create method.
* $q.screen properties are all required.
* Fix bug when there are multiple types and one is an object type, it will currently only include the object type.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
