### PR TITLE
Changed store to this.$store on line 194 in mounted()

### DIFF
--- a/docs/src/pages/quasar-cli/cli-documentation/prefetch-feature.md
+++ b/docs/src/pages/quasar-cli/cli-documentation/prefetch-feature.md
@@ -191,7 +191,7 @@ export default {
   },
   mounted () {
     // Preserve the previous state if it was injected from the server
-    store.registerModule('foo', fooStoreModule, { preserveState: true })
+    this.$store.registerModule('foo', fooStoreModule, { preserveState: true })
   },
   // IMPORTANT: avoid duplicate module registration on the client
   // when the route is visited multiple times.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
