### PR TITLE
feat(web-types) use docsUrl from JSON API

### DIFF
--- a/ui/build/build.web-types.js
+++ b/ui/build/build.web-types.js
@@ -36,14 +36,14 @@ module.exports.generate = function (data) {
       contributions: {
         html: {
           'types-syntax': 'typescript',
-          tags: data.components.map(({ api: { events, props, scopedSlots, slots }, name }) => {
+          tags: data.components.map(({ api: { events, props, scopedSlots, slots, meta }, name }) => {
             let slotTypes = []
             if (slots) {
               Object.entries(slots).forEach(([name, slotApi]) => {
                 slotTypes.push({
                   name,
                   description: getDescription(slotApi),
-                  'doc-url': 'https://quasar.dev'
+                  'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
                 })
               })
             }
@@ -56,10 +56,10 @@ module.exports.generate = function (data) {
                     name,
                     type: resolveType(api),
                     description: getDescription(api),
-                    'doc-url': 'https://quasar.dev'
+                    'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
                   })),
                   description: getDescription(slotApi),
-                  'doc-url': 'https://quasar.dev'
+                  'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
                 })
               })
             }
@@ -78,7 +78,7 @@ module.exports.generate = function (data) {
                     type: resolveType(propApi)
                   },
                   description: getDescription(propApi),
-                  'doc-url': 'https://quasar.dev'
+                  'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
                 }
                 if (propApi.required) {
                   result.required = true
@@ -98,14 +98,14 @@ module.exports.generate = function (data) {
                   name: paramName,
                   type: resolveType(paramApi),
                   description: getDescription(paramApi),
-                  'doc-url': 'https://quasar.dev'
+                  'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
                 })),
                 description: getDescription(eventApi),
-                'doc-url': 'https://quasar.dev'
+                'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
               })),
               slots: slotTypes,
               description: `${name} - Quasar component`,
-              'doc-url': 'https://quasar.dev'
+              'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
             }
             if (props && props.value && ((events && events.input) || props.value.category === 'model')) {
               result['vue-model'] = {
@@ -121,7 +121,7 @@ module.exports.generate = function (data) {
 
             return result
           }),
-          attributes: data.directives.map(({ name, api: { modifiers, value } }) => {
+          attributes: data.directives.map(({ name, api: { modifiers, value, meta } }) => {
             let valueType = value.type
             let result = {
               name: 'v-' + kebabCase(name),
@@ -131,13 +131,13 @@ module.exports.generate = function (data) {
               },
               required: false, // Directive is never required
               description: `${name} - Quasar directive`,
-              'doc-url': 'https://quasar.dev'
+              'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
             }
             if (modifiers) {
               result['vue-modifiers'] = Object.entries(modifiers).map(([name, api]) => ({
                 name,
                 description: getDescription(api),
-                'doc-url': 'https://quasar.dev'
+                'doc-url': meta.docsUrl || 'https://v1.quasar.dev'
               }))
             }
             if (valueType !== 'Boolean') {


### PR DESCRIPTION
This will allow showing correct links to docs in WebStorm Quick Doc ;)

![image](https://user-images.githubusercontent.com/25121817/69761734-8c84b600-1168-11ea-8156-17f2ee68e119.png)

It's a pity I didn't notice earlier that `docsUrl` got added, I could make this before 1.5 release.