### PR TITLE
fix(ui) missing auto spacing classes

### DIFF
--- a/ui/src/css/flex-addon.styl
+++ b/ui/src/css/flex-addon.styl
@@ -53,13 +53,6 @@ fg($name, $size)
       .q-my{$name}-{$space}
         @extends .q-mt{$name}-{$space}, .q-mb{$name}-{$space}
 
-    .q-ml{$name}-auto
-      margin-left auto
-    .q-mr{$name}-auto
-      margin-right auto
-    .q-mx{$name}-auto
-      @extends .q-ml{$name}-auto, .q-mr{$name}-auto
-
     .row, .column, .flex
       if $noProcNotZero
         {fr('&.inline<name>', $name)}

--- a/ui/src/css/variables.styl
+++ b/ui/src/css/variables.styl
@@ -6,6 +6,10 @@ $spaces ?= {
     x: 0,
     y: 0
   },
+  auto: {
+    x: auto,
+    y: auto
+  },
   xs: {
     x: ($space-x-base * .25),
     y: ($space-y-base * .25)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Today I tried to use `q-mt-auto` CSS class and it wasn't there, so this PR fixes it.