### PR TITLE
fix(devserver) Remove "prod" requirement for using publicPath

### DIFF
--- a/app/lib/quasar-config.js
+++ b/app/lib/quasar-config.js
@@ -376,6 +376,7 @@ class QuasarConfig {
       webpackManifest: this.ctx.prod,
       vueRouterMode: 'hash',
       preloadChunks: true,
+      forceDevPublicPath: false,
       // transpileDependencies: [], // leaving here for completeness
       devtool: this.ctx.dev
         ? '#cheap-module-eval-source-map'
@@ -474,7 +475,7 @@ class QuasarConfig {
     }
 
     cfg.build.publicPath =
-      this.ctx.prod && cfg.build.publicPath && ['spa', 'pwa'].includes(this.ctx.modeName)
+      (this.ctx.prod || cfg.build.forceDevPublicPath) && cfg.build.publicPath && ['spa', 'pwa'].includes(this.ctx.modeName)
         ? formatPublicPath(cfg.build.publicPath)
         : (cfg.build.vueRouterMode !== 'hash' ? '/' : '')
 
@@ -711,7 +712,7 @@ class QuasarConfig {
       }
     }
     else {
-      cfg.build.env.__statics = `"${this.ctx.dev ? '/' : cfg.build.publicPath || '/'}statics"`
+      cfg.build.env.__statics = `"${((this.ctx.prod || cfg.build.forceDevPublicPath) && cfg.build.publicPath) ? cfg.build.publicPath : '/' }statics"`
     }
 
     appFilesValidations(cfg)

--- a/docs/src/pages/quasar-cli/quasar-conf-js.md
+++ b/docs/src/pages/quasar-cli/quasar-conf-js.md
@@ -209,7 +209,7 @@ devServer: {
 | afterBuild({ quasarConf }) | Function | Run hook after Quasar built app for production (`$ quasar build`). At this point, the distributables folder has been created and is available should you wish to do something with it. Can use async/await or directly return a Promise. |
 | onPublish(opts) | Function | Run hook if publishing was requested (`$ quasar build -P`), after Quasar built app for production and the afterBuild hook (if specified) was executed. Can use async/await or directly return a Promise. `opts` is Object of form `{arg, distDir}`, where "arg" is the argument supplied (if any) to -P parameter. |
 | publicPath | String | Public path of your app. By default, it uses the root. Use it when your public path is something else, like "&lt;protocol&gt;://&lt;domain&gt;/some/nested/folder" -- in this case, it means the distributables are in "some/nested/folder" on your webserver. |
-| forceDevPublicPath | Boolean | Force use of public path in dev builds. By default, dev uses `/` for the public path. Use this setting to force use of `publicPath` for `base` tag and `statics` folder. |
+| forceDevPublicPath | Boolean | Force use of the custom publicPath in dev builds also (only for SPA and PWA modes). Make sure that you know what you are doing. |
 | vueRouterMode | String | Sets [Vue Router mode](https://router.vuejs.org/en/essentials/history-mode.html): 'hash' or 'history'. Pick wisely. History mode requires configuration on your deployment web server too. |
 | htmlFilename | String | Default is 'index.html'. |
 | productName | String | Default value is taken from package.json > productName field. |

--- a/docs/src/pages/quasar-cli/quasar-conf-js.md
+++ b/docs/src/pages/quasar-cli/quasar-conf-js.md
@@ -209,6 +209,7 @@ devServer: {
 | afterBuild({ quasarConf }) | Function | Run hook after Quasar built app for production (`$ quasar build`). At this point, the distributables folder has been created and is available should you wish to do something with it. Can use async/await or directly return a Promise. |
 | onPublish(opts) | Function | Run hook if publishing was requested (`$ quasar build -P`), after Quasar built app for production and the afterBuild hook (if specified) was executed. Can use async/await or directly return a Promise. `opts` is Object of form `{arg, distDir}`, where "arg" is the argument supplied (if any) to -P parameter. |
 | publicPath | String | Public path of your app. By default, it uses the root. Use it when your public path is something else, like "&lt;protocol&gt;://&lt;domain&gt;/some/nested/folder" -- in this case, it means the distributables are in "some/nested/folder" on your webserver. |
+| forceDevPublicPath | Boolean | Force use of public path in dev builds. By default, dev uses `/` for the public path. Use this setting to force use of `publicPath` for `base` tag and `statics` folder. |
 | vueRouterMode | String | Sets [Vue Router mode](https://router.vuejs.org/en/essentials/history-mode.html): 'hash' or 'history'. Pick wisely. History mode requires configuration on your deployment web server too. |
 | htmlFilename | String | Default is 'index.html'. |
 | productName | String | Default value is taken from package.json > productName field. |


### PR DESCRIPTION
This PR allows `publicPath` and the `base` tag to work on dev builds. It is used in conjunction with webpackDevServer publicPath.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No



Fixes #4840, #4687 

**quasar.conf.js**
```javascript
    build: {
      publicPath: '/path/to/app1/', 
      forceDevPublicPath: true, // this allows publicPath to work in dev and prod builds
      vueRouterMode: 'history',
    },

    devServer: {
      publicPath: '/app1/', // this can match the publicPath from above or be part of the subpath. If using a proxy, set it to match.
    },
```
