### PR TITLE
Update QUploaderBase.js

### DIFF
--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -266,12 +266,12 @@ export default {
       }
 
       if (this.maxTotalSize !== void 0) {
-        let size = 0
+        let size = this.uploadSize
         for (let i = 0; i < files.length; i++) {
           size += files[i].size
           if (size > this.maxTotalSize) {
             if (i > 0) {
-              files = files.slice(0, i - 1)
+              files = files.slice(0, i)
               break
             }
             else {


### PR DESCRIPTION
maxTotalSize applied incorrectly.
1. It is possible to exceed maxTotalSize if uploading files one by one: line 269 allows it, starting size from 0 when adding files in queue, not all in bunch. 
2. Line 274: we always lose the last file not exceeding maxTotalSize when loading files in bunch.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
