### PR TITLE
feat(Dialog-plugin): add style properties in prompt

### DIFF
--- a/ui/src/components/dialog-plugin/DialogPlugin.js
+++ b/ui/src/components/dialog-plugin/DialogPlugin.js
@@ -133,6 +133,11 @@ export default Vue.extend({
           props: {
             value: this.prompt.model,
             type: this.prompt.type,
+            label: this.prompt.label,
+            stackLabel: this.prompt.stackLabel,
+            outlined: this.prompt.outlined,
+            filled: this.prompt.filled,
+            standout: this.prompt.standout,
             color: this.vmColor,
             dense: true,
             autofocus: true,

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -58,6 +58,36 @@
                   "examples": [ "text", "number", "textarea" ]
                 },
 
+                "label": {
+                  "type": "String",
+                  "desc": "A text label that will “float” up above the input field, once the field gets focus",
+                  "examples": [ "Username" ]
+                },
+            
+                "stack-label": {
+                  "type": "Boolean",
+                  "desc": "Label will be always shown above the field regardless of field content (if any)"
+                },
+
+                "filled": {
+                  "type": "Boolean",
+                  "desc": "Use 'filled' design for the field"
+                },
+            
+                "outlined": {
+                  "type": "Boolean",
+                  "desc": "Use 'outlined' design for the field"
+                },
+
+                "standout": {
+                  "type": [ "Boolean", "String" ],
+                  "desc": "Use 'standout' design for the field; Specifies classes to be applied when focused (overriding default ones)",
+                  "examples": [
+                    "standout",
+                    "standout=\"bg-primary text-white\""
+                  ]
+                },
+
                 "isValid": {
                   "type": "Function",
                   "desc": "Is typed content valid?",

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -61,22 +61,26 @@
                 "label": {
                   "type": "String",
                   "desc": "A text label that will “float” up above the input field, once the field gets focus",
-                  "examples": [ "Username" ]
+                  "examples": [ "Username" ],
+                  "addedIn": "v1.9.3"
                 },
             
                 "stack-label": {
                   "type": "Boolean",
-                  "desc": "Label will be always shown above the field regardless of field content (if any)"
+                  "desc": "Label will be always shown above the field regardless of field content (if any)",
+                  "addedIn": "v1.9.3"
                 },
 
                 "filled": {
                   "type": "Boolean",
-                  "desc": "Use 'filled' design for the field"
+                  "desc": "Use 'filled' design for the field",
+                  "addedIn": "v1.9.3"
                 },
             
                 "outlined": {
                   "type": "Boolean",
-                  "desc": "Use 'outlined' design for the field"
+                  "desc": "Use 'outlined' design for the field",
+                  "addedIn": "v1.9.3"
                 },
 
                 "standout": {
@@ -85,7 +89,8 @@
                   "examples": [
                     "standout",
                     "standout=\"bg-primary text-white\""
-                  ]
+                  ],
+                  "addedIn": "v1.9.3"
                 },
 
                 "isValid": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Allows you to configure style properties in Dialog prompt type.