### PR TITLE
feat(docs) Tab to search [WIP]

### DIFF
--- a/docs/src/index.template.html
+++ b/docs/src/index.template.html
@@ -12,6 +12,7 @@
     <meta property="og:image" content="https://cdn.quasar.dev/logo/512/quasar-logo.png" />
     <meta property="og:site_name" content="Quasar Framework" />
 
+    <link type="application/opensearchdescription+xml" rel="search" href="/statics/search_manifest.xml">
     <link rel="icon" type="image/svg+xml" href="https://cdn.quasar.dev/logo/svg/quasar-logo.svg">
     <link rel="icon" type="image/png" sizes="128x128" href="https://cdn.quasar.dev/app-icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="https://cdn.quasar.dev/app-icons/favicon-96x96.png">

--- a/docs/src/layouts/Layout.vue
+++ b/docs/src/layouts/Layout.vue
@@ -299,7 +299,13 @@ export default {
   },
 
   mounted () {
-    this.leftDrawerState = !!this.$route.query.search
+    // If we have a search string in the query (mostly from tab-to-search functionality),
+    // we need to open the drawer to fill in the search string in the input later
+    const searchQuery = this.$route.query.search
+    if (searchQuery) {
+      this.leftDrawerState = true
+    }
+
     import('docsearch.js').then(docsearch => {
       docsearch.default({
         apiKey: '5c15f3938ef24ae49e3a0e69dc4a140f',
@@ -320,12 +326,18 @@ export default {
       if (this.$q.platform.is.desktop === true) {
         window.addEventListener('keypress', this.focusOnSearch)
       }
-    }).then(() => {
-      this.search = this.$route.query.search
-      this.$refs.docAlgolia.focus()
-      setTimeout(() => {
-        this.$refs.docAlgolia.$refs.input.dispatchEvent(new Event('input', {}))
-      })
+      if (searchQuery) {
+        // Here we put search string from query into the input and open the search popup.
+        // Unfortunately, this input is managed completely by Algolia and their code doesn't seem to
+        // have a method of opening the popup programmatically, so we need to simulate typing on that input element.
+        // We also need to dispatch the event only after the input text is populated and Vue will
+        // do that in next render, so we schedule it on the next event loop iteration with setTimeout.
+        this.search = searchQuery
+        this.$refs.docAlgolia.focus()
+        setTimeout(() => {
+          this.$refs.docAlgolia.$refs.input.dispatchEvent(new Event('input', {}))
+        })
+      }
     })
   },
 

--- a/docs/src/layouts/Layout.vue
+++ b/docs/src/layouts/Layout.vue
@@ -299,6 +299,7 @@ export default {
   },
 
   mounted () {
+    this.leftDrawerState = !!this.$route.query.search
     import('docsearch.js').then(docsearch => {
       docsearch.default({
         apiKey: '5c15f3938ef24ae49e3a0e69dc4a140f',
@@ -319,6 +320,12 @@ export default {
       if (this.$q.platform.is.desktop === true) {
         window.addEventListener('keypress', this.focusOnSearch)
       }
+    }).then(() => {
+      this.search = this.$route.query.search
+      this.$refs.docAlgolia.focus()
+      setTimeout(() => {
+        this.$refs.docAlgolia.$refs.input.dispatchEvent(new Event('input', {}))
+      })
     })
   },
 

--- a/docs/src/statics/search_manifest.xml
+++ b/docs/src/statics/search_manifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>Search Quasar docs</ShortName>
-  <Description>Search Quasar documentation</Description>
-  <Url type="text/html" method="get" template="https://tab-to-search-test.netlify.com/start/pick-quasar-flavour?search={searchTerms}"/>
+  <ShortName>Quasar docs</ShortName>
+  <Description>Quasar documentation</Description>
+  <Url type="text/html" method="get" template="https://quasar.dev/start/pick-quasar-flavour?search={searchTerms}"/>
 </OpenSearchDescription>

--- a/docs/src/statics/search_manifest.xml
+++ b/docs/src/statics/search_manifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Search Quasar docs</ShortName>
+  <Description>Search Quasar documentation</Description>
+  <Url type="text/html" method="get" template="https://tab-to-search-test.netlify.com/start/pick-quasar-flavour?search={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
Adds "Tab To Search" functionality for docs.

Demo: https://tab-to-search-test.netlify.com - copy the url to search bar and hit tab (You might need to visit the page first)

fixes #5013

TODO
 - [x] Sync search input with URL query (or route param, but query is probably easier with current setup)
 - [x] Add a search manifest xml file with url template (it's like 5 lines, very simple file)
 - [x] Make sure that loaded page shows the results in popup

 - [ ] Move XML to CDN and replace hardcoded statics url with `cdn.quasar.dev` one (This is on Razvan since I don't have rights for the CDN)

Optional
 - [x] ~~Fetch results on server and redirect to the top result directly~~
        (Better to do in separate PR, it's complicated and I don't have time for that)