### PR TITLE
feat(ui,docs): Add back animation duration prop for QCarousel #4876

### DIFF
--- a/docs/src/examples/QCarousel/Transitions.vue
+++ b/docs/src/examples/QCarousel/Transitions.vue
@@ -81,6 +81,49 @@
           </div>
         </q-carousel-slide>
       </q-carousel>
+
+      <q-carousel
+        v-model="slide"
+        transition-prev="slide-right-then-fade"
+        transition-next="slide-left-then-fade"
+        :transition-duration="{ enter: 2000, leave: 1000 }"
+        swipeable
+        animated
+        control-color="white"
+        prev-icon="arrow_back"
+        next-icon="arrow_forward"
+        navigation-icon="emoji_emotions"
+        navigation
+        padding
+        arrows
+        height="300px"
+        class="bg-secondary text-white shadow-1 rounded-borders"
+      >
+        <q-carousel-slide name="style" class="column no-wrap flex-center">
+          <q-icon name="style" size="56px" />
+          <div class="q-mt-md text-center nested-fade">
+            {{ lorem }}
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide name="tv" class="column no-wrap flex-center">
+          <q-icon name="live_tv" size="56px" />
+          <div class="q-mt-md text-center nested-fade">
+            {{ lorem }}
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide name="layers" class="column no-wrap flex-center">
+          <q-icon name="layers" size="56px" />
+          <div class="q-mt-md text-center nested-fade">
+            {{ lorem }}
+          </div>
+        </q-carousel-slide>
+        <q-carousel-slide name="map" class="column no-wrap flex-center">
+          <q-icon name="terrain" size="56px" />
+          <div class="q-mt-md text-center nested-fade">
+            {{ lorem }}
+          </div>
+        </q-carousel-slide>
+      </q-carousel>
     </div>
   </div>
 </template>
@@ -95,3 +138,44 @@ export default {
   }
 }
 </script>
+
+<style lang="stylus">
+/* A nested transition to demonstrate the transition-duration property */
+.q-transition
+
+  &--slide-left-then-fade
+  &--slide-right-then-fade
+
+    &-leave-active
+      position absolute
+
+    &-enter-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-in 1s
+
+    &-leave-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-out
+
+    &-enter .nested-fade
+    &-leave .nested-fade
+    &-leave-to .nested-fade
+      opacity 0
+
+  &--slide-right-then-fade
+    &-enter
+      transform translate3d(-100%, 0, 0)
+    &-leave-to
+      transform translate3d(100%, 0, 0)
+
+  &--slide-left-then-fade
+    &-enter
+      transform translate3d(100%, 0, 0)
+    &-leave-to
+      transform translate3d(-100%, 0, 0)
+
+</style>

