### PR TITLE
Fix(docs): tooltip typo

### DIFF
--- a/docs/src/components/page-parts/tooltip/TooltipPositioning.vue
+++ b/docs/src/components/page-parts/tooltip/TooltipPositioning.vue
@@ -69,7 +69,7 @@ export default {
     tooltipExport () {
       return `<q-tooltip anchor="${this.anchor}" self="${this.self}">
   Here I am!
-</q-menu>`
+</q-tooltip>`
     }
   }
 }


### PR DESCRIPTION
Fixes a typo in `QTooltip` docs.