### PR TITLE
fix(docs): no-edit on examples that reply on Vue Router

### DIFF
--- a/docs/src/pages/vue-components/button-dropdown.md
+++ b/docs/src/pages/vue-components/button-dropdown.md
@@ -28,9 +28,11 @@ In case you are looking for a dropdown "input" instead of "button" use [Select](
 
 <doc-example title="Using v-model" file="QBtnDropdown/Model" />
 
-<doc-example title="Split and router link on main" file="QBtnDropdown/Link" />
-
 <doc-example title="Disable" file="QBtnDropdown/Disable" />
+
+The following example won't work with UMD version (so in Codepen/jsFiddle too) because it relies on the existence of Vue Router.
+
+<doc-example title="Split and router link on main" file="QBtnDropdown/Link" no-edit />
 
 ## QBtnDropdown API
 <doc-api file="QBtnDropdown" />

--- a/docs/src/pages/vue-components/button.md
+++ b/docs/src/pages/vue-components/button.md
@@ -65,11 +65,11 @@ Should you wish, you can also display a deterministic progress within the button
 
 The two examples below won't work with UMD version (so in Codepen/jsFiddle too) because it relies on the existence of Vue Router.
 
-<doc-example title="Links" file="QBtn/Links" />
+<doc-example title="Links" file="QBtn/Links" no-edit />
 
 For more convoluted use-cases, you can also directly use the native Vue `<router-link>` component to wrap a QBtn. This also gives the opportunity to control the state according to app's current route:
 
-<doc-example title="Scoped slot of RouterLink" file="QBtn/RouterLink" />
+<doc-example title="Scoped slot of RouterLink" file="QBtn/RouterLink" no-edit />
 
 ### Other options
 


### PR DESCRIPTION
Also added similar description/reason to QBtnDropdown example that QBtn example has.