### PR TITLE
feat(Loading): Don't require Loading to be installed in order to work

### DIFF
--- a/ui/src/plugins/Loading.js
+++ b/ui/src/plugins/Loading.js
@@ -5,7 +5,7 @@ import { isSSR } from './Platform.js'
 import uid from '../utils/uid.js'
 
 let
-  vm = null,
+  vm,
   timeout,
   props = {},
   originalDefaults = {
@@ -21,7 +21,7 @@ let
   defaults = { ...originalDefaults }
 
 export default {
-  isActive: false,
+  isActive: void 0,
 
   show (opts) {
     if (isSSR === true) { return }
@@ -32,16 +32,18 @@ export default {
 
     props.customClass += ` text-${props.backgroundColor}`
 
+    this.isActive === void 0 && Vue.util.defineReactive(this, 'isActive', this.isActive)
+
     this.isActive = true
 
-    if (vm) {
+    if (vm !== void 0) {
       vm.$forceUpdate()
       return
     }
 
     clearTimeout(timeout)
     timeout = setTimeout(() => {
-      timeout = null
+      timeout = void 0
 
       const node = document.createElement('div')
       document.body.appendChild(node)
@@ -62,16 +64,16 @@ export default {
               'after-leave': () => {
                 // might be called to finalize
                 // previous leave, even if it was cancelled
-                if (!this.isActive && vm) {
+                if (this.isActive !== true && vm !== void 0) {
                   vm.$destroy()
                   document.body.classList.remove('q-body--loading')
                   vm.$el.remove()
-                  vm = null
+                  vm = void 0
                 }
               }
             }
           }, [
-            this.isActive ? h('div', {
+            this.isActive === true ? h('div', {
               staticClass: 'q-loading fullscreen column flex-center z-max',
               key: uid(),
               class: props.customClass.trim()
@@ -96,10 +98,10 @@ export default {
   },
 
   hide () {
-    if (this.isActive) {
-      if (timeout) {
+    if (this.isActive === true) {
+      if (timeout !== void 0) {
         clearTimeout(timeout)
-        timeout = null
+        timeout = void 0
       }
 
       this.isActive = false
@@ -107,13 +109,12 @@ export default {
   },
 
   setDefaults (opts) {
-    Object.assign(defaults, opts)
+    opts === Object(opts) && Object.assign(defaults, opts)
   },
 
   install ({ $q, cfg: { loading } }) {
-    loading !== void 0 && this.setDefaults(loading)
+    this.setDefaults(loading)
 
     $q.loading = this
-    Vue.util.defineReactive(this, 'isActive', this.isActive)
   }
 }

--- a/ui/src/plugins/LoadingBar.js
+++ b/ui/src/plugins/LoadingBar.js
@@ -38,8 +38,8 @@ export default {
         this.isActive = bar.isActive = bar.calls > 0
       },
       increment: bar.increment,
-      setDefaults: def => {
-        Object.assign(props, def || {})
+      setDefaults: opts => {
+        opts === Object(opts) && Object.assign(props, opts)
         bar.$parent.$forceUpdate()
       }
     })

--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -229,7 +229,7 @@ export default {
     return this.__vm.add(opts)
   },
   setDefaults (opts) {
-    Object.assign(defaults, opts)
+    opts === Object(opts) && Object.assign(defaults, opts)
   },
 
   install (args) {
@@ -241,7 +241,7 @@ export default {
 
     init.call(this, args)
 
-    args.cfg.notify && this.setDefaults(args.cfg.notify)
+    this.setDefaults(args.cfg.notify)
 
     args.$q.notify = this.create.bind(this)
     args.$q.notify.setDefaults = this.setDefaults


### PR DESCRIPTION
- now if you don't add Loading to plugins .show is working but .hide is not
- guard setDefaults to use only objects in Loading, LoadingBar and Notify