--- a/docs/src/examples/QStepper/Transition.vue
+++ b/docs/src/examples/QStepper/Transition.vue
@@ -1,0 +1,194 @@
+<template>
+  <div class="q-pa-md">
+    <q-stepper
+      v-model="step"
+      ref="stepper"
+      animated
+      contracted
+      transition-prev="scale"
+      transition-next="scale"
+    >
+      <q-step
+        :name="1"
+        title="Select campaign settings"
+        icon="settings"
+        :done="step > 1"
+        color="purple"
+      >
+        For each ad campaign that you create, you can control how much you're willing to
+        spend on clicks and conversions, which networks and geographical locations you want
+        your ads to show on, and more.
+      </q-step>
+
+      <q-step
+        :name="2"
+        title="Create an ad group"
+        caption="Optional"
+        icon="create_new_folder"
+        :done="step > 2"
+        color="purple"
+      >
+        An ad group contains one or more ads which target a shared set of keywords.
+      </q-step>
+
+      <q-step
+        :name="3"
+        title="Create an ad"
+        icon="add_comment"
+        color="purple"
+      >
+        Try out different ad text to see what brings in the most customers, and learn how to
+        enhance your ads using features like ad extensions. If you run into any problems with
+        your ads, find out how to tell if they're running and how to resolve approval issues.
+      </q-step>
+    </q-stepper>
+
+    <q-stepper
+      v-model="step"
+      ref="stepper"
+      animated
+      contracted
+      transition-prev="jump-up"
+      transition-next="jump-down"
+    >
+      <q-step
+        :name="1"
+        title="Select campaign settings"
+        icon="settings"
+        :done="step > 1"
+        color="orange"
+      >
+        For each ad campaign that you create, you can control how much you're willing to
+        spend on clicks and conversions, which networks and geographical locations you want
+        your ads to show on, and more.
+      </q-step>
+
+      <q-step
+        :name="2"
+        title="Create an ad group"
+        caption="Optional"
+        icon="create_new_folder"
+        :done="step > 2"
+        color="orange"
+      >
+        An ad group contains one or more ads which target a shared set of keywords.
+      </q-step>
+
+      <q-step
+        :name="3"
+        title="Create an ad"
+        icon="add_comment"
+        color="orange"
+      >
+        Try out different ad text to see what brings in the most customers, and learn how to
+        enhance your ads using features like ad extensions. If you run into any problems with
+        your ads, find out how to tell if they're running and how to resolve approval issues.
+      </q-step>
+    </q-stepper>
+
+    <q-stepper
+      v-model="step"
+      ref="stepper"
+      animated
+      contracted
+      transition-prev="slide-left-then-fade"
+      transition-next="slide-right-then-fade"
+      :transition-duration="{ enter: 2000, leave: 1000 }"
+    >
+      <q-step
+        :name="1"
+        title="Select campaign settings"
+        icon="settings"
+        :done="step > 1"
+        color="teal"
+        class="nested-fade"
+      >
+        For each ad campaign that you create, you can control how much you're willing to
+        spend on clicks and conversions, which networks and geographical locations you want
+        your ads to show on, and more.
+      </q-step>
+
+      <q-step
+        :name="2"
+        title="Create an ad group"
+        caption="Optional"
+        icon="create_new_folder"
+        :done="step > 2"
+        color="teal"
+        class="nested-fade"
+      >
+        An ad group contains one or more ads which target a shared set of keywords.
+      </q-step>
+
+      <q-step
+        :name="3"
+        title="Create an ad"
+        icon="add_comment"
+        color="teal"
+        class="nested-fade"
+      >
+        Try out different ad text to see what brings in the most customers, and learn how to
+        enhance your ads using features like ad extensions. If you run into any problems with
+        your ads, find out how to tell if they're running and how to resolve approval issues.
+      </q-step>
+
+      <template v-slot:navigation>
+        <q-stepper-navigation>
+          <q-btn @click="$refs.stepper.next()" color="deep-orange" :label="step === 3 ? 'Finish' : 'Continue'" />
+          <q-btn v-if="step > 1" flat color="deep-orange" @click="$refs.stepper.previous()" label="Back" class="q-ml-sm" />
+        </q-stepper-navigation>
+      </template>
+    </q-stepper>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      step: 1
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+/* A nested transition to demonstrate the transition-duration property */
+.q-transition
+
+  &--slide-left-then-fade
+  &--slide-right-then-fade
+
+    &-leave-active
+      position absolute
+
+    &-enter-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-in 1s
+
+    &-leave-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-out
+
+    &-enter .nested-fade
+    &-leave .nested-fade
+    &-leave-to .nested-fade
+      opacity 0
+
+  &--slide-right-then-fade
+    &-enter
+      transform translate3d(-100%, 0, 0)
+    &-leave-to
+      transform translate3d(100%, 0, 0)
+
+  &--slide-left-then-fade
+    &-enter
+      transform translate3d(100%, 0, 0)
+    &-leave-to
+      transform translate3d(-100%, 0, 0)
+
+</style>

--- a/docs/src/examples/QTabPanels/Transition.vue
+++ b/docs/src/examples/QTabPanels/Transition.vue
@@ -62,23 +62,24 @@
         <q-tab-panels
           v-model="tab"
           animated
-          transition-prev="jump-up"
-          transition-next="jump-down"
+          transition-prev="slide-left-then-fade"
+          transition-next="slide-right-then-fade"
+          :transition-duration="{ enter: 2000, leave: 1000 }"
           class="bg-teal text-white text-center"
         >
           <q-tab-panel name="mails">
             <div class="text-h6">Mails</div>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit.
+            <span class="nested-fade">Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
           </q-tab-panel>
 
           <q-tab-panel name="alarms">
             <div class="text-h6">Alarms</div>
