### PR TITLE
feat(QSelect): Emit Vue popup-show/popup-hide events, fix inconsistency on blur

### DIFF
--- a/ui/dev/components/form/select-part-1.vue
+++ b/ui/dev/components/form/select-part-1.vue
@@ -195,7 +195,7 @@
       />
 
       <div class="text-h6">
-        Scoped Slot: option
+        Scoped Slot: option (with menu on icon)
       </div>
       <q-select
         v-bind="props"
@@ -209,8 +209,13 @@
             v-bind="scope.itemProps"
             v-on="scope.itemEvents"
           >
-            <q-item-section avatar>
+            <q-item-section avatar @click.stop>
               <q-icon tabindex="0" :name="scope.opt.icon" />
+              <q-menu v-if="scope.opt.disable !== true">
+                <div class="bg-yellow text-black q-pa-md">
+                  Test menu
+                </div>
+              </q-menu>
             </q-item-section>
             <q-item-section>
               <q-item-label v-html="scope.opt.label" />

--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -269,7 +269,10 @@ export default Vue.extend({
     __render (h) {
       const on = {
         ...this.$listeners,
-        input: stop
+        // stop propagating this events from children
+        input: stop,
+        'popup-show': stop,
+        'popup-hide': stop
       }
 
       if (this.autoClose === true) {

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -382,11 +382,15 @@ export default Vue.extend({
     },
 
     __onControlPopupShow (e) {
+      e !== void 0 && stop(e)
+      this.$emit('popup-show', e)
       this.hasPopupOpen = true
       this.__onControlFocusin(e)
     },
 
     __onControlPopupHide (e) {
+      e !== void 0 && stop(e)
+      this.$emit('popup-hide', e)
       this.hasPopupOpen = false
       this.__onControlFocusout(e)
     },

--- a/ui/src/components/field/QField.json
+++ b/ui/src/components/field/QField.json
@@ -63,6 +63,32 @@
     }
   },
 
+  "events": {
+    "popup-show": {
+      "desc": "Emitted if the field has a menu or dialog child when the menu or dialog is shown.",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "addedIn": "v1.1.3"
+    },
+
+    "popup-hide": {
+      "desc": "Emitted if the field has a menu or dialog child when the menu or dialog is hidden.",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "addedIn": "v1.1.3"
+    }
+  },
+
   "methods": {
     "focus": {
       "desc": "Focus field"

--- a/ui/src/components/field/QField.json
+++ b/ui/src/components/field/QField.json
@@ -63,32 +63,6 @@
     }
   },
 
-  "events": {
-    "popup-show": {
-      "desc": "Emitted if the field has a menu or dialog child when the menu or dialog is shown.",
-      "params": {
-        "evt": {
-          "type": "Object",
-          "desc": "JS event object",
-          "__exemption": [ "examples" ]
-        }
-      },
-      "addedIn": "v1.1.3"
-    },
-
-    "popup-hide": {
-      "desc": "Emitted if the field has a menu or dialog child when the menu or dialog is hidden.",
-      "params": {
-        "evt": {
-          "type": "Object",
-          "desc": "JS event object",
-          "__exemption": [ "examples" ]
-        }
-      },
-      "addedIn": "v1.1.3"
-    }
-  },
-
   "methods": {
     "focus": {
       "desc": "Focus field"

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -235,7 +235,10 @@ export default Vue.extend({
     __render (h) {
       const on = {
         ...this.$listeners,
-        input: stop
+        // stop propagating this events from children
+        input: stop,
+        'popup-show': stop,
+        'popup-hide': stop
       }
 
       if (this.autoClose === true) {

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -327,7 +327,7 @@ export default Vue.extend({
         return
       }
 
-      this.dialogFieldFocused === true && this.__focus()
+      (this.hasDialog !== true || this.dialogFieldFocused === true) && this.__focus()
 
       if (this.innerValue.length === 0) {
         const val = this.emitValue === true ? optValue : opt
@@ -844,6 +844,9 @@ export default Vue.extend({
         focusout,
         'popup-show': this.__onControlPopupShow,
         'popup-hide': e => {
+          e !== void 0 && stop(e)
+          this.$emit('popup-hide', e)
+          this.hasDialog !== true && this.__focus()
           this.hasPopupOpen = false
           focusout(e)
         },


### PR DESCRIPTION
- stop propagation of native popup-show/hide from inside another popup
- QSelect - fix inconsistency where:
-- if you open list of options and click outside the QSelect stays focused
-- if it is single selection and you select an option the QSelect is unfocused
-- if it is multiple selection and you clicked on an option and then click outside the QSelect is unfocused