### PR TITLE
fix(quasar): Force QTabs to use full width when in vertical mode and adjust QBadge's position

### DIFF
--- a/ui/src/components/tabs/tabs.styl
+++ b/ui/src/components/tabs/tabs.styl
@@ -114,6 +114,12 @@
     .q-tab
       padding 0 8px
 
+    .q-tab__content
+      width 100%
+
+    .q-badge
+      right -6px
+
     .q-tab__indicator
       height unset
       width 2px


### PR DESCRIPTION
ref #4324