### PR TITLE
feat(registerDescribeApi): node path is now allowed if starting with '~'

### DIFF
--- a/app/lib/app-extension/IndexAPI.js
+++ b/app/lib/app-extension/IndexAPI.js
@@ -215,8 +215,13 @@ module.exports = class IndexAPI {
    *   (relative path to Api file)
    */
   registerDescribeApi (name, relativePath) {
-    const dir = getCallerPath()
-    this.__hooks.describeApi[name] = path.resolve(dir, relativePath)
+    if (relativePath.charAt(0) === '~') {
+      this.__hooks.describeApi[name] = path.resolve(relativePath.slice(1))
+    }
+    else {
+      const dir = getCallerPath()
+      this.__hooks.describeApi[name] = path.resolve(dir, relativePath)
+    }
   }
 
   /**

--- a/app/lib/app-extension/IndexAPI.js
+++ b/app/lib/app-extension/IndexAPI.js
@@ -216,7 +216,10 @@ module.exports = class IndexAPI {
    */
   registerDescribeApi (name, relativePath) {
     if (relativePath.charAt(0) === '~') {
-      this.__hooks.describeApi[name] = path.resolve(relativePath.slice(1))
+      this.__hooks.describeApi[name] = require.resolve(
+        path.resolve(relativePath.slice(1)),
+        { paths: [ appPaths.appDir ] }
+      )
     }
     else {
       const dir = getCallerPath()

--- a/app/lib/app-extension/IndexAPI.js
+++ b/app/lib/app-extension/IndexAPI.js
@@ -216,10 +216,15 @@ module.exports = class IndexAPI {
    */
   registerDescribeApi (name, relativePath) {
     if (relativePath.charAt(0) === '~') {
-      this.__hooks.describeApi[name] = require.resolve(
-        path.resolve(relativePath.slice(1)),
-        { paths: [ appPaths.appDir ] }
-      )
+      try {
+        this.__hooks.describeApi[name] = require.resolve(
+          path.resolve(relativePath.slice(1)),
+          { paths: [ appPaths.appDir ] }
+        )
+      }
+      catch (e) {
+        warn(`⚠️  Extension(${this.extId}): registerDescribeApi - there is no package "${file}" installed`)
+      }
     }
     else {
       const dir = getCallerPath()


### PR DESCRIPTION
Still maintains backwards compatibility with relative path