-            Ad molestiae non facere animi nobis, similique nemo velit reiciendis corporis impedit nam in.
+            <span class="nested-fade">Ad molestiae non facere animi nobis, similique nemo velit reiciendis corporis impedit nam in.</span>
           </q-tab-panel>
 
           <q-tab-panel name="movies">
             <div class="text-h6">Movies</div>
-            Nostrum necessitatibus expedita dolores? Voluptatem repudiandae magni ea.
+            <span class="nested-fade">Nostrum necessitatibus expedita dolores? Voluptatem repudiandae magni ea.</span>
           </q-tab-panel>
         </q-tab-panels>
       </div>
@@ -95,3 +96,44 @@ export default {
   }
 }
 </script>
+
+<style lang="stylus">
+/* A nested transition to demonstrate the transition-duration property */
+.q-transition
+
+  &--slide-left-then-fade
+  &--slide-right-then-fade
+
+    &-leave-active
+      position absolute
+
+    &-enter-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-in 1s
+
+    &-leave-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-out
+
+    &-enter .nested-fade
+    &-leave .nested-fade
+    &-leave-to .nested-fade
+      opacity 0
+
+  &--slide-right-then-fade
+    &-enter
+      transform translate3d(-100%, 0, 0)
+    &-leave-to
+      transform translate3d(100%, 0, 0)
+
+  &--slide-left-then-fade
+    &-enter
+      transform translate3d(100%, 0, 0)
+    &-leave-to
+      transform translate3d(-100%, 0, 0)
+
+</style>

--- a/docs/src/pages/vue-components/stepper.md
+++ b/docs/src/pages/vue-components/stepper.md
@@ -55,6 +55,10 @@ You can also use `prefix` prop (max 2 characters) instead of an icon for each st
 
 <doc-example title="Dark" file="QStepper/Dark" />
 
+For a full list of transitions, please check out [Transitions](/options/transitions).
+
+<doc-example title="Custom transition examples" file="QStepper/Transition" />
+
 ### Message slot
 
 <doc-example title="Message slot with fixed height steps" file="QStepper/MessageSlot" />

--- a/ui/dev/app.styl
+++ b/ui/dev/app.styl
@@ -7,3 +7,41 @@ body
   border-left 4px solid #027be3
   font-weight bold
   margin-left 10px
+
+/* A nested transition for components that inherit the transition-duration property */
+.q-transition
+
+  &--slide-left-then-fade
+  &--slide-right-then-fade
+
+    &-leave-active
+      position absolute
+
+    &-enter-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-in 1s
+
+    &-leave-active
+      transition transform 1s ease-in-out
+
+      & .nested-fade
+        transition opacity 1s ease-out
+
+    &-enter .nested-fade
+    &-leave .nested-fade
+    &-leave-to .nested-fade
+      opacity 0
+
+  &--slide-right-then-fade
+    &-enter
+      transform translate3d(-100%, 0, 0)
+    &-leave-to
+      transform translate3d(100%, 0, 0)
+
+  &--slide-left-then-fade
+    &-enter
+      transform translate3d(100%, 0, 0)
+    &-leave-to
+      transform translate3d(-100%, 0, 0)

--- a/ui/dev/components/components/carousel.vue
+++ b/ui/dev/components/components/carousel.vue
@@ -59,6 +59,7 @@
       transition-next="rotate"
       swipeable
       animated
+
       v-model="slide"
       arrows
       padding
@@ -82,17 +83,20 @@
       </q-carousel-slide>
     </q-carousel>
 
-    <div class="caption">
-      Example creating custom captions for each slide.
-    </div>
+    <p class="caption">
+      Example creating custom captions for each slide including complex transitions that require explicit duration.
+    </p>
     <q-carousel
       arrows
+      transition-prev="slide-right-then-fade"
+      transition-next="slide-left-then-fade"
+      :transition-duration="{ enter: 2000, leave: 1000 }"
       animated
       v-model="slide4"
       height="400px"
     >
       <q-carousel-slide name="first" img-src="https://cdn.quasar.dev/img/mountains.jpg">
-        <div class="absolute-bottom custom-caption">
+        <div class="absolute-bottom custom-caption nested-fade">
           <div class="text-h2">
             First stop
           </div>
