### PR TITLE
feat(portal): Improve ClickOutside and ClosePopup

### DIFF
--- a/ui/dev/components/other/close-popup.vue
+++ b/ui/dev/components/other/close-popup.vue
@@ -170,6 +170,656 @@
         </q-dialog>
       </q-card>
     </q-dialog>
+
+    <div>
+      <q-btn-dropdown color="primary" label="Dropdown Button">
+        <q-list class="bg-white" separator clickable>
+          <q-item v-close-popup>
+            <q-item-section>v-close-popup</q-item-section>
+          </q-item>
+
+          <q-item>
+            <q-item-section>Submenu (QMenu)</q-item-section>
+            <q-item-section side>
+              <q-icon name="keyboard_arrow_right" />
+            </q-item-section>
+            <q-menu>
+              <q-list class="bg-white" separator clickable>
+                <q-item v-close-popup>
+                  <q-item-section>v-close-popup</q-item-section>
+                </q-item>
+              </q-list>
+            </q-menu>
+          </q-item>
+
+          <q-item>
+            <q-item-section>Submenu (QMenu)</q-item-section>
+            <q-item-section side>
+              <q-icon name="keyboard_arrow_right" />
+            </q-item-section>
+            <q-menu auto-close>
+              <q-list class="bg-white" separator clickable>
+                <q-item>
+                  <q-item-section>auto-close</q-item-section>
+                </q-item>
+              </q-list>
+            </q-menu>
+          </q-item>
+
+          <q-item>
+            <q-item-section>Submenu (QPopupProxy)</q-item-section>
+            <q-item-section side>
+              <q-icon name="keyboard_arrow_right" />
+            </q-item-section>
+            <q-popup-proxy>
+              <q-list class="bg-white" separator clickable>
+                <q-item v-close-popup>
+                  <q-item-section>v-close-popup</q-item-section>
+                </q-item>
+                <q-item>
+                  <q-item-section>Submenu (QMenu)</q-item-section>
+                  <q-item-section side>
+                    <q-icon name="keyboard_arrow_right" />
+                  </q-item-section>
+                  <q-menu>
+                    <q-list class="bg-white" separator clickable>
+                      <q-item v-close-popup>
+                        <q-item-section>v-close-popup</q-item-section>
+                      </q-item>
+                    </q-list>
+                  </q-menu>
+                </q-item>
+                <q-item>
+                  <q-item-section>Submenu (QMenu)</q-item-section>
+                  <q-item-section side>
+                    <q-icon name="keyboard_arrow_right" />
+                  </q-item-section>
+                  <q-menu auto-close>
+                    <q-list class="bg-white" separator clickable>
+                      <q-item>
+                        <q-item-section>auto-close</q-item-section>
+                      </q-item>
+                    </q-list>
+                  </q-menu>
+                </q-item>
+              </q-list>
+            </q-popup-proxy>
+          </q-item>
+
+          <q-item v-close-popup>
+            <q-item-section side>
+              <q-icon name="close" />
+            </q-item-section>
+
+            <q-item-section @click.stop>
+              <q-select v-model="selection" :options="options" label="Select" />
+            </q-item-section>
+          </q-item>
+
+          <q-item v-close-popup>
+            <q-item-section side>
+              <q-icon name="close" />
+            </q-item-section>
+
+            <q-item-section @click.stop>
+              <q-input v-model="text" label="Option" />
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                1
+                <q-menu>
+                  <q-list class="bg-white" separator clickable>
+                    <q-item v-close-popup>
+                      <q-item-section @click="text = 'QMenu - v-close-popup'">
+                        QMenu - v-close-popup
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-menu>
+              </q-avatar>
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                2
+                <q-menu auto-close>
+                  <q-list class="bg-white" separator clickable>
+                    <q-item>
+                      <q-item-section @click="text = 'QMenu - auto-close'">
+                        QMenu - auto-close
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-menu>
+              </q-avatar>
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                3
+                <q-menu :close-as-tree="false">
+                  <q-list class="bg-white" separator clickable>
+                    <q-item v-close-popup>
+                      <q-item-section @click="text = 'QMenu - !close-as-tree - v-close-popup'">
+                        QMenu - !close-as-tree - v-close-popup
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-menu>
+              </q-avatar>
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                4
+                <q-menu :close-as-tree="false" auto-close>
+                  <q-list class="bg-white" separator clickable>
+                    <q-item>
+                      <q-item-section @click="text = 'QMenu - !close-as-tree - auto-close'">
+                        QMenu - !close-as-tree - auto-close
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-menu>
+              </q-avatar>
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                5
+                <q-popup-proxy>
+                  <q-list class="bg-white" separator clickable>
+                    <q-item v-close-popup>
+                      <q-item-section @click="text = 'QPopupProxy - v-close-popup'">
+                        QPopupProxy - v-close-popup
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-popup-proxy>
+              </q-avatar>
+            </q-item-section>
+
+            <q-item-section side @click.stop>
+              <q-avatar>
+                6
+                <q-popup-proxy auto-close>
+                  <q-list class="bg-white" separator clickable>
+                    <q-item>
+                      <q-item-section @click="text = 'QPopupProxy - auto-close'">
+                        QPopupProxy - auto-close
+                      </q-item-section>
+                    </q-item>
+                  </q-list>
+                </q-popup-proxy>
+              </q-avatar>
+            </q-item-section>
+          </q-item>
+
+          <q-item>
+            <q-item-section>
+              <q-btn-dropdown color="primary" label="Dropdown Button">
+                <q-list class="bg-white" separator clickable>
+                  <q-item v-close-popup>
+                    <q-item-section>v-close-popup</q-item-section>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QMenu)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QMenu)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu auto-close>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item>
+                          <q-item-section>auto-close</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QPopupProxy)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-popup-proxy>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item v-close-popup>
+                                <q-item-section>v-close-popup</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu auto-close>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item>
+                                <q-item-section>auto-close</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                      </q-list>
+                    </q-popup-proxy>
+                  </q-item>
+
+                  <q-item v-close-popup>
+                    <q-item-section side>
+                      <q-icon name="close" />
+                    </q-item-section>
+
+                    <q-item-section @click.stop>
+                      <q-input v-model="text" label="Option" />
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        1
+                        <q-menu>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QMenu - v-close-popup'">
+                                QMenu - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        2
+                        <q-menu auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QMenu - auto-close'">
+                                QMenu - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        3
+                        <q-menu :close-as-tree="false">
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QMenu - !close-as-tree - v-close-popup'">
+                                QMenu - !close-as-tree - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        4
+                        <q-menu :close-as-tree="false" auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QMenu - !close-as-tree - auto-close'">
+                                QMenu - !close-as-tree - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        5
+                        <q-popup-proxy>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QPopupProxy - v-close-popup'">
+                                QPopupProxy - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-popup-proxy>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        6
+                        <q-popup-proxy auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QPopupProxy - auto-close'">
+                                QPopupProxy - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-popup-proxy>
+                      </q-avatar>
+                    </q-item-section>
+                  </q-item>
+                </q-list>
+              </q-btn-dropdown>
+            </q-item-section>
+          </q-item>
+
+          <q-item>
+            <q-item-section>
+              <q-btn-dropdown persistent color="primary" label="Persistent Dropdown Button">
+                <q-list class="bg-white" separator clickable>
+                  <q-item v-close-popup>
+                    <q-item-section>v-close-popup</q-item-section>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QMenu)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QMenu)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-menu auto-close>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item>
+                          <q-item-section>auto-close</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-item>
+
+                  <q-item>
+                    <q-item-section>Submenu (QPopupProxy)</q-item-section>
+                    <q-item-section side>
+                      <q-icon name="keyboard_arrow_right" />
+                    </q-item-section>
+                    <q-popup-proxy>
+                      <q-list class="bg-white" separator clickable>
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item v-close-popup>
+                                <q-item-section>v-close-popup</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu auto-close>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item>
+                                <q-item-section>auto-close</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                      </q-list>
+                    </q-popup-proxy>
+                  </q-item>
+
+                  <q-item v-close-popup>
+                    <q-item-section side>
+                      <q-icon name="close" />
+                    </q-item-section>
+
+                    <q-item-section @click.stop>
+                      <q-input v-model="text" label="Option" />
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        1
+                        <q-menu>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QMenu - v-close-popup'">
+                                QMenu - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        2
+                        <q-menu auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QMenu - auto-close'">
+                                QMenu - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        3
+                        <q-menu :close-as-tree="false">
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QMenu - !close-as-tree - v-close-popup'">
+                                QMenu - !close-as-tree - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        4
+                        <q-menu :close-as-tree="false" auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QMenu - !close-as-tree - auto-close'">
+                                QMenu - !close-as-tree - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-menu>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        5
+                        <q-popup-proxy>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item v-close-popup>
+                              <q-item-section @click="text = 'QPopupProxy - v-close-popup'">
+                                QPopupProxy - v-close-popup
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-popup-proxy>
+                      </q-avatar>
+                    </q-item-section>
+
+                    <q-item-section side @click.stop>
+                      <q-avatar>
+                        6
+                        <q-popup-proxy auto-close>
+                          <q-list class="bg-white" separator clickable>
+                            <q-item>
+                              <q-item-section @click="text = 'QPopupProxy - auto-close'">
+                                QPopupProxy - auto-close
+                              </q-item-section>
+                            </q-item>
+                          </q-list>
+                        </q-popup-proxy>
+                      </q-avatar>
+                    </q-item-section>
+                  </q-item>
+                </q-list>
+              </q-btn-dropdown>
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-btn-dropdown>
+    </div>
+
+    <div>
+      <q-btn label="Menu">
+        <q-menu>
+          <q-list class="bg-white">
+            <q-item>
+              <q-item-section @click="dialog3 = true">
+                Open dialog
+              </q-item-section>
+              <q-dialog v-model="dialog3">
+                <div class="bg-white q-pa-lg">
+                  <q-btn label="Menu">
+                    <q-menu>
+                      <q-list class="bg-white">
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item v-close-popup>
+                                <q-item-section>v-close-popup</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                        <q-item>
+                          <q-item-section @click="dialog3 = false">
+                            close dialog (model)
+                          </q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section v-close-popup="2">
+                            close dialog (v-close-popup="2")
+                          </q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section v-close-popup="3">
+                            close dialog and menu (v-close-popup="3")
+                          </q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-btn>
+                </div>
+              </q-dialog>
+            </q-item>
+
+            <q-item>
+              <q-item-section @click="dialog4 = true">
+                Open dialog - persistent
+              </q-item-section>
+              <q-dialog v-model="dialog4" persistent>
+                <div class="bg-white q-pa-lg">
+                  <q-btn label="Menu">
+                    <q-menu>
+                      <q-list class="bg-white">
+                        <q-item v-close-popup>
+                          <q-item-section>v-close-popup</q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section>Submenu (QMenu)</q-item-section>
+                          <q-item-section side>
+                            <q-icon name="keyboard_arrow_right" />
+                          </q-item-section>
+                          <q-menu>
+                            <q-list class="bg-white" separator clickable>
+                              <q-item v-close-popup>
+                                <q-item-section>v-close-popup</q-item-section>
+                              </q-item>
+                            </q-list>
+                          </q-menu>
+                        </q-item>
+                        <q-item>
+                          <q-item-section @click="dialog4 = false">
+                            close dialog (model)
+                          </q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section v-close-popup="2">
+                            try to close dialog (v-close-popup="2")
+                          </q-item-section>
+                        </q-item>
+                        <q-item>
+                          <q-item-section v-close-popup="3">
+                            try to close dialog and menu (v-close-popup="3")
+                          </q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-btn>
+                </div>
+              </q-dialog>
+            </q-item>
+          </q-list>
+        </q-menu>
+      </q-btn>
+    </div>
   </div>
 </template>
 
