### PR TITLE
feat(fullscreen mixin): add noRouteFullscreenExit to prevent exiting fullscreen on route change

### DIFF
--- a/ui/src/mixins/fullscreen.js
+++ b/ui/src/mixins/fullscreen.js
@@ -2,7 +2,8 @@ import History from '../history.js'
 
 export default {
   props: {
-    fullscreen: Boolean
+    fullscreen: Boolean,
+    noRouteFullscreenExit: Boolean
   },
 
   data () {
@@ -13,7 +14,7 @@ export default {
 
   watch: {
     $route () {
-      this.exitFullscreen()
+      this.noRouteFullscreenExit !== true && this.exitFullscreen()
     },
 
     fullscreen (v) {

--- a/ui/src/mixins/fullscreen.json
+++ b/ui/src/mixins/fullscreen.json
@@ -13,7 +13,8 @@
     "no-route-fullscreen-exit": {
       "type": "Boolean",
       "desc": "Changing route app won't exit fullscreen",
-      "category": "behavior"
+      "category": "behavior",
+      "addedIn": "v1.1.7"
     }
   },
 

--- a/ui/src/mixins/fullscreen.json
+++ b/ui/src/mixins/fullscreen.json
@@ -8,6 +8,12 @@
         ":fullscreen.sync=\"isFullscreen\""
       ],
       "category": "behavior"
+    },
+
+    "no-route-fullscreen-exit": {
+      "type": "Boolean",
+      "desc": "Changing route app won't exit fullscreen",
+      "category": "behavior"
     }
   },
 


### PR DESCRIPTION
Affects:
- QCarousel
- QEditor
- QTable

close #4452