### PR TITLE
fix(docs): Fix issue of anchors getting hidden

### DIFF
--- a/docs/src/layouts/Layout.vue
+++ b/docs/src/layouts/Layout.vue
@@ -385,6 +385,6 @@ export default {
   &:hover img
     transform: rotate(-360deg)
 
-.q-page-container [id]
-  scroll-margin-top: $toolbar-min-height
+.q-page-container :target
+  scroll-margin-top: ($toolbar-min-height + 16px)
 </style>

--- a/docs/src/layouts/Layout.vue
+++ b/docs/src/layouts/Layout.vue
@@ -384,4 +384,7 @@ export default {
     transition: transform .8s ease-in-out
   &:hover img
     transform: rotate(-360deg)
+
+.q-page-container [id]
+  scroll-margin-top: $toolbar-min-height
 </style>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
When navigating directly to an anchor, for example: https://quasar.dev/introduction-to-quasar#All-Platforms-in-One-Go , the anchor element gets hidden by the header, this issue can be resolved by adding the css property `scroll-margin-top` to all anchor elements (elements with the `id` attribute) in the layout page.

`scroll-margin-top` is [supported by most browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top#Browser_compatibility).
