### PR TITLE
Improve QSlideItem and VTouchPan (allow to only stop the events when detected)

### DIFF
--- a/ui/dev/components/components/list-slide-item-complex.vue
+++ b/ui/dev/components/components/list-slide-item-complex.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="q-layout-padding q-mx-auto" style="max-width: 600px">
+    <h6>Pan the items below (QPullToRefresh on list)</h6>
+
+    <div class="scroll q-pa-sm bg-grey-4" style="max-height: 50vh">
+      <q-pull-to-refresh @refresh="refresh">
+        <q-list bordered separator>
+          <q-item>
+            <q-item-section>
+              <q-item-label>
+                Drag from here for fallback pull to refresh
+              </q-item-label>
+              <q-slider v-model="slider" :min="0" :max="20" />
+            </q-item-section>
+          </q-item>
+
+          <q-slide-item
+            @left="onLeft"
+            @right="onRight"
+            @click.native="onClickItem"
+          >
+            <template v-slot:left>
+              <q-icon name="alarm" />
+            </template>
+            <template v-slot:right>
+              <q-icon name="alarm" />
+            </template>
+            <q-item>
+              <q-item-section side class="q-gutter-y-sm">
+                <q-btn size="sm" unelevated color="primary" label="Btn" @click="onClick" />
+                <q-btn size="sm" unelevated color="primary" to="#test" label="Link" @click="onClick" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>
+                  Item LR
+                  <q-slider v-model="slider" :min="0" :max="20" />
+                </q-item-label>
+              </q-item-section>
+              <q-slide-item
+                @top="onTop"
+                @bottom="onBottom"
+                @click.native="onClickItem"
+              >
+                <template v-slot:top>
+                  <q-icon name="alarm" />
+                </template>
+                <template v-slot:bottom>
+                  <q-icon name="alarm" />
+                </template>
+                <q-item class="bg-yellow">
+                  <q-item-section side class="q-gutter-y-sm">
+                    <q-btn size="sm" unelevated color="primary" label="Btn" @click="onClick" />
+                    <q-btn size="sm" unelevated color="primary" to="#test" label="Link" @click="onClick" />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>
+                      Item TB
+                    </q-item-label>
+                    <q-slider v-model="slider" :min="0" :max="20" />
+                  </q-item-section>
+                  <q-item-section side class="q-gutter-y-sm">
+                    <q-chip size="md" square color="deep-orange" text-color="white">
+                      Top
+                    </q-chip>
+                    <q-chip size="md" square color="deep-orange" text-color="white">
+                      Bottom
+                    </q-chip>
+                  </q-item-section>
+                </q-item>
+              </q-slide-item>
+              <q-item-section side class="q-gutter-y-sm">
+                <q-chip size="md" square color="deep-orange" text-color="white">
+                  Left
+                </q-chip>
+                <q-chip size="md" square color="deep-orange" text-color="white">
+                  Right
+                </q-chip>
+              </q-item-section>
+            </q-item>
+          </q-slide-item>
+
+          <q-slide-item
+            @left="onLeft"
+            @top="onTop"
+            @click.native="onClickItem"
+          >
+            <template v-slot:left>
+              <q-icon name="alarm" />
+            </template>
+            <template v-slot:top>
+              <q-icon name="alarm" />
+            </template>
+            <q-item>
+              <q-item-section side class="q-gutter-y-sm">
+                <q-btn size="sm" unelevated color="primary" label="Btn" @click="onClick" />
+                <q-btn size="sm" unelevated color="primary" to="#test" label="Link" @click="onClick" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>
+                  Item LT
+                </q-item-label>
+                <q-slider v-model="slider" :min="0" :max="20" />
+              </q-item-section>
+              <q-slide-item
+                @right="onRight"
+                @bottom="onBottom"
+                @click.native="onClickItem"
+              >
+                <template v-slot:right>
+                  <q-icon name="alarm" />
+                </template>
+                <template v-slot:bottom>
+                  <q-icon name="alarm" />
+                </template>
+                <q-item class="bg-yellow">
+                  <q-item-section side class="q-gutter-y-sm">
+                    <q-btn size="sm" unelevated color="primary" label="Btn" @click="onClick" />
+                    <q-btn size="sm" unelevated color="primary" to="#test" label="Link" @click="onClick" />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>
+                      Item RB
+                    </q-item-label>
+                    <q-slider v-model="slider" :min="0" :max="20" />
+                  </q-item-section>
+                  <q-item-section side class="q-gutter-y-sm">
+                    <q-chip size="md" square color="deep-orange" text-color="white">
+                      Right
+                    </q-chip>
+                    <q-chip size="md" square color="deep-orange" text-color="white">
+                      Bottom
+                    </q-chip>
+                  </q-item-section>
+                </q-item>
+              </q-slide-item>
+              <q-item-section side class="q-gutter-y-sm">
+                <q-chip size="md" square color="deep-orange" text-color="white">
+                  Left
+                </q-chip>
+                <q-chip size="md" square color="deep-orange" text-color="white">
+                  Top
+                </q-chip>
+              </q-item-section>
+            </q-item>
+          </q-slide-item>
+
+          <template v-for="index in items">
+            <q-slide-item
+              v-for="i in 7" :key="`${ i }_${ index }`"
+              @left="onLeft"
+              @right="onRight"
+              @top="onTop"
+              @bottom="onBottom"
+              @click.native="onClickItem"
+            >
+              <template v-if="i === 1 || i === 5 || i === 7" v-slot:left>
+                <q-icon name="alarm" />
+              </template>
+              <template v-if="i === 2 || i === 5 || i === 7" v-slot:right>
+                <q-icon name="alarm" />
+              </template>
+              <template v-if="i === 3 || i === 6 || i === 7" v-slot:top>
+                <q-icon name="alarm" />
+              </template>
+              <template v-if="i === 4 || i === 6 || i === 7" v-slot:bottom>
+                <q-icon name="alarm" />
+              </template>
+              <q-item>
+                <q-item-section side class="q-gutter-y-sm">
+                  <q-btn size="sm" unelevated color="primary" label="Btn" @click="onClick" />
+                  <q-btn size="sm" unelevated color="primary" to="#test" label="Link" @click="onClick" />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label>
+                    Item {{ index }}.{{ i }}
+                  </q-item-label>
+                  <q-slider v-model="slider" :min="0" :max="20" />
+                </q-item-section>
+                <q-item-section side class="q-gutter-y-sm">
+                  <q-chip v-if="i === 1 || i === 5 || i === 7" size="md" square color="deep-orange" text-color="white">
+                    Left
+                  </q-chip>
+                  <q-chip v-if="i === 2 || i === 5 || i === 7" size="md" square color="deep-orange" text-color="white">
+                    Right
+                  </q-chip>
+                  <q-chip v-if="i === 3 || i === 6 || i === 7" size="md" square color="deep-orange" text-color="white">
+                    Top
+                  </q-chip>
+                  <q-chip v-if="i === 4 || i === 6 || i === 7" size="md" square color="deep-orange" text-color="white">
+                    Bottom
+                  </q-chip>
+                </q-item-section>
+              </q-item>
+            </q-slide-item>
+          </template>
+        </q-list>
+      </q-pull-to-refresh>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      items: [1],
+      slider: 10
+    }
+  },
+
+  methods: {
+    refresh (done) {
+      setTimeout(() => {
+        this.items.push(this.items.length + 1)
+        done()
+      }, 1000)
+    },
+
+    onLeft ({ reset }) {
+      console.log('Left action!')
+      this.finalize(reset)
+    },
+    onRight ({ reset }) {
+      console.log('Right action!')
+      this.finalize(reset)
+    },
+    onTop ({ reset }) {
+      console.log('Top-side action!')
+      this.finalize(reset)
+    },
+    onBottom ({ reset }) {
+      console.log('Bottom-side action!')
+      this.finalize(reset)
+    },
+    finalize (reset) {
+      console.log('Resetting in 2 seconds')
+      setTimeout(() => {
+        reset()
+      }, 2000)
+    },
+
+    onClickItem () {
+      if (this.$q.platform.is.desktop) {
+        console.log('clicked on item')
+      }
+      else {
+        this.$q.notify('clicked on item')
+      }
+    },
+
+    onClick () {
+      console.log('clicked on test btn')
+    }
+  }
+}
+</script>

