### PR TITLE
QTable & QTree define slote-scope props enumerable and configurable.

### DIFF
--- a/ui/src/components/table/table-body.js
+++ b/ui/src/components/table/table-body.js
@@ -81,20 +81,26 @@ export default {
         get: () => this.isRowSelected(data.key),
         set: adding => {
           this.__updateSelection([data.key], [data.row], adding)
-        }
+        },
+        configurable: true,
+        enumerable: true
       })
 
       Object.defineProperty(data, 'expand', {
         get: () => this.rowsExpanded[data.key] === true,
         set: val => {
           this.$set(this.rowsExpanded, data.key, val)
-        }
+        },
+        configurable: true,
+        enumerable: true
       })
 
       data.cols = data.cols.map(col => {
         const c = { ...col }
         Object.defineProperty(c, 'value', {
-          get: () => this.getCellValue(col, data.row)
+          get: () => this.getCellValue(col, data.row),
+          configurable: true,
+          enumerable: true
         })
         return c
       })
@@ -104,7 +110,9 @@ export default {
 
     addBodyCellMetaData (data) {
       Object.defineProperty(data, 'value', {
-        get: () => this.getCellValue(data.col, data.row)
+        get: () => this.getCellValue(data.col, data.row),
+        configurable: true,
+        enumerable: true
       })
       return data
     },

--- a/ui/src/components/table/table-header.js
+++ b/ui/src/components/table/table-header.js
@@ -107,7 +107,9 @@ export default {
               this.computedRows,
               val
             )
-          }
+          },
+          configurable: true,
+          enumerable: true
         })
         data.partialSelected = this.someRowsSelected
         data.multipleSelect = true

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -395,11 +395,15 @@ export default Vue.extend({
 
       Object.defineProperty(scope, 'expanded', {
         get: () => { return meta.expanded },
-        set: val => { val !== meta.expanded && this.setExpanded(key, val) }
+        set: val => { val !== meta.expanded && this.setExpanded(key, val) },
+        configurable: true,
+        enumerable: true
       })
       Object.defineProperty(scope, 'ticked', {
         get: () => { return meta.ticked },
-        set: val => { val !== meta.ticked && this.setTicked([ key ], val) }
+        set: val => { val !== meta.ticked && this.setTicked([ key ], val) },
+        configurable: true,
+        enumerable: true
       })
 
       return scope


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Just make props defined with Object.definePropety enumerable and configurable. 
Main use-case: to pass slots trough wrapper component (v-bind does not bind non-enumerable props), but it can be useful in some other cases. 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
