### PR TITLE
fix(quasar): Consistent apply of disabled/readonly attributes and cursor to field elements

### DIFF
--- a/ui/dev/components/form/input.vue
+++ b/ui/dev/components/form/input.vue
@@ -38,6 +38,20 @@
 
       <q-input v-bind="props" v-model="email" type="email" label="eMail" placeholder="Write an email address" />
 
+      <q-input v-bind="props" v-model="text" label="Tooltip and menu">
+        <q-icon slot="prepend" name="event">
+          <q-tooltip>Tooltip</q-tooltip>
+        </q-icon>
+        <q-icon slot="append" name="delete">
+          <q-tooltip>Tooltip</q-tooltip>
+        </q-icon>
+        <q-menu fit>
+          <div class="q-pa-md text-center">
+            Menu
+          </div>
+        </q-menu>
+      </q-input>
+
       <q-input v-bind="props" v-model="text">
         <q-icon slot="prepend" name="event" />
         <q-icon slot="append" name="delete" />

--- a/ui/src/components/datetime/QDate.js
+++ b/ui/src/components/datetime/QDate.js
@@ -92,7 +92,7 @@ export default Vue.extend({
       const type = this.landscape === true ? 'landscape' : 'portrait'
       return `q-date--${type} q-date--${type}-${this.minimal === true ? 'minimal' : 'standard'}` +
         (this.dark === true ? ' q-date--dark' : '') +
-        (this.readonly === true ? ' q-date--readonly' : '') +
+        (this.readonly === true && this.disable !== true ? ' q-date--readonly' : '') +
         (this.disable === true ? ' disabled' : '')
     },
 

--- a/ui/src/components/datetime/QTime.js
+++ b/ui/src/components/datetime/QTime.js
@@ -86,7 +86,7 @@ export default Vue.extend({
     classes () {
       return {
         'q-time--dark': this.dark,
-        'q-time--readonly': this.readonly,
+        'q-time--readonly': this.readonly === true && this.disable !== true,
         'disabled': this.disable,
         [`q-time--${this.landscape === true ? 'landscape' : 'portrait'}`]: true
       }

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -137,7 +137,7 @@ export default Vue.extend({
         'q-field--with-bottom': this.hideBottomSpace !== true && this.shouldRenderBottom === true,
         'q-field--error': this.hasError,
 
-        'q-field--readonly': this.readonly,
+        'q-field--readonly': this.readonly === true && this.disable !== true,
         'q-field--disabled': this.disable
       }
     },

--- a/ui/src/components/field/field.styl
+++ b/ui/src/components/field/field.styl
@@ -121,12 +121,24 @@ $field-transition = .36s cubic-bezier(.4,0,.2,1)
     padding-left 4px
 
   &--readonly, &--disabled
-    .q-field__control
-      pointer-events none
     .q-placeholder // override "disable" CSS on it
       opacity 1 !important
 
+  &--readonly
+    &.q-field--labeled
+      .q-field__native
+        cursor default
+    &.q-field--float
+      .q-field__native
+        cursor text
+
   &--disabled
+    .q-field__inner
+      cursor not-allowed
+
+    .q-field__control
+      pointer-events none
+
     .q-field__control > div
       opacity .6 !important
 

--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -212,7 +212,8 @@ export default Vue.extend({
         id: this.targetUid,
         type: this.type,
         maxlength: this.maxlength,
-        disabled: this.editable !== true
+        disabled: this.disable === true,
+        readonly: this.readonly === true
       }
 
       if (this.autogrow === true) {

--- a/ui/src/components/input/input.styl
+++ b/ui/src/components/input/input.styl
@@ -16,9 +16,6 @@
     padding-top 17px
     min-height 52px
 
-  &.q-field--readonly .q-field__native
-    pointer-events auto
-
   &.q-field--labeled
     .q-field__control-container
       padding-top 26px

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -860,7 +860,8 @@ export default Vue.extend({
           autofocus: this.autofocus,
           ...this.$attrs,
           id: this.targetUid,
-          disabled: this.editable !== true
+          disabled: this.disable === true,
+          readonly: this.readonly === true
         },
         on
       })

--- a/ui/src/components/select/select.styl
+++ b/ui/src/components/select/select.styl
@@ -22,6 +22,16 @@
   &__dropdown-icon
     cursor pointer
 
+  &.q-field--readonly
+    .q-field__control, .q-select__dropdown-icon
+      cursor default
+    &.q-field--labeled
+      .q-select__input
+        cursor default
+    &.q-field--float
+      .q-select__input
+        cursor text
+
   &__dialog
     width 90vw !important
     max-width 90vw !important


### PR DESCRIPTION
Also allow pointer events in readonly, so that QTooltip/QMenu works.

close #4810, close #4767