### PR TITLE
problem with double usage of single line `

### DIFF
--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -252,7 +252,7 @@ The dist folder now strips out the `-mat` and `-ios` suffixes because there's on
 ### Misc
 
 - `this.$q.i18n` was changed to `this.$q.lang`
-- `import(`quasar-framework/i18n/${lang}`) was changed to `import(`quasar/lang/${lang}`)` where `${lang}` would be `en-us` etc.
+- import(`quasar-framework/i18n/${lang}`) was changed to import(`quasar/lang/${lang}`) where `${lang}` would be `en-us` etc.
 - `this.$q.icons` was changed to `this.$q.iconSet`
 - In previous versions you would access an imported language packs isoName with:
 

--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -252,7 +252,7 @@ The dist folder now strips out the `-mat` and `-ios` suffixes because there's on
 ### Misc
 
 - `this.$q.i18n` was changed to `this.$q.lang`
-- import(`quasar-framework/i18n/${lang}`) was changed to import(`quasar/lang/${lang}`) where `${lang}` would be `en-us` etc.
+- ```import(`quasar-framework/i18n/${lang}`)``` was changed to ```import(`quasar/lang/${lang}`)``` where `${lang}` would be `en-us` etc.
 - `this.$q.icons` was changed to `this.$q.iconSet`
 - In previous versions you would access an imported language packs isoName with:
 


### PR DESCRIPTION
Not a complete fix, but I can't come on a better solution.
There's double usage of ` on the
second line of Misc: https://quasar.dev/start/upgrade-guide#Misc

<img width="797" alt="image" src="https://user-images.githubusercontent.com/3253920/61208814-2fe1ab00-a733-11e9-99b9-cc3331d40a18.png">

