### PR TITLE
Delete .postcssrc.js

### DIFF
--- a/extras/.postcssrc.js
+++ b/extras/.postcssrc.js
@@ -1,5 +1,0 @@
-// https://github.com/michael-ciniawsky/postcss-load-config
-
-module.exports = {
-  plugins: []
-}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: suppress warning

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Other information:**

It's better to delete or to empty the file if you don't need it.
Otherwise during compilation of development server you'll get a warning from postcss-loader

```
You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.
```

And you will receive with for each extras you will import in your quasar.js main file

```
// Extras
import '@quasar/extras/roboto-font/roboto-font.css'
import '@quasar/extras/material-icons/material-icons.css'
```

For instance in this case I'll receive 2 warning.

BTW: I'm building with vue-cli-service and not with quasar-cli so I don't know if you will receive this warning also with quasar cli but I think it's a general warning from postcss

