### PR TITLE
feat(QField) add `validate-not-dirty` prop

### DIFF
--- a/ui/src/mixins/validate.js
+++ b/ui/src/mixins/validate.js
@@ -12,7 +12,8 @@ export default {
     noErrorIcon: Boolean,
 
     rules: Array,
-    lazyRules: Boolean
+    lazyRules: Boolean,
+    validateNotDirty: Boolean
   },
 
   data () {
@@ -28,7 +29,8 @@ export default {
       if (this.rules === void 0) {
         return
       }
-      if (this.lazyRules === true && this.isDirty === false) {
+
+      if (this.validateNotDirty === false && this.lazyRules === true && this.isDirty === false) {
         return
       }
 

--- a/ui/src/mixins/validate.json
+++ b/ui/src/mixins/validate.json
@@ -33,7 +33,14 @@
       "type": "Boolean",
       "desc": "Check validation status against the 'rules' only after field loses focus for first time",
       "category": "behavior"
-    }
+    },
+
+    "validate-not-dirty": {
+      "type": "Boolean",
+      "desc": "Triggers validation even when component is not on \"dirty\" state",
+      "category": "behavior",
+      "addedIn": "v1.5.0"
+     }
   },
 
   "methods": {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When wrapping components with QField to add validation, sometimes it doesn't make sense to wait for the first focusout.