@@ -102,7 +106,7 @@
         </div>
       </q-carousel-slide>
       <q-carousel-slide name="second" img-src="https://cdn.quasar.dev/img/parallax1.jpg">
-        <div class="absolute-bottom custom-caption">
+        <div class="absolute-bottom custom-caption nested-fade">
           <div class="text-h2">
             Second stop
           </div>
@@ -112,7 +116,7 @@
         </div>
       </q-carousel-slide>
       <q-carousel-slide name="third" img-src="https://cdn.quasar.dev/img/parallax2.jpg">
-        <div class="absolute-bottom custom-caption">
+        <div class="absolute-bottom custom-caption nested-fade">
           <div class="text-h2">
             Third stop
           </div>

--- a/ui/dev/components/components/stepper.vue
+++ b/ui/dev/components/components/stepper.vue
@@ -19,6 +19,7 @@
       <q-toggle label="Step 4 disable" v-model="stepDisable" />
 
       <q-toggle label="Keep alive" v-model="keepAlive" />
+      <q-toggle label="Complex Transition" v-model="transitionDuration" />
 
       <q-btn label="One" @click="step = 1" />
       <q-btn label="Two" @click="step = 2" />
@@ -37,6 +38,9 @@
         :keep-alive="keepAlive"
         :alternative-labels="alt"
         :contracted="contracted && !vertical"
+        :transition-prev="transitionDuration ? 'slide-right-then-fade' : 'slide-right'"
+        :transition-next="transitionDuration ? 'slide-left-then-fade' : 'slide-left'"
+        :transition-duration="transitionDuration ? { enter: 2000, leave: 1000 } : ''"
       >
         <q-step :name="1" :prefix="prefix ? 1 : ''" :done="useDone && step > 1" :header-nav="headerNavStep ? step > 1 : true" title="Ad style" icon="map" :caption="caption ? 'Some caption' : null">
           <q-input v-model="myInput" />
@@ -59,6 +63,11 @@
           <div v-for="n in 10" :key="'1.'+n">
             {{ n }} Step 1
           </div>
+
+          <p class="nested-fade">
+            Nested Fade complex transition test
+          </p>
+
           <q-stepper-navigation v-if="!globalNav">
             <q-btn :color="color" @click="$refs.stepper.next()">
               Continue
@@ -74,6 +83,9 @@
             {{ n }} Step 2
           </div>
           <keep-alive-test name="two" />
+          <p class="nested-fade">
+            Nested Fade complex transition test
+          </p>
           <q-stepper-navigation v-if="!globalNav">
             <q-btn :color="color" @click="$refs.stepper.next()">
               Continue
@@ -89,6 +101,9 @@
             {{ n }} Step 3
           </div>
           <keep-alive-test name="three" />
+          <p class="nested-fade">
+            Nested Fade complex transition test
+          </p>
           <q-stepper-navigation v-if="!globalNav">
             <q-btn :color="color" @click="$refs.stepper.next()">
               Continue
@@ -104,6 +119,9 @@
             {{ n }} Step 4
           </div>
           <keep-alive-test name="four" />
+          <p class="nested-fade">
+            Nested Fade complex transition test
+          </p>
           <q-stepper-navigation v-if="!globalNav">
             <q-btn :color="color" @click="$refs.stepper.next()">
               Continue
@@ -119,6 +137,9 @@
             {{ n }} Step 5
           </div>
           <keep-alive-test name="five" />
+          <p class="nested-fade">
+            Nested Fade complex transition test
+          </p>
           <q-stepper-navigation v-if="!globalNav">
             <q-btn :color="color" @click="step = 1">
               Restart