--- a/ui/src/components/list/QSlideItem.js
+++ b/ui/src/components/list/QSlideItem.js
@@ -123,8 +123,10 @@ export default Vue.extend({
   render (h) {
     const
       content = [],
-      horizontal = this.$scopedSlots.left !== void 0 || this.$scopedSlots.right !== void 0,
-      vertical = this.$scopedSlots.top !== void 0 || this.$scopedSlots.bottom !== void 0
+      left = this.$scopedSlots.right !== void 0,
+      right = this.$scopedSlots.left !== void 0,
+      up = this.$scopedSlots.bottom !== void 0,
+      down = this.$scopedSlots.top !== void 0
 
     slotsDef.forEach(slot => {
       const dir = slot[0]
@@ -146,12 +148,14 @@ export default Vue.extend({
       h('div', {
         ref: 'content',
         staticClass: 'q-slide-item__content',
-        directives: horizontal === true || vertical === true ? [{
+        directives: left === true || right === true || up === true || down === true ? [{
           name: 'touch-pan',
           value: this.__pan,
           modifiers: {
-            horizontal,
-            vertical,
+            left,
+            right,
+            up,
+            down,
             prevent: true,
             stop: true,
             mouse: true,

--- a/ui/src/directives/TouchHold.js
+++ b/ui/src/directives/TouchHold.js
@@ -60,7 +60,7 @@ export default {
       start (evt, mouseEvent) {
         ctx.origin = position(evt)
 
-        const startTime = new Date().getTime()
+        const startTime = Date.now()
 
         if (client.is.mobile === true) {
           document.body.classList.add('non-selectable')
@@ -81,7 +81,7 @@ export default {
             touch: mouseEvent !== true,
             mouse: mouseEvent === true,
             position: ctx.origin,
-            duration: new Date().getTime() - startTime
+            duration: Date.now() - startTime
           })
         }, ctx.duration)
       },

--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -79,7 +79,7 @@ function getChanges (evt, ctx, isFinal) {
     direction: dir,
     isFirst: ctx.event.isFirst,
     isFinal: isFinal === true,
-    duration: new Date().getTime() - ctx.event.time,
+    duration: Date.now() - ctx.event.time,
     distance: {
       x: absX,
       y: absY
@@ -165,7 +165,7 @@ export default {
         ctx.event = {
           x: pos.left,
           y: pos.top,
-          time: new Date().getTime(),
+          time: Date.now(),
           mouse: mouseEvent === true,
           detected: false,
           isFirst: true,

--- a/ui/src/directives/TouchRepeat.js
+++ b/ui/src/directives/TouchRepeat.js
@@ -124,7 +124,7 @@ export default {
           touch: mouseEvent !== true && keyboardEvent !== true,
           mouse: mouseEvent === true,
           keyboard: keyboardEvent === true,
-          startTime: new Date().getTime(),
+          startTime: Date.now(),
           repeatCount: 0
         }
 
@@ -150,7 +150,7 @@ export default {
             }
           }
 
-          ctx.event.duration = new Date().getTime() - ctx.event.startTime
+          ctx.event.duration = Date.now() - ctx.event.startTime
           ctx.event.repeatCount += 1
 
           ctx.handler(ctx.event)

--- a/ui/src/directives/TouchRepeat.json
+++ b/ui/src/directives/TouchRepeat.json
@@ -57,7 +57,7 @@
           },
           "startTime": {
             "type": "Number",
-            "desc": "Unix timestamp of the moment when event started; Equivalent to new Date().getTime()",
+            "desc": "Unix timestamp of the moment when event started; Equivalent to Date.now()",
             "examples": [ 1558603256472 ]
           }
         }

--- a/ui/src/directives/TouchSwipe.js
+++ b/ui/src/directives/TouchSwipe.js
@@ -67,7 +67,7 @@ export default {
         ctx.event = {
           x: pos.left,
           y: pos.top,
-          time: new Date().getTime(),
+          time: Date.now(),
           mouse: mouseEvent === true,
           dir: false
         }
@@ -83,7 +83,7 @@ export default {
           return
         }
 
-        const time = new Date().getTime() - ctx.event.time
+        const time = Date.now() - ctx.event.time
 
         if (time === 0) {
           return

--- a/ui/src/utils/event.js
+++ b/ui/src/utils/event.js
@@ -131,11 +131,93 @@ export function create (name, { bubbles = false, cancelable = false } = {}) {
     return new Event(name, { bubbles, cancelable })
   }
   catch (e) {
-    // IE doesn't support `new Event()`, so...`
+    // IE doesn't support `new Event()`, so...
     const evt = document.createEvent('Event')
     evt.initEvent(name, bubbles, cancelable)
     return evt
   }
+}
+
+export function cloneMouseEvent (evt) {
+  let cloned
+
+  try {
+    cloned = new MouseEvent(evt.type, {
+      bubbles: evt.bubbles,
+      cancelable: evt.cancelable,
+      composed: evt.composed,
+
+      detail: evt.detail,
+      view: evt.view,
+      sourceCapabilities: evt.sourceCapabilities,
+
+      screenX: evt.screenX,
+      screenY: evt.screenY,
+      clientX: evt.clientX,
+      clientY: evt.clientY,
+      ctrlKey: evt.ctrlKey,
+      altKey: evt.altKey,
+      shiftKey: evt.shiftKey,
+      metaKey: evt.metaKey,
+      button: evt.button,
+      buttons: evt.buttons,
+      relatedTarget: evt.relatedTarget,
+      region: evt.region
+    })
+  }
+  catch (e) {
+    // IE doesn't support `new MouseEvent()`, so...
+    cloned = document.createEvent('MouseEvents')
+    cloned.initMouseEvent(
+      evt.type,
+      evt.bubbles,
+      evt.cancelable,
+      evt.view,
+      evt.detail,
+      evt.screenX,
+      evt.screenY,
+      evt.clientX,
+      evt.clientY,
+      evt.ctrlKey,
+      evt.altKey,
+      evt.shiftKey,
+      evt.metaKey,
+      evt.button,
+      evt.relatedTarget
+    )
+  }
+
+  evt.defaultPrevented === true && cloned.preventDefault()
+  evt.cancelBubble === true && cloned.stopPropagation()
+
+  return cloned
+}
+
+export function cloneTouchEvent (evt) {
+  // IE doesn't support `TouchEvent`, so this should never be called...
+
+  const cloned = new TouchEvent(evt.type, {
+    bubbles: evt.bubbles,
+    cancelable: evt.cancelable,
+    composed: evt.composed,
+
+    detail: evt.detail,
+    view: evt.view,
+    sourceCapabilities: evt.sourceCapabilities,
+
+    touches: evt.touches,
+    targetTouches: evt.targetTouches,
+    changedTouches: evt.changedTouches,
+    ctrlKey: evt.ctrlKey,
+    shiftKey: evt.shiftKey,
+    altKey: evt.altKey,
+    metaKey: evt.metaKey
+  })
+
+  evt.defaultPrevented === true && cloned.preventDefault()
+  evt.cancelBubble === true && cloned.stopPropagation()
+
+  return cloned
 }
 
 export default {
@@ -150,5 +232,7 @@ export default {
   prevent,
   stopAndPrevent,
   preventDraggable,
-  create
+  create,
+  cloneMouseEvent,
+  cloneTouchEvent
 }


### PR DESCRIPTION
- Improve QTouchPan to allow resuming events stopped if not detected
- Improve VTouchPan to generate synthetic events for over the boundary movement
- Use Date.now() instead of new Date().getTime()
- Add granular modifiers (left, right, up, down) for VTouchPan in QSlideItem 
close #5367