### PR TITLE
fix(QMenu): Don't use touch-position when the opening event does not have position (kbd)

### DIFF
--- a/ui/dev/components/components/popup-proxy.vue
+++ b/ui/dev/components/components/popup-proxy.vue
@@ -5,7 +5,7 @@
         Width {{ $q.screen.width }} --> {{ type }}
       </h6>
 
-      <div class="popup-surface-test">
+      <div class="popup-surface-test" tabindex="0">
         <div>Handles click</div>
 
         <q-popup-proxy>
@@ -23,7 +23,7 @@
         </q-popup-proxy>
       </div>
 
-      <div class="popup-surface-test">
+      <div class="popup-surface-test" tabindex="0">
         <div>Handles click - touch position</div>
 
         <q-popup-proxy touch-position>
@@ -41,10 +41,27 @@
         </q-popup-proxy>
       </div>
 
-      <div class="popup-surface-test">
+      <div class="popup-surface-test" tabindex="0">
         <div>Handles right-click (context)</div>
 
         <q-popup-proxy context-menu>
+          <q-banner>
+            <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
+
+            <input v-model="text">
+            You have lost connection to the internet. This app is offline.
+            <q-btn label="Close" v-close-popup />
+            <div>Popup text.</div>
+
+            <q-btn slot="action" flat color="primary" label="close" v-close-popup />
+          </q-banner>
+        </q-popup-proxy>
+      </div>
+
+      <div class="popup-surface-test" tabindex="0">
+        <div>Handles right-click (context) - touch position</div>
+
+        <q-popup-proxy context-menu touch-position>
           <q-banner>
             <q-icon slot="avatar" name="signal_wifi_off" color="primary" />
 

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -121,7 +121,12 @@ export default Vue.extend({
 
       const { top, left } = this.anchorEl.getBoundingClientRect()
 
-      if (evt !== void 0 && (this.touchPosition || this.contextMenu)) {
+      if (
+        evt !== void 0 &&
+        evt.clientX !== void 0 &&
+        evt.clientY !== void 0 &&
+        (this.touchPosition || this.contextMenu)
+      ) {
         const pos = position(evt)
         this.absoluteOffset = { left: pos.left - left, top: pos.top - top }
       }


### PR DESCRIPTION
close #5108