### PR TITLE
feat(typescript): enhance typings 1

### DIFF
--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -7,7 +7,15 @@ export * from './utils/event';
 
 // others utils
 export function openURL(url: string): void;
-export function debounce(fn: Function, wait?: Number, immediate?: boolean) : Function
-export function extend(...args: any[]): any;
-export function throttle(fn: Function, limit: Number): Function; 
+export function debounce<F extends (...args: any[]) => any>(
+  fn: F,
+  wait?: number,
+  immediate?: boolean
+): F;
+export function extend<R>(deep: boolean, target: any, ...sources: any[]): R;
+export function extend<R>(target: object, ...sources: any[]): R;
+export function throttle<F extends (...args: any[]) => any>(
+  fn: F,
+  limit: number
+): F;
 export function uid(): string;

--- a/ui/types/utils/colors.d.ts
+++ b/ui/types/utils/colors.d.ts
@@ -16,11 +16,11 @@ export namespace colors {
   function rgbToHex(rgb: colorsRgba): string;
   // function rgbToString (color: colorsRgba): string;
   function hexToRgb(hex: string): colorsRgba;
-  function hsvToRgb(hsv: colorsHsva) : colorsRgba;
-  function rgbToHsv(rgb: colorsRgba) : colorsHsva;
-  function textToRgb(color: string) : colorsRgba;
-  function lighten(color: string, percent: number) : string;
-  function luminosity(color: string | colorsRgba) : number;
-  function setBrand(color: string, value: string, element?: Element) : void;
-  function getBrand(color: string, element?: Element) : string;
+  function hsvToRgb(hsv: colorsHsva): colorsRgba;
+  function rgbToHsv(rgb: colorsRgba): colorsHsva;
+  function textToRgb(color: string): colorsRgba;
+  function lighten(color: string, percent: number): string;
+  function luminosity(color: string | colorsRgba): number;
+  function setBrand(color: string, value: string, element?: Element): void;
+  function getBrand(color: string, element?: Element): string | null;
 }

