### PR TITLE
cordova: update commands showing extra params

### DIFF
--- a/docs/src/pages/quasar-cli/developing-mobile-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-mobile-apps/build-commands.md
@@ -24,7 +24,7 @@ $ quasar dev -m cordova -T ios -e iPhone-X,com.apple.CoreSimulator.SimRuntime.iO
 
 # passing extra parameters and/or options to
 # underlying "cordova" executable:
-$ quasar dev -m ios -- some params --and options --here
+$ quasar dev -m cordova -T ios -- some params --and options --here
 ```
 
 In order for you to be able to develop on a device emulator or directly on a phone (with Hot Module Reload included), Quasar CLI follows these steps:
@@ -65,7 +65,7 @@ $ quasar build -m cordova -T [ios|android] --skip-pkg
 
 # passing extra parameters and/or options to
 # underlying "cordova" executable:
-$ quasar build -m ios -- some params --and options --here
+$ quasar build -m cordova -T [ios|android] -- some params --and options --here
 ```
 
 These commands parse and build your `/src` folder then overwrite `/src-cordova/www` then, unless `--skip-pkg` was specified, defer to Cordova CLI to trigger the actual native app creation.


### PR DESCRIPTION
Looks like the sample commands are missing something (see diff).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: doc update suggestion

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