@@ -180,7 +830,14 @@ export default {
       menu: false,
 
       dialog: false,
-      dialog2: false
+      dialog2: false,
+      dialog3: false,
+      dialog4: false,
+
+      text: 'text',
+
+      selection: 'item 1',
+      options: ['item 1', 'item 2']
     }
   },
   methods: {

--- a/ui/src/components/btn/QBtnDropdown.js
+++ b/ui/src/components/btn/QBtnDropdown.js
@@ -78,7 +78,8 @@ export default Vue.extend({
           anchor: this.menuAnchor,
           self: this.menuSelf,
           contentClass: this.contentClass,
-          contentStyle: this.contentStyle
+          contentStyle: this.contentStyle,
+          closeAsTree: false
         },
         on: {
           'before-show': e => {

--- a/ui/src/components/menu/ClickOutside.js
+++ b/ui/src/components/menu/ClickOutside.js
@@ -8,46 +8,50 @@ const
   handlers = {
     click: [],
     focus: []
-  },
-  onClick = e => {
-    stopAndPrevent(e)
+  }
+
+function onClick (e) {
+  stopAndPrevent(e)
+  document.removeEventListener('click', onClick, notPassiveCapture)
+}
+
+function onMouseup () {
+  document.removeEventListener('mouseup', onMouseup, passiveCapture)
+  setTimeout(() => {
     document.removeEventListener('click', onClick, notPassiveCapture)
-  },
-  onMouseup = () => {
-    document.removeEventListener('mouseup', onMouseup, passiveCapture)
-    setTimeout(() => {
-      document.removeEventListener('click', onClick, notPassiveCapture)
-    }, 50)
-  },
-  execHandlers = (list, evt) => {
-    for (let i = list.length - 1; i >= 0; i--) {
-      if (list[i](evt) === void 0) {
-        return
-      }
-    }
-  },
-  globalHandler = evt => {
-    clearTimeout(timer)
+  }, 50)
+}
 
-    if (evt.type === 'focusin') {
-      timer = setTimeout(() => {
-        execHandlers(handlers.focus, evt)
-      }, 200)
-    }
-    else {
-      execHandlers(handlers.click, evt)
-
-      // prevent accidental click/tap on something else
-      // that has a trigger --> improves UX
-      if (Platform.is.desktop !== true) {
-        stopAndPrevent(evt)
-      }
-      else if (evt.type === 'mousedown' && evt.target.classList.contains('q-dialog__backdrop') === true) {
-        document.addEventListener('mouseup', onMouseup, passiveCapture)
-        document.addEventListener('click', onClick, notPassiveCapture)
-      }
+function execHandlers (list, evt) {
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i](evt) === void 0) {
+      return
     }
   }
+}
+
+function globalHandler (evt) {
+  clearTimeout(timer)
+
+  if (evt.type === 'focusin') {
+    timer = setTimeout(() => {
+      execHandlers(handlers.focus, evt)
+    }, 200)
+  }
+  else {
+    execHandlers(handlers.click, evt)
+
+    // prevent accidental click/tap on something else
+    // that has a trigger --> improves UX
+    if (Platform.is.desktop !== true) {
+      stopAndPrevent(evt)
+    }
+    else if (evt.type === 'mousedown' && evt.target.classList.contains('q-dialog__backdrop') === true) {
+      document.addEventListener('mouseup', onMouseup, passiveCapture)
+      document.addEventListener('click', onClick, notPassiveCapture)
+    }
+  }
+}
 
 export default {
   name: 'click-outside',
@@ -61,10 +65,7 @@ export default {
       handler (evt) {
         const target = evt.target
 
-        if (
-          target === void 0 ||
-          target.nodeType === 8
-        ) {
+        if (target === void 0 || target.nodeType === 8) {
           return
         }
 
@@ -102,6 +103,7 @@ export default {
     }
 
     handlers.click.push(ctx.handler)
+
     if (Platform.is.desktop === true) {
       ctx.timerFocusin = setTimeout(() => {
         handlers.focus.push(ctx.handler)

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 
 import AnchorMixin from '../../mixins/anchor.js'
 import ModelToggleMixin from '../../mixins/model-toggle.js'
-import PortalMixin, { closePortalMenus } from '../../mixins/portal.js'
+import PortalMixin, { closePortals } from '../../mixins/portal.js'
 import TransitionMixin from '../../mixins/transition.js'
 
 import ClickOutside from './ClickOutside.js'
@@ -28,6 +28,11 @@ export default Vue.extend({
   props: {
     persistent: Boolean,
     autoClose: Boolean,
+
+    closeAsTree: {
+      type: Boolean,
+      default: true
+    },
 
     noRefocus: Boolean,
     noFocus: Boolean,
@@ -197,7 +202,7 @@ export default Vue.extend({
     },
 
     __onAutoClose (e) {
-      closePortalMenus(this, e)
+      closePortals(this, e, 1)
       this.$listeners.click !== void 0 && this.$emit('click', e)
     },
 
@@ -248,11 +253,14 @@ export default Vue.extend({
             ...this.$attrs
           },
           on,
-          directives: this.persistent !== true ? [{
+          directives: [{
             name: 'click-outside',
-            value: this.hide,
-            arg: [ this.anchorEl ]
-          }] : null
+            value: e => {
+              const vm = this.persistent === true ? void 0 : this.hide(e)
+
+              return this.closeAsTree === true ? vm : void 0
+            }
+          }]
         }, slot(this, 'default')) : null
       ])
     }

--- a/ui/src/components/menu/QMenu.json
+++ b/ui/src/components/menu/QMenu.json
@@ -67,6 +67,13 @@
       "category": "behavior"
     },
 
+    "close-as-tree": {
+      "type": "Boolean",
+      "default": true,
+      "desc": "Close the menu and all of it's parents (as in a submenu)",
+      "category": "behavior"
+    },
+
     "square": {
       "type": "Boolean",
       "desc": "Forces content to have squared borders",

--- a/ui/src/components/popup-edit/QPopupEdit.js
+++ b/ui/src/components/popup-edit/QPopupEdit.js
@@ -143,7 +143,8 @@ export default Vue.extend({
         contentClass: this.classes,
         contentStyle: this.contentStyle,
         cover: true,
-        persistent: this.persistent
+        persistent: this.persistent,
+        closeAsTree: false
       },
       on: {
         show: () => {

--- a/ui/src/components/popup-proxy/QPopupProxy.js
+++ b/ui/src/components/popup-proxy/QPopupProxy.js
@@ -115,6 +115,7 @@ export default Vue.extend({
       component = QMenu
       data.props.contextMenu = this.contextMenu
       data.props.noParentEvent = true
+      data.props.closeAsTree = false
     }
 
     return h(component, data, slot(this, 'default'))

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -877,7 +877,8 @@ export default Vue.extend({
           noFocus: true,
           square: this.squaredMenu,
           transitionShow: this.transitionShow,
-          transitionHide: this.transitionHide
+          transitionHide: this.transitionHide,
+          closeAsTree: false
         },
         on: {
           '&scroll': this.__onVirtualListScroll,

--- a/ui/src/mixins/model-toggle.js
+++ b/ui/src/mixins/model-toggle.js
@@ -72,12 +72,16 @@ export default {
         return
       }
 
+      const parent = this.$parent
+
       if (typeof this.$listeners.input === 'function') {
         this.value !== false && this.$emit('input', false)
       }
       else {
         this.__processHide(evt)
       }
+
+      return parent
     },
 
     __processHide (evt) {

--- a/ui/src/mixins/model-toggle.js
+++ b/ui/src/mixins/model-toggle.js
@@ -72,8 +72,6 @@ export default {
         return
       }
 
-      const parent = this.$parent
-
       if (typeof this.$listeners.input === 'function') {
         this.value !== false && this.$emit('input', false)
       }
@@ -81,7 +79,7 @@ export default {
         this.__processHide(evt)
       }
 
-      return parent
+      return this.$parent
     },
 
     __processHide (evt) {

--- a/ui/src/mixins/model-toggle.json
+++ b/ui/src/mixins/model-toggle.json
@@ -27,7 +27,12 @@
     },
 
     "hide": {
-      "extends": "hide"
+      "extends": "hide",
+      "returns": {
+        "type": "Object",
+        "desc": "Parent node if the hide is successful, void 0 otherwise",
+        "__exemption": [ "examples" ]
+      }
     },
 
     "before-hide": {

--- a/ui/src/mixins/model-toggle.json
+++ b/ui/src/mixins/model-toggle.json
@@ -27,12 +27,7 @@
     },
 
     "hide": {
-      "extends": "hide",
-      "returns": {
-        "type": "Object",
-        "desc": "Parent node if the hide is successful, void 0 otherwise",
-        "__exemption": [ "examples" ]
-      }
+      "extends": "hide"
     },
 
     "before-hide": {
@@ -46,7 +41,12 @@
     },
 
     "hide": {
-      "extends": "hide"
+      "extends": "hide",
+      "returns": {
+        "type": "Object",
+        "desc": "Parent node if the hide is successful, void 0 otherwise",
+        "__exemption": [ "examples" ]
+      }
     },
 
     "toggle": {

--- a/ui/src/mixins/portal.js
+++ b/ui/src/mixins/portal.js
@@ -1,15 +1,15 @@
 import Vue from 'vue'
 
-export function closePortalMenus (vm, evt) {
-  do {
-    if (vm.$options.name === 'QMenu') {
-      vm.hide(evt)
+function closePortalMenus (vm, evt) {
+  while (vm !== void 0) {
+    if (vm.__hasPortal === true && vm.closeAsTree !== true) {
+      return vm.$options.name === 'QMenu' || (vm.$parent !== void 0 && vm.$parent.$options.name === 'QPopupProxy')
+        ? vm.hide(evt)
+        : vm
     }
-    else if (vm.__hasPortal === true || vm.$options.name === 'QPopupProxy') {
-      return vm
-    }
-    vm = vm.$parent
-  } while (vm !== void 0)
+
+    vm = vm.__hasPortal === true ? vm.hide(evt) : vm.$parent
+  }
 }
 
 export function closePortals (vm, evt, depth) {
@@ -17,15 +17,13 @@ export function closePortals (vm, evt, depth) {
     if (vm.__hasPortal === true) {
       depth--
 
-      if (vm.$options.name === 'QMenu') {
-        vm = closePortalMenus(vm, evt)
-        continue
-      }
-
-      vm.hide(evt)
+      vm = vm.closeAsTree === true
+        ? closePortalMenus(vm, evt)
+        : vm.hide(evt)
     }
-
-    vm = vm.$parent
+    else {
+      vm = vm.$parent
+    }
   }
 }
 


### PR DESCRIPTION
- make global queue for click-outside, and process in order with stop condition
- improve close-popup
- add closeAsTree default true on QMenu to allow close process stop when non-default menu
- add more test cases

TBD:
- What should we do when close-popup finds a portal with persistent?
- click prevention related code should be moved in global click-outside?