### PR TITLE
fix(docs): Update QPopupProxy's breakpoint prop description

### DIFF
--- a/ui/src/components/popup-proxy/QPopupProxy.json
+++ b/ui/src/components/popup-proxy/QPopupProxy.json
@@ -14,7 +14,7 @@
 
     "breakpoint": {
       "type": [ "Number", "String" ],
-      "desc": "Breakpoint (in pixels) of window width from where a Menu will get to be used instead of a Dialog",
+      "desc": "Breakpoint (in pixels) of window width/height (whichever is smaller) from where a Menu will get to be used instead of a Dialog",
       "default": 450,
       "examples": [ 992, ":breakpoint=\"1024\"" ],
       "category": "behavior"


### PR DESCRIPTION
Updates QPopupProxy's breakpoint prop description to indicate that both the window height and width are taken into account when deciding which component to render

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I did not test the change as it is a text-only change to the documentation and does not affect component logic.
