### PR TITLE
fix: Wrong QButton text align on long texts #4871

### DIFF
--- a/docs/src/examples/QBtn/ButtonContentClassStyle.vue
+++ b/docs/src/examples/QBtn/ButtonContentClassStyle.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="q-pa-md q-gutter-sm">
+    <q-btn align="left" class="full-width" :content-style="{ textAlign: 'justify' }" color="primary" label="Justified text - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+    <q-btn align="left" class="full-width" :content-style="{ color: 'yellow', textAlign: 'right' }" color="primary" label="Right aligned text - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+    <q-btn align="left" class="full-width" content-class="text-left" color="primary" label="Left aligned text - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+  </div>
+</template>
+
+<style lang="stylus" scoped>
+.btn-fixed-width
+  width 200px
+</style>

--- a/docs/src/pages/vue-components/button.md
+++ b/docs/src/pages/vue-components/button.md
@@ -34,6 +34,10 @@ When not disabled or spinning, QBtn emits a `@click` event, as soon as it is cli
 
 <doc-example title="Button size" file="QBtn/ButtonSize" />
 
+The `content-class` and `content-style` properties are applied directly to the content of the `label` property. In normal circumstances, you do not need to use these properties. However, under certain conditions, you may need to apply them. One such case is when the length of the label text in the button wraps.
+
+<doc-example title="Button content class & style" file="QBtn/ButtonContentClassStyle" />
+
 ### Progress related
 
 Some button actions involve contacting a server, so an asynchronous response. It’s best that you inform the user about a background process taking place until the asynchronous response is ready. QBtn offers this possibility through the `loading` prop. This property will display a QSpinner (by default) instead of the icon and/or label of the button. Custom loading content can also be used (not only text or spinners).

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -18,7 +18,10 @@ export default Vue.extend({
       type: Number,
       validator: v => v >= 0 && v <= 100
     },
-    darkPercentage: Boolean
+    darkPercentage: Boolean,
+
+    contentClass: [Array, String, Object],
+    contentStyle: [Array, String, Object]
   },
 
   computed: {
@@ -147,7 +150,10 @@ export default Vue.extend({
 
     if (this.hasLabel === true) {
       inner.unshift(
-        h('div', [ this.label ])
+        h('div', {
+          class: this.contentClass,
+          style: this.contentStyle
+        }, [ this.label ])
       )
     }
 

--- a/ui/src/components/btn/QBtn.json
+++ b/ui/src/components/btn/QBtn.json
@@ -17,6 +17,26 @@
       "type": "Boolean",
       "desc": "Progress bar on the background should have dark color; To be used along with 'percentage' and 'loading' props",
       "category": "behavior"
+    },
+
+    "content-style": {
+      "type": [ "Array", "String", "Object" ],
+      "desc": "Style definitions to be attributed to the label",
+      "examples": [
+        "text-align: justify",
+        ":content-style=\"{ textAlign: 'justify' }\""
+      ],
+      "category": "style"
+    },
+
+    "content-class": {
+      "type": [ "Array", "String", "Object" ],
+      "desc": "Class definitions to be attributed to the label",
+      "examples": [
+        "text-left",
+        ":content-class=\"{ 'text-left': <condition> }\""
+      ],
+      "category": "style"
     }
   },
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
![image](https://user-images.githubusercontent.com/10262924/62946567-2c772900-bd9e-11e9-9b0f-71b60c28cb43.png)
