### PR TITLE
q-color: fix infinite loop in q-tabs align property when scrollbars appear in q-color

### DIFF
--- a/ui/src/components/color/QColor.js
+++ b/ui/src/components/color/QColor.js
@@ -291,41 +291,41 @@ export default Vue.extend({
       return h('div', {
         staticClass: 'q-color-picker__footer relative-position overflow-hidden'
       }, [
-      h(QTabs, {
-        staticClass: 'absolute-full',
-        props: {
-          value: this.view,
-          dense: true,
-          align: 'justify'
-        },
-        on: {
-          input: val => { this.view = val }
-        }
-      }, [
-        h(QTab, {
+        h(QTabs, {
+          staticClass: 'absolute-full',
           props: {
-            icon: this.$q.iconSet.colorPicker.spectrum,
-            name: 'spectrum',
-            ripple: false
+            value: this.view,
+            dense: true,
+            align: 'justify'
+          },
+          on: {
+            input: val => { this.view = val }
           }
-        }),
+        }, [
+          h(QTab, {
+            props: {
+              icon: this.$q.iconSet.colorPicker.spectrum,
+              name: 'spectrum',
+              ripple: false
+            }
+          }),
 
-        h(QTab, {
-          props: {
-            icon: this.$q.iconSet.colorPicker.tune,
-            name: 'tune',
-            ripple: false
-          }
-        }),
+          h(QTab, {
+            props: {
+              icon: this.$q.iconSet.colorPicker.tune,
+              name: 'tune',
+              ripple: false
+            }
+          }),
 
-        h(QTab, {
-          props: {
-            icon: this.$q.iconSet.colorPicker.palette,
-            name: 'palette',
-            ripple: false
-          }
-        })
-      ])
+          h(QTab, {
+            props: {
+              icon: this.$q.iconSet.colorPicker.palette,
+              name: 'palette',
+              ripple: false
+            }
+          })
+        ])
       ])
     },
 

--- a/ui/src/components/color/QColor.js
+++ b/ui/src/components/color/QColor.js
@@ -288,8 +288,11 @@ export default Vue.extend({
     },
 
     __getFooter (h) {
-      return h(QTabs, {
-        staticClass: 'q-color-picker__footer',
+      return h('div', {
+        staticClass: 'q-color-picker__footer relative-position overflow-hidden'
+      }, [
+      h(QTabs, {
+        staticClass: 'absolute-full',
         props: {
           value: this.view,
           dense: true,
@@ -322,6 +325,7 @@ export default Vue.extend({
             ripple: false
           }
         })
+      ])
       ])
     },
 

--- a/ui/src/components/color/QColor.sass
+++ b/ui/src/components/color/QColor.sass
@@ -4,7 +4,7 @@
   max-width: 350px
   vertical-align: top
 
-  min-width: 150px
+  min-width: 220px
 
   border-radius: $generic-border-radius
   box-shadow: $shadow-2
@@ -51,6 +51,8 @@
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAH0lEQVQoU2NkYGAwZkAFZ5G5jPRRgOYEVDeB3EBjBQBOZwTVugIGyAAAAABJRU5ErkJggg==') !important
 
   &__footer
+    height: 40px
+
     .q-tab--inactive
       background: linear-gradient(to bottom, rgba(0,0,0,.3) 0%, rgba(0,0,0,.15) 25%, rgba(0,0,0,.1))
 

--- a/ui/src/components/color/QColor.styl
+++ b/ui/src/components/color/QColor.styl
@@ -4,7 +4,7 @@
   max-width 350px
   vertical-align top
 
-  min-width 150px
+  min-width 220px
 
   border-radius $generic-border-radius
   box-shadow $shadow-2
@@ -51,6 +51,8 @@
     background-image url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAH0lEQVQoU2NkYGAwZkAFZ5G5jPRRgOYEVDeB3EBjBQBOZwTVugIGyAAAAABJRU5ErkJggg==') !important
 
   &__footer
+    height: 40px
+
     .q-tab--inactive
       background linear-gradient(to bottom, rgba(0,0,0,.3) 0%, rgba(0,0,0,.15) 25%, rgba(0,0,0,.1))
 

--- a/ui/src/components/color/QColor.styl
+++ b/ui/src/components/color/QColor.styl
@@ -51,7 +51,7 @@
     background-image url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAH0lEQVQoU2NkYGAwZkAFZ5G5jPRRgOYEVDeB3EBjBQBOZwTVugIGyAAAAABJRU5ErkJggg==') !important
 
   &__footer
-    height: 40px
+    height 40px
 
     .q-tab--inactive
       background linear-gradient(to bottom, rgba(0,0,0,.3) 0%, rgba(0,0,0,.15) 25%, rgba(0,0,0,.1))


### PR DESCRIPTION
fixes https://github.com/quasarframework/quasar/issues/4710
and https://github.com/quasarframework/quasar/issues/5145

By wrapping the footer in a div and adding `absolute-full` positioning to the `q-tabs` the issue is solved, this is similar to the q-color header.

Note: I separated the changes in two commits to make it easier to read the diffs, the second commit is just formatting (added indentation)