### PR TITLE
update title for better contrast with first section

### DIFF
--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -41,7 +41,7 @@ You may also want to make sure you have the latest of `@quasar/extras` package t
 $ yarn add @quasar/extras@latest
 ```
 
-## Best Practices
+## Upgrading from 0.x to v1
 
 Before you start down this journey of upgrading Quasar Legacy to Quasar v1 you should know a few things:
 1) Read the documentation before asking questions on Discord server or forums.


### PR DESCRIPTION
currently it just says "best practices" and it's unclear that this represents the part "upgrading from 0.x to v1".

As opposed to the first section which says: "Upgrading from older v1 to latest v1"