### PR TITLE
feat(QSelect): Add skipInputValue as second parameter to moveOptionSelection to allow navigation without updating input-value

### DIFF
--- a/docs/src/examples/QSelect/InputFilterAfter.vue
+++ b/docs/src/examples/QSelect/InputFilterAfter.vue
@@ -6,6 +6,8 @@
         v-model="model"
         clearable
         use-input
+        hide-selected
+        fill-input
         input-debounce="0"
         label="Focus after filtering"
         :options="options"
@@ -27,6 +29,8 @@
         v-model="model"
         clearable
         use-input
+        hide-selected
+        fill-input
         input-debounce="0"
         label="Autoselect after filtering"
         :options="options"
@@ -84,9 +88,8 @@ export default {
           // "ref" is the Vue reference to the QSelect
           ref => {
             if (val !== '' && ref.options.length > 0) {
-              // DO NOT use setOptionIndex or moveOptionSelection with fill-input
               ref.setOptionIndex(-1) // reset optionIndex in case there is something selected
-              ref.moveOptionSelection() // focus the first selectable option
+              ref.moveOptionSelection(1, true) // focus the first selectable option and do not update the input-value
             }
           }
         )
@@ -112,8 +115,7 @@ export default {
           // "ref" is the Vue reference to the QSelect
           ref => {
             if (val !== '' && ref.options.length > 0 && ref.optionIndex === -1) {
-              // DO NOT use setmoveOptionSelection or toggleOption with fill-input
-              ref.moveOptionSelection() // focus the first selectable option
+              ref.moveOptionSelection(1, true) // focus the first selectable option and do not update the input-value
               ref.toggleOption(ref.options[ref.optionIndex], true) // toggle the focused option
             }
           }

--- a/ui/dev/src/pages/form/select-part-5-kbd.vue
+++ b/ui/dev/src/pages/form/select-part-5-kbd.vue
@@ -417,7 +417,8 @@ export default {
           this.options = options.filter(v => v.toLowerCase().indexOf(needle) > -1)
         },
         ref => {
-          ref.moveOptionSelection()
+          ref.setOptionIndex(-1)
+          ref.moveOptionSelection(1, true)
         }
       )
     },

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -415,7 +415,7 @@ export default Vue.extend({
       }
     },
 
-    moveOptionSelection (offset = 1) {
+    moveOptionSelection (offset = 1, skipInputValue) {
       if (this.menu === true) {
         let index = this.optionIndex
         do {
@@ -431,7 +431,7 @@ export default Vue.extend({
           this.setOptionIndex(index)
           this.scrollTo(index)
 
-          if (index >= 0 && this.useInput === true && this.fillInput === true) {
+          if (skipInputValue !== true && index >= 0 && this.useInput === true && this.fillInput === true) {
             const inputValue = this.__getOptionLabel(this.options[index])
             if (this.inputValue !== inputValue) {
               this.inputValue = inputValue

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -610,6 +610,11 @@
           "desc": "Number of options to move up or down",
           "default": 1,
           "examples": [ -1, 1, 5 ]
+        },
+        "skipInputValue": {
+          "type": "Boolean",
+          "desc": "Don't set input-value on navigation",
+          "addedIn": "v1.8.0"
         }
       },
       "addedIn": "v1.7.4"


### PR DESCRIPTION
Update examples in docs to use it.