### PR TITLE
fix(docs): wrong formatting for table

### DIFF
--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -998,9 +998,12 @@ The structure looks the same, but some functions have been renamed.
 
 - **replaced** by [QColor](/vue-components/color)
 - Type of `default-value` was changed from `string|object` to `string`
+
 <div class="row">
   <div class="inline-block q-pa-md">
+
 **QColor Properties**
+
 |Legacy|v1|
 |-|-|
 |`after`||
@@ -1025,21 +1028,28 @@ The structure looks the same, but some functions have been renamed.
 |`stack-label`||
 |`suffix`||
 |`warning`||
+
   </div>
   <div class="inline-block q-pa-md">
+
 **QColor Events**
+
 |Legacy|v1|
 |-|-|
 |`@clear(clearVal)`||
+
   </div>
   <div class="inline-block q-pa-md">
+
 **QColor Methods**
+
 |Legacy|v1|
 |-|-|
 |`clear()`||
 |`hide()`||
 |`show()`||
 |`toggle()`||
+
   </div>
 </div>
 


### PR DESCRIPTION
Was something wrong with the table:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/3253920/61264368-43d6ec80-a7c7-11e9-97c8-91332cd88cc7.png">
