### PR TITLE
Found typo on line 86

### DIFF
--- a/docs/src/pages/quasar-cli/developing-mobile-apps/app-icons-cordova.md
+++ b/docs/src/pages/quasar-cli/developing-mobile-apps/app-icons-cordova.md
@@ -83,7 +83,7 @@ And here is what your config.xml should look like:
 <platform name="android">
     <icon density="ldpi" src="res/android/icon-36-ldpi.png" />
     <icon density="mdpi" src="res/android/icon-48-mdpi.png" />
-    <icon density="hppi" src="res/android/icon-72-hdpi.png" />
+    <icon density="hdpi" src="res/android/icon-72-hdpi.png" />
     <icon density="xhdpi" src="res/android/icon-96-xhdpi.png" />
     <icon density="xxhdpi" src="res/android/icon-144-xxhdpi.png" />
     <icon density="xxxhdpi" src="res/android/icon-192-xxxhdpi.png" />


### PR DESCRIPTION
Found typo on line 86 ` <icon density="hppi" src="res/android/icon-72-hdpi.png" />`  it should be ` <icon density="hdpi" src="res/android/icon-72-hdpi.png" />`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
