### PR TITLE
fix(app): Add missing "types" folder into the package.json files list.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,8 @@
     "assets",
     "bin",
     "lib",
-    "templates"
+    "templates",
+    "types"
   ],
   "keywords": [
     "quasar",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

This fixes an issue with missing types in `@quasar/app` because the `types` folder is missing from the "files" entry in `packages.json`.  Since it is not listed the folder is not copied as part of the npm publish process which is why the issue was not found during testing of the original changes.
