### PR TITLE
feat(QDate) enhance disabling features

### DIFF
--- a/ui/dev/components/form/date.vue
+++ b/ui/dev/components/form/date.vue
@@ -143,6 +143,22 @@
           :style="style"
           default-view="Years"
         />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :months="months"
+          :style="style"
+          default-view="Months"
+        />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :months="monthsFn"
+          :style="style"
+          default-view="Months"
+        />
       </div>
 
       <div class="text-h6">
@@ -264,44 +280,6 @@
           no-years
         />
       </div>
-
-      <div class="text-h6">
-        No forward navigation
-      </div>
-      <div class="q-gutter-md column">
-        <q-date
-          v-model="date"
-          v-bind="props"
-          :style="style"
-          no-forward-year-navigation
-        />
-
-        <q-date
-          v-model="date"
-          v-bind="props"
-          :style="style"
-          no-forward-month-navigation
-        />
-      </div>
-
-      <div class="text-h6">
-        No backward navigation
-      </div>
-      <div class="q-gutter-md column">
-        <q-date
-          v-model="date"
-          v-bind="props"
-          :style="style"
-          no-backward-year-navigation
-        />
-
-        <q-date
-          v-model="date"
-          v-bind="props"
-          :style="style"
-          no-backward-month-navigation
-        />
-      </div>
     </div>
   </div>
 </template>
