### PR TITLE
Fix add or remove from vendor chunk

### DIFF
--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -251,11 +251,11 @@ module.exports = function (cfg, configName) {
               chunks: 'all',
               priority: -10,
               // a module is extracted into the vendor chunk if...
-              test: add.length > 0 || rem.length > 0
+              test: add || rem
                 ? module => {
                   if (module.resource) {
-                    if (add.length > 0 && add.test(module.resource)) { return true }
-                    if (rem.length > 0 && rem.test(module.resource)) { return false }
+                    if (add && add.test(module.resource)) { return true }
+                    if (rem && rem.test(module.resource)) { return false }
                   }
                   return regex.test(module.resource)
                 }

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -251,11 +251,11 @@ module.exports = function (cfg, configName) {
               chunks: 'all',
               priority: -10,
               // a module is extracted into the vendor chunk if...
-              test: add || rem
+              test: add !== void 0 || rem !== void 0
                 ? module => {
                   if (module.resource) {
-                    if (add && add.test(module.resource)) { return true }
-                    if (rem && rem.test(module.resource)) { return false }
+                    if (add !== void 0 && add.test(module.resource)) { return true }
+                    if (rem !== void 0 && rem.test(module.resource)) { return false }
                   }
                   return regex.test(module.resource)
                 }


### PR DESCRIPTION
Hi all,

It seems that adding or removing modules from vendor chunk with the vendor property in `quasar.conf.js` does not work at all.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`add.length` and `rem.length` return `undefined`.
length is a property of the constructor of the global object [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)

To check that: `console.log(RegExp.length)`