### PR TITLE
fix(focus related): QBtn, QMenu, ClickOutside, QSelect, Ripple

### DIFF
--- a/ui/dev/components/other/focus-tests.vue
+++ b/ui/dev/components/other/focus-tests.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="q-layout-padding">
-    <div tabindex="0" style="height: 20vh">
+    <div tabindex="0" class="q-pa-lg text-center" style="height: 20vh">
       Focus placeholder
     </div>
-    <q-field label="Field 1 (using popup proxy)">
+    <q-field label="Field 1 (using q-popup-proxy)">
       <template v-slot:control>
         <div class="self-center full-width no-outline" tabindex="0" />
       </template>
@@ -11,39 +11,134 @@
         <q-card>
           <q-card-section>
             Hi from q-popup-proxy
+            <div tabindex="0" class="q-pa-lg text-center">
+              Focus placeholder
+            </div>
           </q-card-section>
           <q-card-actions>
-            <q-btn v-close-popup autofocus>
-              Close
+            <q-btn :type="btnType" v-close-popup autofocus>
+              Close Popup
+            </q-btn>
+            <q-btn :type="btnType" @click="show = true">
+              Open dialog
             </q-btn>
           </q-card-actions>
         </q-card>
       </q-popup-proxy>
     </q-field>
-    <div tabindex="0" style="height: 20vh">
+    <q-field label="Field 1 (using q-menu)">
+      <template v-slot:control>
+        <div class="self-center full-width no-outline" tabindex="0" />
+      </template>
+      <q-menu>
+        <q-card>
+          <q-card-section>
+            Hi from q-menu
+            <div tabindex="0" class="q-pa-lg text-center">
+              Focus placeholder
+            </div>
+          </q-card-section>
+          <q-card-actions>
+            <q-btn :type="btnType" v-close-popup autofocus>
+              Close Menu
+            </q-btn>
+            <q-btn :type="btnType" @click="show = true">
+              Open dialog
+            </q-btn>
+          </q-card-actions>
+        </q-card>
+      </q-menu>
+    </q-field>
+    <div tabindex="0" class="q-pa-lg text-center" style="height: 20vh">
       Focus placeholder
     </div>
     <div>
-      <q-btn @click="show = true">
+      <q-btn :type="btnType" @click="show = true">
         Open dialog
       </q-btn>
 
-      <q-btn>
+      <q-btn :type="btnType">
         Just click
       </q-btn>
+
+      <q-toggle v-model="show" label="Toggle dialog" />
+      <q-toggle v-model="toggle" label="Toggle nothing" />
+      <q-checkbox v-model="forceA" :label="forceALabel" />
     </div>
-    <div tabindex="0" style="height: 20vh">
+    <div tabindex="0" class="q-pa-lg text-center" style="height: 20vh">
       Focus placeholder
+    </div>
+    <div class="row q-gutter-sm">
+      <q-btn :type="btnType" label="Show QSelect" @click="$refs.sel.showPopup()" />
+      <q-checkbox v-model="forceMenu" toggle-indeterminate :label="forceMenuLabel" />
+      <q-select
+        class="col"
+        filled
+        ref="sel"
+        v-model="model"
+        label="QSelect"
+        :options="options"
+        style="max-width: 450px"
+        clearable
+        :behavior="behavior"
+      >
+        <template v-slot:no-option>
+          <q-item>
+            <q-item-section class="text-grey">
+              No results
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
     </div>
 
     <q-dialog v-model="show">
       <q-card>
         <q-card-section>
           Hi from q-dialog