@@ -362,6 +340,11 @@ export default {
       return this.persian === true
         ? [1397, 1398]
         : [2018, 2020, 2015]
+    },
+    months () {
+      return this.persian === true
+        ? ['1397/08']
+        : ['2018/11', '2018/12']
     },
     props () {
       return {
@@ -424,6 +407,10 @@ export default {
 
     yearsFn (year) {
       return year >= 2019 && year <= 2020
+    },
+
+    monthsFn (year, month) {
+      return year === 2019 && month >= 4 && month <= 6
     },
 
     inputLog (value, reason, date) {

--- a/ui/dev/components/form/date.vue
+++ b/ui/dev/components/form/date.vue
@@ -252,6 +252,18 @@
           </template>
         </q-input>
       </div>
+
+      <div class="text-h6">
+        No years
+      </div>
+      <div class="q-gutter-md column">
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          no-years
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/ui/dev/components/form/date.vue
+++ b/ui/dev/components/form/date.vue
@@ -264,6 +264,44 @@
           no-years
         />
       </div>
+
+      <div class="text-h6">
+        No forward navigation
+      </div>
+      <div class="q-gutter-md column">
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          no-forward-year-navigation
+        />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          no-forward-month-navigation
+        />
+      </div>
+
+      <div class="text-h6">
+        No backward navigation
+      </div>
+      <div class="q-gutter-md column">
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          no-backward-year-navigation
+        />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :style="style"
+          no-backward-month-navigation
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/ui/dev/components/form/date.vue
+++ b/ui/dev/components/form/date.vue
@@ -127,6 +127,22 @@
           :options="optionsFn2"
           :style="style"
         />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :years="years"
+          :style="style"
+          default-view="Years"
+        />
+
+        <q-date
+          v-model="date"
+          v-bind="props"
+          :years="yearsFn"
+          :style="style"
+          default-view="Years"
+        />
       </div>
 
       <div class="text-h6">
@@ -292,6 +308,11 @@ export default {
         ? ['1397/08/14', '1397/08/15', '1397/08/18', '1397/08/28']
         : ['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23']
     },
+    years () {
+      return this.persian === true
+        ? [1397, 1398]
+        : [2018, 2020, 2015]
+    },
     props () {
       return {
         dark: this.dark,
@@ -349,6 +370,10 @@ export default {
       return this.persian === true
         ? date >= '1397/08/12' && date <= '1397/08/24'
         : date >= '2018/11/03' && date <= '2018/11/15'
+    },
+
+    yearsFn (year) {
+      return year >= 2019 && year <= 2020
     },
 
     inputLog (value, reason, date) {

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -35,6 +35,8 @@ export default Vue.extend({
     eventColor: [String, Function],
 
     options: [Array, Function],
+    years: [Array, Function],
+    disabledYears: [Array, Function],
 
     firstDayOfWeek: [String, Number],
     todayBtn: Boolean,
@@ -180,6 +182,22 @@ export default Vue.extend({
       return typeof this.options === 'function'
         ? this.options
         : date => this.options.includes(date)
+    },
+
+    isYearActive () {
+      return typeof this.years === 'function'
+        ? this.years
+        : year => this.years.includes(year)
+    },
+
+    isYearDisabled () {
+      return typeof this.disabledYears === 'function'
+        ? this.disabledYears
+        : year => this.disabledYears.includes(year)
+    },
+
+    isYearInSelection () {
+      return year => (this.years !== void 0 && this.isYearActive(year)) || (this.disabledYears !== void 0 && !this.isYearDisabled(year))
     },
 
     days () {
@@ -550,7 +568,8 @@ export default Vue.extend({
         years = []
 
       for (let i = start; i <= stop; i++) {
-        const active = this.innerModel.year === i
+        const active = this.innerModel.year === i,
+          disable = (this.years !== void 0 || this.disabledYears !== void 0) && !this.isYearInSelection(i)
 
         years.push(
           h('div', {
@@ -562,13 +581,14 @@ export default Vue.extend({
                 flat: !active,
                 label: i,
                 dense: true,
+                disable,
                 unelevated: active,
                 color: active ? this.computedColor : null,
                 textColor: active ? this.computedTextColor : null,
                 tabindex: this.computedTabindex
               },
               on: {
-                click: () => { this.__setYear(i) }
+                click: () => { !disable && this.__setYear(i) }
               }
             })
           ])

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -45,7 +45,8 @@ export default Vue.extend({
       type: String,
       default: 'Calendar',
       validator: v => ['Calendar', 'Years', 'Months'].includes(v)
-    }
+    },
+    noYears: Boolean
   },
 
   data () {
@@ -340,12 +341,12 @@ export default Vue.extend({
           }, [
             h('div', {
               key: 'h-yr-' + this.headerSubtitle,
-              staticClass: 'q-date__header-subtitle q-date__header-link',
-              class: this.view === 'Years' ? 'q-date__header-link--active' : 'cursor-pointer',
+              staticClass: `q-date__header-subtitle ${this.noYears === true ? '' : 'q-date__header-link'}`,
+              class: this.noYears === true ? '' : (this.view === 'Years' ? 'q-date__header-link--active' : 'cursor-pointer'),
               attrs: { tabindex: this.computedTabindex },
               on: {
-                click: () => { this.view = 'Years' },
-                keyup: e => { e.keyCode === 13 && (this.view = 'Years') }
+                click: () => { this.noYears !== true && (this.view = 'Years') },
+                keyup: e => { this.noYears !== true && e.keyCode === 13 && (this.view = 'Years') }
               }
             }, [ this.headerSubtitle ])
           ])
@@ -420,7 +421,10 @@ export default Vue.extend({
               name: 'q-transition--jump-' + dir
             }
           }, [
-            h('div', { key }, [
+            h('div', {
+              key,
+              staticClass: 'full-width'
+            }, [
               h(QBtn, {
                 props: {
                   flat: true,
@@ -429,6 +433,7 @@ export default Vue.extend({
                   label,
                   tabindex: this.computedTabindex
                 },
+                staticClass: 'full-width',
                 on: {
                   click: () => { this.view = view }
                 }
@@ -472,7 +477,7 @@ export default Vue.extend({
             dir: this.monthDirection,
             goTo: this.__goToMonth,
             cls: ' col'
-          }).concat(this.__getNavigation(h, {
+          }).concat(this.noYears === true ? [] : this.__getNavigation(h, {
             label: this.innerModel.year,
             view: 'Years',
             key: this.innerModel.year,

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -488,15 +488,15 @@ export default Vue.extend({
             cls: ' col',
             forwardNavigation: this.noForwardMonthNavigation !== true,
             backwardNavigation: this.noBackwardMonthNavigation !== true
-          }).concat(this.noYears === true ? [] : this.__getNavigation(h, {
+          }).concat(this.__getNavigation(h, {
             label: this.innerModel.year,
             view: 'Years',
             key: this.innerModel.year,
             dir: this.yearDirection,
             goTo: this.__goToYear,
             cls: '',
-            forwardNavigation: this.noForwardYearNavigation !== true,
-            backwardNavigation: this.noBackwardYearNavigation !== true
+            forwardNavigation: this.noYears !== true && this.noForwardYearNavigation !== true,
+            backwardNavigation: this.noYears !== true && this.noBackwardYearNavigation !== true
           }))),
 
           h('div', {

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -678,13 +678,11 @@ export default Vue.extend({
       if (month === 13) {
         month = 1
         this.innerModel.year++
-        this.extModel.year++
         yearDir = 'left'
       }
       else if (month === 0) {
         month = 12
         this.innerModel.year--
-        this.extModel.year--
         yearDir = 'right'
       }
 

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -657,11 +657,13 @@ export default Vue.extend({
       if (month === 13) {
         month = 1
         this.innerModel.year++
+        this.extModel.year++
         yearDir = 'left'
       }
       else if (month === 0) {
         month = 12
         this.innerModel.year--
+        this.extModel.year--
         yearDir = 'right'
       }
 

--- a/ui/src/components/datetime/QDate.json
+++ b/ui/src/components/datetime/QDate.json
@@ -8,6 +8,7 @@
   "props": {
     "value": {
       "extends": "value",
+      "required": true,
       "desc": "Date of the component; Either use this property (along with a listener for 'input' event) OR use v-model directive",
       "examples": [
         "v-model=\"myDate\""

--- a/ui/src/components/datetime/QDate.json
+++ b/ui/src/components/datetime/QDate.json
@@ -89,6 +89,52 @@
       "category": "model"
     },
 
+    "years": {
+      "type": [ "Array", "Function" ],
+      "desc": "Optionally configure the years that are selectable; If using a function, it receives the year as an integer and must return a Boolean (is year acceptable or not). If the year is not acceptable, every day of the year will be disabled.",
+      "examples": [
+        ":years=\"[2019, 2018]\"",
+        ":years=\"year => year >= 2015 && year <= 2020\""
+      ],
+      "category": "model"
+    },
+
+    "disabled-years": {
+      "type": [ "Array", "Function" ],
+      "desc": "Optionally configure the years that are disabled; If using a function, it receives the year as an integer and must return a Boolean (is year disabled or not). If the year is disabled, every day of the year will be disabled.",
+      "examples": [
+        ":disabled-years=\"[2015, 2016, 2020]\"",
+        ":disabled-years=\"year => year <= 2010\""
+      ],
+      "category": "model"
+    },
+
+    "months": {
+      "type": [ "Array", "Function" ],
+      "desc": "Optionally configure the months that are selectable; If using a function, it receives the year and the month as an integer and must return a Boolean (is month acceptable or not). If the month is not acceptable, every day of the month will be disabled.",
+      "examples": [
+        ":months=\"['2017/05', '2018/05']\"",
+        ":months=\"(year, month) => year >= 2015 && year <= 2020 && month === 5\""
+      ],
+      "category": "model"
+    },
+
+    "disabled-months": {
+      "type": [ "Array", "Function" ],
+      "desc": "Optionally configure the months that are disabled; If using a function, it receives the year and the month as an integer and must return a Boolean (is month disabled or not). If the month is disabled, every day of the month will be disabled.",
+      "examples": [
+        ":disabled-months=\"['2015/05', '2016/04', '2020/10']\"",
+        ":disabled-months=\"(year, month) => year <= 2010 && month >= 5 && month <= 10\""
+      ],
+      "category": "model"
+    },
+
+    "no-years": {
+      "type": "Boolean",
+      "desc": "Disables the Years view",
+      "category": "behavior"
+    },
+
     "first-day-of-week": {
       "type": [ "String", "Number" ],
       "desc": "Sets the day of the week that is considered the first day (0 - Sunday, 1 - Monday, ...); This day will show in the left-most column of the calendar",

--- a/ui/src/components/datetime/date.styl
+++ b/ui/src/components/datetime/date.styl
@@ -105,6 +105,8 @@
 
   &__years-item, &__months-item
     flex 0 0 (round(1 / 3 * 100, 4))%
+    & > .disabled
+      opacity: 0.18 !important
 
   &__months-content
     flex 0 0 (round(10 / 12 * 100, 4))%


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Initially I wanted to allow disabling specific years from the Years view because I want to create an YearPicker app extension, but when i discussed it with the staff on Discord, some other features came out. This PR addresses:

- controling disabled years (`years` and `disabled-years` props)
- disabling Years view (`no-years` prop)
- disabling backward and forward navigation on Months and Years view (`no-backward-month-navigation`, `no-forward-month-navigation`, `no-backward-year-navigation`, `no-forward-year-navigation` props) *so users can disable going to future/past dates*