### PR TITLE
Fix(QExpansionItem): #4581 - Caption styling in QExpansionItem

### DIFF
--- a/ui/src/components/list/QExpansionItem.js
+++ b/ui/src/components/list/QExpansionItem.js
@@ -27,6 +27,7 @@ export default Vue.extend({
 
     caption: String,
     captionLines: [ Number, String ],
+    captionStyle: Boolean,
 
     dark: Boolean,
     dense: Boolean,
@@ -157,7 +158,7 @@ export default Vue.extend({
 
             this.caption
               ? h(QItemLabel, {
-                props: { lines: this.captionLines, caption: true }
+                props: { lines: this.captionLines, caption: this.captionStyle }
               }, [ this.caption ])
               : null
           ])

--- a/ui/src/components/list/QExpansionItem.json
+++ b/ui/src/components/list/QExpansionItem.json
@@ -43,6 +43,13 @@
       "category": "content"
     },
 
+    "caption-style": {
+      "type": "Boolean",
+      "desc": "Use caption styling on caption property",
+      "default": true,
+      "category": "style"
+    },
+
     "caption-lines": {
       "type": [ "Number", "String" ],
       "desc": "Apply ellipsis when there's not enough space to render on the specified number of lines; If more than one line specified, then it will only work on webkit browsers because it uses the '-webkit-line-clamp' CSS property!",


### PR DESCRIPTION
Caption in QExpansionItem does not respect colors used in `header-class`