### PR TITLE
feat(QItem): Adds transition-show & transition-hide to QItem

### DIFF
--- a/ui/src/components/list/QItem.js
+++ b/ui/src/components/list/QItem.js
@@ -3,11 +3,12 @@ import Vue from 'vue'
 import { RouterLinkMixin } from '../../mixins/router-link.js'
 import slot from '../../utils/slot.js'
 import { stopAndPrevent } from '../../utils/event.js'
+import TransitionMixin from '../../mixins/transition.js'
 
 export default Vue.extend({
   name: 'QItem',
 
-  mixins: [ RouterLinkMixin ],
+  mixins: [ RouterLinkMixin, TransitionMixin ],
 
   props: {
     active: Boolean,
@@ -124,10 +125,13 @@ export default Vue.extend({
       return h('router-link', data, this.__getContent(h))
     }
 
-    return h(
-      this.tag,
-      data,
-      this.__getContent(h)
+    return h('transition', {
+      props: { name: this.transition }
+    }, [h(
+        this.tag,
+        data,
+        this.__getContent(h)
+      )]
     )
   }
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The main idea of this change is to add the possibility of using transition-show and transition-hide to QItem, so when you show or hide the item, it animates. It has to be used with v-show or v-if.
This PR doesn't affect the documentation. If it is merged, I will make the necessary changes to it.

