### PR TITLE
fix(QInput/QSelect): Pass the original event to __onComposition because destructuring removes all props from event, and consider type 'change' to be similar to compositionend

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -180,7 +180,7 @@ export default Vue.extend({
     },
 
     __onChange (e) {
-      this.__onComposition({ ...e, type: 'compositionend' })
+      this.__onComposition(e)
 
       clearTimeout(this.emitTimer)
       this.emitValueFn !== void 0 && this.emitValueFn()

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -808,7 +808,7 @@ export default Vue.extend({
     },
 
     __onChange (e) {
-      this.__onComposition({ ...e, type: 'compositionend' })
+      this.__onComposition(e)
     },
 
     __onInput (e) {

--- a/ui/src/mixins/composition.js
+++ b/ui/src/mixins/composition.js
@@ -4,7 +4,7 @@ const isChinese = /[\u4e00-\u9fff\u3400-\u4dbf\u{20000}-\u{2a6df}\u{2a700}-\u{2b
 export default {
   methods: {
     __onComposition (e) {
-      if (e.type === 'compositionend') {
+      if (e.type === 'compositionend' || e.type === 'change') {
         if (e.target.composing !== true) { return }
         e.target.composing = false
         this.__onInput(e)


### PR DESCRIPTION
close #5347
