### PR TITLE
Fix: #5987 - webpack conflict for [contenthash]

### DIFF
--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -13,7 +13,7 @@ module.exports = function (cfg, configName) {
 
   const needsHash = !cfg.ctx.dev && !['electron', 'cordova', 'capacitor'].includes(cfg.ctx.modeName)
   const fileHash = needsHash ? '.[hash:8]' : ''
-  const chunkHash = needsHash ? '.[contenthash:8]' : ''
+  const chunkHash = needsHash ? '.[hash:8]' : ''
   const resolveModules = [
     'node_modules',
     appPaths.resolve.app('node_modules'),
@@ -330,7 +330,7 @@ module.exports = function (cfg, configName) {
       // extract css into its own file
       chain.plugin('mini-css-extract')
         .use(MiniCssExtractPlugin, [{
-          filename: 'css/[name].[contenthash:8].css'
+          filename: 'css/[name].[hash:8].css'
         }])
 
       // dedupe & minify CSS (only if extracted)

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -13,7 +13,7 @@ module.exports = function (cfg, configName) {
 
   const needsHash = !cfg.ctx.dev && !['electron', 'cordova', 'capacitor'].includes(cfg.ctx.modeName)
   const fileHash = needsHash ? '.[hash:8]' : ''
-  const chunkHash = needsHash ? '.[contenthash:8]' : ''
+  const chunkHash = needsHash ? '.[chash:8]' : ''
   const resolveModules = [
     'node_modules',
     appPaths.resolve.app('node_modules'),
@@ -330,7 +330,7 @@ module.exports = function (cfg, configName) {
       // extract css into its own file
       chain.plugin('mini-css-extract')
         .use(MiniCssExtractPlugin, [{
-          filename: 'css/[name].[contenthash:8].css'
+          filename: 'css/[name].[chash:8].css'
         }])
 
       // dedupe & minify CSS (only if extracted)

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -13,7 +13,7 @@ module.exports = function (cfg, configName) {
 
   const needsHash = !cfg.ctx.dev && !['electron', 'cordova', 'capacitor'].includes(cfg.ctx.modeName)
   const fileHash = needsHash ? '.[hash:8]' : ''
-  const chunkHash = needsHash ? '.[chash:8]' : ''
+  const chunkHash = needsHash ? '.[hash:8]' : ''
   const resolveModules = [
     'node_modules',
     appPaths.resolve.app('node_modules'),
@@ -330,7 +330,7 @@ module.exports = function (cfg, configName) {
       // extract css into its own file
       chain.plugin('mini-css-extract')
         .use(MiniCssExtractPlugin, [{
-          filename: 'css/[name].[chash:8].css'
+          filename: 'css/[name].[hash:8].css'
         }])
 
       // dedupe & minify CSS (only if extracted)


### PR DESCRIPTION
> This appears to be a conflict with webpack 4.3 which introduced a [contenthash] variable of its own: https://github.com/webpack/webpack/releases/tag/v4.3.0

Source: https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/763