@@ -217,7 +238,8 @@ export default {
       useDone: false,
       headerNavStep: false,
 
-      keepAlive: true
+      keepAlive: true,
+      transitionDuration: false
     }
   },
   watch: {

--- a/ui/dev/components/components/tabs.vue
+++ b/ui/dev/components/components/tabs.vue
@@ -488,6 +488,33 @@
           Tab Four <br> Lorem ipsum dolor sit amet consectetur adipisicing elit. Quis labore inventore accusantium, perferendis eos sapiente culpa consectetur deserunt praesentium cumque distinctio placeat, recusandae id qui odit similique officia? Mollitia, ea!
         </q-tab-panel>
       </q-tab-panels>
+
+      <q-tab-panels
+        v-model="tab"
+        swipeable
+        animated
+        transition-prev="slide-left-then-fade"
+        transition-next="slide-right-then-fade"
+        :transition-duration="{ enter: 2000, leave: 1000 }"
+        class="q-mt-lg text-black text-center"
+        style="height: 150px"
+      >
+        <q-tab-panel name="one">
+          transition-duration test Tab One <br> <span class="nested-fade">Lorem ipsum dolor sit amet consectetur adipisicing elit. Provident obcaecati repellendus dolores totam nostrum ut repudiandae perspiciatis est accusamus, eaque natus modi rem beatae optio cumque, velit ducimus autem magnam.</span>
+        </q-tab-panel>
+
+        <q-tab-panel name="two">
+          transition-duration test Tab Two <br> <span class="nested-fade">Lorem ipsum dolor sit amet consectetur adipisicing elit. Provident obcaecati repellendus dolores totam nostrum ut repudiandae perspiciatis est accusamus, eaque natus modi rem beatae optio cumque, velit ducimus autem magnam.</span>
+        </q-tab-panel>
+
+        <q-tab-panel name="three">
+          transition-duration test Tab Three <br> <span class="nested-fade">Lorem ipsum dolor sit amet consectetur adipisicing elit. Quis labore inventore accusantium, perferendis eos sapiente culpa consectetur deserunt praesentium cumque distinctio placeat, recusandae id qui odit similique officia? Mollitia, ea!</span>
+        </q-tab-panel>
+
+        <q-tab-panel disable name="four">
+          transition-duration test Tab Four <br> <span class="nested-fade">Lorem ipsum dolor sit amet consectetur adipisicing elit. Quis labore inventore accusantium, perferendis eos sapiente culpa consectetur deserunt praesentium cumque distinctio placeat, recusandae id qui odit similique officia? Mollitia, ea!</span>
+        </q-tab-panel>
+      </q-tab-panels>
     </div>
   </div>
 </template>

--- a/ui/src/mixins/panel-parent.json
+++ b/ui/src/mixins/panel-parent.json
@@ -15,7 +15,7 @@
 
     "animated": {
       "type": "Boolean",
-      "desc": "Enable transitions between panel (also see 'transition-prev' and 'transition-next' props)",
+      "desc": "Enable transitions between panel (also see 'transition-prev', 'transition-next', and 'transition-duration' props)",
       "category": "behavior"
     },
 
@@ -43,7 +43,18 @@
       "desc": "One of Quasar's embedded transitions (has effect only if 'animated' prop is set)",
       "default": "slide-left",
       "category": "behavior"
+    },
+
+    "transition-duration": {
+      "type": ["Number", "String", "Object"],
+      "desc": "If Vue can not automatically determine when transition-prev or transition-next is finished, specify an explicit transition duration (in milliseconds).",
+      "category": "behavior",
+      "examples": [
+        ":transition-duration=\"1000\"",
+        ":transition-duration=\"{ enter: 500, leave: 800 }\""
+      ]
     }
+
   },
 
   "events": {

--- a/ui/src/mixins/panel.js
+++ b/ui/src/mixins/panel.js
@@ -43,6 +43,9 @@ export const PanelParentMixin = {
       type: String,
       default: 'slide-left'
     },
+    transitionDuration: {
+      type: [Number, String, Object]
+    },
 
     keepAlive: Boolean
   },
@@ -226,7 +229,8 @@ export const PanelParentMixin = {
         ? [
           h('transition', {
             props: {
-              name: this.panelTransition
+              name: this.panelTransition,
+              duration: this.transitionDuration
             }
           }, content)
         ]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs]

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Add transition-duration property to all components that support transitions
(QCarousel, QStepper, QTabPanel) allowing nested transitions to be viewed.
Previously, when the first transition completed, subsequent animations were
skipped showing the final state immediately.  The transition-duration property
defines an explicit time (in milliseconds) for the total animation.  All
transitions in this time are animated as intended.  Examples requiring/using
this commit have been included in the appropriate ui/dev pages.

Documentation includes api description of transition-duration property and
examples requiring/using the property on each of the transition supporting
components.

**Other information:**