### PR TITLE
feat(mini-to-overlay): allow mini drawer to "open" as overlay

### DIFF
--- a/ui/dev/components/layout/layout.vue
+++ b/ui/dev/components/layout/layout.vue
@@ -342,7 +342,7 @@
             <q-toggle dense v-model="leftMiniToOverlay" label="Left Mini to Overlay" />
           </div>
           <div>
-            <q-select v-model="leftBehavior" :options="drawerBehaviorOptions" />
+            <q-select emit-value v-model="leftBehavior" :options="drawerBehaviorOptions" />
           </div>
           <div>
             <q-input type="number" align="right" prefix="Bkpt" placeholder="Bkpt" v-model="leftBreakpoint" />
@@ -365,7 +365,7 @@
             <q-toggle dense v-model="rightMiniToOverlay" label="Right Mini to Overlay" />
           </div>
           <div>
-            <q-select v-model="rightBehavior" :options="drawerBehaviorOptions" />
+            <q-select emit-value v-model="rightBehavior" :options="drawerBehaviorOptions" />
           </div>
           <div>
             <q-input type="number" align="right" prefix="Bkpt" placeholder="Bkpt" v-model="rightBreakpoint" />

--- a/ui/dev/components/layout/layout.vue
+++ b/ui/dev/components/layout/layout.vue
@@ -74,6 +74,8 @@
         :overlay="rightOverlay"
         :behavior="rightBehavior"
         :breakpoint="rightBreakpoint"
+        :mini="rightMini"
+        :mini-to-overlay="rightMiniToOverlay"
         :content-class="drawerClass"
         @on-layout="drawerOnLayout"
       >
@@ -161,6 +163,7 @@
           :overlay="leftOverlay"
           :behavior="leftBehavior"
           :breakpoint="leftBreakpoint"
+          :mini-to-overlay="leftMiniToOverlay"
           :content-class="drawerClass"
         >
           <!--
@@ -336,6 +339,9 @@
             <q-toggle dense v-model="leftOverlay" label="Left as Overlay" />
           </div>
           <div>
+            <q-toggle dense v-model="leftMiniToOverlay" label="Left Mini to Overlay" />
+          </div>
+          <div>
             <q-select v-model="leftBehavior" :options="drawerBehaviorOptions" />
           </div>
           <div>
@@ -354,6 +360,9 @@
           </div>
           <div>
             <q-toggle dense v-model="rightOverlay" label="Right as Overlay" />
+          </div>
+          <div>
+            <q-toggle dense v-model="rightMiniToOverlay" label="Right Mini to Overlay" />
           </div>
           <div>
             <q-select v-model="rightBehavior" :options="drawerBehaviorOptions" />
@@ -486,7 +495,9 @@ export default {
       leftBreakpoint: 992,
       rightBreakpoint: 992,
       leftMini: true,
+      leftMiniToOverlay: true,
       rightMini: false,
+      rightMiniToOverlay: false,
 
       bordered: false,
       elevated: false,
@@ -531,7 +542,7 @@ export default {
     drawerClass () {
       return this.whiteLayout
         ? 'bg-white'
-        : 'bg-grey-3'
+        : 'bg-grey-5'
     }
   },
   watch: {

--- a/ui/src/components/layout/QDrawer.js
+++ b/ui/src/components/layout/QDrawer.js
@@ -37,6 +37,7 @@ export default Vue.extend({
       default: 300
     },
     mini: Boolean,
+    miniToOverlay: Boolean,
     miniWidth: {
       type: Number,
       default: 57
@@ -137,12 +138,12 @@ export default Vue.extend({
     },
 
     offset (val) {
-      this.__update('offset', val)
+      this.__update('offset', this.miniToOverlay ? this.miniWidth : val)
     },
 
     onLayout (val) {
       this.$listeners['on-layout'] !== void 0 && this.$emit('on-layout', val)
-      this.__update('space', val)
+      this.__update('space', this.miniToOverlay ? this.value : val)
     },
 
     $route () {
@@ -160,7 +161,7 @@ export default Vue.extend({
 
     size (val) {
       this.applyPosition()
-      this.__update('size', val)
+      this.__update('size', this.miniToOverlay ? this.miniWidth : val)
     },
 
     '$q.lang.rtl' () {
@@ -260,9 +261,9 @@ export default Vue.extend({
           this.mobileView === true
             ? ' fixed q-drawer--on-top q-drawer--mobile q-drawer--top-padding'
             : ` q-drawer--${this.isMini === true ? 'mini' : 'standard'}` +
-              (this.fixed === true || this.onLayout !== true ? ' fixed' : '') +
-              (this.overlay === true ? ' q-drawer--on-top' : '') +
-              (this.headerSlot === true ? ' q-drawer--top-padding' : '')
+            (this.fixed === true || this.onLayout !== true ? ' fixed' : '') +
+            (this.overlay === true || this.miniToOverlay === true ? ' q-drawer--on-top' : '') +
+            (this.headerSlot === true ? ' q-drawer--top-padding' : '')
         )
     },
 


### PR DESCRIPTION
A new property mini-to-overlay is added to allow letting the QDrawer be mini and move to full size without moving the page content, as an overlay. The drawer can still be hidden via v-model.

The reason behind this feature is I was trying to toggle overlay in combination with turning mini off for the QDrawer and it lead to trying to override css with !important and I thought it might be something others would like as well.

This adds a new property `mini-to-overlay` to QDrawer to allow it to move from mini=true to mini=false without moving the page content and overlay the page. The drawer can still be hidden via v-model and I didn't touch the behavior or breakpoint props. It should not be used in combination with overlay.

I also added new toggles to test it in the dev layout page and fixed the selects for the behavior. Set Left Mini to Overlay on and then toggle the mini property.

What do you think? Did I miss anything? Do I need to update docs somewhere?