### PR TITLE
feat(typescript): enhance types 2

### DIFF
--- a/ui/types/utils/date.d.ts
+++ b/ui/types/utils/date.d.ts
@@ -1,18 +1,9 @@
-export interface BuildDateOptions {
+export interface DateOptions {
   milliseconds?: number;
   seconds?: number;
   minutes?: number;
   hours?: number;
   date?: number;
-  month?: number;
-  year?: number;
-}
-export interface ModifyDateOptions {
-  milliseconds?: number;
-  seconds?: number;
-  minutes?: number;
-  hours?: number;
-  days?: number;
   month?: number;
   year?: number;
 }
@@ -29,23 +20,23 @@ export type DateUnitOptions = "second" | "minute" | "hour" | "day" | "month" | "
 export namespace date {
   function isValid(date: number | string): boolean;
   function extractDate(str: string, mask: string, locale?: DateLocale): Date;
-  function buildDate(options: BuildDateOptions, utc?: boolean): string;
+  function buildDate(options: DateOptions, utc?: boolean): string;
   function getDayOfWeek(date: Date | number | string): number;
   function getWeekOfYear(date: Date | number | string): number;
   function isBetweenDates(date: Date | number | string, from: Date | number | string, to: Date | number | string, opts?: { inclusiveFrom: boolean; inclusiveTo: boolean }): boolean;
-  function addToDate(date: Date | number | string, options: ModifyDateOptions): Date;
-  function subtractFromDate(date: Date | number | string, options: ModifyDateOptions): Date;
-  function adjustDate(date: Date | number | string, options: ModifyDateOptions, utc?: boolean): Date;
+  function addToDate(date: Date | number | string, options: DateOptions): Date;
+  function subtractFromDate(date: Date | number | string, options: DateOptions): Date;
+  function adjustDate(date: Date | number | string, options: DateOptions, utc?: boolean): Date;
   function startOfDate(date: Date | number | string, option: DateUnitOptions): Date;
   function endOfDate(date: Date | number | string, option: DateUnitOptions): Date;
   function getMaxDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
   function getMinDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
-  function getDateDiff(date: Date | number | string, subtract: Date | number | string, unit?: string): Date;
+  function getDateDiff(date: Date | number | string, subtract: Date | number | string, unit?: DateUnitOptions): Date;
   function getDayOfYear(date: Date | number | string): number;
   function inferDateFormat(date: Date | number | string): "date" | "number" | "string";
   function getDateBetween(date: Date | number | string, min?: Date | number | string, max?: Date | number | string): Date;
   function isSameDate(date: Date | number | string, date2: Date | number | string, unit?: DateUnitOptions): boolean;
   function daysInMonth(date: Date | number | string): number;
-  function formatDate(date: Date | number | string | undefined, format: string, locale?: DateLocale, __forcedYear?: number): string;
+  function formatDate(date: Date | number | string | undefined, format?: string, locale?: DateLocale, __forcedYear?: number): string;
   function clone<D extends Date | number | string>(date: D): D;
 }

--- a/ui/types/utils/dom.d.ts
+++ b/ui/types/utils/dom.d.ts
@@ -10,5 +10,6 @@ export namespace dom {
   function width(el: Element): number;
   function css(el: Element, css: Partial<CSSStyleDeclaration>): void;
   function cssBatch(elements: Element[], css: Partial<CSSStyleDeclaration>): void;
-  function ready(fn: Function): any;
+  function ready<F extends (...args: any[]) => any>(fn: F): ReturnType<F>;
+  function ready(fn?: any): void;
 }

--- a/ui/types/utils/event.d.ts
+++ b/ui/types/utils/event.d.ts
@@ -1,7 +1,14 @@
+// Allow using `passive` and `notPassive` with `removeEventListener`
+// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal
+// See https://github.com/quasarframework/quasar/pull/5729#issuecomment-559588257
+interface RemoveEventListenerFix {
+  capture: undefined;
+}
+
 export interface ListenOpts {
   hasPassive: boolean;
-  passive: undefined | { passive: true };
-  notPassive: undefined | { passive: false };
+  passive: undefined | ({ passive: true } & RemoveEventListenerFix);
+  notPassive: undefined | ({ passive: false } & RemoveEventListenerFix);
   passiveCapture: true | { passive: true; capture: true };
   notPassiveCapture: true | { passive: false; capture: true };
 }

--- a/ui/types/utils/event.d.ts
+++ b/ui/types/utils/event.d.ts
@@ -1,9 +1,9 @@
 export interface ListenOpts {
   hasPassive: boolean;
-  passive?: AddEventListenerOptions;
-  notPassive?: AddEventListenerOptions;
-  passiveCapture?: AddEventListenerOptions;
-  notPassiveCapture?: AddEventListenerOptions;
+  passive: undefined | { passive: true };
+  notPassive: undefined | { passive: false };
+  passiveCapture: true | { passive: true; capture: true };
+  notPassiveCapture: true | { passive: false; capture: true };
 }
 
 export namespace event {
@@ -13,7 +13,7 @@ export namespace event {
   function rightClick(evt: MouseEvent): boolean;
   function position(evt: TouchEvent): { top: number; left: number };
   function getEventPath(evt: Event): EventTarget[];
-  function getMouseWheelDistance(evt: WheelEvent): {x: number; y: number };
+  function getMouseWheelDistance(evt: WheelEvent): { x: number; y: number };
   function stop(evt: Event): void;
   function prevent(evt: Event): void;
   function stopAndPrevent(evt: Event): void;

--- a/ui/types/utils/format.d.ts
+++ b/ui/types/utils/format.d.ts
@@ -1,7 +1,7 @@
 export namespace format {
   function humanStorageSize(size: number) : string;
   function capitalize(text: string) : string;
-  function between(v: number, min: number, max: number) : boolean;
+  function between(v: number, min: number, max: number) : number;
   function normalizeToInterval(v: number, min: number, max: number) : number;
   function pad(v: string, length?: number, char?: string) : string;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
Depending on the choices taken, the implementation of some functions will need to be updated slightly.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
PR follow private discussion with Razvan about starting to enhance TS types in batches.
Please check if changes reflect actual implementations in a way you like.

_In this batch_
Changes to `utils` helpers signatures which **would require an implementation update too**.
Those implementation changes are not committed into the PR, just proposed into the following section.
This can also be a good moment to decide if TS signatures should be as much adherent to the implementation as possible, or if they should represent the "ideal" scenario (like functions had been written with TS) and be stricter and cleaner than their actual JS implementation.

I can give a try to update the implementation, after your feedback, but without automatic tests covering my back and most context still unclear, I'd prefer not to.

_Details_
- `BuildDateOptions` and `ModifyDateOptions` differ only by the `date`/`days` property, but inside `getChange`, `days` key name seems to be transformed into `date` anyway, so this can be probably reduced to a common `DateOptions` for all methods. Funny enough, it seems to me that if you provide a `date` key to `getChange` it should work anyway. To me, keeping a different APIs for very similar options isn't ideal and only one should be chosen and used
- `getDateDiff` return type was `Date`, while apparently a number is always returned. `unit` argument was `string` type, but this could cause an uncaught error if someone inserts a random string, because the inner switch doesn't have a default case (while it probably should), making the function effectively returning void in those scenario. I put `DateUnitOptions` to narrow thre type, **but this require to update switch case conditions** which atm are all plurals, while `DateUnitOptions` are all singular. I'd advocate to use the same set of singular words everywhere, if possible.
- `formatDate` `format` argument should be optional, looking at the implementation. `date` should be optional by implementation too, meaning that if you pass an invalid value the function will accept it and just return void. An `Error` should be thrown in those cases instead IMO, to fail fast. I don't think is possible to model current behavior in a meaningful way in TS.

---

- `ready` was missing any real typing. The first signature cover the case where a function is provided and we return its result, while the second covers all cases where executions stops immediately because provided parameter isn't a function. IMO, the second signature should be omitted in order to allow usage only when a function parameter is provided.

---

- Proposed `ListenOpts` version is more adhering to the current implementation, ~~but depending on where it used and how, you could still prefer previous one. I still don't have all use cases in mind, but I understood that the complexity of this type is given by the browser support or lack of support of providing an options object when defining a listener. @GordonBlahut you already had issues with this API, would this typings work for you or the more general ones are better?~~
After fixing usage with `removeEventListener`, seems like the new version is actually better than the old one. _This update should not be a breaking change_.
- an `event.getEventKey(evt)` is mentioned into documentation but I cannot find any other reference of it in the codebase, maybe it must be removed?

---

-  `between` return type seems to be always a number, never a boolean. What is the actual expected behaviour of this function? Current signature suggest that it should check if a value is into an interval, but documentation and usage in the codebase explains it differently. Documentation refers to it as if it was `normalizeToInterval` function and of course it seems it's used like that. This is very confusing. The implementation of the two is pretty similar too.