### PR TITLE
Changes for documentation in webpack-chain usage

### DIFF
--- a/docs/src/pages/quasar-cli/cli-documentation/handling-webpack.md
+++ b/docs/src/pages/quasar-cli/cli-documentation/handling-webpack.md
@@ -38,9 +38,9 @@ build: {
     chain.module.rule('eslint')
       .test(/\.(js|vue)$/)
       .enforce('pre')
-       .exclude
-          .add((/[\\/]node_modules[\\/]/))
-          .end()
+      .exclude
+        .add((/[\\/]node_modules[\\/]/))
+        .end()
       .use('eslint-loader')
         .loader('eslint-loader')
   }

--- a/docs/src/pages/quasar-cli/cli-documentation/handling-webpack.md
+++ b/docs/src/pages/quasar-cli/cli-documentation/handling-webpack.md
@@ -38,7 +38,9 @@ build: {
     chain.module.rule('eslint')
       .test(/\.(js|vue)$/)
       .enforce('pre')
-      .exclude(/[\\/]node_modules[\\/]/)
+       .exclude
+          .add((/[\\/]node_modules[\\/]/))
+          .end()
       .use('eslint-loader')
         .loader('eslint-loader')
   }


### PR DESCRIPTION
fix: If used with chain, webpack config gave error: ```exclude is not a function```. I changed the example of webpack-chain usage.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
