### PR TITLE
fix: #4411 Add tsName for Dialog Options

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -92,19 +92,19 @@ function getMethodDefinition (key, methodDef, required) {
   return def
 }
 
-function getObjectParamDefinition (def) {
+function getObjectParamDefinition (def, required) {
   let res = []
 
   Object.keys(def).forEach(propName => {
     const propDef = def[propName]
     if (propDef.type && propDef.type === 'Function') {
       res.push(
-        getMethodDefinition(propName, propDef, true)
+        getMethodDefinition(propName, propDef, required)
       )
     }
     else {
       res.push(
-        getPropDefinition(propName, def[propName], true)
+        getPropDefinition(propName, propDef, required)
       )
     }
   })
@@ -150,7 +150,7 @@ function copyPredefinedTypes (dir, parentDir) {
   })
 }
 
-function addToExtraInterfaces (def) {
+function addToExtraInterfaces (def, required) {
   if (
     def !== void 0 &&
     def.tsType !== void 0 &&
@@ -158,7 +158,7 @@ function addToExtraInterfaces (def) {
     def.definition !== void 0
   ) {
     extraInterfaces[def.tsType] = getObjectParamDefinition(
-      def.definition
+      def.definition, required
     )
   }
 }
@@ -198,7 +198,7 @@ function writeIndexDTS (apis) {
       const returns = method.returns
       writeLine(contents, `): ${returns ? getTypeVal(returns, content.type === 'plugin') : 'void'}`)
 
-      addToExtraInterfaces(returns)
+      addToExtraInterfaces(returns, true)
     }
 
     // Close class declaration

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -62,6 +62,7 @@ function getPropDefinition (key, propDef, required) {
 
   if (!propName.startsWith('...')) {
     const propType = getTypeVal(propDef, required)
+    addToExtraInterfaces(propDef)
     return `${propName}${!propDef.required && !required ? '?' : ''} : ${propType}`
   }
 }
@@ -91,13 +92,21 @@ function getMethodDefinition (key, methodDef, required) {
   return def
 }
 
-function getObjectFunctionsDefinition (def) {
+function getObjectParamDefinition (def) {
   let res = []
 
   Object.keys(def).forEach(propName => {
-    res.push(
-      getMethodDefinition(propName, def[propName], true)
-    )
+    const propDef = def[propName]
+    if (propDef.type && propDef.type === 'Function') {
+      res.push(
+        getMethodDefinition(propName, propDef, true)
+      )
+    }
+    else {
+      res.push(
+        getPropDefinition(propName, def[propName], true)
+      )
+    }
   })
 
   return res
@@ -141,6 +150,19 @@ function copyPredefinedTypes (dir, parentDir) {
   })
 }
 
+function addToExtraInterfaces (def) {
+  if (
+    def !== void 0 &&
+    def.tsType !== void 0 &&
+    extraInterfaces[def.tsType] === void 0 &&
+    def.definition !== void 0
+  ) {
+    extraInterfaces[def.tsType] = getObjectParamDefinition(
+      def.definition
+    )
+  }
+}
+
 function writeIndexDTS (apis) {
   var contents = []
   var quasarTypeContents = []
@@ -176,16 +198,7 @@ function writeIndexDTS (apis) {
       const returns = method.returns
       writeLine(contents, `): ${returns ? getTypeVal(returns, content.type === 'plugin') : 'void'}`)
 
-      if (
-        returns !== void 0 &&
-        returns.tsType !== void 0 &&
-        extraInterfaces[returns.tsType] === void 0 &&
-        returns.definition !== void 0
-      ) {
-        extraInterfaces[returns.tsType] = getObjectFunctionsDefinition(
-          returns.definition
-        )
-      }
+      addToExtraInterfaces(returns)
     }
 
     // Close class declaration

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -9,6 +9,7 @@
       "params": {
         "opts": {
           "desc": "Dialog options",
+          "tsType": "QDialogOptions",
           "definition": {
             "title": {
               "type": "String",


### PR DESCRIPTION
This change will fix issues with the tsType feature in the Typescript build generation script (build.types.js) to better support using tsType for non return types and non function types.  

In addition added tsName to Dialog.json for QDialogOptions
```
...
"methods": {
    "create": {
      "tsInjectionPoint": true,
      "params": {
        "opts": {
          "desc": "Dialog options",
          "tsType": "QDialogOptions",
          "definition": {
...
```
This change will enable the overriding of QDialogOptions type by an application developer to [inject additional properties](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) when using a custom component.  This would be the same as the [type augmentation strategy](https://vuejs.org/v2/guide/typescript.html#Augmenting-Types-for-Use-with-Plugins) recommended in VueJs.

There is PR will provide one way of resolving issue #4411, but is limited in that it will globally change the type definition for `QDialogOptions`.  

In addtion, PR #4498 provides and additional option that is more dynamic when the properties are local to a single use, but is less type safe of a solution.

Both PRs should be considered and documentation updates should be considered to fully resolve this issue.

**What kind of change does this PR introduce?** (check at least one)

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
