### PR TITLE
fix: QTable - Sorting on boolean column fails (fix #1689)

### DIFF
--- a/ui/src/components/table/table-sort.js
+++ b/ui/src/components/table/table-sort.js
@@ -38,7 +38,7 @@ export default {
             return sortDate(A, B) * dir
           }
           if (typeof A === 'boolean' && typeof B === 'boolean') {
-            return (a - b) * dir
+            return (A - B) * dir
           }
 
           [A, B] = [A, B].map(s => (s + '').toLocaleString().toLowerCase())


### PR DESCRIPTION
- Corrects typos in commit 6291793

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Tested by `npm run test` for linting and by rebuilding `dist/quasar.esm.js` with `npm run build`.  No linting errors.  Tests show Boolean columns are now sorted properly.