### PR TITLE
feat(QBtnToggle) add clearable prop

### DIFF
--- a/ui/dev/components/components/button-toggle.vue
+++ b/ui/dev/components/components/button-toggle.vue
@@ -79,6 +79,12 @@
         </div>
       </template>
     </q-btn-toggle>
+
+    <q-btn-toggle v-model="model" :options="[
+      {label: 'One Clearable', value: 'one'},
+      {label: 'Two', value: 'two'}
+    ]" clearable
+    />
   </div>
 </template>
 

--- a/ui/src/components/btn-toggle/QBtnToggle.js
+++ b/ui/src/components/btn-toggle/QBtnToggle.js
@@ -66,11 +66,13 @@ export default Vue.extend({
   methods: {
     __set (value, opt) {
       if (this.readonly !== true) {
-        if (this.clearable === true && value === this.value) {
-          this.$emit('input', null, null)
-          this.$emit('clear')
+        if (this.value === value) {
+          if (this.clearable === true) {
+            this.$emit('input', null, null)
+            this.$emit('clear')
+          }
         }
-        else if (value !== this.value) {
+        else {
           this.$emit('input', value, opt)
         }
       }

--- a/ui/src/components/btn-toggle/QBtnToggle.js
+++ b/ui/src/components/btn-toggle/QBtnToggle.js
@@ -52,7 +52,9 @@ export default Vue.extend({
     stack: Boolean,
     stretch: Boolean,
 
-    spread: Boolean
+    spread: Boolean,
+
+    clearable: Boolean
   },
 
   computed: {
@@ -63,8 +65,14 @@ export default Vue.extend({
 
   methods: {
     __set (value, opt) {
-      if (this.readonly !== true && value !== this.value) {
-        this.$emit('input', value, opt)
+      if (this.readonly !== true) {
+        if (this.clearable === true && value === this.value) {
+          this.$emit('input', null, null)
+          this.$emit('clear')
+        }
+        else if (value !== this.value) {
+          this.$emit('input', value, opt)
+        }
       }
     }
   },

--- a/ui/src/components/btn-toggle/QBtnToggle.json
+++ b/ui/src/components/btn-toggle/QBtnToggle.json
@@ -150,12 +150,23 @@
       "type": "Boolean",
       "desc": "When used on flexbox parent, button will stretch to parent's height",
       "category": "content"
-    }
+    },
+
+    "clearable": {
+      "type": "Boolean",
+      "desc": "Clears model on click of the selected button",
+      "category": "model",
+      "addedIn": "v1.5.0"
+    },
   },
 
   "events": {
     "input": {
       "extends": "input"
+    },
+    "clear": {
+      "desc": "When using the 'clearable' property, this event is emitted when the selected button is clicked",
+      "addedIn": "v1.5.0"
     }
   }
 }

--- a/ui/src/components/btn-toggle/QBtnToggle.json
+++ b/ui/src/components/btn-toggle/QBtnToggle.json
@@ -154,19 +154,20 @@
 
     "clearable": {
       "type": "Boolean",
-      "desc": "Clears model on click of the selected button",
+      "desc": "Clears model on click of the already selected button",
       "category": "model",
-      "addedIn": "v1.5.0"
-    },
+      "addedIn": "v1.4.4"
+    }
   },
 
   "events": {
     "input": {
       "extends": "input"
     },
+
     "clear": {
-      "desc": "When using the 'clearable' property, this event is emitted when the selected button is clicked",
-      "addedIn": "v1.5.0"
+      "desc": "When using the 'clearable' property, this event is emitted when the already selected button is clicked",
+      "addedIn": "v1.4.4"
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I'm looking for suggestions for the prop name, as this is not a Quasar standard (users might think "clearable" adds a clear icon on the component?)
Maybe `resets-selected` `resets-active`, I don't know