### PR TITLE
Put the computed hasError on the map

### DIFF
--- a/ui/src/mixins/validate.json
+++ b/ui/src/mixins/validate.json
@@ -2,7 +2,7 @@
   "props": {
     "error": {
       "type": "Boolean",
-      "desc": "Does field have validation errors?",
+      "desc": "External validation error trigger",
       "category": "behavior"
     },
 
@@ -35,6 +35,12 @@
       "category": "behavior"
     }
   },
+  
+  "computed": {
+    "hasError": {
+      "desc": "True if it fails the validation test"
+    }
+  }
 
   "methods": {
     "resetValidation": {


### PR DESCRIPTION
Put the computed hasError on the map and clarify the documentation regarding the prop error.
It does solve the issue #4616 
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Small change in the docs and added a missing computed in the typedef.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.
