### PR TITLE
feat(docs): multi-image slide with QCarousel

### DIFF
--- a/docs/src/examples/QCarousel/MultiImageSlides.vue
+++ b/docs/src/examples/QCarousel/MultiImageSlides.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="q-pa-md">
+    <q-carousel
+      v-model="slide"
+      transition-prev="slide-right"
+      transition-next="slide-left"
+      swipeable
+      animated
+      control-color="primary"
+      navigation
+      padding
+      arrows
+      height="300px"
+      class="bg-white text-black shadow-1 rounded-borders no-shadow"
+    >
+      <q-carousel-slide :name="1" class="column no-wrap">
+        <div class="row fit justify-start items-center q-gutter-xs q-col-gutter no-wrap">
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/mountains.jpg" />
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/parallax1.jpg" />
+        </div>
+      </q-carousel-slide>
+      <q-carousel-slide :name="2" class="column no-wrap">
+        <div class="row fit justify-start items-center q-gutter-xs q-col-gutter no-wrap">
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/parallax2.jpg" />
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/quasar.jpg" />
+        </div>
+      </q-carousel-slide>
+      <q-carousel-slide :name="3" class="column no-wrap">
+        <div class="row fit justify-start items-center q-gutter-xs q-col-gutter no-wrap">
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/cat.jpg" />
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/linux-avatar.png" />
+        </div>
+      </q-carousel-slide>
+      <q-carousel-slide :name="4" class="column no-wrap">
+        <div class="row fit justify-start items-center q-gutter-xs q-col-gutter no-wrap">
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/material.png" />
+          <q-img class="col-6 full-height" src="https://cdn.quasar.dev/img/donuts.png" />
+        </div>
+      </q-carousel-slide>
+    </q-carousel>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      slide: 1
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/carousel.md
+++ b/docs/src/pages/vue-components/carousel.md
@@ -30,6 +30,7 @@ In the examples above, you can also swipe with your finger (or swiping with the 
 
 ### Media content
 <doc-example title="Image slides" file="QCarousel/ImageSlides" />
+<doc-example title="Multi-image slides" file="QCarousel/MultiImageSlides" />
 
 <doc-example title="Captions" file="QCarousel/Captions" />
 


### PR DESCRIPTION
This is an example of how to put more than 1 item in a QCarouselSlide. In this case, multiple QImg's are used.