### PR TITLE
fix(QSlideTransition): Workaround transitionend not firing when animated element is hidden

### DIFF
--- a/ui/dev/components/other/slide-transition.vue
+++ b/ui/dev/components/other/slide-transition.vue
@@ -32,6 +32,23 @@
           >
         </div>
       </q-slide-transition>
+
+      <div class="caption row col-gutter-sm items-center">
+        V-Show test (height 0) - enable first Inner and then Outer
+        <q-toggle v-model="outerCondition" label="Outer block" />
+        <q-toggle v-model="innerCondition" label="Inner block" />
+        <q-btn label="Toggle both" @click="toggleConditions" />
+      </div>
+      <q-slide-transition>
+        <div v-show="outerCondition">
+          <div>Outer block</div>
+          <q-slide-transition>
+            <div v-if="innerCondition">
+              Inner Block
+            </div>
+          </q-slide-transition>
+        </div>
+      </q-slide-transition>
     </div>
   </div>
 </template>
@@ -41,12 +58,19 @@ export default {
   data () {
     return {
       visibleVShow: true,
-      visibleVIf: true
+      visibleVIf: true,
+      outerCondition: false,
+      innerCondition: false
     }
   },
   methods: {
     log (msg) {
       console.log(msg)
+    },
+
+    toggleConditions () {
+      this.outerCondition = !this.outerCondition
+      this.innerCondition = !this.innerCondition
     }
   }
 }

--- a/ui/src/components/slide-transition/QSlideTransition.js
+++ b/ui/src/components/slide-transition/QSlideTransition.js
@@ -39,6 +39,7 @@ export default Vue.extend({
       this.animating = false
 
       clearTimeout(this.timer)
+      clearTimeout(this.timerFallback)
       this.el.removeEventListener('transitionend', this.animListener)
       this.animListener = null
     }
@@ -75,6 +76,7 @@ export default Vue.extend({
               this.__end(el, 'show')
             }
             el.addEventListener('transitionend', this.animListener)
+            this.timerFallback = setTimeout(this.animListener, this.duration * 1.1)
           }, 100)
         },
         leave: (el, done) => {
@@ -97,6 +99,7 @@ export default Vue.extend({
               this.__end(el, 'hide')
             }
             el.addEventListener('transitionend', this.animListener)
+            this.timerFallback = setTimeout(this.animListener, this.duration * 1.1)
           }, 100)
         }
       }


### PR DESCRIPTION
This is not going to provide the best animation but it will ensure the animated element will end up in the correct state.

ref #4630