### PR TITLE
Clarify @input event

### DIFF
--- a/ui/src/mixins/panel-parent.json
+++ b/ui/src/mixins/panel-parent.json
@@ -48,7 +48,7 @@
 
   "events": {
     "input": {
-      "desc": "Emitted when component's model changes (current panel name); Is also used by v-model",
+      "desc": "Emitted when the component changes the model; note this event _isn't_ fired if the model is changed externally",
       "params": {
         "value": {
           "type": [ "String", "Number" ],

--- a/ui/src/mixins/panel-parent.json
+++ b/ui/src/mixins/panel-parent.json
@@ -48,7 +48,7 @@
 
   "events": {
     "input": {
-      "desc": "Emitted when the component changes the model; note this event _isn't_ fired if the model is changed externally",
+      "desc": "Emitted when the component changes the model; This event _isn't_ fired if the model is changed externally; Is also used by v-model",
       "params": {
         "value": {
           "type": [ "String", "Number" ],


### PR DESCRIPTION
This caused me some confusion, and now I understand it I'm updating the description to match my current understanding:

Removed reference to panel name, as this doesn't make sense for QStepper or QCarousel.
Clarify that @input event only fires when the component changes the model, not when the model is changed externally.
Note there are other references to 'panel' in other parts of this doc, so perhaps all should be changed to 'panel / slide / step'? Happy to do that if it's useful.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
