### PR TITLE
docs: fix uploader nodejs example

### DIFF
--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -145,8 +145,8 @@ app.post('/upload', (req, res) => {
     console.log('Fields', fields)
     console.log('Received:', Object.keys(files))
     console.log()
+    res.send('Thank you')
   })
-  res.send('Thank you')
 })
 
 app.listen(port, () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Other information:**
I don't know why it happens, but if you place the nodejs server behind a reverse proxy and send a response outside of `form.parse()`, the upload fails without any error or warnings for larger files. It probably has something to do with buffering of the request, not sure why.
I figured I'd make a PR so no one else runs into the problem with this example.
