### PR TITLE
Allow overriding default Notify actions

### DIFF
--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -78,6 +78,9 @@ const Notifications = {
 
       const actions =
         (config.actions || []).concat(defaults.actions || [])
+      if (config.actions === null || (Array.isArray(config.actions) && config.actions.length === 0)) {
+        actions.splice(0, actions.length)
+      }
 
       if (actions.length > 0) {
         notif.actions = actions.map(item => {


### PR DESCRIPTION
If config.actions is explicitly set to null or an empty array, default actions should not be added.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I'm not sure if it's intended, but to me it seems counter-intuitive that default actions can't be unset once they're defined.