### PR TITLE
fix(QTable): Apply immutable sort on rows

### DIFF
--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -154,7 +154,7 @@ export default Vue.extend({
       }
 
       if (this.columnToSort) {
-        rows = this.sortMethod(rows, sortBy, descending)
+        rows = this.sortMethod(rows.slice() /* We need immutable sort */, sortBy, descending)
       }
 
       const rowsNumber = rows.length


### PR DESCRIPTION
If the rows were inside a freeze object sort would fail (good behavior)

ref #5648 - do not close the issue