### PR TITLE
fix(props): removed redundant maxlength prop in QInput

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -21,7 +21,6 @@ export default Vue.extend({
 
     debounce: [String, Number],
 
-    maxlength: [Number, String],
     autogrow: Boolean, // makes a textarea
 
     inputClass: [Array, String, Object],


### PR DESCRIPTION
maxlength is brought in via QField mixin.
ran `yarn build` and verified QInput.json