### PR TITLE
feat(cli) Yarn Workspaces & Lerna Hoisted Upgrade

### DIFF
--- a/cli/bin/quasar-upgrade
+++ b/cli/bin/quasar-upgrade
@@ -54,6 +54,17 @@ if (!fs.existsSync(path.join(root, 'node_modules'))) {
 
 const pkg = require(path.join(root, 'package.json'))
 
+function getPackageLocation(packageName, upperPaths = 0) {
+  const baseFile = upperPaths ?
+    path.join(root, ...Array(upperPaths).fill('..'), 'node_modules', packageName, 'package.json')
+    : path.join(root, 'node_modules', packageName, 'package.json')
+
+  return !fs.existsSync(baseFile)
+    ? getPackageLocation(packageName, upperPaths + 1)
+    : baseFile
+}
+
+
 function getLatestVersion (packager, packageName, curVersion) {
   let versions
 
@@ -108,7 +119,7 @@ function upgradeQuasar () {
         continue
       }
 
-      const json = path.join(root, 'node_modules', packageName, 'package.json')
+      const json = getPackageLocation(packageName)
       const curVersion = fs.existsSync(json)
         ? require(json).version
         : null
@@ -163,7 +174,7 @@ function upgradeQuasar () {
     deps[type].forEach(dep => {
       // need to delete tha package otherwise
       // installing the new version might fail on Windows
-      removeSync(path.join(root, 'node_modules', dep.packageName))
+      removeSync(getPackageLocation(dep.packageName))
 
       params.push(`${dep.packageName}@^${dep.latestVersion}`)
     })

--- a/cli/bin/quasar-upgrade
+++ b/cli/bin/quasar-upgrade
@@ -55,11 +55,13 @@ if (!fs.existsSync(path.join(root, 'node_modules'))) {
 const pkg = require(path.join(root, 'package.json'))
 
 function getPackageLocation(packageName, upperPaths = 0) {
-  const baseFile = upperPaths ?
-    path.join(root, ...Array(upperPaths).fill('..'), 'node_modules', packageName, 'package.json')
+  const fill = Array(upperPaths).fill('..')
+
+  const baseFile = upperPaths || !fs.existsSync(path.join(root, ...fill, 'package.json'))
+    ? path.join(root, ...fill, 'node_modules', packageName, 'package.json')
     : path.join(root, 'node_modules', packageName, 'package.json')
 
-  return !fs.existsSync(baseFile)
+  return !fs.existsSync(baseFile) && upperPaths <= 10
     ? getPackageLocation(packageName, upperPaths + 1)
     : baseFile
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I've added on the CLI Upgrade function the possibility to check on hoisted node_modules for the packages, not on the just local packages. So when you are checking for upgrades with Yarn Workspaces or Lerna Hoisted you can use the Quasar CLI upgrade within the package without any problem.