### PR TITLE
fix(QTree): Change the order of tick changing (from indeterminate should change to ticked) #5769

### DIFF
--- a/ui/dev/components/components/tree.vue
+++ b/ui/dev/components/components/tree.vue
@@ -119,8 +119,8 @@ export default {
     return {
       selected: null,
       tickStrategy: 'leaf',
-      ticked: ['Node 2.2'],
-      expanded: ['Node 2.1.4 - Disabled', 'Node 2.1.3 - freeze exp / tickable'],
+      ticked: ['Node 2.2', 'Node child - disabled'],
+      expanded: ['Node 2.1.4 - Disabled', 'Node 2.1.3 - freeze exp / tickable', 'Node parent'],
       selectableNodes: true,
       dark: null,
       accordion: false,
@@ -295,6 +295,18 @@ export default {
             {
               label: 'Node 2.5 - Lazy load empty',
               lazy: true
+            }
+          ]
+        },
+        {
+          label: 'Node parent',
+          children: [
+            {
+              label: 'Node child - disabled',
+              disabled: true
+            },
+            {
+              label: 'Node child - enabled'
             }
           ]
         }

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -598,8 +598,8 @@ export default Vue.extend({
     },
 
     __onTickedClick (meta, state) {
-      if (meta.indeterminate && state) {
-        state = false
+      if (meta.indeterminate && state !== true) {
+        state = true
       }
       if (meta.strictTicking) {
         this.setTicked([ meta.key ], state)


### PR DESCRIPTION
If an indeterminate parent has a ticked disabled child the parent can never change to ticked.