### PR TITLE
feat(docs) add "share" options to flex playground

### DIFF
--- a/docs/src/assets/page-utils.js
+++ b/docs/src/assets/page-utils.js
@@ -1,6 +1,4 @@
-export function copyHeading (id) {
-  const text = window.location.origin + window.location.pathname + '#' + id
-
+export function copyToClipboard (text) {
   var textArea = document.createElement('textarea')
   textArea.className = 'fixed-top'
   textArea.value = text
@@ -10,6 +8,12 @@ export function copyHeading (id) {
 
   document.execCommand('copy')
   document.body.removeChild(textArea)
+}
+
+export function copyHeading (id) {
+  const text = window.location.origin + window.location.pathname + '#' + id
+
+  copyToClipboard(text)
 
   this.$q.notify({
     message: 'Anchor has been copied to clipboard.',

--- a/docs/src/components/page-parts/layout/grid/FlexChild.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexChild.vue
@@ -4,33 +4,33 @@
       <q-btn :label="index" size="sm" flat dense :class="buttonClasses" @click="emitChange" />
       <q-btn icon="clear" size="xs" flat dense @click="onDelete"/>
     </div>
-    <q-input filled v-model="width" dense label="Width (ex: '200px', '20em')" @input="emitChange">
-      <template v-if="width.length > 0" v-slot:append>
+    <q-input filled v-model="child.width" dense label="Width (ex: '200px', '20em')" @input="emitChange">
+      <template v-if="child.width.length > 0" v-slot:append>
         <q-btn icon="clear" size="xs" flat dense @click="width = ''"/>
       </template>
     </q-input>
 
-    <q-input filled v-model="height" dense label="Height (ex: '300px', '25em')" @input="emitChange">
-      <template v-if="height.length > 0" v-slot:append>
+    <q-input filled v-model="child.height" dense label="Height (ex: '300px', '25em')" @input="emitChange">
+      <template v-if="child.height.length > 0" v-slot:append>
         <q-btn icon="clear" size="xs" flat dense @click="height = ''"/>
       </template>
     </q-input>
-    <q-select color="blue-12" v-model="widthGroup" :options="widthOptions" label="Width" emit-value map-options dense options-dense @input="emitChange" />
-    <q-select color="blue-12" v-model="breakpointGroup" :options="breakpointOptions" label="Break Points" multiple emit-value map-options dense options-dense @input="emitChange">
-      <template v-if="breakpointGroup" v-slot:append>
-        <q-icon name="cancel" @click.stop="breakpointGroup = null" class="cursor-pointer" />
+    <q-select color="blue-12" v-model="child.widthGroup" :options="widthOptions" label="Width" emit-value map-options dense options-dense @input="emitChange" />
+    <q-select color="blue-12" v-model="child.breakpointGroup" :options="breakpointOptions" label="Break Points" multiple emit-value map-options dense options-dense @input="emitChange">
+      <template v-if="child.breakpointGroup" v-slot:append>
+        <q-icon name="cancel" @click.stop="child.breakpointGroup = null" class="cursor-pointer" />
       </template>
     </q-select>
-    <q-select color="blue-12" v-model="alignmentGroup" :options="alignmentOptions" label="Alignment Options" emit-value map-options dense options-dense @input="emitChange" />
-    <q-select color="blue-12" v-model="offsetGroup" :options="offsetOptions" label="Offset Options" emit-value map-options dense options-dense @input="emitChange" />
-    <q-select color="blue-12" v-model="gutterGroup" :options="gutterOptions" label="Gutter Options" multiple emit-value map-options dense options-dense @input="emitChange">
-      <template v-if="gutterGroup" v-slot:append>
-        <q-icon name="cancel" @click.stop="gutterGroup = null" class="cursor-pointer" />
+    <q-select color="blue-12" v-model="child.alignmentGroup" :options="alignmentOptions" label="Alignment Options" emit-value map-options dense options-dense @input="emitChange" />
+    <q-select color="blue-12" v-model="child.offsetGroup" :options="offsetOptions" label="Offset Options" emit-value map-options dense options-dense @input="emitChange" />
+    <q-select color="blue-12" v-model="child.gutterGroup" :options="gutterOptions" label="Gutter Options" multiple emit-value map-options dense options-dense @input="emitChange">
+      <template v-if="child.gutterGroup" v-slot:append>
+        <q-icon name="cancel" @click.stop="child.gutterGroup = null" class="cursor-pointer" />
       </template>
     </q-select>
-    <q-select color="blue-12" v-model="colGutterGroup" :options="colGutterOptions" label="Col Gutter Options" multiple emit-value map-options dense options-dense @input="emitChange">
-      <template v-if="colGutterGroup" v-slot:append>
-        <q-icon name="cancel" @click.stop="colGutterGroup = null" class="cursor-pointer" />
+    <q-select color="blue-12" v-model="child.colGutterGroup" :options="colGutterOptions" label="Col Gutter Options" multiple emit-value map-options dense options-dense @input="emitChange">
+      <template v-if="child.colGutterGroup" v-slot:append>
+        <q-icon name="cancel" @click.stop="child.colGutterGroup = null" class="cursor-pointer" />
       </template>
     </q-select>
   </div>
@@ -42,14 +42,12 @@ export default {
 
   props: {
     index: Number,
-    selectedIndex: Number
+    selectedIndex: Number,
+    child: Object
   },
 
   data () {
     return {
-      width: '',
-      height: '',
-      widthGroup: '',
       widthOptions: [
         { label: 'none', value: '' },
         { label: 'col', value: 'col' },
@@ -69,7 +67,6 @@ export default {
         { label: 'col-11', value: 'col-11' },
         { label: 'col-12', value: 'col-12' }
       ],
-      breakpointGroup: null,
       breakpointOptions: [
         { label: 'col-xs-1', value: 'col-xs-1' },
         { label: 'col-xs-2', value: 'col-xs-2' },
@@ -132,7 +129,6 @@ export default {
         { label: 'col-xl-11', value: 'col-xl-11' },
         { label: 'col-xl-12', value: 'col-xl-12' }
       ],
-      alignmentGroup: '',
       alignmentOptions: [
         { label: 'none', value: '' },
         { label: 'self-start', value: 'self-start' },
@@ -141,7 +137,6 @@ export default {
         { label: 'self-stretch', value: 'self-stretch' },
         { label: 'self-baseline', value: 'self-baseline' }
       ],
-      offsetGroup: '',
       offsetOptions: [
         { label: 'none', value: '' },
         { label: 'offset-1', value: 'offset-1' },
@@ -157,7 +152,6 @@ export default {
         { label: 'offset-11', value: 'offset-11' },
         { label: 'offset-12', value: 'offset-12' }
       ],
-      gutterGroup: null,
       gutterOptions: [
         { label: 'q-gutter-xs', value: 'q-gutter-xs' },
         { label: 'q-gutter-sm', value: 'q-gutter-sm' },
@@ -175,7 +169,6 @@ export default {
         { label: 'q-gutter-y-lg', value: 'q-gutter-y-lg' },
         { label: 'q-gutter-y-xl', value: 'q-gutter-y-xl' }
       ],
-      colGutterGroup: null,
       colGutterOptions: [
         { label: 'q-col-gutter-xs', value: 'q-col-gutter-xs' },
         { label: 'q-col-gutter-sm', value: 'q-col-gutter-sm' },
@@ -207,17 +200,17 @@ export default {
 
     styles () {
       return '' +
-        (this.height ? ('min-height: ' + this.height + '; max-height: ' + this.height + '; ') : '') +
-        (this.width ? ('min-width: ' + this.width + '; max-width: ' + this.width + ';') : '')
+        (this.child.height ? ('min-height: ' + this.child.height + '; max-height: ' + this.child.height + '; ') : '') +
+        (this.child.width ? ('min-width: ' + this.child.width + '; max-width: ' + this.child.width + ';') : '')
     },
 
     classes () {
-      return (this.widthGroup +
-        ' ' + (this.breakpointGroup === null ? '' : this.breakpointGroup) +
-        ' ' + this.alignmentGroup +
-        ' ' + this.offsetGroup +
-        ' ' + (this.gutterGroup === null ? '' : this.gutterGroup) +
-        ' ' + (this.colGutterGroup === null ? '' : this.colGutterGroup))
+      return (this.child.widthGroup +
+        ' ' + (this.child.breakpointGroup === null ? '' : this.child.breakpointGroup) +
+        ' ' + this.child.alignmentGroup +
+        ' ' + this.child.offsetGroup +
+        ' ' + (this.child.gutterGroup === null ? '' : this.child.gutterGroup) +
+        ' ' + (this.child.colGutterGroup === null ? '' : this.child.colGutterGroup))
         .replace(/,/g, ' ')
         .replace(/' '/g, ' ')
     }

--- a/docs/src/components/page-parts/layout/grid/FlexChild.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexChild.vue
@@ -6,13 +6,13 @@
     </div>
     <q-input filled v-model="child.width" dense label="Width (ex: '200px', '20em')" @input="emitChange">
       <template v-if="child.width.length > 0" v-slot:append>
-        <q-btn icon="clear" size="xs" flat dense @click="width = ''"/>
+        <q-btn icon="clear" size="xs" flat dense @click="child.width = ''"/>
       </template>
     </q-input>
 
     <q-input filled v-model="child.height" dense label="Height (ex: '300px', '25em')" @input="emitChange">
       <template v-if="child.height.length > 0" v-slot:append>
-        <q-btn icon="clear" size="xs" flat dense @click="height = ''"/>
+        <q-btn icon="clear" size="xs" flat dense @click="child.height = ''"/>
       </template>
     </q-input>
     <q-select color="blue-12" v-model="child.widthGroup" :options="widthOptions" label="Width" emit-value map-options dense options-dense @input="emitChange" />

--- a/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
@@ -49,7 +49,7 @@
 
 <script>
 import Child from './FlexChild'
-import { copyToClipboard } from '../../../../assets/page-utils'
+import { copyToClipboard } from 'assets/page-utils'
 
 const queryParams = {
   containerGroup: 'string',

--- a/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
@@ -24,10 +24,14 @@
     <div class="text-weight-medium q-mt-sm">Container Classes</div>
     <q-input filled v-model="classes" dense readonly class="q-py-sm" />
     <div class="text-subtitle2 float-left">Results <span class="text-weight-thin">(children: {{ children.length }}/10)</span></div>
+    <q-btn class="float-right" round dense flat icon="share" @click="share">
+      <q-tooltip>{{ copied ? 'Copied to clipboard' : 'Share URL' }}</q-tooltip>
+    </q-btn>
     <q-btn class="float-right" label="Add Child" icon="add" dense flat :disabled="children.length >= 10" @click="addChild" />
     <div class="row full-width bg-blue-grey-2" style="min-height: 400px">
       <div id="parent" :class="classes" style="overflow: hidden;">
         <child v-for="(child, index) in children" :key="index"
+          :child="child"
           :ref="'child' + index"
           :index="index"
           :selected-index="selectedIndex"
@@ -45,6 +49,19 @@
 
 <script>
 import Child from './FlexChild'
+import { copyToClipboard } from '../../../../assets/page-utils'
+
+const queryParams = {
+  containerGroup: 'string',
+  directionGroup: 'string',
+  wrapGroup: 'string',
+  justifyGroup: 'string',
+  itemsGroup: 'string',
+  contentGroup: 'string',
+  children: 'object',
+  childClasses: 'string',
+  childStyles: 'string'
+}
 
 export default {
   name: 'FlexPlayground',
@@ -110,12 +127,28 @@ export default {
       children: [],
       childClasses: '',
       childStyles: '',
-      selectedIndex: 0
+      selectedIndex: 0,
+      copied: false
     }
   },
 
   mounted () {
-    this.addChild()
+    const query = this.$route.query
+    for (let param in queryParams) {
+      if (param in query) {
+        const paramType = queryParams[param]
+        switch (paramType) {
+          case 'object':
+            this[param] = JSON.parse(query[param])
+            break
+          default:
+            this[param] = query[param]
+        }
+      }
+    }
+    if (!query.children) {
+      this.addChild()
+    }
   },
 
   computed: {
@@ -134,7 +167,16 @@ export default {
   methods: {
     addChild () {
       if (this.children.length < 10) {
-        this.children.push({})
+        this.children.push({
+          width: '',
+          height: '',
+          widthGroup: '',
+          breakpointGroup: null,
+          alignmentGroup: '',
+          offsetGroup: '',
+          gutterGroup: null,
+          colGutterGroup: null
+        })
       }
     },
     onDelete (index) {
@@ -145,6 +187,36 @@ export default {
       let child = this.$refs['child' + index][0]
       this.childClasses = child.classes
       this.childStyles = child.styles
+    },
+    share () {
+      let playgroudUrl = window.location.href
+      if (playgroudUrl.includes('?')) {
+        playgroudUrl = playgroudUrl.substring(0, playgroudUrl.indexOf('?'))
+      }
+      let queryString = '',
+        index = 0,
+        paramsCount = Object.keys(queryParams).length
+      for (let param in queryParams) {
+        const paramType = queryParams[param]
+        let value
+        switch (paramType) {
+          case 'object':
+            value = JSON.stringify(this[param])
+            break
+          default:
+            value = this[param]
+        }
+        queryString += `${param}=${encodeURIComponent(value)}`
+        index++
+        if (index < paramsCount) {
+          queryString += '&'
+        }
+      }
+      copyToClipboard(`${playgroudUrl}?${queryString}`)
+      this.copied = true
+      setTimeout(() => {
+        this.copied = false
+      }, 1500)
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This feature was requested by @webnoob because he needed to show someone from Discord how to do an specific layout.
@hawkeye64 also mentioned having a "Codepen" link and we are also thinking about making the Flex Playground page standalone (like the Layout Builder, opening outside of quasar docs so we can have more screen space without drawers etc).
