### PR TITLE
feat(QTable): support for nested row key

### DIFF
--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -43,7 +43,7 @@ export default Vue.extend({
       default: () => []
     },
     rowKey: {
-      type: String,
+      type: [String, Function],
       default: 'id'
     },
 

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -11,9 +11,9 @@
 
     "row-key": {
       "type": "String",
-      "desc": "Property of each row that defines the unique key of each row; The value of property must be string or number",
+      "desc": "Property of each row that defines the unique key of each row; The value of property must be string, number or a function returning the desired (nested) key in the row",
       "default": "id",
-      "examples": [ "myprop" ],
+      "examples": [ "row-key=\"name\"", ":row-key=\"row => row.name\"" ],
       "category": "general"
     },
 

--- a/ui/src/components/table/table-body.js
+++ b/ui/src/components/table/table-body.js
@@ -4,7 +4,7 @@ export default {
   methods: {
     getTableRowBody (h, row, body) {
       const
-        key = row[this.rowKey],
+        key = typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey],
         selected = this.isRowSelected(key)
 
       return body(this.addBodyRowMeta({
@@ -19,7 +19,7 @@ export default {
     getTableRow (h, row) {
       const
         bodyCell = this.$scopedSlots['body-cell'],
-        key = row[this.rowKey],
+        key = typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey],
         selected = this.isRowSelected(key),
         child = bodyCell
           ? this.computedCols.map(col => bodyCell(this.addBodyCellMetaData({ row, col })))

--- a/ui/src/components/table/table-grid.js
+++ b/ui/src/components/table/table-grid.js
@@ -49,7 +49,7 @@ export default {
 
       return h('div', { staticClass: 'row' }, this.computedRows.map(row => {
         const
-          key = row[this.rowKey],
+          key = typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey],
           selected = this.isRowSelected(key)
 
         return item(this.addBodyRowMeta({

--- a/ui/src/components/table/table-header.js
+++ b/ui/src/components/table/table-header.js
@@ -81,7 +81,7 @@ export default {
                   val = false
                 }
                 this.__updateSelection(
-                  this.computedRows.map(row => row[this.rowKey]),
+                  this.computedRows.map(row => typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]),
                   this.computedRows,
                   val
                 )
@@ -106,7 +106,7 @@ export default {
               val = false
             }
             this.__updateSelection(
-              this.computedRows.map(row => row[this.rowKey]),
+              this.computedRows.map(row => typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]),
               this.computedRows,
               val
             )

--- a/ui/src/components/table/table-row-selection.js
+++ b/ui/src/components/table/table-row-selection.js
@@ -14,7 +14,7 @@ export default {
   computed: {
     selectedKeys () {
       const keys = {}
-      this.selected.map(row => row[this.rowKey]).forEach(key => {
+      this.selected.map(row => typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]).forEach(key => {
         keys[key] = true
       })
       return keys
@@ -34,13 +34,13 @@ export default {
 
     allRowsSelected () {
       if (this.multipleSelection === true) {
-        return this.computedRows.length > 0 && this.computedRows.every(row => this.selectedKeys[row[this.rowKey]] === true)
+        return this.computedRows.length > 0 && this.computedRows.every(row => this.selectedKeys[typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]] === true)
       }
     },
 
     someRowsSelected () {
       if (this.multipleSelection === true) {
-        return !this.allRowsSelected && this.computedRows.some(row => this.selectedKeys[row[this.rowKey]] === true)
+        return !this.allRowsSelected && this.computedRows.some(row => this.selectedKeys[typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]] === true)
       }
     },
 
@@ -67,7 +67,7 @@ export default {
           added === true
             ? this.selected.concat(rows)
             : this.selected.filter(
-              row => keys.includes(row[this.rowKey]) === false
+              row => keys.includes(typeof this.rowKey === 'function' ? this.rowKey(row) : row[this.rowKey]) === false
             )
         )
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
Currently, only a string can be used for the row-key. In some cases the key (ID) is nested inside an object (https://github.com/mrichar1/jsonapi-vuex). This PR provides the ability to use a nested row key similar to the `field` property of a column.
