### PR TITLE
fix: Removed dekstop check in escape-key.js #4930

### DIFF
--- a/ui/src/utils/escape-key.js
+++ b/ui/src/utils/escape-key.js
@@ -16,18 +16,14 @@ export default {
   },
 
   register (comp, fn) {
-    if (Platform.is.desktop === true) {
-      this.__installed !== true && this.__install()
-      handlers.push({ comp, fn })
-    }
+    this.__installed !== true && this.__install()
+    handlers.push({ comp, fn })
   },
 
   pop (comp) {
-    if (Platform.is.desktop === true) {
-      const index = handlers.findIndex(h => h.comp === comp)
-      if (index > -1) {
-        handlers.splice(index, 1)
-      }
+    const index = handlers.findIndex(h => h.comp === comp)
+    if (index > -1) {
+      handlers.splice(index, 1)
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In some cases, the Platform.js doesn't have the .is property. This will throw an exception and causes dropdowns (QSelect, QMenu, etc.) not to work. With this check removed, the Esc key will always be installed without throwing exceptions. This will also work on mobiles even though there is no Esc key.