### PR TITLE
feat(app/capacitor): add android https support

### DIFF
--- a/app/lib/capacitor/index.js
+++ b/app/lib/capacitor/index.js
@@ -27,6 +27,7 @@ class CapacitorRunner {
 
     if (this.target === 'android') {
       require('../helpers/fix-android-cleartext')('capacitor')
+      require('../helpers/allow-unsigned-cert-android')()
     }
   }
 

--- a/app/lib/helpers/allow-unsigned-cert-android.js
+++ b/app/lib/helpers/allow-unsigned-cert-android.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const appPaths = require('../app-paths')
+
+module.exports = function() {
+  const mainActivityPath = appPaths.resolve.capacitor(
+    'android/app/src/main/java/org/cordova/quasar/app/MainActivity.java'
+  )
+  const enableHttpsSelfSignedPath = appPaths.resolve.capacitor(
+    'android/app/src/main/java/org/cordova/quasar/app/EnableHttpsSelfSigned.java'
+  )
+
+  if (fs.existsSync(mainActivityPath)) {
+    // Allow unsigned certificates in MainActivity
+    let mainActivity = fs.readFileSync(mainActivityPath, 'utf8')
+
+    if (!/EnableHttpsSelfSigned\.enable/.test(mainActivity)) {
+      mainActivity = mainActivity.replace(
+        /this\.init\(.*}}\);/ms,
+        match => `${match}
+    if (BuildConfig.DEBUG) {
+      EnableHttpsSelfSigned.enable(findViewById(R.id.webview));
+    }`
+      )
+
+      fs.writeFileSync(mainActivityPath, mainActivity, 'utf-8')
+    }
+
+    // Add helper file
+    if (!fs.existsSync(enableHttpsSelfSignedPath)) {
+      const appId = mainActivity.match(/package ([a-zA-Z\.]*);/)[1]
+      fs.writeFileSync(
+        enableHttpsSelfSignedPath,
+        `package ${appId};
+import android.net.http.SslError;
+import android.webkit.SslErrorHandler;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+public class EnableHttpsSelfSigned {
+  public static void enable(WebView webview) {
+    webview.setWebViewClient(new WebViewClient() {
+      @Override
+      public void onReceivedSslError(WebView view, final SslErrorHandler handler, SslError error) {
+        handler.proceed();
+      }
+    });
+  }
+}`
+      )
+    }
+  }
+}

--- a/app/lib/quasar-config.js
+++ b/app/lib/quasar-config.js
@@ -594,9 +594,9 @@ class QuasarConfig {
       if (this.ctx.mode.cordova || this.ctx.mode.capacitor || this.ctx.mode.electron) {
         cfg.devServer.open = false
 
-        if (cfg.devServer.https === true && this.ctx.mode.capacitor) {
+        if (cfg.devServer.https === true && this.ctx.mode.capacitor && this.ctx.target === 'ios') {
           console.log(` ⚠️  `)
-          console.log(` ⚠️  Capacitor does not currently supports HTTPS protocol. Please disable it from quasar.conf.js > devServer > https`)
+          console.log(` ⚠️  Capacitor does not currently supports HTTPS protocol on iOS. Please disable it from quasar.conf.js > devServer > https`)
           console.log(` ⚠️  `)
           console.log()
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Automatically adds code to allow the webview to load https code with a self-signed certificate on dev command. Only allows unsigned code during dev builds.