### PR TITLE
Update mdi-v3.js

### DIFF
--- a/ui/icon-set/mdi-v3.js
+++ b/ui/icon-set/mdi-v3.js
@@ -47,7 +47,7 @@ export default {
     strikethrough: 'mdi-format-strikethrough-variant',
     underline: 'mdi-format-underline',
     unorderedList: 'mdi-format-list-bulleted',
-    orderedList: 'mdi-format-list-numbers',
+    orderedList: 'mdi-format-list-numbered',
     subscript: 'mdi-format-subscript',
     superscript: 'mdi-format-superscript',
     hyperlink: 'mdi-link',


### PR DESCRIPTION
mdi-format-list-numbers probably renamed to mdi-format-list-numbered and it affects the qEditor toolbar numbered list button displays without corresponding icon.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
