### PR TITLE
Add example on how to use inline (data uri) images/icons

### DIFF
--- a/docs/src/pages/vue-components/icon.md
+++ b/docs/src/pages/vue-components/icon.md
@@ -69,6 +69,18 @@ This is not restricted to SVG only. You can use whatever image type you want (pn
 <q-input clearable clear-icon="img:statics/bla/bla/my.gif" ... />
 ```
 
+It is also possible to inline the image (svg, png, jpeg, gif...) and dynamically change it's style (svg):
+
+```html
+<q-icon name="img:data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>" />
+<q-btn icon="
+img:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" ... />
+
+A working example demo can be found here:
+https://jsfiddle.net/Zireael/7vzxc926/27/
+```
+
+
 All `icon` related props from Quasar components can make use of this.
 
 ::: tip


### PR DESCRIPTION
Add a more advanced example of using external icons/images generated through code rather than by importing from file. by taking advantage of 'data uri' syntax. SVG icon looks can be modified by using props in computed property or even css classes in this way.

Please see working demo I've made:

https://jsfiddle.net/Zireael/7vzxc926/27/

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
