### PR TITLE
fix(Fastclick): fixed syntax error in IE11 due to the ES6 arrow function

### DIFF
--- a/fastclick/fastclick.js
+++ b/fastclick/fastclick.js
@@ -631,7 +631,7 @@
 
   define(function() {
     return function () {
-      document.addEventListener('DOMContentLoaded', () => {
+      document.addEventListener('DOMContentLoaded', function () {
         new FastClick(document.body)
       }, false)
     }


### PR DESCRIPTION
Changed ES6 arrow function to the classic anonymous function.

**What kind of change does this PR introduce?** (check at least one)

- Bugfix

**Does this PR introduce a breaking change?** (check one)

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
IE11(or any other browser that doesn't support ES6 syntax) was throwing syntax error because of an ES6 arrow function.