### PR TITLE
clarify(docs): add a line saying you can also use your own icons 📍

### DIFF
--- a/docs/src/pages/options/quasar-icon-sets.md
+++ b/docs/src/pages/options/quasar-icon-sets.md
@@ -9,7 +9,9 @@ Quasar components have their own icons. Rather than forcing you into using one i
 
 You can install multiple icon libraries, but you must choose only one to use on Quasar's components.
 
-Quasar currently supports: [Material Icons](https://material.io/icons/) , [Font Awesome](http://fontawesome.io/icons/), [Ionicons](http://ionicons.com/), [MDI](https://materialdesignicons.com/) and [Eva Icons](https://akveo.github.io/eva-icons). It is also possible to use your own icons with any Quasar component, see the [QIcon page](/vue-components/icon#Images-instead-of-webfont) for more info on this.
+Quasar currently supports: [Material Icons](https://material.io/icons/) , [Font Awesome](http://fontawesome.io/icons/), [Ionicons](http://ionicons.com/), [MDI](https://materialdesignicons.com/) and [Eva Icons](https://akveo.github.io/eva-icons).
+
+It is also possible to use your own icons (as images in any format) with any Quasar component, see the [QIcon page](/vue-components/icon#Images-instead-of-webfont) for more info on this.
 
 ::: tip
 Related pages: [Installing Icon Libraries](/options/installing-icon-libraries) and [QIcon component](/vue-components/icon).

--- a/docs/src/pages/options/quasar-icon-sets.md
+++ b/docs/src/pages/options/quasar-icon-sets.md
@@ -9,7 +9,7 @@ Quasar components have their own icons. Rather than forcing you into using one i
 
 You can install multiple icon libraries, but you must choose only one to use on Quasar's components.
 
-Quasar currently supports: [Material Icons](https://material.io/icons/) , [Font Awesome](http://fontawesome.io/icons/), [Ionicons](http://ionicons.com/), [MDI](https://materialdesignicons.com/) and [Eva Icons](https://akveo.github.io/eva-icons).
+Quasar currently supports: [Material Icons](https://material.io/icons/) , [Font Awesome](http://fontawesome.io/icons/), [Ionicons](http://ionicons.com/), [MDI](https://materialdesignicons.com/) and [Eva Icons](https://akveo.github.io/eva-icons). It is also possible to use your own icons with any Quasar component, see the [QIcon page](/vue-components/icon#Images-instead-of-webfont) for more info on this.
 
 ::: tip
 Related pages: [Installing Icon Libraries](/options/installing-icon-libraries) and [QIcon component](/vue-components/icon).


### PR DESCRIPTION
Just added one line that you _can_ use your own icons.

I thought it was important to also clarify this on the [Icon Sets](https://v1.quasar-framework.org/options/quasar-icon-sets) page.