### PR TITLE
fix(quasar): Hide native Firefox field invalid, keep label float on invalid numeric fields

### DIFF
--- a/ui/dev/components/form/input.vue
+++ b/ui/dev/components/form/input.vue
@@ -28,6 +28,16 @@
 
       <q-input v-bind="props" v-model="text" label="Label" />
 
+      <q-input v-bind="props" v-model="text" required label="Required" placeholder="Write something" />
+
+      <q-input v-bind="props" v-model="invalid" pattern="[a-z]*" label="Only [a-z]" placeholder="Write something" />
+
+      <q-input v-bind="props" v-model="number" type="number" label="Number" placeholder="Write a number" />
+
+      <q-input v-bind="props" v-model="number" type="number" step="0.1" label="Number - step 0.1" placeholder="Write a number" />
+
+      <q-input v-bind="props" v-model="email" type="email" label="eMail" placeholder="Write an email address" />
+
       <q-input v-bind="props" v-model="text">
         <q-icon slot="prepend" name="event" />
         <q-icon slot="append" name="delete" />
@@ -440,6 +450,10 @@ export default {
 
       pass: '',
       password: true,
+
+      invalid: '123',
+      number: 1.1,
+      email: 'a',
 
       prefix: null,
       suffix: null,

--- a/ui/src/components/field/field.styl
+++ b/ui/src/components/field/field.styl
@@ -145,8 +145,14 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     &:-webkit-autofill
       -webkit-animation-name q-autofill
       -webkit-animation-fill-mode both
+
     &:-webkit-autofill + .q-field__label
       transform translate3d(0, -40%, 0) scale3d(.75, .75, .75)
+    &[type="number"]:invalid + .q-field__label
+      transform translate3d(0, -40%, 0) scale3d(.75, .75, .75)
+
+    &:invalid
+      box-shadow none
 
   &--focused
     .q-field__label
@@ -328,9 +334,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       .q-field__prefix, .q-field__suffix
         opacity 0
 
-    &:not(.q-field--float)
       .q-field__native, .q-select__input
-
         &::-webkit-input-placeholder
           color transparent
         &::-moz-placeholder
@@ -368,8 +372,12 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
 
     &.q-field--float .q-field__label
       transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
-    .q-field__native:-webkit-autofill + .q-field__label
-      transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
+
+    .q-field__native, .q-select__input
+      &:-webkit-autofill + .q-field__label
+        transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
+      &[type="number"]:invalid + .q-field__label
+        transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
 
   &--borderless, &--standard
 


### PR DESCRIPTION
- fix float label on dense autofilled fields
close #4369