### PR TITLE
mistake in docs - this.$q.fullscreen is undefined

### DIFF
--- a/docs/src/pages/quasar-plugins/app-fullscreen.md
+++ b/docs/src/pages/quasar-plugins/app-fullscreen.md
@@ -18,7 +18,6 @@ For an exhaustive list of properties and methods, please check out the API secti
 :::
 
 ``` js
-// outside of a Vue file
 import { AppFullscreen } from 'quasar'
 
 // Requesting fullscreen mode:
@@ -40,27 +39,6 @@ AppFullscreen.exit()
   })
 ```
 
-``` js
-// inside of a Vue file
-
-// Requesting fullscreen mode:
-this.$q.fullscreen.request()
-  .then(() => { // v1.5.0+
-    // success!
-  })
-  .catch(err => { // v1.5.0+
-    // oh, no!!!
-  })
-
-// Exiting fullscreen mode:
-this.$q.fullscreen.exit()
-  .then(() => { // v1.5.0+
-    // success!
-  })
-  .catch(err => { // v1.5.0+
-    // oh, no!!!
-  })
-```
 
 <doc-example title="Basic" file="AppFullscreen/Basic" />
 
@@ -82,7 +60,7 @@ It all depends on the Web Fullscreen API support of the platform the code is run
 <script>
 export default {
   watch: {
-    '$q.fullscreen.isActive' (val) {
+    'AppFullscreen.isActive' (val) {
       console.log(val ? 'In fullscreen now' : 'Exited fullscreen')
     }
   }


### PR DESCRIPTION
The docs suggest using $q.fullscreen / this.$q.fullscreen but fullscreen is undefined on $q. You have to import { AppFullscreen } from 'quasar'

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
