### PR TITLE
fix(quasar): QSelect related fixes

### DIFF
--- a/ui/dev/components/form/select-part-3.vue
+++ b/ui/dev/components/form/select-part-3.vue
@@ -73,20 +73,97 @@
           </q-item>
         </template>
       </q-select>
+
+      <q-select
+        filled
+        v-model="model2"
+        use-input
+        hide-selected
+        fill-input
+        emit-value
+        map-options
+        label="Lazy filter with new options"
+        :options="objectOptions"
+        @filter="filterObjectFn"
+        style="width: 250px"
+        clearable
+      >
+        <template v-slot:no-option>
+          <q-item>
+            <q-item-section class="text-grey">
+              No results
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
+
+      <q-select
+        filled
+        v-model="model3"
+        use-input
+        hide-selected
+        fill-input
+        emit-value
+        map-options
+        label="Lots of options"
+        :options="lotsOptions"
+        @filter="filterLotsFn"
+        style="width: 250px"
+        clearable
+      >
+        <template v-slot:no-option>
+          <q-item>
+            <q-item-section class="text-grey">
+              No results
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
     </div>
   </div>
 </template>
 
 <script>
-const stringOptions = [
-  'Google', 'Facebook', 'Twitter', 'Apple', 'Oracle'
-]
+const
+  stringOptions = [
+    'Google', 'Facebook', 'Twitter', 'Apple', 'Oracle'
+  ],
+  objectOptions = () => ([
+    {
+      label: 'Google',
+      value: 1
+    },
+    {
+      label: 'Facebook',
+      value: 2
+    },
+    {
+      label: 'Twitter',
+      value: 3
+    },
+    {
+      label: 'Apple',
+      value: 4
+    },
+    {
+      label: 'Oracle',
+      value: 5
+    }
+  ]),
+  lotsOptions = () => Array(50).fill(0).map((item, i) => ({
+    value: i,
+    label: `Item ${i}`
+  }))
 
 export default {
   data () {
     return {
       model: 'Twitter',
-      options: stringOptions
+      model2: null,
+      model3: null,
+      options: stringOptions,
+      objectOptions: objectOptions(),
+      lotsOptions: lotsOptions()
     }
   },
 
@@ -103,6 +180,38 @@ export default {
       update(() => {
         const needle = val.toLowerCase()
         this.options = stringOptions.filter(v => v.toLowerCase().indexOf(needle) > -1)
+      })
+    },
+
+    filterObjectFn (val, update) {
+      console.log('filterObjectFn', val)
+      if (val === '') {
+        update(() => {
+          this.objectOptions = objectOptions()
+        })
+        return
+      }
+
+      setTimeout(() => {
+        update(() => {
+          const needle = val.toLowerCase()
+          this.objectOptions = objectOptions().filter(v => v.label.toLowerCase().indexOf(needle) > -1)
+        })
+      }, 100)
+    },
+
+    filterLotsFn (val, update) {
+      console.log('filterLotsFn', val)
+      if (val === '') {
+        update(() => {
+          this.lotsOptions = lotsOptions()
+        })
+        return
+      }
+
+      update(() => {
+        const needle = val.toLowerCase()
+        this.lotsOptions = lotsOptions().filter(v => v.label.toLowerCase().indexOf(needle) > -1)
       })
     }
   }

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -281,6 +281,10 @@ export default Vue.extend({
 
   beforeDestroy () {
     // When the menu is destroyed while open we can only emit the event on anchorEl
-    this.value === true && this.anchorEl !== void 0 && this.anchorEl.dispatchEvent(create('popup-hide', { bubbles: true }))
+    if (this.value === true && this.anchorEl !== void 0) {
+      this.anchorEl.dispatchEvent(
+        create('popup-hide', { bubbles: true })
+      )
+    }
   }
 })

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -277,5 +277,10 @@ export default Vue.extend({
     __onPortalClose () {
       closeRootMenu(this.menuId)
     }
+  },
+
+  beforeDestroy () {
+    // When the menu is destroyed while open we can only emit the event on anchorEl
+    this.value === true && this.anchorEl !== void 0 && this.anchorEl.dispatchEvent(create('popup-hide', { bubbles: true }))
   }
 })

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -98,7 +98,12 @@ export default Vue.extend({
     innerValue: {
       handler () {
         if (
-          this.useInput === true && this.fillInput === true && this.multiple !== true &&
+          this.useInput === true &&
+          this.fillInput === true &&
+          this.multiple !== true &&
+          // Prevent re-entering in filter while filtering
+          // Also prevent clearing inputValue while filtering
+          this.innerLoading !== true &&
           ((this.dialog !== true && this.menu !== true) || this.hasValue !== true)
         ) {
           this.__resetInputValue()
@@ -289,7 +294,7 @@ export default Vue.extend({
 
       const optValue = this.__getOptionValue(opt)
 
-      this.multiple !== true && this.updateInputValue(this.fillInput === true ? optValue : '', true)
+      this.multiple !== true && this.updateInputValue(this.fillInput === true ? this.__getOptionLabel(opt) : '', true)
       this.focus()
 
       if (this.multiple !== true) {
@@ -673,7 +678,7 @@ export default Vue.extend({
 
       if (this.$listeners.filter !== void 0) {
         this.inputTimer = setTimeout(() => {
-          this.filter(this.inputValue)
+          this.filter(this.inputValue, true)
         }, this.inputDebounce)
       }
     },
@@ -688,7 +693,7 @@ export default Vue.extend({
       }
     },
 
-    filter (val) {
+    filter (val, userInput) {
       if (this.$listeners.filter === void 0 || this.focused !== true) {
         return
       }
@@ -704,6 +709,7 @@ export default Vue.extend({
         val !== '' &&
         this.multiple !== true &&
         this.innerValue.length > 0 &&
+        userInput !== true &&
         val === this.__getOptionLabel(this.innerValue[0])
       ) {
         val = ''
@@ -825,7 +831,8 @@ export default Vue.extend({
             dark: this.optionsDark,
             square: true,
             loading: this.innerLoading,
-            filled: true
+            filled: true,
+            stackLabel: this.inputValue.length > 0
           },
           on: {
             ...this.$listeners,

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -294,7 +294,9 @@ export default Vue.extend({
 
       const optValue = this.__getOptionValue(opt)
 
-      this.multiple !== true && this.updateInputValue(this.fillInput === true ? this.__getOptionLabel(opt) : '', true)
+      this.multiple !== true && this.updateInputValue(
+        this.fillInput === true ? this.__getOptionLabel(opt) : '', true
+      )
       this.focus()
 
       if (this.multiple !== true) {


### PR DESCRIPTION
- emit 'popup-hide' in QMenu on destroy
- set stackLabel in QSelect dialog field
- prevent clearing inputValue in QSelect while loading
- fix not filtering when the inputValue matches selected value
- fix setting inputValue to value instead of label on toggle

ref #4238, ref #4235, ref #4237