### PR TITLE
fix: #4584 - Add Quasar Plugin Type for use with Quasar Testing extension.

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -163,11 +163,32 @@ function addToExtraInterfaces (def, required) {
   }
 }
 
+function writeQuasarPluginProps (contents, nameName, props, isLast) {
+  writeLine(contents, `${nameName}: {`, 1)
+  props.forEach(prop => writeLine(contents, prop, 2))
+  writeLine(contents, `}${isLast ? '' : ','}`, 1)
+}
+
+function addQuasarPluginOptions (contents, components, directives, plugins) {
+  writeLine(contents, `export interface QuasarPluginOptions {`)
+  writeLine(contents, `lang: any,`, 1)
+  writeLine(contents, `config: any,`, 1)
+  writeLine(contents, `iconSet: any,`, 1)
+  writeQuasarPluginProps(contents, 'components', components)
+  writeQuasarPluginProps(contents, 'directives', directives)
+  writeQuasarPluginProps(contents, 'plugins', plugins, true)
+  writeLine(contents, `}`)
+  writeLine(contents)
+}
+
 function writeIndexDTS (apis) {
   var contents = []
   var quasarTypeContents = []
+  var components = []
+  var directives = []
+  var plugins = []
 
-  writeLine(contents, `import Vue, { VueConstructor } from 'vue'`)
+  writeLine(contents, `import Vue, { VueConstructor, PluginObject } from 'vue'`)
   writeLine(contents)
   writeLine(quasarTypeContents, 'export as namespace quasar')
   writeLine(quasarTypeContents, `export * from './utils'`)
@@ -178,8 +199,21 @@ function writeIndexDTS (apis) {
     const content = data.api
     const typeName = data.name
 
-    // Declare class
     const extendsVue = (content.type === 'component' || content.type === 'mixin')
+    const typeValue = `${extendsVue ? `VueConstructor<${typeName}>` : typeName}`
+    // Add Type to the appropriate section of types
+    const propTypeDef = `${typeName}: ${typeValue}`
+    if (content.type === 'component') {
+      write(components, propTypeDef)
+    }
+    else if (content.type === 'directive') {
+      write(directives, propTypeDef)
+    }
+    else if (content.type === 'plugin') {
+      write(plugins, propTypeDef)
+    }
+
+    // Declare class
     writeLine(quasarTypeContents, `export const ${typeName}: ${extendsVue ? `VueConstructor<${typeName}>` : typeName}`)
     writeLine(contents, `export interface ${typeName} ${extendsVue ? 'extends Vue ' : ''}{`)
 
@@ -255,7 +289,12 @@ function writeIndexDTS (apis) {
     writeLine(contents, '}')
   }
 
+  addQuasarPluginOptions(contents, components, directives, plugins)
+
   quasarTypeContents.forEach(line => write(contents, line))
+
+  writeLine(contents, `export const Quasar: PluginObject<QuasarPluginOptions>`)
+  writeLine(contents)
 
   writeLine(contents, `import './vue'`)
 


### PR DESCRIPTION
Fixes #4584 by adding a new Typescript Type for Quasar Plugin and it's options.  Currently the it does not try to generate a specific type of the language files, iconSets, or config options.  These are currently set to an any type.  

For lang and iconSets we could consider reading each one of these files, derive a generated type and then declare a const for each file so each imported language or iconSet would be typed as well.  I'm not sure there is value in it at this current stage since there are very few cases where a type would be needed out side of importing the option and setting it directly to the plugin option object.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.
