### PR TITLE
fix(rel): changing links to sponsor quasar to rel="sponsored"

### DIFF
--- a/docs/src/components/DocPage.vue
+++ b/docs/src/components/DocPage.vue
@@ -69,7 +69,7 @@ q-page.doc-page
       a(href="https://facebook.quasar.dev", target="_blank", rel="noopener")
         q-icon(name="fab fa-facebook")
 
-      a(href="https://donate.quasar.dev", rel="noopener", target="_blank")
+      a(href="https://donate.quasar.dev", rel="sponsored", target="_blank")
         q-icon(name="fas fa-medkit")
 
     div.q-mt-md

--- a/docs/src/components/page-parts/sponsors-and-backers/DonatingButtons.vue
+++ b/docs/src/components/page-parts/sponsors-and-backers/DonatingButtons.vue
@@ -8,7 +8,7 @@
       type="a"
       href="https://donate.quasar.dev"
       target="_blank"
-      rel="noopener"
+      rel="sponsored"
     >
       <div class="row items-center no-wrap">
         <q-icon left name="fab fa-github" />


### PR DESCRIPTION
A per this google blog: https://webmasters.googleblog.com/2019/09/evolving-nofollow-new-ways-to-identify.html