### PR TITLE
fix(ui): fix attributes not being passed on correctly

### DIFF
--- a/ui/src/components/checkbox/QCheckbox.js
+++ b/ui/src/components/checkbox/QCheckbox.js
@@ -7,6 +7,7 @@ import { cache } from '../../utils/vm.js'
 
 export default Vue.extend({
   name: 'QCheckbox',
+  inheritAttrs: false,
 
   mixins: [ CheckboxMixin ],
 
@@ -68,7 +69,10 @@ export default Vue.extend({
     this.disable !== true && content.unshift(
       h('input', {
         staticClass: 'q-checkbox__native q-ma-none q-pa-none invisible',
-        attrs: { type: 'checkbox' }
+        attrs: {
+          ...this.$attrs,
+          type: 'checkbox'
+        }
       })
     )
 

--- a/ui/src/components/color/QColor.js
+++ b/ui/src/components/color/QColor.js
@@ -31,6 +31,7 @@ const palette = [
 
 export default Vue.extend({
   name: 'QColor',
+  inheritAttrs: false,
 
   mixins: [ DarkMixin ],
 
@@ -247,9 +248,10 @@ export default Vue.extend({
             h('input', {
               staticClass: 'fit',
               domProps: { value: this.model[this.topView] },
-              attrs: this.editable !== true ? {
-                readonly: true
-              } : null,
+              attrs: {
+                ...this.$attrs,
+                readonly: this.editable !== true
+              },
               on: cache(this, 'topIn', {
                 input: evt => {
                   this.__updateErrorIcon(this.__onEditorChange(evt) === true)
@@ -436,6 +438,7 @@ export default Vue.extend({
               value: this.model.r
             },
             attrs: {
+              ...this.$attrs,
               maxlength: 3,
               readonly: this.editable !== true
             },
@@ -467,6 +470,7 @@ export default Vue.extend({
               value: this.model.g
             },
             attrs: {
+              ...this.$attrs,
               maxlength: 3,
               readonly: this.editable !== true
             },
@@ -498,6 +502,7 @@ export default Vue.extend({
               value: this.model.b
             },
             attrs: {
+              ...this.$attrs,
               maxlength: 3,
               readonly: this.editable !== true
             },
@@ -527,6 +532,7 @@ export default Vue.extend({
               value: this.model.a
             },
             attrs: {
+              ...this.$attrs,
               maxlength: 3,
               readonly: this.editable !== true
             },

--- a/ui/src/components/radio/QRadio.js
+++ b/ui/src/components/radio/QRadio.js
@@ -7,6 +7,7 @@ import { cache } from '../../utils/vm.js'
 
 export default Vue.extend({
   name: 'QRadio',
+  inheritAttrs: false,
 
   mixins: [ DarkMixin ],
 
@@ -80,7 +81,10 @@ export default Vue.extend({
     this.disable !== true && content.unshift(
       h('input', {
         staticClass: 'q-radio__native q-ma-none q-pa-none invisible',
-        attrs: { type: 'radio' }
+        attrs: {
+          ...this.$attrs,
+          type: 'radio'
+        }
       })
     )
 

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -25,6 +25,7 @@ const validateNewValueMode = v => ['add', 'add-unique', 'toggle'].includes(v)
 
 export default Vue.extend({
   name: 'QSelect',
+  inheritAttrs: false,
 
   mixins: [ QField, VirtualScroll, CompositionMixin ],
 
@@ -825,8 +826,8 @@ export default Vue.extend({
         domProps: { value: this.inputValue !== void 0 ? this.inputValue : '' },
         attrs: {
           // required for Android in order to show ENTER key when in form
-          type: 'search',
           ...this.$attrs,
+          type: 'search',
           tabindex: this.tabindex,
           'data-autofocus': fromDialog === true ? false : this.autofocus,
           id: this.targetUid,

--- a/ui/src/components/toggle/QToggle.js
+++ b/ui/src/components/toggle/QToggle.js
@@ -7,6 +7,7 @@ import { cache } from '../../utils/vm.js'
 
 export default Vue.extend({
   name: 'QToggle',
+  inheritAttrs: false,
 
   mixins: [ CheckboxMixin ],
 
@@ -58,7 +59,10 @@ export default Vue.extend({
     this.disable !== true && inner.unshift(
       h('input', {
         staticClass: 'q-toggle__native absolute q-ma-none q-pa-none invisible',
-        attrs: { type: 'checkbox' }
+        attrs: {
+          ...this.$attrs,
+          type: 'checkbox'
+        }
       })
     )
 

--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -11,6 +11,7 @@ import { cache } from '../../utils/vm.js'
 
 export default {
   mixins: [ DarkMixin ],
+  inheritAttrs: false,
 
   props: {
     label: String,
@@ -361,6 +362,7 @@ export default {
           ref: 'input',
           staticClass: 'q-uploader__input overflow-hidden absolute-full',
           attrs: {
+            ...this.$attrs,
             tabindex: -1,
             type: 'file',
             title: '', // try to remove default tooltip


### PR DESCRIPTION
Be explicit in $attrs inheritance. Vue does not always get it right.
https://cdn.discordapp.com/attachments/596275881907978240/659171134062985226/unknown.png
Also, make sure user doesn't change type as per component ($attrs needs to be first)
As per: https://vuejs.org/v2/guide/components-props.html#Disabling-Attribute-Inheritance