### PR TITLE
fix(ie): Restrict QField's label width in IE

### DIFF
--- a/ui/dev/components/components/list-item.vue
+++ b/ui/dev/components/components/list-item.vue
@@ -616,6 +616,12 @@
           General
         </q-item-label>
 
+        <q-item>
+          <q-item-section class="scroll">
+            <q-input v-model="text" label="Text field label - Text field label - Text field label - Text field label - Text field label - Text field label" filled />
+          </q-item-section>
+        </q-item>
+
         <q-item tag="label">
           <q-item-section side>
             <q-checkbox :dark="dark" v-model="check1" />
@@ -771,7 +777,9 @@ export default {
 
       check1: true,
       check2: false,
-      check3: false
+      check3: false,
+
+      text: 'text'
     }
   },
 

--- a/ui/src/components/field/field.styl
+++ b/ui/src/components/field/field.styl
@@ -148,7 +148,7 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     transition transform $field-transition, right $field-transition
 
   &--float .q-field__label
-    transform translate3d(0, -40%, 0) scale3d(.75, .75, .75)
+    transform translate3d(0, -40%, 0) scale3d(.75, .75, 1)
     right calc(-100% / 3)
 
   .q-field__native, .q-select__input
@@ -157,9 +157,9 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       -webkit-animation-fill-mode both
 
     &:-webkit-autofill + .q-field__label
-      transform translate3d(0, -40%, 0) scale3d(.75, .75, .75)
+      transform translate3d(0, -40%, 0) scale3d(.75, .75, 1)
     &[type="number"]:invalid + .q-field__label
-      transform translate3d(0, -40%, 0) scale3d(.75, .75, .75)
+      transform translate3d(0, -40%, 0) scale3d(.75, .75, 1)
 
     &:invalid
       box-shadow none
@@ -381,13 +381,13 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
       font-size 24px
 
     &.q-field--float .q-field__label
-      transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
+      transform translate3d(0, -30%, 0) scale3d(.75, .75, 1)
 
     .q-field__native, .q-select__input
       &:-webkit-autofill + .q-field__label
-        transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
+        transform translate3d(0, -30%, 0) scale3d(.75, .75, 1)
       &[type="number"]:invalid + .q-field__label
-        transform translate3d(0, -30%, 0) scale3d(.75, .75, .75)
+        transform translate3d(0, -30%, 0) scale3d(.75, .75, 1)
 
   &--borderless, &--standard
 

--- a/ui/src/ie-compat/ie.styl
+++ b/ui/src/ie-compat/ie.styl
@@ -115,6 +115,9 @@ ie_style = @block
         .q-field__messages
           left 0
 
+    &--float .q-field__label
+      max-width 100%
+
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)
   {ie_style}
 


### PR DESCRIPTION
Elements occupy the width before scale in IE