### PR TITLE
Fixes [#5049 ]SCSS override for boot files

### DIFF
--- a/app/templates/entry/client-entry.js
+++ b/app/templates/entry/client-entry.js
@@ -29,7 +29,6 @@ import 'quasar/dist/quasar.<%= __css.quasarSrcExt %>'
 import 'quasar/src/css/flex-addon.<%= __css.quasarSrcExt %>'
 <% } %>
 
-
 import Vue from 'vue'
 import createApp from './app.js'
 
@@ -73,7 +72,7 @@ Vue.config.productionTip = false
 console.info('[Quasar] Running <%= ctx.modeName.toUpperCase() + (ctx.mode.ssr && ctx.mode.pwa ? ' + PWA' : '') %>.')
 <% if (ctx.mode.pwa) { %>console.info('[Quasar] Forcing PWA into the network-first approach to not break Hot Module Replacement while developing.')<% } %>
 <% } %>
-    
+
 const { app, <%= store ? 'store, ' : '' %>router } = createApp()
 
 <% if (ctx.mode.cordova && ctx.target.ios) { %>

--- a/app/templates/entry/client-entry.js
+++ b/app/templates/entry/client-entry.js
@@ -29,9 +29,6 @@ import 'quasar/dist/quasar.<%= __css.quasarSrcExt %>'
 import 'quasar/src/css/flex-addon.<%= __css.quasarSrcExt %>'
 <% } %>
 
-<% css.length > 0 && css.filter(asset => asset.client !== false).forEach(asset => { %>
-import '<%= asset.path %>'
-<% }) %>
 
 import Vue from 'vue'
 import createApp from './app.js'
@@ -73,6 +70,10 @@ console.info('[Quasar] Running <%= ctx.modeName.toUpperCase() + (ctx.mode.ssr &&
 <% if (ctx.mode.pwa) { %>console.info('[Quasar] Forcing PWA into the network-first approach to not break Hot Module Replacement while developing.')<% } %>
 <% } %>
 
+<% css.length > 0 && css.filter(asset => asset.client !== false).forEach(asset => { %>
+  import '<%= asset.path %>'
+<% }) %>
+    
 const { app, <%= store ? 'store, ' : '' %>router } = createApp()
 
 <% if (ctx.mode.cordova && ctx.target.ios) { %>

--- a/app/templates/entry/client-entry.js
+++ b/app/templates/entry/client-entry.js
@@ -51,6 +51,10 @@ if (boot.length > 0) {
 import <%= importName %> from '<%= asset.path %>'
 <% }) } %>
 
+<% css.length > 0 && css.filter(asset => asset.client !== false).forEach(asset => { %>
+  import '<%= asset.path %>'
+<% }) %>
+
 <% if (preFetch) { %>
 import { addPreFetchHooks } from './client-prefetch.js'
 <% } %>
@@ -69,10 +73,6 @@ Vue.config.productionTip = false
 console.info('[Quasar] Running <%= ctx.modeName.toUpperCase() + (ctx.mode.ssr && ctx.mode.pwa ? ' + PWA' : '') %>.')
 <% if (ctx.mode.pwa) { %>console.info('[Quasar] Forcing PWA into the network-first approach to not break Hot Module Replacement while developing.')<% } %>
 <% } %>
-
-<% css.length > 0 && css.filter(asset => asset.client !== false).forEach(asset => { %>
-  import '<%= asset.path %>'
-<% }) %>
     
 const { app, <%= store ? 'store, ' : '' %>router } = createApp()
 


### PR DESCRIPTION
Fixes the issue that custom css is not overriding the css rules imported through the boot files.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

