### PR TITLE
fix(quasar): Persistent property of QMenu was not blocking ESC key dismissal

### DIFF
--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -132,8 +132,10 @@ export default Vue.extend({
       }
 
       EscapeKey.register(this, () => {
-        this.$emit('escape-key')
-        this.hide()
+        if (this.persistent !== true) {
+          this.$emit('escape-key')
+          this.hide()
+        }
       })
 
       this.__showPortal()


### PR DESCRIPTION
Was affecting:
- QMenu
- QBtnDropdown
- QPopupEdit
- QpopupProxy

ref #4150