### PR TITLE
Fixing QDialog basic confirm example

### DIFF
--- a/docs/src/examples/Dialog/Basic.vue
+++ b/docs/src/examples/Dialog/Basic.vue
@@ -26,6 +26,7 @@ export default {
       this.$q.dialog({
         title: 'Confirm',
         message: 'Would you like to turn on the wifi?',
+        cancel: true,
         persistent: true
       }).onOk(() => {
         console.log('>>>> OK')


### PR DESCRIPTION
The confirm dialog for the basic example did not have the "Cancel" button