+          <div tabindex="0" class="q-pa-lg text-center">
+            Focus placeholder
+          </div>
+          <div tabindex="0" class="q-pa-lg text-center">
+            Open popup proxy
+            <q-popup-proxy>
+              <q-card>
+                <q-card-section>
+                  Hi from q-popup-proxy
+                  <div tabindex="0" class="q-pa-lg text-center">
+                    Focus placeholder
+                  </div>
+                </q-card-section>
+                <q-card-actions>
+                  <q-btn :type="btnType" v-close-popup autofocus>
+                    Close Popup
+                  </q-btn>
+                </q-card-actions>
+              </q-card>
+            </q-popup-proxy>
+          </div>
+          <div tabindex="0" class="q-pa-lg text-center">
+            Open menu
+            <q-menu>
+              <q-card>
+                <q-card-section>
+                  Hi from q-menu
+                  <div tabindex="0" class="q-pa-lg text-center">
+                    Focus placeholder
+                  </div>
+                </q-card-section>
+                <q-card-actions>
+                  <q-btn :type="btnType" v-close-popup autofocus>
+                    Close Menu
+                  </q-btn>
+                </q-card-actions>
+              </q-card>
+            </q-menu>
+          </div>
         </q-card-section>
         <q-card-actions>
-          <q-btn @click="show = false" autofocus>
-            Close
+          <q-btn :type="btnType" @click="show = false" autofocus>
+            Close Dialog
           </q-btn>
         </q-card-actions>
       </q-card>
@@ -55,7 +150,36 @@
 export default {
   data () {
     return {
-      show: false
+      show: false,
+      toggle: false,
+      forceMenu: false,
+      forceA: false,
+      model: null,
+      options: [ 'Google', 'Facebook', 'Twitter', 'Apple', 'Oracle' ]
+    }
+  },
+
+  computed: {
+    behavior () {
+      return this.forceMenu === null
+        ? 'default'
+        : (this.forceMenu === true ? 'menu' : 'dialog')
+    },
+
+    forceMenuLabel () {
+      if (this.forceMenu === true) {
+        return 'Force menu'
+      }
+
+      return this.forceMenu === false ? 'Force dialog' : 'Based on platform'
+    },
+
+    btnType () {
+      return this.forceA === true ? 'a' : 'button'
+    },
+
+    forceALabel () {
+      return this.forceA === true ? 'Force A' : 'Force Button'
     }
   }
 }

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -5,8 +5,17 @@ import QSpinner from '../spinner/QSpinner.js'
 
 import BtnMixin from './btn-mixin.js'
 
+import Platform from '../../plugins/Platform.js'
+
 import slot from '../../utils/slot.js'
