### PR TITLE
feat(IDE) generate web-types (helper file for WebStorm)

### DIFF
--- a/ui/build/build.utils.js
+++ b/ui/build/build.utils.js
@@ -2,7 +2,8 @@ const
   fs = require('fs'),
   path = require('path'),
   zlib = require('zlib'),
-  { green, blue, red, cyan } = require('chalk')
+  { green, blue, red, cyan } = require('chalk'),
+  kebabRegex = /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g
 
 function getSize (code) {
   return (code.length / 1024).toFixed(2) + 'kb'
@@ -63,4 +64,11 @@ module.exports.rollupQuasarUMD = function (config = {}) {
       }
     }
   }
+}
+
+module.exports.kebabCase = function (str) {
+  return str.replace(
+    kebabRegex,
+    match => '-' + match.toLowerCase()
+  ).substring(1)
 }

--- a/ui/build/build.vetur.js
+++ b/ui/build/build.vetur.js
@@ -2,16 +2,8 @@ const
   path = require('path')
 
 const
-  { logError, writeFile } = require('./build.utils'),
-  resolve = file => path.resolve(__dirname, '../dist/vetur', file),
-  kebabRegex = /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g
-
-function kebabCase (str) {
-  return str.replace(
-    kebabRegex,
-    match => '-' + match.toLowerCase()
-  ).substring(1)
-}
+  { logError, writeFile, kebabCase } = require('./build.utils'),
+  resolve = file => path.resolve(__dirname, '../dist/vetur', file)
 
 function getTags (data) {
   const tags = {}

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -19,7 +19,7 @@ function resolveType (type) {
 module.exports.generate = function (data) {
   try {
     const webtypes = JSON.stringify({
-      $schema: '../../schema/web-types.schema.json',
+      $schema: '',
       framework: 'vue',
       name: 'quasar',
       version: process.env.VERSION || require('../package.json').version,

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -4,11 +4,11 @@ const
   { logError, writeFile, kebabCase } = require('./build.utils')
 
 function resolveType (type) {
-  // TODO transform "values" and arrays of values
+  // TODO transform Object with "values" and arrays Objects with values
   if (Array.isArray(type)) {
     return type.map(resolveType).join('|')
   }
-  if (['Any', 'String', 'Boolean', 'Number'].includes(type)) {
+  if (['Any', 'String', 'Boolean', 'Number', 'Object'].includes(type)) {
     return type.toLowerCase()
   }
   if (type === 'Array') {
@@ -137,8 +137,7 @@ module.exports.generate = function (data) {
       fs.mkdirSync(webTypesPath)
     }
     writeFile(path.resolve(webTypesPath, 'web-types.json'), webtypes)
-  }
-  catch (err) {
+  } catch (err) {
     logError(`build.web-types.js: something went wrong...`)
     console.log()
     console.error(err)

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -17,7 +17,12 @@ function resolveType (type) {
   return type
 }
 
-// TODO add examples to descriptions
+function getDescription (propApi) {
+  return propApi.examples
+    ? propApi.desc + '\n\nExamples:\n' + propApi.examples.join('\n')
+    : propApi.desc
+}
+
 module.exports.generate = function (data) {
   try {
     const webtypes = JSON.stringify({
@@ -42,7 +47,7 @@ module.exports.generate = function (data) {
                     kind: 'expression',
                     type: resolveType(propApi.type)
                   },
-                  description: propApi.desc,
+                  description: getDescription(propApi),
                   'doc-url': 'https://quasar.dev'
                 }
                 if (propApi.required) {
@@ -62,15 +67,15 @@ module.exports.generate = function (data) {
                 arguments: eventApi.params && Object.entries(eventApi.params).map(([paramName, paramApi]) => ({
                   name: paramName,
                   type: resolveType(paramApi.type),
-                  description: paramApi.desc,
+                  description: getDescription(paramApi),
                   'doc-url': 'https://quasar.dev'
                 })),
-                description: eventApi.desc,
+                description: getDescription(eventApi),
                 'doc-url': 'https://quasar.dev'
               })),
               slots: slots && Object.entries(slots).map(([name, slotApi]) => ({
                 name,
-                description: slotApi.desc,
+                description: getDescription(slotApi),
                 'doc-url': 'https://quasar.dev'
               })),
               'vue-scoped-slots': scopedSlots && Object.entries(scopedSlots).map(([name, slotApi]) => ({
@@ -78,10 +83,10 @@ module.exports.generate = function (data) {
                 properties: slotApi.scope && Object.entries(slotApi.scope).map(([name, api]) => ({
                   name,
                   type: resolveType(api.type),
-                  description: api.desc,
+                  description: getDescription(api),
                   'doc-url': 'https://quasar.dev'
                 })),
-                description: slotApi.desc,
+                description: getDescription(slotApi),
                 'doc-url': 'https://quasar.dev'
               })),
               description: `${name} - Quasar component`,
@@ -116,7 +121,7 @@ module.exports.generate = function (data) {
             if (modifiers) {
               result['vue-modifiers'] = Object.entries(modifiers).map(([name, api]) => ({
                 name,
-                description: api.desc,
+                description: getDescription(api),
                 'doc-url': 'https://quasar.dev'
               }))
             }

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -30,7 +30,7 @@ module.exports.generate = function (data) {
             let result = {
               name,
               // TODO source file can be wrong - this is just a guess for now
-              'source-file': `./quasar/src/components/${kebabCase(name.substr(1))}/${name}.js`,
+              'source-file': `./src/components/${kebabCase(name.substr(1))}/${name}.js`,
               attributes: props && Object.entries(props).map(([name, propApi]) => {
                 let result = {
                   name,
@@ -87,7 +87,7 @@ module.exports.generate = function (data) {
           attributes: data.directives.map(directiveApi => {
             return {
               name: 'v-' + kebabCase(directiveApi.name),
-              'source-file': `./node_modules/quasar/src/directives/${directiveApi.name}.js`,
+              'source-file': `./src/directives/${directiveApi.name}.js`,
               type: resolveType(directiveApi.api.value.type),
               description: `${directiveApi.name} - Quasar directive`,
               'doc-url': 'https://quasar.dev'

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -1,0 +1,113 @@
+const
+  path = require('path'),
+  fs = require('fs'),
+  { logError, writeFile, kebabCase } = require('./build.utils')
+
+function resolveType (type) {
+  if (Array.isArray(type)) {
+    return type.map(resolveType)
+  }
+  if (['Any', 'String', 'Boolean', 'Number'].includes(type)) {
+    return type.toLowerCase()
+  }
+  if (type === 'Array') {
+    return 'any[]'
+  }
+  return type
+}
+
+module.exports.generate = function (data) {
+  try {
+    const webtypes = JSON.stringify({
+      $schema: '../../schema/web-types.schema.json',
+      framework: 'vue',
+      name: 'quasar',
+      version: process.env.VERSION || require('../package.json').version,
+      contributions: {
+        html: {
+          'types-syntax': 'typescript',
+          tags: data.components.map(({ api: { events, props, scopedSlots, slots }, name }) => {
+            let result = {
+              name,
+              // TODO source file can be wrong - this is just a guess for now
+              'source-file': `./quasar/src/components/${kebabCase(name.substr(1))}/${name}.js`,
+              attributes: props && Object.entries(props).map(([name, propApi]) => {
+                let result = {
+                  name,
+                  type: resolveType(propApi.type),
+                  description: propApi.desc,
+                  'doc-url': 'https://quasar.dev'
+                }
+                if (propApi.required) {
+                  result.required = true
+                }
+                if (propApi.default) {
+                  result.default = JSON.stringify(propApi.default)
+                }
+                return result
+              }),
+              events: events && Object.entries(events).map(([name, eventApi]) => ({
+                name,
+                arguments: eventApi.params && Object.entries(eventApi.params).map(([paramName, paramApi]) => ({
+                  name: paramName,
+                  type: resolveType(paramApi.type),
+                  description: paramApi.desc,
+                  'doc-url': 'https://quasar.dev'
+                })),
+                description: eventApi.desc,
+                'doc-url': 'https://quasar.dev'
+              })),
+              slots: slots && Object.entries(slots).map(([name, slotApi]) => ({
+                name,
+                description: slotApi.desc,
+                'doc-url': 'https://quasar.dev'
+              })),
+              'vue-scoped-slots': scopedSlots && Object.entries(scopedSlots).map(([name, slotApi]) => ({
+                name,
+                properties: slotApi.scope && Object.entries(slotApi.scope).map(([name, api]) => ({
+                  name,
+                  type: resolveType(api.type),
+                  description: api.desc,
+                  'doc-url': 'https://quasar.dev'
+                })),
+                description: slotApi.desc,
+                'doc-url': 'https://quasar.dev'
+              })),
+              description: `${name} - Quasar component`,
+              'doc-url': 'https://quasar.dev'
+            }
+            if (props && props.value && ((events && events.input) || props.value.category === 'model')) {
+              result['vue-model'] = {
+                prop: 'value',
+                event: 'input'
+              }
+            }
+            return Object.fromEntries(Object.entries(result).filter(([_, v]) => v))
+          }),
+          attributes: data.directives.map(directiveApi => {
+            return {
+              name: 'v-' + kebabCase(directiveApi.name),
+              'source-file': `./node_modules/quasar/src/directives/${directiveApi.name}.js`,
+              type: resolveType(directiveApi.api.value.type),
+              description: `${directiveApi.name} - Quasar directive`,
+              'doc-url': 'https://quasar.dev'
+            }
+          })
+        }
+      }
+    }, null, 2)
+    let webTypesPath = path.resolve(__dirname, '../dist/web-types')
+
+    if (!fs.existsSync(webTypesPath)) {
+      fs.mkdirSync(webTypesPath)
+    }
+    writeFile(path.resolve(webTypesPath, 'web-types.json'), webtypes)
+  }
+  catch (err) {
+    logError(`build.web-types.js: something went wrong...`)
+    console.log()
+    console.error(err)
+    console.log()
+    process.exit(1)
+  }
+}

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -145,7 +145,8 @@ module.exports.generate = function (data) {
       fs.mkdirSync(webTypesPath)
     }
     writeFile(path.resolve(webTypesPath, 'web-types.json'), webtypes)
-  } catch (err) {
+  }
+  catch (err) {
     logError(`build.web-types.js: something went wrong...`)
     console.log()
     console.error(err)

--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -3,10 +3,13 @@ const
   fs = require('fs'),
   { logError, writeFile, kebabCase } = require('./build.utils')
 
-function resolveType (type) {
+function resolveType ({ type, values }) {
   // TODO transform Object with "values" and arrays Objects with values
   if (Array.isArray(type)) {
-    return type.map(resolveType).join('|')
+    return type.map(type => resolveType({ type })).join('|')
+  }
+  if (type === 'String' && values) {
+    return values.map(v => v === null ? 'null' : `'${v}'`).join('|')
   }
   if (['Any', 'String', 'Boolean', 'Number', 'Object'].includes(type)) {
     return type.toLowerCase()
@@ -45,7 +48,7 @@ module.exports.generate = function (data) {
                   name,
                   value: {
                     kind: 'expression',
-                    type: resolveType(propApi.type)
+                    type: resolveType(propApi)
                   },
                   description: getDescription(propApi),
                   'doc-url': 'https://quasar.dev'
@@ -66,7 +69,7 @@ module.exports.generate = function (data) {
                 name,
                 arguments: eventApi.params && Object.entries(eventApi.params).map(([paramName, paramApi]) => ({
                   name: paramName,
-                  type: resolveType(paramApi.type),
+                  type: resolveType(paramApi),
                   description: getDescription(paramApi),
                   'doc-url': 'https://quasar.dev'
                 })),
@@ -82,7 +85,7 @@ module.exports.generate = function (data) {
                 name,
                 properties: slotApi.scope && Object.entries(slotApi.scope).map(([name, api]) => ({
                   name,
-                  type: resolveType(api.type),
+                  type: resolveType(api),
                   description: getDescription(api),
                   'doc-url': 'https://quasar.dev'
                 })),
@@ -128,7 +131,7 @@ module.exports.generate = function (data) {
             if (valueType !== 'Boolean') {
               result.value = {
                 kind: 'expression',
-                type: resolveType(value.type)
+                type: resolveType(value)
               }
             }
             return result

--- a/ui/build/script.build.javascript.js
+++ b/ui/build/script.build.javascript.js
@@ -95,6 +95,7 @@ require('./build.api').generate()
     require('./build.vetur').generate(data)
     require('./build.lang-index').generate()
     require('./build.types').generate(data)
+    require('./build.web-types').generate(data)
   })
 
 /**

--- a/ui/package.json
+++ b/ui/package.json
@@ -106,6 +106,7 @@
     "tags": "dist/vetur/quasar-tags.json",
     "attributes": "dist/vetur/quasar-attributes.json"
   },
+  "web-types": "dist/web-types/web-types.json",
   "engines": {
     "node": ">= 8.9.0",
     "npm": ">= 5.6.0",


### PR DESCRIPTION
Initial work

This PR should improve completion and Quasar support in JetBrains editors. Webstorm already uses those files but JetBrains generates them themselves and publish to @web-types scope. They support linking custom web-types linked through package.json, though.

It would be more appropriate if we generated these files during build so that we don't have to wait until WebStorm team catches up after every release. We can also be responsible for its content and make sure it's correct and complete. We already generate Vetur helpers, that's a similar story.

More information:
https://github.com/JetBrains/web-types/
https://youtrack.jetbrains.com/issue/WEB-31682#focus=streamItem-27-3538850.0-0