### PR TITLE
(feat) QDate close button

### DIFF
--- a/ui/dev/components/form/date.vue
+++ b/ui/dev/components/form/date.vue
@@ -9,6 +9,7 @@
         <q-toggle :dark="dark" v-model="biggerHeight" label="More Height" />
         <q-toggle :dark="dark" v-model="minimal" label="Minimal" />
         <q-toggle :dark="dark" v-model="todayBtn" label="Today Button" />
+        <q-toggle :dark="dark" v-model="closeBtn" label="Close Button" />
         <q-toggle :dark="dark" v-model="persian" label="Persian calendar model" />
       </div>
 
@@ -344,6 +345,7 @@ export default {
       biggerHeight: false,
       minimal: false,
       todayBtn: false,
+      closeBtn: false,
 
       mask: '[Month: ]MMM[, Day: ]Do[, Year: ]YYYY',
 
@@ -385,6 +387,7 @@ export default {
         readonly: this.readonly,
         minimal: this.minimal,
         todayBtn: this.todayBtn,
+        closeBtn: this.closeBtn,
         calendar: this.persian ? 'persian' : 'gregorian'
       }
     },

--- a/ui/icon-set/eva-icons.js
+++ b/ui/icon-set/eva-icons.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'eva-arrow-ios-back-outline',
     arrowRight: 'eva-arrow-ios-forward-outline',
     now: 'eva-clock-outline',
