### PR TITLE
fix(QDialog): should keep at least 24px padding on minimized on ios

### DIFF
--- a/ui/src/components/dialog/QDialog.sass
+++ b/ui/src/components/dialog/QDialog.sass
@@ -1,5 +1,3 @@
-$dialog-minimized-padding: 24px
-
 .q-dialog
 
   &__title
@@ -30,7 +28,7 @@ $dialog-minimized-padding: 24px
         min-width: 64px
 
     &--minimized
-      padding: $dialog-minimized-padding
+      padding: 24px
       > div
         max-height: calc(100vh - 48px)
 
@@ -86,10 +84,10 @@ body.q-ios-padding .q-dialog__inner
   padding-top: env(safe-area-inset-top) !important
   padding-bottom: env(safe-area-inset-bottom) !important
   &--minimized
-    padding-top: calc(env(safe-area-inset-top) + $dialog-minimized-padding) !important
-    padding-bottom: calc(env(safe-area-inset-bottom) + $dialog-minimized-padding) !important
+    padding-top: calc(env(safe-area-inset-top) + 24px) !important
+    padding-bottom: calc(env(safe-area-inset-bottom) + 24px) !important
   > div
-    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - ($dialog-minimized-padding * 2)) !important
+    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - (24px * 2)) !important
 
 @media (max-width: $breakpoint-xs-max)
   .q-dialog__inner

--- a/ui/src/components/dialog/QDialog.sass
+++ b/ui/src/components/dialog/QDialog.sass
@@ -1,3 +1,5 @@
+$dialog-minimized-padding: 24px
+
 .q-dialog
 
   &__title
@@ -28,7 +30,7 @@
         min-width: 64px
 
     &--minimized
-      padding: 24px
+      padding: $dialog-minimized-padding
       > div
         max-height: calc(100vh - 48px)
 
@@ -83,6 +85,9 @@ body.q-ios-padding .q-dialog__inner
   padding-top: $ios-statusbar-height !important
   padding-top: env(safe-area-inset-top) !important
   padding-bottom: env(safe-area-inset-bottom) !important
+  &--minimized
+    padding-top: calc(env(safe-area-inset-top) + $dialog-minimized-padding) !important
+    padding-bottom: calc(env(safe-area-inset-bottom) + $dialog-minimized-padding) !important
   > div
     max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important
 

--- a/ui/src/components/dialog/QDialog.sass
+++ b/ui/src/components/dialog/QDialog.sass
@@ -89,7 +89,7 @@ body.q-ios-padding .q-dialog__inner
     padding-top: calc(env(safe-area-inset-top) + $dialog-minimized-padding) !important
     padding-bottom: calc(env(safe-area-inset-bottom) + $dialog-minimized-padding) !important
   > div
-    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important
+    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - ($dialog-minimized-padding * 2)) !important
 
 @media (max-width: $breakpoint-xs-max)
   .q-dialog__inner

--- a/ui/src/components/dialog/QDialog.styl
+++ b/ui/src/components/dialog/QDialog.styl
@@ -1,3 +1,5 @@
+$dialog-minimized-padding = 24px
+
 .q-dialog
 
   &__title
@@ -28,7 +30,7 @@
         min-width: 64px
 
     &--minimized
-      padding: 24px
+      padding: $dialog-minimized-padding
       > div
         max-height: calc(100vh - 48px)
 
@@ -83,6 +85,9 @@ body.q-ios-padding .q-dialog__inner
   padding-top: $ios-statusbar-height !important
   padding-top: env(safe-area-inset-top) !important
   padding-bottom: env(safe-area-inset-bottom) !important
+  &--minimized
+    padding-top: "calc(env(safe-area-inset-top) + %s) !important" % $dialog-minimized-padding
+    padding-bottom: "calc(env(safe-area-inset-bottom) + %s) !important" % $dialog-minimized-padding
   > div
     // quotes are stylus workaround to not error when parsing env()
     max-height: "calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important" % $ios-statusbar-height

--- a/ui/src/components/dialog/QDialog.styl
+++ b/ui/src/components/dialog/QDialog.styl
@@ -90,7 +90,7 @@ body.q-ios-padding .q-dialog__inner
     padding-bottom: "calc(env(safe-area-inset-bottom) + %s) !important" % $dialog-minimized-padding
   > div
     // quotes are stylus workaround to not error when parsing env()
-    max-height: "calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important" % $ios-statusbar-height
+    max-height: "calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - (%s * 2)) !important" % $dialog-minimized-padding
 
 @media (max-width: $breakpoint-xs-max)
   .q-dialog__inner


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Explanation
On the browser a minimized QDialog will always have a minimum of 24px padding.
On my iPad mini, the statusbar had a minimum padding for just the status bar, but the bottom had 0 padding. I believe that it should keep that minimum of 24px of padding, just like the browser.
No need to have 0px padding for dialogs on iPads.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
