### PR TITLE
fix(firefox): Remove outlines from q-focus-target and button on mobile. Use targetTouches (firefox populates touches and changedTouches late). Guard re-entry in mouseStart for touch directives.

### DIFF
--- a/ui/dev/components/components/list-slide-item.vue
+++ b/ui/dev/components/components/list-slide-item.vue
@@ -131,7 +131,7 @@
             <q-avatar color="primary" text-color="white" icon="bluetooth" />
           </q-item-section>
           <q-item-section>
-            <q-item-label>No actions</q-item-label>
+            <q-item-label>Slide left/right</q-item-label>
             <q-btn label="test btn" @click="onClick" />
           </q-item-section>
         </q-item>
@@ -146,7 +146,7 @@
             <q-avatar color="primary" text-color="white" icon="bluetooth" />
           </q-item-section>
           <q-item-section>
-            <q-item-label>No actions</q-item-label>
+            <q-item-label>Slide left/right</q-item-label>
             <q-btn to="/" label="test btn" @click="onClick" />
           </q-item-section>
         </q-item>

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -198,7 +198,7 @@ export default Vue.extend({
     const
       inner = [].concat(slot(this, 'default')),
       data = {
-        staticClass: 'q-btn inline q-btn-item non-selectable',
+        staticClass: 'q-btn inline q-btn-item non-selectable no-outline',
         class: this.classes,
         style: this.style,
         attrs: this.attrs

--- a/ui/src/css/core/visibility.sass
+++ b/ui/src/css/core/visibility.sass
@@ -103,6 +103,9 @@ $platforms: desktop, mobile, native-mobile, cordova, capacitor, electron, touch,
   .xl-hide, .xs, .lt-sm, .sm, .lt-md, .md, .lt-lg, .lg, .lt-xl
     display: none !important
 
+.q-focus-helper
+  outline: 0
+
 body.desktop
   .q-focus-helper
     position: absolute
@@ -112,7 +115,6 @@ body.desktop
     height: 100%
     pointer-events: none
     border-radius: inherit
-    outline: 0
     opacity: 0
     transition: background-color .3s cubic-bezier(.25, .8, .5, 1), opacity .4s cubic-bezier(.25, .8, .5, 1)
 

--- a/ui/src/css/core/visibility.styl
+++ b/ui/src/css/core/visibility.styl
@@ -102,6 +102,9 @@ for type in desktop mobile native-mobile cordova capacitor electron touch within
   .xl-hide, .xs, .lt-sm, .sm, .lt-md, .md, .lt-lg, .lg, .lt-xl
     display none !important
 
+.q-focus-helper
+  outline 0
+
 body.desktop
   .q-focus-helper
     position absolute
@@ -111,7 +114,6 @@ body.desktop
     height 100%
     pointer-events none
     border-radius inherit
-    outline 0
     opacity 0
     transition background-color .3s cubic-bezier(.25, .8, .5, 1), opacity .4s cubic-bezier(.25, .8, .5, 1)
 

--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -120,7 +120,7 @@ export default {
       direction: getModifierDirections(modifiers),
 
       mouseStart (evt) {
-        if (leftClick(evt) === true) {
+        if (ctx.event === void 0 && leftClick(evt) === true) {
           addEvt(ctx, 'temp', [
             [ document, 'mousemove', 'move', 'notPassiveCapture' ],
             [ document, 'mouseup', 'end', 'passiveCapture' ]

--- a/ui/src/directives/TouchRepeat.js
+++ b/ui/src/directives/TouchRepeat.js
@@ -64,7 +64,7 @@ export default {
           // so we need to avoid it
           ctx.skipMouse = false
         }
-        else if (leftClick(evt) === true) {
+        else if (ctx.event === void 0 && leftClick(evt) === true) {
           addEvt(ctx, 'temp', [
             [ document, 'mousemove', 'move', 'passiveCapture' ],
             [ document, 'mouseup', 'end', 'passiveCapture' ]

--- a/ui/src/utils/event.js
+++ b/ui/src/utils/event.js
@@ -40,6 +40,9 @@ export function position (e) {
   else if (e.changedTouches && e.changedTouches[0]) {
     e = e.changedTouches[0]
   }
+  else if (e.targetTouches && e.targetTouches[0]) {
+    e = e.targetTouches[0]
+  }
 
   return {
     top: e.clientY,


### PR DESCRIPTION
close #5334
