### PR TITLE
fix(QDrawer): Prevent looping when the page content with drawer has scrollbar and without it doesn't

### DIFF
--- a/ui/dev/components/layout/layout-container-drawer-loop.vue
+++ b/ui/dev/components/layout/layout-container-drawer-loop.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="q-layout-padding">
+    <q-input
+      v-model.number="width"
+      type="number"
+      class="q-my-lg"
+      dense
+      filled
+      label="Layout width (fun from 1024 to 1039"
+      input-class="text-right"
+      style="width: 210px"
+    />
+
+    <q-layout view="hHh lpr fFf" container :style="containerStyle" class="q-mt-xl shadow-2">
+      <q-header reveal class="bg-black">
+        <q-toolbar>
+          <q-toolbar-title>Header</q-toolbar-title>
+          <q-btn flat @click="drawer = !drawer" round dense icon="menu" />
+        </q-toolbar>
+      </q-header>
+
+      <q-footer reveal>
+        <q-toolbar>
+          <q-toolbar-title>Footer</q-toolbar-title>
+          <q-btn flat @click="drawer = !drawer" round dense icon="menu" />
+        </q-toolbar>
+      </q-footer>
+
+      <q-drawer
+        side="right"
+        v-model="drawer"
+        bordered
+      >
+        <div v-for="n in contentSize * 2 + 5" :key="n">
+          Drawer {{ n }} / {{ contentSize * 2 + 5 }}
+        </div>
+      </q-drawer>
+
+      <q-page-container>
+        <q-page padding>
+          <div v-for="n in contentSize" :key="n">
+            My page My page My page My page My page My page
+            My page My page My page My page My page My page {{ n }} / {{ contentSize }}
+          </div>
+        </q-page>
+
+        <q-page-scroller position="bottom">
+          <q-btn fab icon="keyboard_arrow_up" color="red" />
+        </q-page-scroller>
+
+        <q-page-scroller position="top" scroll-reverse :scroll-offset="2000">
+          <q-btn fab icon="keyboard_arrow_down" color="red" />
+        </q-page-scroller>
+      </q-page-container>
+    </q-layout>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      drawer: true,
+      width: 1030,
+      contentSize: 30
+    }
+  },
+
+  computed: {
+    containerStyle () {
+      return {
+        height: '800px',
+        width: this.width + 'px'
+      }
+    }
+  }
+}
+</script>

--- a/ui/dev/components/layout/layout-drawer-loop.vue
+++ b/ui/dev/components/layout/layout-drawer-loop.vue
@@ -1,0 +1,55 @@
+<template>
+  <q-layout view="hHh lpr fFf">
+    <q-header reveal class="bg-black">
+      <q-toolbar>
+        <q-toolbar-title>Header - window.innerHeight to 1128 and window.innerWidth to 1028</q-toolbar-title>
+        <q-btn flat @click="drawer = !drawer" round dense icon="menu" />
+      </q-toolbar>
+    </q-header>
+
+    <q-footer reveal>
+      <q-toolbar>
+        <q-toolbar-title>Footer</q-toolbar-title>
+        <q-btn flat @click="drawer = !drawer" round dense icon="menu" />
+      </q-toolbar>
+    </q-footer>
+
+    <q-drawer
+      side="right"
+      v-model="drawer"
+      bordered
+    >
+      <div v-for="n in contentSize" :key="n">
+        Drawer {{ n }} / {{ contentSize }}
+      </div>
+    </q-drawer>
+
+    <q-page-container>
+      <q-page padding>
+        <div v-for="n in contentSize" :key="n">
+          My page My page My page My page My page My page
+          My page My page My page My page My page Pa {{ n }} / {{ contentSize }}
+        </div>
+      </q-page>
+
+      <q-page-scroller position="bottom">
+        <q-btn fab icon="keyboard_arrow_up" color="red" />
+      </q-page-scroller>
+
+      <q-page-scroller position="top" scroll-reverse :scroll-offset="2000">
+        <q-btn fab icon="keyboard_arrow_down" color="red" />
+      </q-page-scroller>
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      drawer: true,
+      contentSize: 47
+    }
+  }
+}
+</script>

--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -84,7 +84,7 @@ export default Vue.extend({
   data () {
     const belowBreakpoint = (
       this.behavior === 'mobile' ||
-      (this.behavior !== 'desktop' && this.layout.width <= this.breakpoint)
+      (this.behavior !== 'desktop' && this.layout.totalWidth <= this.breakpoint)
     )
 
     return {
@@ -117,7 +117,7 @@ export default Vue.extend({
       }
     },
 
-    'layout.width' (val) {
+    'layout.totalWidth' (val) {
       this.__updateLocal('belowBreakpoint', (
         this.behavior === 'mobile' ||
         (this.behavior !== 'desktop' && val <= this.breakpoint)
@@ -132,14 +132,14 @@ export default Vue.extend({
     behavior (val) {
       this.__updateLocal('belowBreakpoint', (
         val === 'mobile' ||
-        (val !== 'desktop' && this.layout.width <= this.breakpoint)
+        (val !== 'desktop' && this.layout.totalWidth <= this.breakpoint)
       ))
     },
 
     breakpoint (val) {
       this.__updateLocal('belowBreakpoint', (
         this.behavior === 'mobile' ||
-        (this.behavior !== 'desktop' && this.layout.width <= val)
+        (this.behavior !== 'desktop' && this.layout.totalWidth <= val)
       ))
     },
 
@@ -559,12 +559,12 @@ export default Vue.extend({
       this[`__${action}`](false, true)
     }
 
-    if (this.layout.width !== 0) {
+    if (this.layout.totalWidth !== 0) {
       fn()
       return
     }
 
-    this.watcher = this.$watch('layout.width', () => {
+    this.watcher = this.$watch('layout.totalWidth', () => {
       this.watcher()
       this.watcher = void 0
 

--- a/ui/src/components/layout/QLayout.js
+++ b/ui/src/components/layout/QLayout.js
@@ -93,6 +93,10 @@ export default Vue.extend({
           width: `calc(100% + ${this.scrollbarWidth}px)`
         }
       }
+    },
+
+    totalWidth () {
+      return this.width + this.scrollbarWidth
     }
   },
 


### PR DESCRIPTION
Consider total layout width (with scrollbar) for calculating belowBreakpoint