### PR TITLE
feat(docs) add "edit in codepen" option in flex playground

### DIFF
--- a/docs/src/components/Codepen.vue
+++ b/docs/src/components/Codepen.vue
@@ -32,11 +32,10 @@ export default {
 
   props: {
     title: String,
-    slugifiedTitle: String,
-    parts: Object
+    slugifiedTitle: String
   },
 
-  data: () => ({ active: false }),
+  data: () => ({ active: false, parts: {} }),
 
   computed: {
     css () {
@@ -79,6 +78,7 @@ export default {
         .replace(/___TEMP_REPLACEMENT___/gs, '>')
         .trim()
     },
+
     editors () {
       const flag = (this.html && 0b100) | (this.css && 0b010) | (this.js && 0b001)
       return flag.toString(2)
@@ -124,7 +124,8 @@ export default {
   },
 
   methods: {
-    open () {
+    open (parts) {
+      this.parts = parts
       if (this.active) {
         this.$el.submit()
         return

--- a/docs/src/components/DocExample.vue
+++ b/docs/src/components/DocExample.vue
@@ -8,7 +8,7 @@ q-card.doc-example.q-my-lg(:class="classes", flat, bordered)
     div.col-auto
       q-btn(dense, flat, round, icon="fab fa-github", @click="openGitHub")
         q-tooltip View on GitHub
-      q-btn.q-ml-sm(v-if="noEdit === false", dense, flat, round, icon="fab fa-codepen", @click="$refs.codepen.open()")
+      q-btn.q-ml-sm(v-if="noEdit === false", dense, flat, round, icon="fab fa-codepen", @click="$refs.codepen.open(parts)")
         q-tooltip Edit in Codepen
       q-btn.q-ml-sm(dense, flat, round, icon="code", @click="expanded = !expanded")
         q-tooltip View Source
@@ -50,7 +50,7 @@ q-card.doc-example.q-my-lg(:class="classes", flat, bordered)
   .row
     component.col.doc-example__content(:is="component", :class="componentClass")
 
-  codepen(ref="codepen", :title="title", :slugifiedTitle="slugifiedTitle", :parts="parts")
+  codepen(ref="codepen", :title="title", :slugifiedTitle="slugifiedTitle")
 </template>
 
 <script>

--- a/docs/src/components/page-parts/layout/grid/FlexChild.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexChild.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="classes" :style="styles" style="overflow: auto;" @click="emitChange">
+  <div :class="classes" :style="styles" @click="emitChange">
     <div class="row justify-between items-center">
       <q-btn :label="index" size="sm" flat dense :class="buttonClasses" @click="emitChange" />
       <q-btn icon="clear" size="xs" flat dense @click="onDelete"/>
@@ -199,7 +199,7 @@ export default {
     },
 
     styles () {
-      return '' +
+      return 'overflow: auto;' +
         (this.child.height ? ('min-height: ' + this.child.height + '; max-height: ' + this.child.height + '; ') : '') +
         (this.child.width ? ('min-width: ' + this.child.width + '; max-width: ' + this.child.width + ';') : '')
     },

--- a/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
@@ -27,6 +27,9 @@
     <q-btn class="float-right" round dense flat icon="share" @click="share">
       <q-tooltip>{{ copied ? 'Copied to clipboard' : 'Share URL' }}</q-tooltip>
     </q-btn>
+    <q-btn class="float-right" round dense flat icon="fab fa-codepen" @click="$refs.codepen.open(codepenParts())">
+      <q-tooltip>Edit in Codepen</q-tooltip>
+    </q-btn>
     <q-btn class="float-right" label="Add Child" icon="add" dense flat :disabled="children.length >= 10" @click="addChild" />
     <div class="row full-width bg-blue-grey-2" style="min-height: 400px">
       <div id="parent" :class="classes" style="overflow: hidden;">
@@ -44,11 +47,14 @@
     <q-input filled v-model="childClasses" dense readonly class="q-py-sm" />
     <div class="text-weight-medium q-mt-sm">Child Styles</div>
     <q-input filled v-model="childStyles" dense readonly class="q-py-sm" />
+
+    <codepen ref="codepen" title="Flex example" slugifiedTitle="flex-example" />
   </div>
 </template>
 
 <script>
 import Child from './FlexChild'
+import Codepen from '../../../Codepen'
 import { copyToClipboard } from 'assets/page-utils'
 
 const queryParams = {
@@ -67,7 +73,8 @@ export default {
   name: 'FlexPlayground',
 
   components: {
-    Child
+    Child,
+    Codepen
   },
 
   data () {
@@ -217,6 +224,32 @@ export default {
       setTimeout(() => {
         this.copied = false
       }, 1500)
+    },
+    codepenParts () {
+      const children = this.children.map((child, index) => {
+        const childRef = this.$refs[`child${index}`]
+        return `<div class="${childRef[0].classes} bg-grey-6" style="${childRef[0].styles}">
+          <q-card>
+            <q-card-section>
+              Child #${index}
+            </q-card-section>
+          </q-card>
+        </div>`
+      })
+
+      const template = `
+        <div class="flex flex-center column">
+          <div class="text-h6">Flex playground example</div>
+          <div class="row bg-blue-grey-2" style="min-height: 400px; width: 80%; padding: 24px;">
+            <div id="parent" class="${this.classes}" style="overflow: hidden;">
+              ${children}
+            </div>
+          </div>
+        </div>
+      `
+      return {
+        template
+      }
     }
   }
 }

--- a/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
+++ b/docs/src/components/page-parts/layout/grid/FlexPlayground.vue
@@ -27,7 +27,7 @@
     <q-btn class="float-right" round dense flat icon="share" @click="share">
       <q-tooltip>{{ copied ? 'Copied to clipboard' : 'Share URL' }}</q-tooltip>
     </q-btn>
-    <q-btn class="float-right" round dense flat icon="fab fa-codepen" @click="$refs.codepen.open(codepenParts())">
+    <q-btn class="float-right" round dense flat icon="fab fa-codepen" @click="editInCodepen">
       <q-tooltip>Edit in Codepen</q-tooltip>
     </q-btn>
     <q-btn class="float-right" label="Add Child" icon="add" dense flat :disabled="children.length >= 10" @click="addChild" />
@@ -225,7 +225,7 @@ export default {
         this.copied = false
       }, 1500)
     },
-    codepenParts () {
+    editInCodepen () {
       const children = this.children.map((child, index) => {
         const childRef = this.$refs[`child${index}`]
         return `<div class="${childRef[0].classes} bg-grey-6" style="${childRef[0].styles}">
@@ -247,9 +247,7 @@ export default {
           </div>
         </div>
       `
-      return {
-        template
-      }
+      this.$refs.codepen.open({ template })
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

There's one little issue right now: if you click on codepen button before changes are propagated, the codepen won't have the latest classes set.