### PR TITLE
feat(proton) watch for rust files on dev

### DIFF
--- a/app/lib/proton/index.js
+++ b/app/lib/proton/index.js
@@ -1,15 +1,15 @@
 const
   fs = require('fs'),
   fse = require('fs-extra'),
-  readline = require('readline')
+  readline = require('readline'),
+  chokidar = require('chokidar'),
+  debounce = require('lodash.debounce')
 
 const
   log = require('../helpers/logger')('app:proton'),
   { spawn } = require('../helpers/spawn'),
   onShutdown = require('../helpers/on-shutdown'),
-  appPaths = require('../app-paths'),
-  chokidar = require('chokidar'),
-  debounce = require('lodash.debounce')
+  appPaths = require('../app-paths')
 
 class protonRunner {
   constructor() {

--- a/app/lib/proton/index.js
+++ b/app/lib/proton/index.js
@@ -11,7 +11,7 @@ const
   onShutdown = require('../helpers/on-shutdown'),
   appPaths = require('../app-paths')
 
-class protonRunner {
+class ProtonRunner {
   constructor() {
     this.pid = 0
 
@@ -174,4 +174,4 @@ class protonRunner {
   }
 }
 
-module.exports = new protonRunner()
+module.exports = new ProtonRunner()

--- a/app/lib/proton/index.js
+++ b/app/lib/proton/index.js
@@ -14,6 +14,7 @@ const
 class protonRunner {
   constructor() {
     this.pid = 0
+    this.protonWatcher = null
 
     onShutdown(() => {
       this.stop()
@@ -46,7 +47,7 @@ class protonRunner {
     }
 
     // Start watching for proton app changes
-    chokidar
+    this.protonWatcher = chokidar
       .watch([
         appPaths.resolve.proton('src'),
         appPaths.resolve.proton('lib'), // TODO remove this when the lib is isolated from template
@@ -125,6 +126,7 @@ class protonRunner {
 
   stop() {
     return new Promise((resolve, reject) => {
+      this.protonWatcher && this.protonWatcher.close()
       this.__stopCargo().then(resolve)
     })
   }


### PR DESCRIPTION
I can't restart the application properly (only after the new binary is compiled) because to do that I would need to: 
1- Replace `cargo run` with `cargo build` followed by running the binary myself (and that includes reading the binary name), or 
2- Read the `cargo run` output and wait for the message "Finished compiling", both not good solutions. 

So right now it closes the application, then compiles and runs it again.