### PR TITLE
fix(docs): prettier.eslintIntegration is no longer used

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -72,8 +72,6 @@ To edit the settings use the command `Open Settings JSON` in the Command Palette
         "source.fixAll": true
     },
 
-    "prettier.eslintIntegration": true,
-
     "vetur.format.defaultFormatter.html": "prettyhtml",
     "vetur.format.defaultFormatter.js": "prettier-eslint"
 }


### PR DESCRIPTION
Setting prettier.eslintIntegration is no longer used for anything and should be deleted as per https://github.com/prettier/prettier-vscode#linter-integration

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
