### PR TITLE
Fix: correctly applies content-style on QScrollArea root elements

### DIFF
--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -263,6 +263,7 @@ export default Vue.extend({
 
     return h('div', {
       staticClass: 'q-scrollarea',
+      style: this.contentStyle,
       on: {
         mouseenter: () => { this.hover = true },
         mouseleave: () => { this.hover = false }


### PR DESCRIPTION
Add's static style (content-style prop) to the root element, when it's on desktop. Otherwise, style cannot be applied to the root element.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No