### PR TITLE
feat(cli) if quasar dep is a pinned version, `upgrade -i` keeps it

### DIFF
--- a/cli/bin/quasar-upgrade
+++ b/cli/bin/quasar-upgrade
@@ -168,8 +168,8 @@ function upgradeQuasar () {
       // installing the new version might fail on Windows
       removeSync(path.join(root, 'node_modules', dep.packageName))
 
-      const fixedVersion = !pkg.dependencies[dep.packageName].startsWith('^')
-      params.push(`${dep.packageName}@${fixedVersion ? '' : '^'}${dep.latestVersion}`)
+      const pinnedVersion = !pkg.dependencies[dep.packageName].startsWith('^')
+      params.push(`${dep.packageName}@${pinnedVersion ? '' : '^'}${dep.latestVersion}`)
     })
 
     console.log()

--- a/cli/bin/quasar-upgrade
+++ b/cli/bin/quasar-upgrade
@@ -168,8 +168,8 @@ function upgradeQuasar () {
       // installing the new version might fail on Windows
       removeSync(path.join(root, 'node_modules', dep.packageName))
 
-      const pinnedVersion = !pkg.dependencies[dep.packageName].startsWith('^')
-      params.push(`${dep.packageName}@${pinnedVersion ? '' : '^'}${dep.latestVersion}`)
+      const notPinned = pkg.dependencies[dep.packageName].startsWith('^')
+      params.push(`${dep.packageName}@${notPinned ? '^' : ''}${dep.latestVersion}`)
     })
 
     console.log()

--- a/cli/bin/quasar-upgrade
+++ b/cli/bin/quasar-upgrade
@@ -168,7 +168,8 @@ function upgradeQuasar () {
       // installing the new version might fail on Windows
       removeSync(path.join(root, 'node_modules', dep.packageName))
 
-      params.push(`${dep.packageName}@^${dep.latestVersion}`)
+      const fixedVersion = !pkg.dependencies[dep.packageName].startsWith('^')
+      params.push(`${dep.packageName}@${fixedVersion ? '' : '^'}${dep.latestVersion}`)
     })
 
     console.log()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

If dev running `quasar upgrade -i` likes to use its dependency with pinned version, keeping it is a good idea IMO.