### PR TITLE
fix(app): generator improperly using fs.existsSync

### DIFF
--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -1,5 +1,5 @@
 const
-  fs = require('fs'),
+  fs = require('fs-extra'),
   path = require('path'),
   compileTemplate = require('lodash.template')
 
@@ -48,10 +48,16 @@ class Generator {
     log(`Generating Webpack entry point`)
     const data = this.quasarConfig.getBuildConfig()
 
-    // ensure .quasar folder
-    if (!fs.existsSync(quasarFolder)){
-      fs.mkdirSync(quasarFolder)
-    }
+    // ensure .quasar folder and that it is NOT a file
+    fs.existsSync(quasarFolder, (exists) => {
+      if (exists) { // somehow its a file, not a folder
+        fs.remove(quasarFolder).then(() => {
+          fs.ensureDirSync(quasarFolder)
+        })
+      } else {
+        fs.ensureDirSync(quasarFolder)
+      }
+    })
 
     this.files.forEach(file => {
       fs.writeFileSync(file.dest, file.template(data), 'utf-8')

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -1,5 +1,5 @@
 const
-  fs = require('fs-extra'),
+  fs = require('fs'),
   path = require('path'),
   compileTemplate = require('lodash.template')
 
@@ -48,16 +48,15 @@ class Generator {
     log(`Generating Webpack entry point`)
     const data = this.quasarConfig.getBuildConfig()
 
-    // ensure .quasar folder and that it is NOT a file
-    fs.existsSync(quasarFolder, (exists) => {
-      if (exists) { // somehow its a file, not a folder
-        fs.remove(quasarFolder).then(() => {
-          fs.ensureDirSync(quasarFolder)
-        })
-      } else {
-        fs.ensureDirSync(quasarFolder)
-      }
-    })
+    // ensure .quasar folder
+    if (!fs.existsSync(quasarFolder)) {
+      fs.mkdirSync(quasarFolder)
+    }
+    else if (!fs.lstatSync(quasarFolder).isDirectory()) {
+      const { removeSync } = require('fs-extra')
+      removeSync(quasarFolder)
+      fs.mkdirSync(quasarFolder)
+    }
 
     this.files.forEach(file => {
       fs.writeFileSync(file.dest, file.template(data), 'utf-8')


### PR DESCRIPTION
I stumbled across this while preparing the `tauri` merge. The issue is that `fs.existsSync` is there to detect if a FILE exists, not a folder. This is an edge case that shouldn't ever occur, except for cases where the operator makes a mistake or an app-extension / something else is being a bad actor. This PR remediates the improper call and catches this wild edge case, deleting the file that has no reason for existence and then safely creating the folder. 

Note: if .quasar is a folder, nothing changes from current behavior.

I am filing this as a separate PR, because it shouldn't get lost in the maze of commits and changes from the tauri work.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] It's been tested on a Tauri app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
