### PR TITLE
hint(docs): explain to read further down for more info

### DIFF
--- a/docs/src/pages/quasar-cli/developing-capacitor-apps/preparation.md
+++ b/docs/src/pages/quasar-cli/developing-capacitor-apps/preparation.md
@@ -11,7 +11,7 @@ Before we dive in to the actual development, we need to do some preparation work
 
 * You will need to install Android Studio and the Android platform SDK on your machine. You can [download the Android Studio here](https://developer.android.com/studio/index.html) and follow these [installation steps](https://developer.android.com/studio/install.html) afterwards.
 
-* Make sure that after you install the Android SDK you then accept its licenses. Open the terminal and go to the folder where the SDK was installed, in tools/bin and call `sdkmanager --licenses`.
+* Make sure that after you install the Android SDK you then accept its licenses. Open the terminal and go to the folder where the SDK was installed, in tools/bin and call `sdkmanager --licenses`. (see down below for more info on where the SDK is located)
 
 * Add Android installation to your path:
 


### PR DESCRIPTION
the other day I got stuck at the top, because I couldn't find the SDK folder.
This is however, explained further down in a hint in the docs.

A small hint to look further down in the docs would help a lot of people I think!

Partially related to #5766 