### PR TITLE
feat(typescript): generate QuasarLanguageCodes dynamically

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -199,12 +199,29 @@ function addQuasarPluginOptions (contents, components, directives, plugins) {
   writeLine(contents)
 }
 
+function addQuasarLangCodes (contents) {
+  // We are able to read this file only because
+  //  it's been generated before type generation take place
+  const langFile = path.resolve(__dirname, '../lang/index.json')
+  const langJson = JSON.parse(fs.readFileSync(langFile, 'utf-8'))
+
+  // Assure we are doing a module augmentation instead of a module overwrite
+  writeLine(contents, `import './lang'`)
+  writeLine(contents, `declare module './lang' {`)
+  writeLine(contents, `export interface QuasarLanguageCodesHolder {`, 2)
+  langJson.forEach(({ isoName }) => writeLine(contents, `'${isoName}': true`, 3))
+  writeLine(contents, `}`, 2)
+  writeLine(contents, `}`)
+}
+
 function writeIndexDTS (apis) {
   var contents = []
   var quasarTypeContents = []
   var components = []
   var directives = []
   var plugins = []
+
+  addQuasarLangCodes(quasarTypeContents)
 
   writeLine(contents, `import Vue, { VueConstructor, PluginObject } from 'vue'`)
   writeLine(contents)

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -202,8 +202,7 @@ function addQuasarPluginOptions (contents, components, directives, plugins) {
 function addQuasarLangCodes (contents) {
   // We are able to read this file only because
   //  it's been generated before type generation take place
-  const langFile = path.resolve(__dirname, '../lang/index.json')
-  const langJson = JSON.parse(fs.readFileSync(langFile, 'utf-8'))
+  const langJson = require('../lang/index.json')
 
   // Assure we are doing a module augmentation instead of a module overwrite
   writeLine(contents, `import './lang'`)

--- a/ui/types/lang.d.ts
+++ b/ui/types/lang.d.ts
@@ -1,50 +1,18 @@
 import { StringDictionary } from "./ts-helpers";
 
-export type QuasarLanguageCodes =
-  | "ar"
-  | "bg"
-  | "ca"
-  | "cs"
-  | "da"
-  | "de"
-  | "el"
-  | "en-gb"
-  | "en-us"
-  | "eo"
-  | "es"
-  | "fa-ir"
-  | "fi"
-  | "fr"
-  | "gn"
-  | "he"
-  | "hr"
-  | "hu"
-  | "id"
-  | "it"
-  | "ja"
-  | "km"
-  | "ko-kr"
-  | "lu"
-  | "lv"
-  | "ml"
-  | "ms"
-  | "nb-no"
-  | "nl"
-  | "pl"
-  | "pt-br"
-  | "pt"
-  | "ro"
-  | "ru"
-  | "sk"
-  | "sl"
-  | "sr"
-  | "sv"
-  | "th"
-  | "tr"
-  | "uk"
-  | "vi"
-  | "zh-hans"
-  | "zh-hant";
+/*
+  `QuasarLanguageCodes` is a discriminated union of available languages iso codes.
+  That list is generated at build-time based on `lang/index.json`
+    (itself generated at build time, but before TS typings).
+  We need its reference to be defined **before** build-time because
+    it's used by the framework configuration.
+  This empty interface is filled at build-time thanks to interface merging,
+    it allows `QuasarLanguageCodes` to exist (with value `never`) before build
+    and to have the right value when referenced by the end-user.
+*/
+export interface QuasarLanguageCodesHolder {}
+
+export type QuasarLanguageCodes = keyof QuasarLanguageCodesHolder;
 
 type QuasarLanguageGeneralLabel =
   | "clear"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As per [request](https://github.com/quasarframework/quasar/pull/5735#issuecomment-563253493), `QuasarLanguageCodes` are now generated dynamically.
They aren't used anywhere just yet, they will be used into an interface in following PRs.