### PR TITLE
fix|feat(QTooltip) reposition on content change

### DIFF
--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -76,6 +76,8 @@ export default Vue.extend({
       this.__showPortal()
 
       this.__nextTick(() => {
+        this.observer = new MutationObserver(mutations => this.updatePosition())
+        this.observer.observe(this.__portal.$el, { attributes: false, childList: true, characterData: true, subtree: true })
         this.updatePosition()
         this.__configureScrollTarget()
       })
@@ -86,6 +88,7 @@ export default Vue.extend({
     },
 
     __hide (evt) {
+      this.observer.disconnect()
       this.__anchorCleanup()
 
       this.__setTimeout(() => {


### PR DESCRIPTION
added mutation observer

I use dual purpose buttons with tooltips that must reposition on change of tooltip content

I dont see this introducing any performance cost, the observer is only active when the tooltip is shown

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the dev branch and not the master branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. fix: #xxx[,#xxx], where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated in the docs (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a new feature, the PR's description includes:

 - [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)