### PR TITLE
Change Quasar Plugin options to support only passing some options.

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -202,7 +202,7 @@ function writeIndexDTS (apis) {
     const extendsVue = (content.type === 'component' || content.type === 'mixin')
     const typeValue = `${extendsVue ? `VueConstructor<${typeName}>` : typeName}`
     // Add Type to the appropriate section of types
-    const propTypeDef = `${typeName}: ${typeValue}`
+    const propTypeDef = `${typeName}?: ${typeValue}`
     if (content.type === 'component') {
       write(components, propTypeDef)
     }
@@ -293,7 +293,7 @@ function writeIndexDTS (apis) {
 
   quasarTypeContents.forEach(line => write(contents, line))
 
-  writeLine(contents, `export const Quasar: PluginObject<QuasarPluginOptions>`)
+  writeLine(contents, `export const Quasar: PluginObject<Partial<QuasarPluginOptions>>`)
   writeLine(contents)
 
   writeLine(contents, `import './vue'`)


### PR DESCRIPTION
Modify the type definition used for Quasar Plugin Options to enable passing only the needed properties to the plugins.  The current type requires all possible properties to be specified when installing the plugin.

This is related to issue #4584 and an issue introduced in PR #4634.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