--- a/ui/types/utils/date.d.ts
+++ b/ui/types/utils/date.d.ts
@@ -27,25 +27,25 @@ export interface DateLocale {
 export type DateUnitOptions = "second" | "minute" | "hour" | "day" | "month" | "year";
 
 export namespace date {
-  function isValid(date: string): boolean;
+  function isValid(date: number | string): boolean;
   function extractDate(str: string, mask: string, locale?: DateLocale): Date;
   function buildDate(options: BuildDateOptions, utc?: boolean): string;
-  function getDayOfWeek(date: Date | number | string | number): number;
-  function getWeekOfYear (date: Date | number | string) : number;
-  function isBetweenDates (date: Date | number | string, from: Date, to: Date, opts? : { inclusiveFrom: boolean, inclusiveTo: boolean}) : boolean;
+  function getDayOfWeek(date: Date | number | string): number;
+  function getWeekOfYear(date: Date | number | string): number;
+  function isBetweenDates(date: Date | number | string, from: Date | number | string, to: Date | number | string, opts?: { inclusiveFrom: boolean; inclusiveTo: boolean }): boolean;
   function addToDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function subtractFromDate(date: Date | number | string, options: ModifyDateOptions): Date;
-  function adjustDate (date: Date | number | string, options: ModifyDateOptions, utc?: boolean) : Date;
-  function startOfDate(date: Date | number | string, option: DateUnitOptions) : Date;
-  function endOfDate(date: Date | number | string, option: DateUnitOptions) : Date;
-  function getMaxDate (date: Date | number | string, ...args: (Date | number | string)[]) : Date;
-  function getMinDate (date: Date | number | string, ...args: (Date | number | string)[]) : Date;
-  function getDateDiff (date: Date | number | string, subtract: Date | number | string, unit?: string) : Date;
-  function getDayOfYear (date: Date | number | string) : number;
-  function inferDateFormat (date: any) : string;
-  function getDateBetween (date: Date | number | string, min: Date | number | string, max: Date | number | string) : Date
-  function isSameDate (date: Date | number | string, date2: Date | number | string, unit?: string) : boolean;
-  function daysInMonth (date: Date | number | string) : number;
+  function adjustDate(date: Date | number | string, options: ModifyDateOptions, utc?: boolean): Date;
+  function startOfDate(date: Date | number | string, option: DateUnitOptions): Date;
+  function endOfDate(date: Date | number | string, option: DateUnitOptions): Date;
+  function getMaxDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
+  function getMinDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
+  function getDateDiff(date: Date | number | string, subtract: Date | number | string, unit?: string): Date;
+  function getDayOfYear(date: Date | number | string): number;
+  function inferDateFormat(date: Date | number | string): "date" | "number" | "string";
+  function getDateBetween(date: Date | number | string, min?: Date | number | string, max?: Date | number | string): Date;
+  function isSameDate(date: Date | number | string, date2: Date | number | string, unit?: DateUnitOptions): boolean;
+  function daysInMonth(date: Date | number | string): number;
   function formatDate(date: Date | number | string | undefined, format: string, locale?: DateLocale, __forcedYear?: number): string;
-  function clone (date: Date) : Date;
+  function clone<D extends Date | number | string>(date: D): D;
 }

--- a/ui/types/utils/dom.d.ts
+++ b/ui/types/utils/dom.d.ts
@@ -4,11 +4,11 @@ export interface DomOffset {
 }
 
 export namespace dom {
-  function offset(el: Element) : DomOffset
-  function style(el: Element, property: string) : string;
-  function height(el: Element) : number;
-  function width(el: Element) : number;
-  function css(el: Element, css: any) : void;
-  function cssBatch(elements: Element[], css: any) : void;
-  function ready(fn: Function) : any;
+  function offset(el: Element): DomOffset;
+  function style(el: Element, property: string): string;
+  function height(el: Element): number;
+  function width(el: Element): number;
+  function css(el: Element, css: Partial<CSSStyleDeclaration>): void;
+  function cssBatch(elements: Element[], css: Partial<CSSStyleDeclaration>): void;
+  function ready(fn: Function): any;
 }

--- a/ui/types/utils/scroll.d.ts
+++ b/ui/types/utils/scroll.d.ts
@@ -1,18 +1,18 @@
 export namespace scroll {
-  function getScrollTarget(el: Element | Window): Element;
+  function getScrollTarget(el: HTMLElement): HTMLElement | Window;
 
-  function getScrollHeight(el: Element | Window): number;
-  function getScrollWidth(el: Element | Window): number;
+  function getScrollHeight(el: HTMLElement | Window): number;
+  function getScrollWidth(el: HTMLElement | Window): number;
 
-  function getScrollPosition(scrollTarget: Element | Window): number;
-  function getHorizontalScrollPosition(scrollTarget: Element | Window): number;
+  function getScrollPosition(scrollTarget: HTMLElement | Window): number;
+  function getHorizontalScrollPosition(scrollTarget: HTMLElement | Window): number;
 
-  function animScrollTo(el: Element | Window, to: number, duration: number): void;
-  function animHorizontalScrollTo(el: Element | Window, to: number, duration: number): void;
+  function animScrollTo(el: HTMLElement | Window, to: number, duration: number): void;
+  function animHorizontalScrollTo(el: HTMLElement | Window, to: number, duration: number): void;
 
-  function setScrollPosition(scrollTarget: Element | Window, offset: number, duration?: number): void;
-  function setHorizontalScrollPosition(scrollTarget: Element | Window, offset: number, duration?: number): void;
+  function setScrollPosition(scrollTarget: HTMLElement | Window, offset: number, duration?: number): void;
+  function setHorizontalScrollPosition(scrollTarget: HTMLElement | Window, offset: number, duration?: number): void;
 
   function getScrollbarWidth(): number;
-  function hasScrollbar(el: Element | Window, onY?: boolean): boolean;
+  function hasScrollbar(el: HTMLElement | Window, onY?: boolean): boolean;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
PR follow private discussion with Razvan about starting to enhance TS types in batches.
Please check if changes reflect actual implementations in a way you like.

_In this batch_
Only simple changes to `utils` helpers signatures.

_Details_
- `debounce` and `throttle` now return input function type, instead of a generic untyped function
- `extend` signature has been made a bit more helpful, even if there is no way into TS to model an indefinite number of arguments of different shape. Now it's possible to explicitly state the result type at least

---

- `getBrand` return type now can also be `null`, to reflect scenarios where no color of given name is found on specified element

---

- `isValid` and `isBetweenDates` input types has been broadened, because they are wrapped anyway into a `new Date()` before usage
- `inferDateFormat` is now stricter
- `getDateBetween` reflect the possible absence of `min` and `max` parameters
- `isSameDate` last parameter got a stricter signature, its type was already present
- `clone` implementation is open to a lot of edge cases, because it will return as-is any value which is not a Date (including Objects, Arrays, etc which are passed by reference). I put some strict typings (still looser than current one), but a signature more adhering to implementation should be `function clone<D>(date: D): D;` which is much broader.

---

- `css` and `cssBatch` now have more typesafe signature

---

- as suggested by Kerry, all `Element` as been updated to `HTMLElement` into scroll methods
- `getScrollTarget` apparently had parameter and return types switched: `Window` doesn't have a `.closest` method, which is used by the implementation