### PR TITLE
Support using custom entry templates via quasar.conf.js

### DIFF
--- a/app/lib/app-files-validations.js
+++ b/app/lib/app-files-validations.js
@@ -39,11 +39,11 @@ module.exports = function (cfg) {
 
   file = appPaths.resolve.app(cfg.sourceFiles.rootComponent)
   content = fs.readFileSync(file, 'utf-8')
-  if (content.indexOf('q-app') === -1) {
+  if (content.indexOf(cfg.rootId || 'q-app') === -1) {
     console.log(`\n ⚠️  Quasar requires a minor change to the root component:
    ${file}
 
-  Please add: id="q-app" (or write #q-app if using Pug)
+  Please add: id="${cfg.rootId || 'q-app'}" (or write ${cfg.rootId ? "#"+cfg.rootId : "#q-app"} if using Pug)
   to the outermost HTML element of the template.
 
 ${green('Example:')}

--- a/app/lib/app-files-validations.js
+++ b/app/lib/app-files-validations.js
@@ -39,11 +39,11 @@ module.exports = function (cfg) {
 
   file = appPaths.resolve.app(cfg.sourceFiles.rootComponent)
   content = fs.readFileSync(file, 'utf-8')
-  if (content.indexOf(cfg.rootId || 'q-app') === -1) {
+  if (content.indexOf(cfg.sourceFiles.rootId || 'q-app') === -1) {
     console.log(`\n ⚠️  Quasar requires a minor change to the root component:
    ${file}
 
-  Please add: id="${cfg.rootId || 'q-app'}" (or write ${cfg.rootId ? "#"+cfg.rootId : "#q-app"} if using Pug)
+  Please add: id="${cfg.sourceFiles.rootId || 'q-app'}" (or write ${cfg.sourceFiles.rootId ? "#"+cfg.sourceFiles.rootId : "#q-app"} if using Pug)
   to the outermost HTML element of the template.
 
 ${green('Example:')}

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -10,7 +10,7 @@ const
 
 class Generator {
   constructor (quasarConfig) {
-    const { ctx, preFetch } = quasarConfig.getBuildConfig()
+    const { ctx, preFetch, templates } = quasarConfig.getBuildConfig()
 
     this.alreadyGenerated = false
     this.quasarConfig = quasarConfig
@@ -39,7 +39,7 @@ class Generator {
       return {
         filename,
         dest: path.join(quasarFolder, filename),
-        template: compileTemplate(content)
+        template: (templates && templates[file]) ? templates[file] : compileTemplate(content)
       }
     })
   }

--- a/app/package.json
+++ b/app/package.json
@@ -2,6 +2,10 @@
   "name": "@quasar/app",
   "version": "1.3.3",
   "description": "Quasar Framework local CLI",
+	"scripts" : {
+		"push": "git push",
+		"pull": "git pull"
+	},
   "bin": {
     "quasar": "./bin/quasar"
   },
@@ -89,13 +93,13 @@
     "stylus-loader": "3.0.2",
     "terser-webpack-plugin": "2.2.1",
     "url-loader": "3.0.0",
-    "vue": "2.6.10",
+    "vue": "lopugit/vue#dev",
     "vue-loader": "15.7.2",
     "vue-router": "3.1.3",
     "vue-server-renderer": "2.6.10",
     "vue-style-loader": "4.1.2",
     "vue-template-compiler": "2.6.10",
-    "vuex": "3.1.2",
+    "vuex": "lopugit/vuex#dev",
     "webpack": "4.41.2",
     "webpack-bundle-analyzer": "3.6.0",
     "webpack-chain": "6.0.0",

--- a/app/templates/entry/app.js
+++ b/app/templates/entry/app.js
@@ -51,7 +51,7 @@ export default function (<%= ctx.mode.ssr ? 'ssrContext' : '' %>) {
   // Here we inject the router, store to all child components,
   // making them available everywhere as `this.$router` and `this.$store`.
   const app = {
-    <% if (!ctx.mode.ssr) { %>el: '#q-app',<% } %>
+    <% if (!ctx.mode.ssr) { %>el: <% print((rootId ? "#"+rootId : false) || '#q-app') %>,<% } %>
     router,
     <%= store ? 'store,' : '' %>
     render: h => h(App)<% if (__needsAppMountHook === true) { %>,

--- a/app/templates/entry/app.js
+++ b/app/templates/entry/app.js
@@ -51,7 +51,7 @@ export default function (<%= ctx.mode.ssr ? 'ssrContext' : '' %>) {
   // Here we inject the router, store to all child components,
   // making them available everywhere as `this.$router` and `this.$store`.
   const app = {
-    <% if (!ctx.mode.ssr) { %>el: <% print((rootId ? "#"+rootId : false) || '#q-app') %>,<% } %>
+    <% if (!ctx.mode.ssr) { %>el: <% print((sourceFiles.rootId ? "#"+sourceFiles.rootId : false) || '#q-app') %>,<% } %>
     router,
     <%= store ? 'store,' : '' %>
     render: h => h(App)<% if (__needsAppMountHook === true) { %>,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**


So I'm in a special situation where I really need to be able to modify the entry templates, the absolute source code, and this little PR introduces that ability.

To use it you put the following in your quasar.conf.js file

```
compileTemplate = require("lodash.template")

module.exports = function (ctx) {

  return {
    ...cfg,
    templates: {
      "app.js": compileTemplate(fs.readFileSync('src/templates/app.js', 'utf-8'))
    }
  }
}

```

Hope you like :)