### PR TITLE
fix(Notify plugin): actions CSS - sane default color (black)

### DIFF
--- a/ui/src/plugins/Notify.sass
+++ b/ui/src/plugins/Notify.sass
@@ -50,7 +50,7 @@ body.q-ios-padding .q-notifications__list
     padding: 8px 0
 
   &__actions
-    color: #c581ff
+    color: #000000
 
   &--standard
     padding: 0 16px

--- a/ui/src/plugins/Notify.styl
+++ b/ui/src/plugins/Notify.styl
@@ -50,7 +50,7 @@ body.q-ios-padding .q-notifications__list
     padding 8px 0
 
   &__actions
-    color #c581ff
+    color #000000
 
   &--standard
     padding 0 16px


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Changing a default CSS color

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The default text color for the notification's actions is an odd purple. I figure having the default be black makes more sense.