### PR TITLE
fix(QCheckbox) Indeterminate bug

### DIFF
--- a/ui/src/components/checkbox/QCheckbox.js
+++ b/ui/src/components/checkbox/QCheckbox.js
@@ -17,7 +17,7 @@ export default Vue.extend({
 
   computed: {
     isIndeterminate () {
-      return this.value === void 0 || this.value === this.indeterminateValue
+      return this.value === this.indeterminateValue || this.value === this.indeterminateValue
     },
 
     classes () {

--- a/ui/src/components/checkbox/QCheckbox.js
+++ b/ui/src/components/checkbox/QCheckbox.js
@@ -17,7 +17,7 @@ export default Vue.extend({
 
   computed: {
     isIndeterminate () {
-      return this.value === this.indeterminateValue || this.value === this.indeterminateValue
+      return this.value === this.indeterminateValue
     },
 
     classes () {

--- a/ui/src/mixins/checkbox.js
+++ b/ui/src/mixins/checkbox.js
@@ -76,7 +76,7 @@ export default {
           ? this.indeterminateValue
           : this.falseValue
       }
-      else if (this.isFalse === true) {
+      else if (this.isIndeterminate === false || this.isFalse === true) {
         val = this.trueValue
       }
       else {

--- a/ui/src/mixins/checkbox.js
+++ b/ui/src/mixins/checkbox.js
@@ -6,7 +6,7 @@ export default {
 
   props: {
     value: {
-      required: true
+      default: null
     },
     val: {},
 
@@ -76,7 +76,7 @@ export default {
           ? this.indeterminateValue
           : this.falseValue
       }
-      else if (this.isIndeterminate === false || this.isFalse === true) {
+      else if (this.isFalse === true) {
         val = this.trueValue
       }
       else {


### PR DESCRIPTION
my use case was to allow false to be null/undefined

such as in a v-for of an object array where I want item.selected without having to append a selected property to each item in advance.

`:false-value="null" :indeterminate-value="''"`

`indeterminateValue `is `null `by default so having the `void 0` comparison was redundant and caused the bug

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the dev branch and not the master branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. fix: #xxx[,#xxx], where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated in the docs (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a new feature, the PR's description includes:

 - [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
