### PR TITLE
fix(QStepper): center first and last child dots of the stepper in contracted mode (fix: #4072)

### DIFF
--- a/ui/src/components/stepper/stepper.styl
+++ b/ui/src/components/stepper/stepper.styl
@@ -190,10 +190,7 @@
       &--alternative-labels
         .q-stepper__tab
           min-height 72px
-          &:first-child
-            align-items flex-start
-          &:last-child
-            align-items flex-end
+          justify-content center
       .q-stepper__tab
         padding 24px 0
     .q-stepper__tab:not(:last-child)

--- a/ui/src/components/stepper/stepper.styl
+++ b/ui/src/components/stepper/stepper.styl
@@ -184,6 +184,9 @@
   &--contracted
     .q-stepper__header
       min-height 72px
+      &--standard-labels
+        .q-stepper__tab
+          justify-content center
       &--alternative-labels
         .q-stepper__tab
           min-height 72px
@@ -193,12 +196,6 @@
             align-items flex-end
       .q-stepper__tab
         padding 24px 0
-        &:first-child
-          .q-stepper__dot
-            transform translate3d(24px, 0, 0)
-        &:last-child
-          .q-stepper__dot
-            transform translate3d(-24px, 0, 0)
     .q-stepper__tab:not(:last-child)
       .q-stepper__dot:after
         display block !important


### PR DESCRIPTION
…tracted mode

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