-import { stopAndPrevent } from '../../utils/event.js'
+import { stopAndPrevent, listenOpts } from '../../utils/event.js'
+
+const { passiveCapture } = listenOpts
+
+let
+  touchTarget = void 0,
+  keyboardTarget = void 0,
+  mouseTarget = void 0
 
 export default Vue.extend({
   name: 'QBtn',
@@ -24,40 +33,50 @@ export default Vue.extend({
   computed: {
     hasLabel () {
       return this.label !== void 0 && this.label !== null && this.label !== ''
+    },
+
+    computedRipple () {
+      if (this.ripple === false) {
+        return false
+      }
+
+      return Object.assign({ keyCodes: [] }, this.ripple === true ? {} : this.ripple)
     }
   },
 
   methods: {
     click (e) {
-      if (this.pressed === true) { return }
+      if (e.defaultPrevented === true) {
+        return
+      }
 
       if (e !== void 0) {
+        const el = document.activeElement
         // focus button if it came from ENTER on form
         // prevent the new submit (already done)
-        if (this.type === 'submit') {
-          const el = document.activeElement
-
-          if (
+        if (
+          this.type === 'submit' &&
+          (
+            (this.$q.platform.is.ie === true && (e.clientX < 0 || e.clientY < 0)) ||
             (
               el !== document.body &&
               this.$el.contains(el) === false &&
               // required for iOS and desktop Safari
               el.contains(this.$el) === false
-            ) ||
-            (this.$q.platform.is.ie === true && (e.clientX < 0 || e.clientY < 0))
-          ) {
-            stopAndPrevent(e)
-            this.$el.focus()
-            return
+            )
+          )
+        ) {
+          this.$el.focus()
+
+          const onClickCleanup = () => {
+            document.removeEventListener('keydown', stopAndPrevent, true)
+            document.removeEventListener('keyup', onClickCleanup, passiveCapture)
+            this.$el !== void 0 && this.$el.removeEventListener('blur', onClickCleanup, passiveCapture)
           }
-        }
 
-        if (e.qKeyEvent !== true && this.$refs.blurTarget !== void 0) {
-          this.$refs.blurTarget.focus()
-        }
-
-        if (e.defaultPrevented === true) {
-          return
+          document.addEventListener('keydown', stopAndPrevent, true)
+          document.addEventListener('keyup', onClickCleanup, passiveCapture)
+          this.$el.addEventListener('blur', onClickCleanup, passiveCapture)
         }
 
         this.hasRouterLink === true && stopAndPrevent(e)
@@ -80,49 +99,96 @@ export default Vue.extend({
 
     __onKeydown (e) {
       if ([13, 32].includes(e.keyCode) === true) {
-        // focus external button if the focus helper was focused before
-        this.$el.focus()
-
         stopAndPrevent(e)
 
-        if (this.pressed !== true) {
-          this.pressed = true
+        if (keyboardTarget !== this.$el) {
+          keyboardTarget !== void 0 && this.__cleanup()
+
+          // focus external button if the focus helper was focused before
+          this.$el.focus()
+
+          keyboardTarget = this.$el
           this.$el.classList.add('q-btn--active')
-          document.addEventListener('keyup', this.__onKeyupAbort)
+          document.addEventListener('keyup', this.__onPressEnd, true)
+          this.$el.addEventListener('blur', this.__onPressEnd, passiveCapture)
         }
       }
 
       this.$emit('keydown', e)
     },
 
-    __onKeyup (e) {
-      if ([13, 32].includes(e.keyCode) === true) {
-        this.__onKeyupAbort()
+    __onTouchstart (e) {
+      if (touchTarget !== this.$el) {
+        touchTarget !== void 0 && this.__cleanup()
 
-        // for click trigger
-        const evt = new MouseEvent('click', e)
-        evt.qKeyEvent = true
-        e.defaultPrevented === true && evt.preventDefault()
-        this.$el.dispatchEvent(evt)
-
-        stopAndPrevent(e)
-
-        // for ripple
-        e.qKeyEvent = true
+        touchTarget = e.target
+        touchTarget.addEventListener('touchcancel', this.__onPressEnd, passiveCapture)
+        touchTarget.addEventListener('touchend', this.__onPressEnd, passiveCapture)
       }
 
-      this.$emit('keyup', e)
+      this.$emit('touchstart', e)
     },
 
-    __onKeyupAbort () {
-      this.pressed = false
-      document.removeEventListener('keyup', this.__onKeyupAbort)
-      this.$el && this.$el.classList.remove('q-btn--active')
+    __onMousedown (e) {
+      if (mouseTarget !== this.$el) {
+        mouseTarget !== void 0 && this.__cleanup()
+
+        mouseTarget = this.$el
+        document.addEventListener('mouseup', this.__onPressEnd, passiveCapture)
+      }
+
+      this.$emit('mousedown', e)
+    },
+
+    __onPressEnd (e) {
+      if (e !== void 0 && e.type === 'keyup') {
+        if (keyboardTarget === this.$el && [13, 32].includes(e.keyCode) === true) {
+          // for click trigger
+          const evt = new MouseEvent('click', e)
+          evt.qKeyEvent = true
+          e.defaultPrevented === true && evt.preventDefault()
+          this.$el.dispatchEvent(evt)
+
+          stopAndPrevent(e)
+
+          // for ripple
+          e.qKeyEvent = true
+        }
+
+        this.$emit('keyup', e)
+      }
+
+      this.__cleanup()
+    },
+
+    __cleanup () {
+      if (
+        (touchTarget === this.$el || mouseTarget === this.$el) &&
+        this.$refs.blurTarget !== void 0 &&
+        this.$refs.blurTarget !== document.activeElement
+      ) {
+        this.$refs.blurTarget.focus()
+      }
+      if (touchTarget === this.$el) {
+        touchTarget.removeEventListener('touchcancel', this.__onPressEnd, passiveCapture)
+        touchTarget.removeEventListener('touchend', this.__onPressEnd, passiveCapture)
+        touchTarget = void 0
+      }
+      if (mouseTarget === this.$el) {
+        document.removeEventListener('mouseup', this.__onPressEnd, passiveCapture)
+        mouseTarget = void 0
+      }
+      if (keyboardTarget === this.$el) {
+        document.removeEventListener('keyup', this.__onPressEnd, true)
+        this.$el !== void 0 && this.$el.removeEventListener('blur', this.__onPressEnd, passiveCapture)
+        keyboardTarget = void 0
+      }
+      this.$el !== void 0 && this.$el.classList.remove('q-btn--active')
     }
   },
 
   beforeDestroy () {
-    document.removeEventListener('keyup', this.__onKeyupAbort)
+    this.__cleanup()
   },
 
   render (h) {
@@ -140,13 +206,17 @@ export default Vue.extend({
         ...this.$listeners,
         click: this.click,
         keydown: this.__onKeydown,
-        keyup: this.__onKeyup
+        mousedown: this.__onMousedown
+      }
+
+      if (Platform.has.touch === true) {
+        data.on.touchstart = this.__onTouchstart
       }
 
       if (this.ripple !== false) {
         data.directives = [{
           name: 'ripple',
-          value: this.ripple,
+          value: this.computedRipple,
           modifiers: { center: this.isRound }
         }]
       }

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -36,11 +36,12 @@ export default Vue.extend({
     },
 
     computedRipple () {
-      if (this.ripple === false) {
-        return false
-      }
-
-      return Object.assign({ keyCodes: [] }, this.ripple === true ? {} : this.ripple)
+      return this.ripple === false
+        ? false
+        : Object.assign(
+          { keyCodes: [] },
+          this.ripple === true ? {} : this.ripple
+        )
     }
   },
 

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -170,20 +170,24 @@ export default Vue.extend({
       ) {
         this.$refs.blurTarget.focus()
       }
+
       if (touchTarget === this.$el) {
         touchTarget.removeEventListener('touchcancel', this.__onPressEnd, passiveCapture)
         touchTarget.removeEventListener('touchend', this.__onPressEnd, passiveCapture)
         touchTarget = void 0
       }
+
       if (mouseTarget === this.$el) {
         document.removeEventListener('mouseup', this.__onPressEnd, passiveCapture)
         mouseTarget = void 0
       }
+
       if (keyboardTarget === this.$el) {
         document.removeEventListener('keyup', this.__onPressEnd, true)
         this.$el !== void 0 && this.$el.removeEventListener('blur', this.__onPressEnd, passiveCapture)
         keyboardTarget = void 0
       }
+
       this.$el !== void 0 && this.$el.classList.remove('q-btn--active')
     }
   },

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -155,7 +155,16 @@ export default Vue.extend({
       this.__anchorCleanup(true)
 
       // check null for IE
-      if (this.__refocusTarget !== void 0 && this.__refocusTarget !== null) {
+      if (
+        this.__refocusTarget !== void 0 &&
+        this.__refocusTarget !== null &&
+        (
+          // menu was hidden from code or ESC plugin
+          evt === void 0 ||
+          // menu was not closed from a mouse or touch clickOutside
+          evt.qClickOutside !== true
+        )
+      ) {
         this.__refocusTarget.focus()
       }
 
@@ -233,8 +242,17 @@ export default Vue.extend({
 
     __onClickOutside (e) {
       if (this.persistent !== true && this.showing === true) {
+        const targetClassList = e.target.classList
+
         this.hide(e)
-        stopAndPrevent(e)
+        if (
+          // always prevent touch event
+          e.type === 'touchstart' ||
+          // prevent click if it's on a dialog backdrop
+          targetClassList.contains('q-dialog__backdrop')
+        ) {
+          stopAndPrevent(e)
+        }
         return true
       }
     },

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -645,7 +645,8 @@ export default Vue.extend({
       }
       else if (this.editable === true) {
         data = {
-          ref: 'target',
+          // there can be only one (when dialog is opened the control in dialog should be target)
+          ref: this.hasDialog === true && fromDialog !== true && this.menu === true ? void 0 : 'target',
           attrs: {
             tabindex: 0,
             autofocus: this.autofocus
@@ -870,7 +871,6 @@ export default Vue.extend({
         'popup-hide': e => {
           e !== void 0 && stop(e)
           this.$emit('popup-hide', e)
-          this.hasDialog !== true && this.__focus()
           this.hasPopupOpen = false
           focusout(e)
         },
@@ -1003,8 +1003,6 @@ export default Vue.extend({
       return h(QDialog, {
         props: {
           value: this.dialog,
-          noRefocus: true,
-          noFocus: true,
           position: this.useInput === true ? 'top' : void 0,
           transitionShow: this.transitionShowComputed,
           transitionHide: this.transitionHide

--- a/ui/src/directives/Ripple.js
+++ b/ui/src/directives/Ripple.js
@@ -65,12 +65,14 @@ function updateCtx (ctx, { value, modifiers, arg }) {
       ? {
         stop: value.stop === true || modifiers.stop === true,
         center: value.center === true || modifiers.center === true,
-        color: value.color || arg
+        color: value.color || arg,
+        keyCodes: [].concat(value.keyCodes || 13)
       }
       : {
         stop: modifiers.stop,
         center: modifiers.center,
-        color: arg
+        color: arg,
+        keyCodes: [13]
       }
   }
 }
@@ -91,7 +93,7 @@ export default {
       },
 
       keyup (evt) {
-        if (ctx.enabled === true && evt.keyCode === 13 && evt.qKeyEvent !== true) {
+        if (ctx.enabled === true && ctx.modifiers.keyCodes.indexOf(evt.keyCode) > -1 && evt.qKeyEvent !== true) {
           showRipple(evt, el, ctx, true)
         }
       }

--- a/ui/src/directives/Ripple.json
+++ b/ui/src/directives/Ripple.json
@@ -15,13 +15,19 @@
 
       "color": {
         "type": "String",
+        "desc": "List of keyCode that should trigger the ripple",
+        "examples": [ "[]", "[13, 32]" ]
+      },
+
+      "keyCodes": {
+        "type": [ "Array", "Number" ],
         "desc": "Color name from Quasar Color Palette; Overrides default dynamic color",
         "examples": [ "orange-5" ]
       }
     },
     "examples": [
       "v-ripple=\"booleanState\"",
-      "v-ripple=\"{ center: true, color: 'primary' }\""
+      "v-ripple=\"{ center: true, color: 'primary', keyCodes: [] }\""
     ]
   },
 

--- a/ui/src/mixins/ripple.json
+++ b/ui/src/mixins/ripple.json
@@ -4,7 +4,7 @@
       "type": [ "Boolean", "Object" ],
       "desc": "Configure material ripple (disable it by setting it to 'false' or supply a config object)",
       "default": true,
-      "examples": [ false, "{ center: true, color: 'teal' }" ],
+      "examples": [ false, "{ center: true, color: 'teal', keyCodes: [] }" ],
       "category": "style"
     }
   }


### PR DESCRIPTION
- QBtn: simplify logic and prevent keyboard clicks with different sources on keydown and keyup
- ClickOutside: prevent hiding a dialog backdrop, listen on click to be able to prevent it
- QMenu: on hide only refocus if closed from code, ESC plugin or not from a mouse/touch event on clickOutside
- QSelect: fix duplicate ref 'target', fix focusing
- Ripple: add configuration for keyCodes that should trigger it

close #5255