### PR TITLE
Fix language formats

### DIFF
--- a/app/templates/ssr/index.js
+++ b/app/templates/ssr/index.js
@@ -50,7 +50,7 @@ app.get('*', (req, res) => {
   // and potentially look here for inspiration:
   // https://ponyfoo.com/articles/content-security-policy-in-express-apps
 
-  // https://developer.mozilla.org/en-us/docs/Web/HTTP/Headers/X-Frame-Options
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
   // res.setHeader('X-frame-options', 'SAMEORIGIN') // one of DENY | SAMEORIGIN | ALLOW-FROM https://example.com
 
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

--- a/docs/src-ssr/index.js
+++ b/docs/src-ssr/index.js
@@ -42,7 +42,7 @@ extension.extendApp({ app })
 // this should be last get(), rendering with SSR
 app.get('*', (req, res) => {
   res.setHeader('Content-Type', 'text/html')
-  // https://developer.mozilla.org/en-us/docs/Web/HTTP/Headers/X-Frame-Options
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
   res.setHeader('X-frame-options', 'SAMEORIGIN')
 
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

--- a/docs/src/pages/options/quasar-language-packs.md
+++ b/docs/src/pages/options/quasar-language-packs.md
@@ -20,7 +20,7 @@ For a complete list of available Quasar Languages, check [Quasar Languages on Gi
 
 ## Configuring the default Language Pack
 
-Unless configured otherwise (see below), Quasar uses the `en-us` Language Pack by default.
+Unless configured otherwise (see below), Quasar uses the `en-US` Language Pack by default.
 
 ### Hardcoded Default Language Pack
 If the default Quasar Language Pack is not dynamically determined (does not depends on cookies for example), then you can:
@@ -62,7 +62,7 @@ Include the language pack JS tag for your Quasar version and also tell Quasar to
 </script>
 ```
 
-Check what tags you need to include in your HTML files by generating a sample with `$ quasar create <folder> --kit umd` and specifying a language code for Quasar Language Pack (other than the default "en-us").
+Check what tags you need to include in your HTML files by generating a sample with `$ quasar create <folder> --kit umd` and specifying a language code for Quasar Language Pack (other than the default "en-US").
 
 ### Dynamically Picking Default Language
 Quasar CLI: If your desired Quasar Language Pack must be dynamically selected (example: depends on a cookie), then you need to create a boot file: `$ quasar new boot quasar-lang-pack`. This will create `/src/boot/quasar-lang-pack.js` file. Edit it to:

--- a/docs/src/pages/start/umd.md
+++ b/docs/src/pages/start/umd.md
@@ -48,13 +48,13 @@ UMD is all about adding Quasar style and javascript tags. This is a full list. C
   <script src="https://cdn.jsdelivr.net/npm/quasar@^1.0.3/dist/quasar.umd.min.js"></script>
 
   <!--
-    If you want to add a Quasar Language pack (other than "en-us").
-    Notice "pt-br" in "i18n.pt-br.umd.min.js" for Brazilian Portuguese language pack.
+    If you want to add a Quasar Language pack (other than "en-US").
+    Notice "pt-BR" in "i18n.pt-BR.umd.min.js" for Brazilian Portuguese language pack.
     Replace version below (1.0.0-beta.0) with your desired version of Quasar.
     Also check final <script> tag below to enable the language
     Language pack list: https://github.com/quasarframework/quasar/tree/dev/ui/lang
   -->
-  <script src="https://cdn.jsdelivr.net/npm/quasar@^1.0.3/dist/lang/pt-br.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/quasar@^1.0.3/dist/lang/pt-BR.umd.min.js"></script>
 
   <!--
     If you want to make Quasar components (not your own) use a specific set of icons (unless you're using Material Icons already).
@@ -64,7 +64,7 @@ UMD is all about adding Quasar style and javascript tags. This is a full list. C
   <script src="https://cdn.jsdelivr.net/npm/quasar@^1.0.3/dist/icon-set/fontawesome-v5.umd.min.js"></script>
 
   <script>
-    // if using a Quasar language pack other than the default "en-us";
+    // if using a Quasar language pack other than the default "en-US";
     // requires the language pack style tag from above
     Quasar.lang.set(Quasar.lang.ptBr) // notice camel-case "ptBr"
 
@@ -217,7 +217,7 @@ Quasar.iconSet.set(Quasar.iconSet.fontawesomeV5)
 The list of available [Quasar Icon Sets](/options/quasar-icon-sets) can be found on [GitHub](https://github.com/quasarframework/quasar/tree/dev/ui/icon-set).
 
 ### Changing Quasar Language Pack
-Assuming you have already included the CDN link to your desired Quasar I18n Language (unless you want "en-us" language pack which is used by default), you can then tell Quasar to use it:
+Assuming you have already included the CDN link to your desired Quasar I18n Language (unless you want "en-US" language pack which is used by default), you can then tell Quasar to use it:
 
 ```js
 // example setting German language,

--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -252,7 +252,7 @@ The dist folder now strips out the `-mat` and `-ios` suffixes because there's on
 ### Misc
 
 - `this.$q.i18n` was changed to `this.$q.lang`
-- ```import(`quasar-framework/i18n/${lang}`)``` was changed to ```import(`quasar/lang/${lang}`)``` where `${lang}` would be `en-us` etc.
+- ```import(`quasar-framework/i18n/${lang}`)``` was changed to ```import(`quasar/lang/${lang}`)``` where `${lang}` would be `en-US` etc.
 - `this.$q.icons` was changed to `this.$q.iconSet`
 - In previous versions you would access an imported language packs isoName with:
 

--- a/docs/src/pages/vue-components/table.md
+++ b/docs/src/pages/vue-components/table.md
@@ -89,7 +89,7 @@ columns: [ // array of Objects
 <doc-example title="Dense" file="QTable/Dense" />
 
 ::: tip
-You can use the `dense` prop along with `$q.screen` to create a responsive behavior. Example: `:dense="$q.screen.lt.md`. More info: [Screen Plugin](/options/screen-plugin).
+You can use the `dense` prop along with `$q.screen` to create a responsive behavior. Example: `:dense="$q.screen.lt.md"`. More info: [Screen Plugin](/options/screen-plugin).
 :::
 
 ### Sticky header/column

--- a/ui/dev/App.vue
+++ b/ui/dev/App.vue
@@ -9,7 +9,7 @@
     >
       <q-btn dense flat size="sm" icon="visibility" @click="showSelector = !showSelector" class="absolute-top-right z-top" />
       <template v-if="showSelector">
-        <q-btn dense flat size="sm" :icon="lang === 'he' ? 'navigate_before' : 'navigate_next'" @click="lang = lang === 'en-us' ? 'he' : 'en-us'" class="absolute-bottom-right z-top" />
+        <q-btn dense flat size="sm" :icon="lang === 'he' ? 'navigate_before' : 'navigate_next'" @click="lang = lang === 'en-US' ? 'he' : 'en-US'" class="absolute-bottom-right z-top" />
         <q-select
           label="Quasar Language"
           dense

--- a/ui/dev/spa.index.html
+++ b/ui/dev/spa.index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta name="format-detection" content="telephone=no">

--- a/ui/lang/en-GB.js
+++ b/ui/lang/en-GB.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'en-gb',
+  isoName: 'en-GB',
   nativeName: 'English (UK)',
   label: {
     clear: 'Clear',

--- a/ui/lang/en-US.js
+++ b/ui/lang/en-US.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'en-us',
+  isoName: 'en-US',
   nativeName: 'English (US)',
   label: {
     clear: 'Clear',

--- a/ui/lang/index.json
+++ b/ui/lang/index.json
@@ -28,11 +28,11 @@
     "nativeName": "ελληνικά"
   },
   {
-    "isoName": "en-gb",
+    "isoName": "en-GB",
     "nativeName": "English (UK)"
   },
   {
-    "isoName": "en-us",
+    "isoName": "en-US",
     "nativeName": "English (US)"
   },
   {
@@ -44,7 +44,7 @@
     "nativeName": "Español"
   },
   {
-    "isoName": "fa-ir",
+    "isoName": "fa-IR",
     "nativeName": "فارسی"
   },
   {
@@ -88,7 +88,7 @@
     "nativeName": "ខ្មែរ"
   },
   {
-    "isoName": "ko-kr",
+    "isoName": "ko-KR",
     "nativeName": "한국어"
   },
   {
@@ -108,7 +108,7 @@
     "nativeName": "Bahasa Melayu"
   },
   {
-    "isoName": "nb-no",
+    "isoName": "nb-NO",
     "nativeName": "Norsk"
   },
   {
@@ -120,7 +120,7 @@
     "nativeName": "Polski"
   },
   {
-    "isoName": "pt-br",
+    "isoName": "pt-BR",
     "nativeName": "Português (BR)"
   },
   {
@@ -168,11 +168,11 @@
     "nativeName": "Tiếng Việt"
   },
   {
-    "isoName": "zh-hans",
+    "isoName": "zh-CN",
     "nativeName": "中文(简体)"
   },
   {
-    "isoName": "zh-hant",
+    "isoName": "zh-TW",
     "nativeName": "中文(繁體)"
   }
 ]

--- a/ui/lang/ko-KR.js
+++ b/ui/lang/ko-KR.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'ko-kr',
+  isoName: 'ko-KR',
   nativeName: '한국어',
   label: {
     clear: '초기화',

--- a/ui/lang/nb-NO.js
+++ b/ui/lang/nb-NO.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'nb-no',
+  isoName: 'nb-NO',
   nativeName: 'Norsk',
   label: {
     clear: 'Tøm',

--- a/ui/lang/pt-BR.js
+++ b/ui/lang/pt-BR.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'pt-br',
+  isoName: 'pt-BR',
   nativeName: 'Português (BR)',
   label: {
     clear: 'Limpar',

--- a/ui/lang/zh-CN.js
+++ b/ui/lang/zh-CN.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'zh-hans',
+  isoName: 'zh-CN',
   nativeName: '中文(简体)',
   label: {
     clear: '清空',
@@ -22,7 +22,7 @@ export default {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
     monthsShort: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
     headerTitle: function (date) {
-      return new Intl.DateTimeFormat('zh-hans', {
+      return new Intl.DateTimeFormat('zh-CN', {
         weekday: 'short', month: 'short', day: 'numeric'
       }).format(date)
     },

--- a/ui/lang/zh-TW.js
+++ b/ui/lang/zh-TW.js
@@ -1,5 +1,5 @@
 export default {
-  isoName: 'zh-hant',
+  isoName: 'zh-TW',
   nativeName: '中文(繁體)',
   label: {
     clear: '清除',
@@ -22,7 +22,7 @@ export default {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
     monthsShort: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
     headerTitle: function (date) {
-      return new Intl.DateTimeFormat('zh-hant', {
+      return new Intl.DateTimeFormat('zh-TW', {
         weekday: 'short', month: 'short', day: 'numeric'
       }).format(date)
     },

--- a/ui/src/lang.js
+++ b/ui/src/lang.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-import langEn from '../lang/en-us.js'
+import langEn from '../lang/en-US.js'
 import { isSSR } from './plugins/Platform.js'
 
 export default {
@@ -60,7 +60,7 @@ export default {
       navigator.browserLanguage ||
       navigator.userLanguage ||
       navigator.systemLanguage
-    
+
     return val
   }
 }

--- a/ui/src/lang.js
+++ b/ui/src/lang.js
@@ -60,9 +60,7 @@ export default {
       navigator.browserLanguage ||
       navigator.userLanguage ||
       navigator.systemLanguage
-
-    if (val) {
-      return val.toLowerCase()
-    }
+    
+    return val
   }
 }


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:
**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [ ] It's been tested on a Tauri app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Navigator's language info should not be lowercased, cause a lot of repo like i18n , Electron language detector and browser navigator itself outputs no-lowercased language format like 'en-US','zh-TW','zh-CN'