### PR TITLE
fix: action handlers in Notify are again triggered before onDismiss (fix #6380)

### DIFF
--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -133,8 +133,8 @@ const Notifications = {
         on: {
           click: typeof handler === 'function'
             ? () => {
-              noDismiss !== true && notif.meta.close()
               handler()
+              noDismiss !== true && notif.meta.close()
             }
             : () => {
               notif.meta.close()


### PR DESCRIPTION
Only change in the order of functions. No verification of the impact on performance.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Assuming that 1.9.0 did not introduced the bug as a breaking change.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.