### PR TITLE
fix(docs): "loading" should be in "state" category

### DIFF
--- a/ui/src/components/btn/__btn-mixin.json
+++ b/ui/src/components/btn/__btn-mixin.json
@@ -145,7 +145,7 @@
     "loading": {
       "type": "Boolean",
       "desc": "Put button into loading state (displays a QSpinner -- can be overriden by using a 'loading' slot)",
-      "category": "behavior|content"
+      "category": "behavior|state"
     },
 
     "disable": {


### PR DESCRIPTION
I feel that "loading" should be in "state" category.

→　Just like "disable" and "readonly" are state props. "loading" is also a state.

It literally says:
> Put button into loading **state**
