### PR TITLE
build(ast): analize components exported as plain objects

### DIFF
--- a/ui/build/ast.js
+++ b/ui/build/ast.js
@@ -2,11 +2,14 @@ const
   recast = require('recast'),
   parser = require('recast/parsers/babel')
 
+// Analize component JS file
 module.exports.evaluate = (source, lookup, callback) => {
   const ast = recast.parse(source, { parser })
   for (const node of ast.program.body) {
     if (node.type === 'ExportDefaultDeclaration') {
-      const properties = node.declaration.arguments[0].properties
+      const properties =
+        node.declaration.properties || // When exporting a plain object (`export default { ... }`)
+        node.declaration.arguments[0].properties // When exporting a wrapped object (`export default Vue.extend({ ... })`)
       for (const property of properties) {
         const propName = property.key.name
         if (lookup.includes(propName)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
`Vue.extend` isn't mandatory for the component to work (it's just a noop wrapper), this PR allow to export plain objects without build errors

Before:
- `export default { ... }` throw an esoteric error
- `export default Vue.extend({ ... })` works

After:
- `export default { ... }` works
- `export default Vue.extend({ ... })` works