### PR TITLE
fix: managing typescript erros for dialog custom component evoking (fix: #4411)

### DIFF
--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -179,6 +179,13 @@
               "type": "Object",
               "desc": "Required if using 'component' prop and you need access to vuex store, router and so on; Specify root of your App",
               "examples": [ "root: this.$root" ]
+            },
+
+            "[prop: string]": {
+              "type": "Any",
+              "desc": "Component props to be carried on",
+              "examples": [ "anyString: anyValue" ],
+              "required": true
             }
           }
         }


### PR DESCRIPTION
Included to get rid of typescript errors related to custom component evoking props. This should fix #4411 

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix

**Does this PR introduce a breaking change?** (check one)
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
The tag is marked as required cause typescript custom properties it's optional by default and the type definitions build script mark all not required as optional, causing an error.
