### PR TITLE
Add ARIA tags for radio groups

### DIFF
--- a/ui/src/components/option-group/QOptionGroup.js
+++ b/ui/src/components/option-group/QOptionGroup.js
@@ -49,6 +49,10 @@ export default Vue.extend({
 
     model () {
       return Array.isArray(this.value) ? this.value.slice() : this.value
+    },
+
+    role () {
+      return this.type === 'radio' ? 'radiogroup' : 'group'
     }
   },
 
@@ -74,7 +78,8 @@ export default Vue.extend({
   render (h) {
     return h('div', {
       staticClass: 'q-option-group q-gutter-x-sm',
-      class: this.inline ? 'q-option-group--inline' : null
+      class: this.inline ? 'q-option-group--inline' : null,
+      attrs: { role: 'radiogroup' }
     }, this.options.map(opt => h('div', [
       h(this.component, {
         props: {

--- a/ui/src/components/radio/QRadio.js
+++ b/ui/src/components/radio/QRadio.js
@@ -110,7 +110,7 @@ export default Vue.extend({
     return h('div', {
       staticClass: 'q-radio cursor-pointer no-outline row inline no-wrap items-center',
       class: this.classes,
-      attrs: { tabindex: this.computedTabindex },
+      attrs: { tabindex: this.computedTabindex, role: 'radio', 'aria-checked': this.isTrue },
       on: {
         click: this.set,
         keydown: this.__keyDown


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Added a couple ARIA tags for improved accessibility

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
A few simple additions for screen-readers to announce radio button elements better.