### PR TITLE
Changed the QDialog max-width calculation

### DIFF
--- a/ui/src/components/dialog/dialog.styl
+++ b/ui/src/components/dialog/dialog.styl
@@ -95,7 +95,7 @@ body.q-ios-padding .q-dialog__inner
 
 @media (min-width $breakpoint-sm-min)
   .q-dialog__inner--minimized > div
-    max-width 560px
+    max-width calc(100vw - 48px)
 
 .q-body--dialog
   overflow hidden


### PR DESCRIPTION
… to match a previous max-height calculation in the same dialog.styl file.

My dialog was not resizing correctly based on a width larger than 560px, which was surprising to me.

See also https://en.wikipedia.org/wiki/Principle_of_least_astonishment


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
