### PR TITLE
fix(QDate): Don't use formatDate for Persian calendar

### DIFF
--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -674,20 +674,23 @@ export default Vue.extend({
         date.day = Math.min(date.day, maxDay)
       }
 
-      const val = formatDate(
-        new Date(
-          date.year,
-          date.month - 1,
-          date.day,
-          this.extModel.hour,
-          this.extModel.minute,
-          this.extModel.second,
-          this.extModel.millisecond
-        ),
-        this.mask,
-        this.computedLocale,
-        date.year
-      )
+      let val = String(date.year) + '/' + String(date.month).padStart(2, '0') + '/' + String(date.day).padStart(2, '0')
+      if (this.calendar !== 'persian') {
+        val = formatDate(
+          new Date(
+            date.year,
+            date.month - 1,
+            date.day,
+            this.extModel.hour,
+            this.extModel.minute,
+            this.extModel.second,
+            this.extModel.millisecond
+          ),
+          this.mask,
+          this.computedLocale,
+          date.year
+        )
+      }
 
       if (val !== this.value) {
         this.$emit('input', val, reason, date)

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -15,9 +15,14 @@ export default Vue.extend({
   mixins: [ DateTimeMixin ],
 
   props: {
+    title: String,
+    subtitle: String,
+
     emitImmediately: Boolean,
 
     mask: {
+      // this mask is forced
+      // when using persian calendar
       default: 'YYYY/MM/DD'
     },
 
@@ -92,6 +97,10 @@ export default Vue.extend({
     },
 
     headerTitle () {
+      if (this.title !== void 0 && this.title !== null && this.title.length > 0) {
+        return this.title
+      }
+
       const model = this.extModel
       if (model.dateHash === null) { return ' --- ' }
 
@@ -117,9 +126,13 @@ export default Vue.extend({
     },
 
     headerSubtitle () {
-      return this.extModel.year !== null
-        ? this.extModel.year
-        : ' --- '
+      return this.subtitle !== void 0 && this.subtitle !== null && this.subtitle.length > 0
+        ? this.subtitle
+        : (
+          this.extModel.year !== null
+            ? this.extModel.year
+            : ' --- '
+        )
     },
 
     dateArrow () {
@@ -246,7 +259,13 @@ export default Vue.extend({
 
   methods: {
     __getModels (val, mask, locale) {
-      const external = __splitDate(val, mask, locale, this.calendar)
+      const external = __splitDate(
+        val,
+        this.calendar === 'persian' ? 'YYYY/MM/DD' : mask,
+        locale,
+        this.calendar
+      )
+
       return {
         external,
         inner: external.dateHash === null
@@ -674,9 +693,9 @@ export default Vue.extend({
         date.day = Math.min(date.day, maxDay)
       }
 
-      let val = String(date.year) + '/' + String(date.month).padStart(2, '0') + '/' + String(date.day).padStart(2, '0')
-      if (this.calendar !== 'persian') {
-        val = formatDate(
+      const val = this.calendar === 'persian'
+        ? date.year + '/' + pad(date.month) + '/' + pad(date.day)
+        : formatDate(
           new Date(
             date.year,
             date.month - 1,
@@ -690,7 +709,6 @@ export default Vue.extend({
           this.computedLocale,
           date.year
         )
-      }
 
       if (val !== this.value) {
         this.$emit('input', val, reason, date)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Introduction of `mask` prop for `QDate` broke the Persian calendar mode because  `formatDate` relies on JavaScript's native `Date` class and that's not compatible with Persian calendar system.

This PR simply skips `formatDate` if the `calendar` prop of component is set to `persian`.
I wanted to add a warning to the docs that the `mask` prop does not work with Persian calendar but it seems the docs are not updated yet to include this new feature.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
