### PR TITLE
feat(docs): Add example for using rowspan attribute in QTable component

### DIFF
--- a/docs/src/examples/QTable/RowSpan.vue
+++ b/docs/src/examples/QTable/RowSpan.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="q-pa-md">
+    <q-table
+      title="Treats"
+      :data="rowsData"
+      :columns="columns"
+      :pagination.sync="pagination"
+      :rows-per-page-options="[3, 6, 9, 12, 15, 18, 0]"
+      row-key="name">
+      <template v-slot:body="props">
+        <q-tr :props="props">
+          <template v-for="cell in props.row.cells">
+            <q-td v-if="cell.rowspan" :key="cell.value" :rowspan="cell.rowspan" class="text-center">{{ cell.value }}</q-td>
+            <q-td v-else :key="cell.value" class="text-center">{{ cell.value }}</q-td>
+          </template>
+        </q-tr>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      pagination: {
+        page: 1,
+        rowsPerPage: 9
+      },
+      columns: [
+        { name: 'name', label: 'Dessert (100g serving)', align: 'center' },
+        { name: 'treats', align: 'center', label: 'Treats' },
+        { name: 'quantity', align: 'center', label: 'Quantity' }
+      ],
+      rowsData: [
+        {
+          cells: [
+            { value: 'Frozen Yogurt', rowspan: 3 },
+            { value: 'Calories' },
+            { value: '159' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Fat (g)' },
+            { value: '6' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Carbs (g)' },
+            { value: '24' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Ice cream sandwich', rowspan: 3 },
+            { value: 'Calories' },
+            { value: '237' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Fat (g)' },
+            { value: '9' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Carbs (g)' },
+            { value: '37' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Eclair', rowspan: 3 },
+            { value: 'Calories' },
+            { value: '262' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Fat (g)' },
+            { value: '16' }
+          ]
+        },
+        {
+          cells: [
+            { value: 'Carbs (g)' },
+            { value: '23' }
+          ]
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/table.md
+++ b/docs/src/pages/vue-components/table.md
@@ -230,6 +230,10 @@ We can also customize only one particular column only. The syntax for this slot 
 
 <doc-example title="Body-cell-[name] slot" file="QTable/SlotBodyCellName" />
 
+Using slot with `rowspan` attribute
+
+<doc-example title="Rowspan attribute" file="QTable/RowSpan" />
+
 ### Header slots
 
 The example below shows how you can use a slot to customize the entire header row:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR shows how use `rowspan` attribute in `QTable` component.