### PR TITLE
fix(quasar): Misc adjustment for dialogs

### DIFF
--- a/ui/dev/components/form/input.vue
+++ b/ui/dev/components/form/input.vue
@@ -45,7 +45,7 @@
         <q-icon slot="append" name="delete">
           <q-tooltip>Tooltip</q-tooltip>
         </q-icon>
-        <q-menu fit>
+        <q-menu fit no-focus>
           <div class="q-pa-md text-center">
             Menu
           </div>
@@ -405,7 +405,7 @@
       </q-input>
 
       <q-input :dark="dark" v-model="text" filled hint="With menu" style="margin-bottom: 100px">
-        <q-menu fit auto-close>
+        <q-menu fit auto-close no-focus>
           <q-list padding style="min-width: 100px">
             <q-item
               v-for="n in 2"

--- a/ui/dev/components/form/select-part-2.vue
+++ b/ui/dev/components/form/select-part-2.vue
@@ -382,7 +382,7 @@
             <template #loading>
               <div class="q-anchor--skip" @click.prevent>
                 Click for menu
-                <q-menu fit>
+                <q-menu fit no-focus>
                   <div class="q-pa-md text-center">
                     Menu
                   </div>

--- a/ui/src/components/dialog/dialog.styl
+++ b/ui/src/components/dialog/dialog.styl
@@ -30,7 +30,7 @@
     &--minimized
       padding 24px
       > div
-        max-height calc(100vh - 108px)
+        max-height calc(100vh - 48px)
 
     &--maximized
       > div
@@ -74,8 +74,8 @@
     pointer-events all
     background $dimmed-background
 
-body.cordova .q-dialog__inner--minimized > div
-  max-height calc(100vh - 48px)
+body.mobile:not(cordova) .q-dialog__inner--minimized > div
+  max-height calc(100vh - 108px)
 
 body.q-ios-padding .q-dialog__inner
   padding-top $ios-statusbar-height !important

--- a/ui/src/components/dialog/dialog.styl
+++ b/ui/src/components/dialog/dialog.styl
@@ -74,7 +74,7 @@
     pointer-events all
     background $dimmed-background
 
-body.mobile:not(cordova) .q-dialog__inner--minimized > div
+body.mobile:not(.cordova) .q-dialog__inner--minimized > div
   max-height calc(100vh - 108px)
 
 body.q-ios-padding .q-dialog__inner

--- a/ui/src/components/dialog/dialog.styl
+++ b/ui/src/components/dialog/dialog.styl
@@ -30,7 +30,7 @@
     &--minimized
       padding 24px
       > div
-        max-height calc(100vh - 48px)
+        max-height calc(100vh - 108px)
 
     &--maximized
       > div
@@ -73,6 +73,9 @@
     z-index -1
     pointer-events all
     background $dimmed-background
+
+body.cordova .q-dialog__inner--minimized > div
+  max-height calc(100vh - 48px)
 
 body.q-ios-padding .q-dialog__inner
   padding-top $ios-statusbar-height !important

--- a/ui/src/components/dialog/dialog.styl
+++ b/ui/src/components/dialog/dialog.styl
@@ -74,6 +74,7 @@
     pointer-events all
     background $dimmed-background
 
+// addressbar always gets shown, so need to slim this down
 body.mobile:not(.cordova) .q-dialog__inner--minimized > div
   max-height calc(100vh - 108px)
 