-    today: 'eva-calendar-outline'
+    today: 'eva-calendar-outline',
+    close: 'eva-close'
   },
   editor: {
     bold: 'format_bold',

--- a/ui/icon-set/fontawesome-v5-pro.js
+++ b/ui/icon-set/fontawesome-v5-pro.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'fal fa-chevron-left',
     arrowRight: 'fal fa-chevron-right',
     now: 'fal fa-clock',
-    today: 'fal fa-calendar-check'
+    today: 'fal fa-calendar-check',
+    close: 'fal fa-times'
   },
   editor: {
     bold: 'fal fa-bold',

--- a/ui/icon-set/fontawesome-v5.js
+++ b/ui/icon-set/fontawesome-v5.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'fas fa-chevron-left',
     arrowRight: 'fas fa-chevron-right',
     now: 'far fa-clock',
-    today: 'far fa-calendar-check'
+    today: 'far fa-calendar-check',
+    close: 'fas fa-times'
   },
   editor: {
     bold: 'fas fa-bold',

--- a/ui/icon-set/ionicons-v4.js
+++ b/ui/icon-set/ionicons-v4.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'ion-ios-arrow-back',
     arrowRight: 'ion-ios-arrow-forward',
     now: 'ion-time',
-    today: 'ion-calendar'
+    today: 'ion-calendar',
+    close: 'ion-close'
   },
   editor: { // requires Material icons for some as Ionicons simply does not have everything needed
     bold: 'format_bold',

--- a/ui/icon-set/material-icons-outlined.js
+++ b/ui/icon-set/material-icons-outlined.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'o_chevron_left',
     arrowRight: 'o_chevron_right',
     now: 'o_access_time',
-    today: 'o_today'
+    today: 'o_today',
+    close: 'o_close'
   },
   editor: {
     bold: 'o_format_bold',

--- a/ui/icon-set/material-icons-round.js
+++ b/ui/icon-set/material-icons-round.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'r_chevron_left',
     arrowRight: 'r_chevron_right',
     now: 'r_access_time',
-    today: 'r_today'
+    today: 'r_today',
+    close: 'r_close'
   },
   editor: {
     bold: 'r_format_bold',

--- a/ui/icon-set/material-icons-sharp.js
+++ b/ui/icon-set/material-icons-sharp.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 's_chevron_left',
     arrowRight: 's_chevron_right',
     now: 's_access_time',
-    today: 's_today'
+    today: 's_today',
+    close: 's_close'
   },
   editor: {
     bold: 's_format_bold',

--- a/ui/icon-set/material-icons.js
+++ b/ui/icon-set/material-icons.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'chevron_left',
     arrowRight: 'chevron_right',
     now: 'access_time',
-    today: 'today'
+    today: 'today',
+    close: 'close'
   },
   editor: {
     bold: 'format_bold',

--- a/ui/icon-set/mdi-v3.js
+++ b/ui/icon-set/mdi-v3.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'mdi-chevron-left',
     arrowRight: 'mdi-chevron-right',
     now: 'mdi-clock-outline',
-    today: 'mdi-calendar-today'
+    today: 'mdi-calendar-today',
+    close: 'mdi-close'
   },
   editor: {
     bold: 'mdi-format-bold',

--- a/ui/icon-set/mdi-v4.js
+++ b/ui/icon-set/mdi-v4.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'mdi-chevron-left',
     arrowRight: 'mdi-chevron-right',
     now: 'mdi-clock-outline',
-    today: 'mdi-calendar-today'
+    today: 'mdi-calendar-today',
+    close: 'mdi-close'
   },
   editor: {
     bold: 'mdi-format-bold',

--- a/ui/icon-set/themify.js
+++ b/ui/icon-set/themify.js
@@ -39,7 +39,8 @@ export default {
     arrowLeft: 'ti-angle-left',
     arrowRight: 'ti-angle-right',
     now: 'ti-time',
-    today: 'ti-calendar'
+    today: 'ti-calendar',
+    close: 'ti-close'
   },
   editor: {
     bold: 'format_bold',

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -11,6 +11,7 @@ const yearsInterval = 20
 const viewIsValid = v => ['Calendar', 'Years', 'Months'].includes(v)
 
 const KEYCODE_TAB = 9
+const KEYCODE_ENTER = 13
 
 export default Vue.extend({
   name: 'QDate',
@@ -380,6 +381,7 @@ export default Vue.extend({
                 on: {
                   click: () => { this.view = 'Years' },
                   keyup: e => {
+                    e.keyCode === KEYCODE_ENTER && (this.view = 'Years')
                     if (e.keyCode === KEYCODE_TAB) {
                       this.$refs.subtitle.classList.add('focus-only')
                     }
@@ -409,6 +411,7 @@ export default Vue.extend({
                   on: {
                     click: () => { this.view = 'Calendar' },
                     keyup: e => {
+                      e.keyCode === KEYCODE_ENTER && (this.view = 'Calendar')
                       if (e.keyCode === KEYCODE_TAB) {
                         this.$refs.headerTitle.classList.add('focus-only')
                       }

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -10,6 +10,8 @@ import { jalaaliMonthLength, toGregorian } from '../../utils/date-persian.js'
 const yearsInterval = 20
 const viewIsValid = v => ['Calendar', 'Years', 'Months'].includes(v)
 
+const KEYCODE_TAB = 9
+
 export default Vue.extend({
   name: 'QDate',
 
@@ -39,6 +41,7 @@ export default Vue.extend({
 
     firstDayOfWeek: [String, Number],
     todayBtn: Boolean,
+    closeBtn: Boolean,
     minimal: Boolean,
     defaultView: {
       type: String,
@@ -332,35 +335,36 @@ export default Vue.extend({
       if (this.minimal === true) { return }
 
       return h('div', {
-        staticClass: 'q-date__header',
-        class: this.headerClass
+        staticClass: 'row q-date__header-bkg',
+        class: this.headerClass,
+        attrs: { role: 'region', 'aria-label': 'Calendar header' }
       }, [
-        h('div', {
-          staticClass: 'relative-position'
+        this.closeBtn === true ? h('div', {
+          staticClass: 'col-shrink'
         }, [
-          h('transition', {
+          h(QBtn, {
+            staticClass: 'q-date__header-close',
+            attrs: { 'aria-label': 'close pop up calendar' },
             props: {
-              name: 'q-transition--fade'
-            }
-          }, [
-            h('div', {
-              key: 'h-yr-' + this.headerSubtitle,
-              staticClass: 'q-date__header-subtitle q-date__header-link',
-              class: this.view === 'Years' ? 'q-date__header-link--active' : 'cursor-pointer',
-              attrs: { tabindex: this.computedTabindex },
-              on: {
-                click: () => { this.view = 'Years' },
-                keyup: e => { e.keyCode === 13 && (this.view = 'Years') }
-              }
-            }, [ this.headerSubtitle ])
-          ])
-        ]),
+              icon: this.$q.iconSet.datetime.close,
+              flat: true,
+              size: 'md',
+              dense: true,
+              round: true,
+              tabindex: this.computedTabindex
+            },
+            directives: [{
+              name: 'close-popup',
+              value: true
+            }]
+          })
+        ]) : null,
 
         h('div', {
-          staticClass: 'q-date__header-title relative-position flex no-wrap'
+          staticClass: 'col q-date__header'
         }, [
           h('div', {
-            staticClass: 'relative-position col'
+            staticClass: 'relative-position'
           }, [
             h('transition', {
               props: {
@@ -368,31 +372,67 @@ export default Vue.extend({
               }
             }, [
               h('div', {
-                key: 'h-sub' + this.headerTitle,
-                staticClass: 'q-date__header-title-label q-date__header-link',
-                class: this.view === 'Calendar' ? 'q-date__header-link--active' : 'cursor-pointer',
-                attrs: { tabindex: this.computedTabindex },
+                key: 'h-yr-' + this.headerSubtitle,
+                ref: 'subtitle',
+                staticClass: 'q-date__header-subtitle q-date__header-link',
+                class: this.view === 'Years' ? 'q-date__header-link--active' : 'cursor-pointer',
+                attrs: { tabindex: this.computedTabindex, role: 'button' },
                 on: {
-                  click: () => { this.view = 'Calendar' },
-                  keyup: e => { e.keyCode === 13 && (this.view = 'Calendar') }
+                  click: () => { this.view = 'Years' },
+                  keyup: e => {
+                    if (e.keyCode === KEYCODE_TAB) {
+                      this.$refs.subtitle.classList.add('focus-only')
+                    }
+                  }
                 }
-              }, [ this.headerTitle ])
+              }, [ this.headerSubtitle ])
             ])
           ]),
 
-          this.todayBtn === true ? h(QBtn, {
-            staticClass: 'q-date__header-today',
-            props: {
-              icon: this.$q.iconSet.datetime.today,
-              flat: true,
-              size: 'sm',
-              round: true,
-              tabindex: this.computedTabindex
-            },
-            on: {
-              click: this.setToday
-            }
-          }) : null
+          h('div', {
+            staticClass: 'q-date__header-title relative-position flex no-wrap'
+          }, [
+            h('div', {
+              staticClass: 'relative-position col'
+            }, [
+              h('transition', {
+                props: {
+                  name: 'q-transition--fade'
+                }
+              }, [
+                h('div', {
+                  key: 'h-sub' + this.headerTitle,
+                  ref: 'headerTitle',
+                  staticClass: 'q-date__header-title-label q-date__header-link',
+                  class: this.view === 'Calendar' ? 'q-date__header-link--active' : 'cursor-pointer',
+                  attrs: { tabindex: this.computedTabindex, role: 'button' },
+                  on: {
+                    click: () => { this.view = 'Calendar' },
+                    keyup: e => {
+                      if (e.keyCode === KEYCODE_TAB) {
+                        this.$refs.headerTitle.classList.add('focus-only')
+                      }
+                    }
+                  }
+                }, [ this.headerTitle ])
+              ])
+            ]),
+
+            this.todayBtn === true ? h(QBtn, {
+              staticClass: 'q-date__header-today',
+              attrs: { 'aria-label': 'select today\'s date' },
+              props: {
+                icon: this.$q.iconSet.datetime.today,
+                flat: true,
+                size: 'sm',
+                round: true,
+                tabindex: this.computedTabindex
+              },
+              on: {
+                click: this.setToday
+              }
+            }) : null
+          ])
         ])
       ])
     },

--- a/ui/src/components/date/QDate.json
+++ b/ui/src/components/date/QDate.json
@@ -105,6 +105,12 @@
       "desc": "Display a button that selects the current day",
       "category": "content"
     },
+    
+    "close-btn": {
+      "type": "Boolean",
+      "desc": "Display a button that closes the popup (if there is one) q-date is contained in",
+      "category": "content"
+    },
 
     "minimal": {
       "type": "Boolean",

--- a/ui/src/components/date/QDate.sass
+++ b/ui/src/components/date/QDate.sass
@@ -17,6 +17,12 @@
     background-color: var(--q-color-primary)
     padding: 16px
 
+  &__header-bkg
+    border-top-left-radius: inherit
+    color white
+    background-color $primary
+    background-color var(--q-color-primary)
+
   &__actions
     padding: 0 16px 16px
 
@@ -112,6 +118,11 @@
   &__today
     box-shadow: 0 0 1px 0 currentColor
 
+  &__header-close
+    margin 10px
+    margin-right 0px
+    margin-bottom 0px
+
   &__years-content
     padding: 0 8px
 
@@ -166,6 +177,11 @@
       min-width: 110px
       width: 110px
 
+    .q-date__header-bkg
+      border-bottom-left-radius inherit
+      min-width 110px
+      width 110px
+
     .q-date__header-title
       flex-direction: column
     .q-date__header-today
@@ -177,3 +193,6 @@
 
   &--dark
     border-color: $separator-dark-color
+
+  .focus-only:focus
+    outline: 2px solid white;  

--- a/ui/src/components/date/QDate.styl
+++ b/ui/src/components/date/QDate.styl
@@ -17,6 +17,12 @@
     background-color var(--q-color-primary)
     padding 16px
 
+  &__header-bkg
+    border-top-left-radius inherit
+    color white
+    background-color $primary
+    background-color var(--q-color-primary)
+
   &__actions
     padding 0 16px 16px
 
@@ -112,6 +118,11 @@
   &__today
     box-shadow 0 0 1px 0 currentColor
 
+  &__header-close
+    margin 10px
+    margin-right 0px
+    margin-bottom 0px
+
   &__years-content
     padding 0 8px
 
@@ -164,6 +175,11 @@
       min-width 110px
       width 110px
 
+    .q-date__header-bkg
+      border-bottom-left-radius inherit
+      min-width 110px
+      width 110px
+
     .q-date__header-title
       flex-direction column
     .q-date__header-today
@@ -175,3 +191,6 @@
 
   &--dark
     border-color $separator-dark-color
+
+  .focus-only:focus
+    outline: 2px solid white;  


### PR DESCRIPTION
Adds a close button prop to QDate. The close button closes the calendar if it's in a pop-up, a feature that would help with ARIA-compliance.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
