### PR TITLE
feat(quasar): Tweaks on QSelect dropdown indicator and on QField append slot

### DIFF
--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -204,6 +204,13 @@ export default Vue.extend({
         }, this.__getControlContainer(h))
       )
 
+      this.$scopedSlots.append !== void 0 && node.push(
+        h('div', {
+          staticClass: 'q-field__append q-field__marginal row no-wrap items-center',
+          key: 'append'
+        }, this.$scopedSlots.append())
+      )
+
       this.hasError === true && this.noErrorIcon === false && node.push(
         this.__getInnerAppendNode(h, 'error', [
           h(QIcon, { props: { name: this.$q.iconSet.field.error, color: 'negative' } })
@@ -221,8 +228,7 @@ export default Vue.extend({
           )
         )
       }
-
-      if (this.clearable === true && this.hasValue === true && this.editable === true) {
+      else if (this.clearable === true && this.hasValue === true && this.editable === true) {
         node.push(
           this.__getInnerAppendNode(h, 'inner-clearable-append', [
             h(QIcon, {
@@ -235,13 +241,6 @@ export default Vue.extend({
           ])
         )
       }
-
-      this.$scopedSlots.append !== void 0 && node.push(
-        h('div', {
-          staticClass: 'q-field__append q-field__marginal row no-wrap items-center',
-          key: 'append'
-        }, this.$scopedSlots.append())
-      )
 
       this.__getInnerAppend !== void 0 && node.push(
         this.__getInnerAppendNode(h, 'inner-append', this.__getInnerAppend(h))
@@ -358,7 +357,7 @@ export default Vue.extend({
     },
 
     __getInnerAppendNode (h, key, content) {
-      return h('div', {
+      return content === null ? null : h('div', {
         staticClass: 'q-field__append q-field__marginal row no-wrap items-center q-anchor--skip',
         key
       }, content)

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -643,7 +643,7 @@ export default Vue.extend({
     },
 
     __getInnerAppend (h) {
-      return this.hideDropdownIcon !== true
+      return this.loading !== true && this.innerLoading !== true && this.hideDropdownIcon !== true
         ? [
           h(QIcon, {
             staticClass: 'q-select__dropdown-icon',


### PR DESCRIPTION
Also:
- hide dropdown indicator in QSelect when loading is visible
- do not render __getInnerAppendNode in QField when content is null
- reorder append slot in QField so that the default indicators are at the end
- hide clearable icon while loading is visible