### PR TITLE
fix(QTable): When there is no data, the header defaults to not selected

### DIFF
--- a/ui/src/components/table/table-row-selection.js
+++ b/ui/src/components/table/table-row-selection.js
@@ -33,7 +33,7 @@ export default {
     },
 
     allRowsSelected () {
-      return this.computedRows.every(
+      return !!this.computedRows.length && this.computedRows.every(
         row => this.selectedKeys[ this.getRowKey(row) ] === true
       )
     },

--- a/ui/src/components/table/table-row-selection.js
+++ b/ui/src/components/table/table-row-selection.js
@@ -33,7 +33,7 @@ export default {
     },
 
     allRowsSelected () {
-      return !!this.computedRows.length && this.computedRows.every(
+      return this.computedRows.length > 0 && this.computedRows.every(
         row => this.selectedKeys[ this.getRowKey(row) ] === true
       )
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