--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -191,7 +191,6 @@ export default Vue.extend({
         change: this.__onChange,
         compositionstart: this.__onCompositionStart,
         compositionend: this.__onCompositionEnd,
-        focus: stop,
         blur: stop
       }
 
@@ -201,6 +200,18 @@ export default Vue.extend({
 
       if (this.hasMask === true) {
         on.keydown = this.__onMaskedKeydown
+      }
+
+      if (this.editable === true && this.$q.platform.is.mobile === true) {
+        on.focus = e => {
+          stop(e)
+          setTimeout(() => {
+            this.$el !== void 0 && this.$el.scrollIntoView(true)
+          }, 300)
+        }
+      }
+      else {
+        on.focus = stop
       }
 
       const attrs = {

--- a/ui/src/components/layout/QDrawer.js
+++ b/ui/src/components/layout/QDrawer.js
@@ -126,6 +126,10 @@ export default Vue.extend({
       ))
     },
 
+    'layout.container' (val) {
+      this.showing === true && this.__preventScroll(val !== true)
+    },
+
     'layout.width' (val) {
       this.__updateLocal('belowBreakpoint', (
         this.behavior === 'mobile' ||
@@ -438,9 +442,7 @@ export default Vue.extend({
       if (this.belowBreakpoint === true) {
         this.mobileOpened = true
         this.applyBackdrop(1)
-        if (this.layout.container !== true) {
-          this.__preventScroll(true)
-        }
+        this.layout.container !== true && this.__preventScroll(true)
       }
       else {
         this.__setScrollable(false)

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -117,37 +117,33 @@ export default Vue.extend({
       this.__showPortal()
       this.__configureScrollTarget()
 
-      this.timer = setTimeout(() => {
-        const { top, left } = this.anchorEl.getBoundingClientRect()
+      const { top, left } = this.anchorEl.getBoundingClientRect()
 
-        if (this.touchPosition || this.contextMenu) {
-          const pos = position(evt)
-          this.absoluteOffset = { left: pos.left - left, top: pos.top - top }
-        }
-        else {
-          this.absoluteOffset = void 0
-        }
+      if (this.touchPosition || this.contextMenu) {
+        const pos = position(evt)
+        this.absoluteOffset = { left: pos.left - left, top: pos.top - top }
+      }
+      else {
+        this.absoluteOffset = void 0
+      }
 
+      if (this.unwatch === void 0) {
+        this.unwatch = this.$watch('$q.screen.width', this.updatePosition)
+      }
+
+      this.$el.dispatchEvent(create('popup-show', { bubbles: true }))
+
+      if (this.noFocus !== true) {
+        document.activeElement.blur()
+      }
+      this.$nextTick(() => {
         this.updatePosition()
+        this.noFocus !== true && this.focus()
+      })
 
-        if (this.unwatch === void 0) {
-          this.unwatch = this.$watch('$q.screen.width', this.updatePosition)
-        }
-
-        this.$el.dispatchEvent(create('popup-show', { bubbles: true }))
-
-        if (this.noFocus !== true) {
-          document.activeElement.blur()
-
-          this.$nextTick(() => {
-            this.focus()
-          })
-        }
-
-        this.timer = setTimeout(() => {
-          this.$emit('show', evt)
-        }, 300)
-      }, 0)
+      this.timer = setTimeout(() => {
+        this.$emit('show', evt)
+      }, 300)
     },
 
     __hide (evt) {
@@ -201,7 +197,7 @@ export default Vue.extend({
 
     __onAutoClose (e) {
       closePortalMenus(this, e)
-      this.$emit('click', e)
+      this.$listeners.click !== void 0 && this.$emit('click', e)
     },
 
     updatePosition () {

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -136,6 +136,7 @@ export default Vue.extend({
       if (this.noFocus !== true) {
         document.activeElement.blur()
       }
+
       this.$nextTick(() => {
         this.updatePosition()
         this.noFocus !== true && this.focus()

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -604,7 +604,7 @@ export default Vue.extend({
       const child = this.__getSelection(h, fromDialog)
 
       if (this.useInput === true && (fromDialog === true || this.hasDialog === false)) {
-        child.push(this.__getInput(h))
+        child.push(this.__getInput(h, fromDialog))
       }
       else if (this.editable === true) {
         data = {
@@ -677,7 +677,7 @@ export default Vue.extend({
       this.__onInputValue(e)
     },
 
-    __getInput (h) {
+    __getInput (h, fromDialog) {
       const on = {
         input: this.__onInputValue,
         // Safari < 10.2 & UIWebView doesn't fire compositionend when
@@ -697,6 +697,13 @@ export default Vue.extend({
       if (this.hasDialog === true) {
         on.click = stop
       }
+      else if (this.useInput === true && this.$q.platform.is.mobile === true) {
+        on.focus = () => {
+          setTimeout(() => {
+            this.$el !== void 0 && this.$el.scrollIntoView(true)
+          }, 300)
+        }
+      }
 
       return h('input', {
         ref: 'target',
@@ -708,9 +715,9 @@ export default Vue.extend({
         attrs: {
           // required for Android in order to show ENTER key when in form
           type: 'search',
-          tabindex: 0,
-          autofocus: this.autofocus,
           ...this.$attrs,
+          tabindex: 0,
+          autofocus: fromDialog === true ? false : this.autofocus,
           id: this.targetUid,
           disabled: this.disable === true,
           readonly: this.readonly === true
@@ -932,7 +939,7 @@ export default Vue.extend({
           noRefocus: true,
           noFocus: true,
           position: this.useInput === true ? 'top' : void 0,
-          transitionShow: this.transitionShow,
+          transitionShow: this.transitionShowComputed,
           transitionHide: this.transitionHide
         },
         on: {
@@ -1027,6 +1034,10 @@ export default Vue.extend({
             ? this.$scopedSlots['no-option'] !== void 0 || this.$listeners.filter !== void 0 || this.noOptions === false
             : true
         )
+
+      this.transitionShowComputed = this.hasDialog === true && this.useInput === true && this.$q.platform.is.ios === true
+        ? 'fade'
+        : this.transitionShow
     },
 
     __onPostRender () {

--- a/ui/src/components/select/select.styl
+++ b/ui/src/components/select/select.styl
@@ -35,7 +35,7 @@
   &__dialog
     width 90vw !important
     max-width 90vw !important
-    max-height calc(100vh - 70px) !important
+    max-height calc(100vh - 80px) !important
     background white
     display flex
     flex-direction column
@@ -48,5 +48,8 @@
     color white
     background $grey-9
 
-body.platform-ios .q-select__dialog
+body.cordova .q-select__dialog
+  max-height calc(100vh - 70px) !important
+
+body.platform-ios .q-dialog__inner--top .q-select__dialog
   max-height 50vh !important

--- a/ui/src/components/select/select.styl
+++ b/ui/src/components/select/select.styl
@@ -48,6 +48,7 @@
     color white
     background $grey-9
 
+// addressbar always gets shown, so need to slim this down
 body.mobile:not(.cordova) .q-select__dialog
   max-height calc(100vh - 80px) !important
 

--- a/ui/src/components/select/select.styl
+++ b/ui/src/components/select/select.styl
@@ -35,7 +35,7 @@
   &__dialog
     width 90vw !important
     max-width 90vw !important
-    max-height calc(100vh - 80px) !important
+    max-height calc(100vh - 70px) !important
     background white
     display flex
     flex-direction column
@@ -48,8 +48,8 @@
     color white
     background $grey-9
 
-body.cordova .q-select__dialog
-  max-height calc(100vh - 70px) !important
+body.mobile:not(.cordova) .q-select__dialog
+  max-height calc(100vh - 80px) !important
 
 body.platform-ios .q-dialog__inner--top .q-select__dialog
   max-height 50vh !important

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -76,14 +76,14 @@ export default Vue.extend({
 
       this.__showPortal()
 
-      this.timer = setTimeout(() => {
+      this.$nextTick(() => {
         this.updatePosition()
+        this.__configureScrollTarget()
+      })
 
-        this.timer = setTimeout(() => {
-          this.$emit('show', evt)
-          this.__configureScrollTarget()
-        }, 300)
-      }, 0)
+      this.timer = setTimeout(() => {
+        this.$emit('show', evt)
+      }, 300)
     },
 
     __hide (evt) {
@@ -101,6 +101,8 @@ export default Vue.extend({
     },
 
     updatePosition () {
+      if (this.anchorEl === void 0) { return }
+
       const el = this.__portal.$el
 
       if (el.nodeType === 8) { // IE replaces the comment with delay
@@ -109,8 +111,6 @@ export default Vue.extend({
         }, 25)
         return
       }
-
-      if (this.anchorEl === void 0) { return }
 
       setPosition({
         el,
@@ -140,17 +140,17 @@ export default Vue.extend({
     __unconfigureAnchorEl () {
       // mobile hover ref https://stackoverflow.com/a/22444532
       if (this.$q.platform.is.mobile) {
-        this.anchorEl.removeEventListener('touchstart', this.__delayShow)
+        this.anchorEl.removeEventListener('touchstart', this.__delayShow, listenOpts.passive)
         ;['touchcancel', 'touchmove', 'click'].forEach(evt => {
-          this.anchorEl.removeEventListener(evt, this.__delayHide)
+          this.anchorEl.removeEventListener(evt, this.__delayHide, listenOpts.passive)
         })
       }
       else {
-        this.anchorEl.removeEventListener('mouseenter', this.__delayShow)
+        this.anchorEl.removeEventListener('mouseenter', this.__delayShow, listenOpts.passive)
       }
 
       if (this.$q.platform.is.ios !== true) {
-        this.anchorEl.removeEventListener('mouseleave', this.__delayHide)
+        this.anchorEl.removeEventListener('mouseleave', this.__delayHide, listenOpts.passive)
       }
     },
 
@@ -159,17 +159,17 @@ export default Vue.extend({
 
       // mobile hover ref https://stackoverflow.com/a/22444532
       if (this.$q.platform.is.mobile) {
-        this.anchorEl.addEventListener('touchstart', this.__delayShow)
+        this.anchorEl.addEventListener('touchstart', this.__delayShow, listenOpts.passive)
         ;['touchcancel', 'touchmove', 'click'].forEach(evt => {
-          this.anchorEl.addEventListener(evt, this.__delayHide)
+          this.anchorEl.addEventListener(evt, this.__delayHide, listenOpts.passive)
         })
       }
       else {
-        this.anchorEl.addEventListener('mouseenter', this.__delayShow)
+        this.anchorEl.addEventListener('mouseenter', this.__delayShow, listenOpts.passive)
       }
 
       if (this.$q.platform.is.ios !== true) {
-        this.anchorEl.addEventListener('mouseleave', this.__delayHide)
+        this.anchorEl.addEventListener('mouseleave', this.__delayHide, listenOpts.passive)
       }
     },
 

--- a/ui/src/utils/dom.js
+++ b/ui/src/utils/dom.js
@@ -46,6 +46,20 @@ export function ready (fn) {
   document.addEventListener('DOMContentLoaded', fn, false)
 }
 
+export function childHasFocus (el, focusedEl) {
+  if (el === void 0 || el.contains(focusedEl) === true) {
+    return true
+  }
+
+  for (let next = el.nextElementSibling; next !== null; next = next.nextElementSibling) {
+    if (next.contains(focusedEl)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export default {
   offset,
   style,


### PR DESCRIPTION
- make maxHeight of dialogs smaller - it overflows on Android
- scrollIntoView QInput and QSelect on mobiles
- use fade as transitionShow in QSelect dialog on iOS
- make maxHeight of QSelect dialog smaller (overflow on Android)