### PR TITLE
feat(QEditor) propagate all events

### DIFF
--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -271,6 +271,7 @@ export default Vue.extend({
     },
 
     __onKeydown (e) {
+      this.$listeners.keydown !== void 0 && this.$emit('keydown', e)
       if (!e.ctrlKey) {
         this.refreshToolbar()
         this.$q.platform.is.ie && this.$nextTick(this.__onInput)
@@ -386,11 +387,16 @@ export default Vue.extend({
               ? { innerHTML: this.value }
               : undefined,
             on: {
+              ...this.$listeners,
               input: this.__onInput,
               keydown: this.__onKeydown,
-              click: this.refreshToolbar,
+              click: e => {
+                this.refreshToolbar()
+                this.$listeners.click !== void 0 && this.$emit('click', e)
+              },
               blur: () => {
                 this.caret.save()
+                this.$listeners.blur !== void 0 && this.$emit('blur')
               }
             }
           }

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -293,7 +293,7 @@ export default Vue.extend({
       this.$emit('click', e)
     },
 
-    __onBlur (e) {
+    __onBlur () {
       this.caret.save()
       this.$emit('blur')
     },

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -271,7 +271,8 @@ export default Vue.extend({
     },
 
     __onKeydown (e) {
-      this.$listeners.keydown !== void 0 && this.$emit('keydown', e)
+      this.$emit('keydown', e)
+
       if (!e.ctrlKey) {
         this.refreshToolbar()
         this.$q.platform.is.ie && this.$nextTick(this.__onInput)
@@ -392,11 +393,11 @@ export default Vue.extend({
               keydown: this.__onKeydown,
               click: e => {
                 this.refreshToolbar()
-                this.$listeners.click !== void 0 && this.$emit('click', e)
+                this.$emit('click', e)
               },
               blur: () => {
                 this.caret.save()
-                this.$listeners.blur !== void 0 && this.$emit('blur')
+                this.$emit('blur')
               }
             }
           }

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -288,6 +288,16 @@ export default Vue.extend({
       }
     },
 
+    __onClick (e) {
+      this.refreshToolbar()
+      this.$emit('click', e)
+    },
+
+    __onBlur (e) {
+      this.caret.save()
+      this.$emit('blur')
+    },
+
     runCmd (cmd, param, update = true) {
       this.focus()
       this.caret.apply(cmd, param, () => {
@@ -391,14 +401,8 @@ export default Vue.extend({
               ...this.$listeners,
               input: this.__onInput,
               keydown: this.__onKeydown,
-              click: e => {
-                this.refreshToolbar()
-                this.$emit('click', e)
-              },
-              blur: () => {
-                this.caret.save()
-                this.$emit('blur')
-              }
+              click: this.__onClick,
+              blur: this.__onBlur
             }
           }
         )


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Someone from Discord mentioned that he couldn't listen to the `blur` event on QEditor, so I went ahead and propagated all listeners to the QEditor content div, similar to the way other components works.