### PR TITLE
feat(QField/QInput/QSelect): Individual color of label

### DIFF
--- a/docs/src/examples/QField/Coloring.vue
+++ b/docs/src/examples/QField/Coloring.vue
@@ -10,6 +10,15 @@
         </template>
       </q-field>
 
+      <q-field color="purple-12" label-color="purple-12" label="Label" stack-label>
+        <template v-slot:prepend>
+          <q-icon name="event" />
+        </template>
+        <template v-slot:control>
+          <div class="self-center full-width no-outline" tabindex="0">{{text}}</div>
+        </template>
+      </q-field>
+
       <q-field color="teal" filled label="Label" stack-label>
         <template v-slot:prepend>
           <q-icon name="event" />

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -29,6 +29,7 @@ export default Vue.extend({
     prefix: String,
     suffix: String,
 
+    labelColor: String,
     color: String,
     bgColor: String,
 
@@ -290,6 +291,14 @@ export default Vue.extend({
       return node
     },
 
+    __getFieldLabelColor(h) {
+      const cls = [];
+      if (this.labelColor !== void 0) {
+        cls.push('text-' + this.labelColor)
+      }
+      return cls;
+    },
+
     __getControlContainer (h) {
       const node = []
 
@@ -323,7 +332,8 @@ export default Vue.extend({
 
       this.label !== void 0 && node.push(
         h('div', {
-          staticClass: 'q-field__label no-pointer-events absolute ellipsis'
+          staticClass: 'q-field__label no-pointer-events absolute ellipsis',
+          class: this.__getFieldLabelColor(h)
         }, [ this.label ])
       )
 

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -184,6 +184,12 @@ export default Vue.extend({
 
       return cls
     },
+    
+    labelClass () {
+      if (this.labelColor !== void 0) {
+        return 'text-' + this.labelColor
+      }
+    },
 
     controlSlotScope () {
       return {
@@ -291,14 +297,6 @@ export default Vue.extend({
       return node
     },
 
-    __getFieldLabelColor(h) {
-      const cls = [];
-      if (this.labelColor !== void 0) {
-        cls.push('text-' + this.labelColor)
-      }
-      return cls;
-    },
-
     __getControlContainer (h) {
       const node = []
 
@@ -333,7 +331,7 @@ export default Vue.extend({
       this.label !== void 0 && node.push(
         h('div', {
           staticClass: 'q-field__label no-pointer-events absolute ellipsis',
-          class: this.__getFieldLabelColor(h)
+          class: this.labelClass
         }, [ this.label ])
       )
 

--- a/ui/src/components/field/__QField.json
+++ b/ui/src/components/field/__QField.json
@@ -42,6 +42,10 @@
       "category": "content"
     },
 
+    "label-color" : {
+      "extends": "color"
+    },
+
     "color": {
       "extends": "color"
     },

--- a/ui/src/components/field/__QField.json
+++ b/ui/src/components/field/__QField.json
@@ -43,7 +43,8 @@
     },
 
     "label-color" : {
-      "extends": "color"
+      "extends": "color",
+      "addedIn": "v1.7.0"
     },
 
     "color": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


If adding a **new feature**, the PR's description includes:

This adds a `label-color` attribute to fields, allowing high priority fields to have a different label color. This color is prioritized over the on-focus color.

Normal Label:  
![label-plain](https://user-images.githubusercontent.com/15874076/70263981-21854180-175d-11ea-90e2-42188c3aeece.png)

With `label-color="yellow"`  
![label-colored](https://user-images.githubusercontent.com/15874076/70263998-2c3fd680-175d-11ea-9512-fafec677c1bc.png)



**Other information:**
I added doc updates to include an example, but I am not sure if I updated all the right things.