### PR TITLE
Safari/Cordova/iOS: restrict adding files to the first one

### DIFF
--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -237,6 +237,12 @@ export default {
       files = files.filter(file => !this.files.some(f => file.name === f.name))
       if (files.length === 0) { return }
 
+      // FYI, Safari on Cordova/iOS allows selecting multiple files even when the
+      // multiple attribute is not specified.
+      if (this.multiple !== true) {
+        files = [ files[0] ]
+      }
+
       // filter file types
       if (this.accept !== void 0) {
         files = Array.prototype.filter.call(files, file => {
@@ -324,7 +330,6 @@ export default {
       let files = e.dataTransfer.files
 
       if (files.length > 0) {
-        files = this.multiple ? files : [ files[0] ]
         this.__addFiles(null, files)
       }
 

--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -237,12 +237,6 @@ export default {
       files = files.filter(file => !this.files.some(f => file.name === f.name))
       if (files.length === 0) { return }
 
-      // FYI, Safari on Cordova/iOS allows selecting multiple files even when the
-      // multiple attribute is not specified.
-      if (this.multiple !== true) {
-        files = [ files[0] ]
-      }
-
       // filter file types
       if (this.accept !== void 0) {
         files = Array.prototype.filter.call(files, file => {
@@ -258,6 +252,13 @@ export default {
       if (this.maxFileSize !== void 0) {
         files = Array.prototype.filter.call(files, file => file.size <= this.maxFileSize)
         if (files.length === 0) { return }
+      }
+
+      // Cordova/iOS allows selecting multiple files even when the
+      // multiple attribute is not specified. We also normalize drag'n'dropped
+      // files here:
+      if (this.multiple !== true) {
+        files = [ files[0] ]
       }
 
       if (this.maxTotalSize !== void 0) {


### PR DESCRIPTION
Restrict adding files to the first one if the multiple attribute is not specified.

Safari in an Cordova/iOS app allows selecting (and returns) multiple files,
even if the multiple attribute is not specified.

Moved the relevant check from __onDrop() to __addFiles().

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
