### PR TITLE
fix(4877) Add missing type definitions

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -192,6 +192,8 @@ function writeIndexDTS (apis) {
   writeLine(contents)
   writeLine(quasarTypeContents, 'export as namespace quasar')
   writeLine(quasarTypeContents, `export * from './utils'`)
+  writeLine(quasarTypeContents, `export * from './globals'`)
+  writeLine(quasarTypeContents, `export * from './boot'`)
 
   const injections = {}
 

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -269,10 +269,14 @@ function writeIndexDTS (apis) {
   for (const key in injections) {
     const injectionDefs = injections[key]
     if (injectionDefs) {
+      const injectionName = `${key.toUpperCase().replace('$', '')}VueGlobals`
+      writeLine(contents, `import { ${injectionName} } from "./globals";`)
+      writeLine(contents, `declare module "./globals" {`)
       writeLine(contents, `export interface ${key.toUpperCase().replace('$', '')}VueGlobals {`)
       for (const defKey in injectionDefs) {
         writeLine(contents, injectionDefs[defKey], 1)
       }
+      writeLine(contents, '}')
       writeLine(contents, '}')
     }
   }

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -272,7 +272,7 @@ function writeIndexDTS (apis) {
       const injectionName = `${key.toUpperCase().replace('$', '')}VueGlobals`
       writeLine(contents, `import { ${injectionName} } from "./globals";`)
       writeLine(contents, `declare module "./globals" {`)
-      writeLine(contents, `export interface ${key.toUpperCase().replace('$', '')}VueGlobals {`)
+      writeLine(contents, `export interface ${injectionName} {`)
       for (const defKey in injectionDefs) {
         writeLine(contents, injectionDefs[defKey], 1)
       }

--- a/ui/types/boot.d.ts
+++ b/ui/types/boot.d.ts
@@ -1,0 +1,21 @@
+import Vue, { ComponentOptions, VueConstructor } from 'vue';
+import VueRouter from 'vue-router';
+
+export interface QSsrContext {
+    req: {
+        headers: Record<string, string>;
+    };
+    res: {
+        setHeader(name: string, value: string): void;
+    };
+}
+
+export interface BootFileParams<TStore = any> {
+    app?: Vue;
+    Vue?: VueConstructor<Vue>;
+    store?: TStore;
+    router?: VueRouter;
+    ssrContext?: QSsrContext | null;
+}
+
+export type BootFile = (params: BootFileParams) => void

--- a/ui/types/boot.d.ts
+++ b/ui/types/boot.d.ts
@@ -11,11 +11,9 @@ export interface QSsrContext {
 }
 
 export interface BootFileParams<TStore = any> {
-    app?: Vue;
-    Vue?: VueConstructor<Vue>;
-    store?: TStore;
-    router?: VueRouter;
+    app: Vue;
+    Vue: VueConstructor<Vue>;
+    store: TStore;
+    router: VueRouter;
     ssrContext?: QSsrContext | null;
 }
-
-export type BootFile = (params: BootFileParams) => void

--- a/ui/types/globals.d.ts
+++ b/ui/types/globals.d.ts
@@ -1,0 +1,7 @@
+export interface QVueGlobals {
+    version: string;
+    lang: any;
+    iconSet: any;
+    electron: any;
+    cordova: any;
+}


### PR DESCRIPTION
Add missing type definitions to Quasar.  In addtion to fixing #4877, I reviewed the [Vue Prototype Injects](https://quasar.dev/options/vue-prototype-injections#Introduction) and added any additional missing properties to $q which included: version, lang, iconSet, electron, and cordova. 

Also added type defintions for Bootfile and it's parameters.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

