### PR TITLE
fix(Api): add more precision in the options-cover props with use-input of QSelect

### DIFF
--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -117,7 +117,7 @@
 
     "options-cover": {
       "type": "Boolean",
-      "desc": "Expanded menu will cover the component",
+      "desc": "Expanded menu will cover the component (don't work with use-input)",
       "category": "options"
     },
 

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -117,7 +117,7 @@
 
     "options-cover": {
       "type": "Boolean",
-      "desc": "Expanded menu will cover the component (don't work with use-input)",
+      "desc": "Expanded menu will cover the component (will not work along with 'use-input' prop for obvious reasons)",
       "category": "options"
     },
 


### PR DESCRIPTION
We can't use options-cover and use-input simultaneously.

`cover: this.optionsCover === true && this.noOptions !== true && this.useInput !== true,`