### PR TITLE
fix(docs): adjust explanation of columns' name 🖍

### DIFF
--- a/docs/src/pages/vue-components/table.md
+++ b/docs/src/pages/vue-components/table.md
@@ -33,7 +33,9 @@ Let’s take an example of configuring the `columns` property. We are going to t
 columns: [ // array of Objects
   // column Object definition
   {
-    // unique id (used by pagination.sortBy, QTable slot "body-cell-[name]", ...)
+    // unique id
+    // identifies column
+    // (used by pagination.sortBy, "body-cell-[name]" slot, ...)
     name: 'desc',
 
     // label for header

--- a/docs/src/pages/vue-components/table.md
+++ b/docs/src/pages/vue-components/table.md
@@ -33,7 +33,7 @@ Let’s take an example of configuring the `columns` property. We are going to t
 columns: [ // array of Objects
   // column Object definition
   {
-    // unique id (used by row-key, pagination.sortBy, ...)
+    // unique id (used by pagination.sortBy, QTable slot "body-cell-[name]", ...)
     name: 'desc',
 
     // label for header


### PR DESCRIPTION
I had a really hard time understanding the difference between `row-key` which is often set to `name` in the examples here, and the `name` field on the `columns` object.

I know in retrospect it's a really simple difference: columns each have a `name` and rows each have an id or something to be set with `row-key`.

But I believe that the `row-key` has nothing to do with the columns `name` field if I'm not mistaken. So writing "used by row-key" at the columns `name` only further confused me. 😅

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
