### PR TITLE
feat(QPopupEdit) add "before-show" and "before-hide" events to QPopupEdit.json

### DIFF
--- a/ui/src/components/popup-edit/QPopupEdit.json
+++ b/ui/src/components/popup-edit/QPopupEdit.json
@@ -243,7 +243,7 @@
     
     "before-hide": {
       "extends": "before-hide",
-      "desc": "Emitted right before Popup gets hide"
+      "desc": "Emitted right before Popup gets dismissed"
     },
     
     "hide": {

--- a/ui/src/components/popup-edit/QPopupEdit.json
+++ b/ui/src/components/popup-edit/QPopupEdit.json
@@ -231,11 +231,21 @@
       "extends": "input",
       "desc": "Emitted when Popup gets cancelled in order to reset model to its initial value; Is also used by v-model"
     },
-
+    
+    "before-show": {
+      "extends": "before-show",
+      "desc": "Emitted right before Popup gets shown"
+    },
+    
     "show": {
       "desc": "Emitted right after Popup gets shown"
     },
-
+    
+    "before-hide": {
+      "extends": "before-hide",
+      "desc": "Emitted right before Popup gets hide"
+    },
+    
     "hide": {
       "desc": "Emitted right after Popup gets dismissed"
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
