### PR TITLE
fix:4616 - Add computed property support to API Doc and TS Types

### DIFF
--- a/docs/src/components/ApiRows.js
+++ b/docs/src/components/ApiRows.js
@@ -233,6 +233,18 @@ export default {
       return child
     },
 
+    computed (h, computed) {
+      const child = []
+
+      for (let propName in computed) {
+        child.push(
+          this.getProp(h, computed[propName], propName)
+        )
+      }
+
+      return child
+    },
+
     slots (h, slots) {
       const child = []
 

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -119,7 +119,8 @@ export default {
         props: null
       },
       filter: '',
-      filteredApi: {}
+      filteredApi: {},
+      api: {}
     }
   },
 

--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -35,9 +35,9 @@ function getMixedInAPI (api, mainFile) {
 }
 
 const topSections = {
-  plugin: [ 'injection', 'quasarConfOptions', 'props', 'methods' ],
-  component: [ 'behavior', 'props', 'slots', 'scopedSlots', 'events', 'methods' ],
-  directive: [ 'value', 'arg', 'modifiers' ]
+  plugin: [ 'injection', 'quasarConfOptions', 'props', 'methods', 'computed' ],
+  component: [ 'behavior', 'props', 'slots', 'scopedSlots', 'events', 'methods', 'computed' ],
+  directive: [ 'value', 'arg', 'modifiers', 'computed' ]
 }
 
 const objectTypes = {
@@ -140,6 +140,12 @@ const objectTypes = {
     props: [ 'tsInjectionPoint', 'desc', 'link', 'params', 'returns' ],
     required: [ 'desc' ],
     isBoolean: [ 'tsInjectionPoint' ],
+    isObject: [ 'params', 'returns' ]
+  },
+
+  computed: {
+    props: [ 'desc', 'link', 'params', 'returns', 'category', 'type' ],
+    required: [ 'desc', 'type' ],
     isObject: [ 'params', 'returns' ]
   },
 
@@ -273,7 +279,7 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
     })
   }
 
-  ;[ 'params', 'definition', 'scope', 'props' ].forEach(prop => {
+  ;[ 'params', 'definition', 'scope', 'props', 'computed' ].forEach(prop => {
     if (!obj[prop]) { return }
 
     for (let item in obj[prop]) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -57,21 +57,21 @@ function getTypeVal (def, required) {
     : convertTypeVal(def.type, def, required)
 }
 
-function getPropDefinition (key, propDef, required) {
+function getPropDefinition (key, propDef, required, isReadOnly = false) {
   const propName = toCamelCase(key)
 
   if (!propName.startsWith('...')) {
     const propType = getTypeVal(propDef, required)
     addToExtraInterfaces(propDef)
-    return `${propName}${!propDef.required && !required ? '?' : ''} : ${propType}`
+    return `${isReadOnly ? 'readonly ' : ''}${propName}${!propDef.required && !required ? '?' : ''} : ${propType}`
   }
 }
 
-function getPropDefinitions (propDefs, required) {
+function getPropDefinitions (propDefs, required, isReadOnly = false) {
   const defs = []
 
   for (const key in propDefs) {
-    const def = getPropDefinition(key, propDefs[key], required)
+    const def = getPropDefinition(key, propDefs[key], required, isReadOnly)
     def && defs.push(def)
   }
 
@@ -200,6 +200,10 @@ function writeIndexDTS (apis) {
 
       addToExtraInterfaces(returns, true)
     }
+
+    // Write Computed Props
+    const computed = getPropDefinitions(content.computed, content.type === 'plugin', true)
+    computed.forEach(comp => writeLine(contents, comp, 1))
 
     // Close class declaration
     writeLine(contents, `}`)

--- a/ui/src/mixins/validate.json
+++ b/ui/src/mixins/validate.json
@@ -51,5 +51,12 @@
         }
       }
     }
+  },
+  "computed": {
+    "hasError": {
+      "type": "Boolean",
+      "desc": "Does field have validation errors?",
+      "category": "behavior"
+    }
   }
 }


### PR DESCRIPTION
Add support for Computed properties in the API documentation and generated typescript types.  This resolve #4616 by adding hasError to the validation mixin API JSON file and adding support in the doc ApiRows to render computed properties.  Also updated the Typescript generation script to generate a readonly property for computed properties.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
