### PR TITLE
feat(app, docs): Add support for Lerna package Electron build (fix #6345)

### DIFF
--- a/app/lib/electron/index.js
+++ b/app/lib/electron/index.js
@@ -89,11 +89,14 @@ class ElectronRunner {
 
   build (quasarConfig) {
     const cfg = quasarConfig.getBuildConfig()
+    
+    if (!cfg.electron.customInstall) cfg.electron.customInstall = ''
+		const [ customCmd, ...customParams ] = cfg.electron.customInstall.split(' ')
 
     return new Promise(resolve => {
       spawn(
-        nodePackager,
-        [ 'install', '--production' ].concat(cfg.electron.unPackagedInstallParams),
+        customCmd || nodePackager,
+				(customCmd ? customParams : ['install', '--production']).concat(cfg.electron.unPackagedInstallParams),
         { cwd: cfg.build.distDir },
         code => {
           if (code) {

--- a/app/lib/webpack/electron/plugin.electron-package-json.js
+++ b/app/lib/webpack/electron/plugin.electron-package-json.js
@@ -12,6 +12,11 @@ module.exports = class ElectronPackageJson {
 
       // we don't need this (also, faster install time & smaller bundles)
       delete pkg.devDependencies
+      
+      if (pkg.electronNameAppend){
+        pkg.name = pkg.name + '-electron'
+        delete pkg.electronNameAppend
+      }
 
       pkg.main = './electron-main.js'
       const source = JSON.stringify(pkg)

--- a/docs/src/pages/quasar-cli/developing-electron-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-electron-apps/build-commands.md
@@ -34,9 +34,9 @@ It builds your app for production and then uses electron-packager to pack it int
 If you want to build for Windows with a custom icon using a non-Windows platform, you must have [wine](https://www.winehq.org/) installed. [More Info](https://github.com/electron-userland/electron-packager#building-windows-apps-from-non-windows-platforms).
 
 ### Instructions for Lerna monorepo users
-Quasar automatically detects and use your preferred node packager (yarn or npm) to install the dependencies of your Electron build. If your app is part of a [Lerna monorepo](https://lerna.js.org/), you will find that the default build process fails to resolve your symlinked dependencies. To make this work, enable the following configurations.
+Quasar automatically detects and uses your preferred node packager (yarn or npm) to install the dependencies of your Electron build. If your app is part of a [Lerna monorepo](https://lerna.js.org/), you will find that the default build process fails to resolve your symlinked dependencies. To make this work, enable the following configurations.
 
-1. Specify custom dependency installation command (in this case [lerna bootsrap](https://github.com/lerna/lerna/tree/master/commands/bootstrap)) :
+1. Specify custom dependency installation command (in this case [lerna bootstrap](https://github.com/lerna/lerna/tree/master/commands/bootstrap)) :
 ```
 // quasar.conf.js
 

--- a/docs/src/pages/quasar-cli/developing-electron-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-electron-apps/build-commands.md
@@ -33,6 +33,25 @@ It builds your app for production and then uses electron-packager to pack it int
 ### A note for non-Windows users
 If you want to build for Windows with a custom icon using a non-Windows platform, you must have [wine](https://www.winehq.org/) installed. [More Info](https://github.com/electron-userland/electron-packager#building-windows-apps-from-non-windows-platforms).
 
+### Instructions for Lerna monorepo users
+Quasar automatically detects and use your preferred node packager (yarn or npm) to install the dependencies of your Electron build. If your app is part of a [Lerna monorepo](https://lerna.js.org/), you will find that the default build process fails to resolve your symlinked dependencies. To make this work, enable the following configurations.
+
+1. Specify custom dependency installation command (in this case [lerna bootsrap](https://github.com/lerna/lerna/tree/master/commands/bootstrap)) :
+```
+// quasar.conf.js
+
+electron: {
+  customInstall: 'lerna bootstrap -- --production'
+}
+```
+
+2. Request to append '-electron' to your build's package name (to avoid [Lerna fail on duplicate package names](https://github.com/lerna/lerna/issues/1980)) :
+```
+// package.json
+
+"electronNameAppend": true,
+```
+
 ## Publishing (electron-builder only)
 ```bash
 $ quasar build -m electron -P always


### PR DESCRIPTION
### Motivation
Building Electron apps is currently impossible in a Lerna monorepo environment, as symlinked dependencies fail to resolve. The reason for this is that the yarn/npm install command is hardcoded inside Quasar, making it impossible to use [lerna bootstrap](https://github.com/lerna/lerna/tree/master/commands/bootstrap) as required. 

I propose here a general `electron.customInstall` config which would not only solve this, but also any other case where the install command needs to be specified manually. 

Lastly, to satisfy Lerna, another config was needed to [avoid package name duplication](https://github.com/lerna/lerna/issues/1980). Feel free to rename these configs as you see fit. Fixes [#6345](https://github.com/quasarframework/quasar/issues/6345).

### What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

### The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

### If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)