### PR TITLE
Add cursor-pointer class when @click is defined on QTr

### DIFF
--- a/ui/src/components/table/QTr.js
+++ b/ui/src/components/table/QTr.js
@@ -13,7 +13,8 @@ export default Vue.extend({
   computed: {
     classes () {
       return 'q-tr' + (this.props === void 0 || this.props.header === true ? '' : ' ' + this.props.__trClass) +
-        (this.noHover === true ? ' q-tr--no-hover' : '')
+        (this.noHover === true ? ' q-tr--no-hover' : '') +
+        (this.$listeners['click'] !== void 0 ? 'cursor-pointer' = '')
     }
   },
 

--- a/ui/src/components/table/QTr.js
+++ b/ui/src/components/table/QTr.js
@@ -14,7 +14,7 @@ export default Vue.extend({
     classes () {
       return 'q-tr' + (this.props === void 0 || this.props.header === true ? '' : ' ' + this.props.__trClass) +
         (this.noHover === true ? ' q-tr--no-hover' : '') +
-        (this.$listeners['click'] !== void 0 ? 'cursor-pointer' = '')
+        (this.$listeners['click'] !== void 0 ? ' cursor-pointer' = '')
     }
   },
 

--- a/ui/src/components/table/QTr.js
+++ b/ui/src/components/table/QTr.js
@@ -13,15 +13,15 @@ export default Vue.extend({
   computed: {
     classes () {
       return 'q-tr' + (this.props === void 0 || this.props.header === true ? '' : ' ' + this.props.__trClass) +
-        (this.noHover === true ? ' q-tr--no-hover' : '') +
-        (this.$listeners['click'] !== void 0 ? ' cursor-pointer' = '')
+        (this.noHover === true ? ' q-tr--no-hover' : '')
     }
   },
 
   render (h) {
     return h('tr', {
       on: this.$listeners,
-      class: this.classes
+      staticClass: this.classes,
+      class: this.$listeners.click !== void 0 ? 'cursor-pointer' : ''
     }, slot(this, 'default'))
   }
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR is a continuance of https://github.com/quasarframework/quasar/issues/5849
When there's a @click listener on QTr, auto-add the `cursor-pointer` class.