### PR TITLE
fix(app): deduplicate code when using core-js@3

### DIFF
--- a/babel-preset-app/index.js
+++ b/babel-preset-app/index.js
@@ -77,8 +77,9 @@ module.exports = (_, opts) => {
     ]
   ]
 
-  // use @babel/runtime-corejs{2,3} so that helpers will reference core-js instead
-  if (presetEnv.corejs && presetEnv.useBuiltIns === 'usage') {
+  // Use @babel/runtime-corejs2 so that helpers will reference existing core-js.
+  // Not using @babel/runtime-corejs3 that would just duplicate code with core-js-pure.
+  if (presetEnv.corejs == 2 && presetEnv.useBuiltIns === 'usage') {
     plugins.push([
       require('babel-plugin-module-resolver'), {
         alias: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] ~When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)~
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

~If adding a **new feature**, the PR's description includes:~
- [ ] ~A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~

**Other information:**

Only applies to users explicitly requiring core-js@3 (babel.config.js):

```js
module.exports = {
  presets: [
      ['@quasar/babel-preset-app', {
        presetEnv: { corejs: 3 }
      }]
  ]
}
```

`core-js-pure` dependency is unexpectedly added to the build, generating duplicated code and bigger bundle size (>30kB parsed JS) as show on the screenshot below. Core-js documents this behaviour [here](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babelruntime) and according to a babel team member in a [related issue](https://github.com/babel/babel/issues/10271#issuecomment-528379505):

> `useBuiltIns` and `@babel/plugin-transform-runtime` are mutually exclusive

even when `/plugin-transform-runtime` has `corejs: false` option as explained by issue OP.

To reproduce, enable `analyze: true` in `quasar.conf.js` with `corejs: 3` set in `babel.config.js` as shown above, after running [`yarn add -D core-js` as required by babel](https://babeljs.io/docs/en/babel-preset-env#usebuiltins):

![core-js-pure-3](https://user-images.githubusercontent.com/12909094/72470661-6b902700-37e1-11ea-9eea-f4e9ea06c84a.png)

Note: uninstall `core-js@3` dependency if you want to revert to `core-js@2` (default) in `babel.config.js` to avoid reference errors.