### PR TITLE
feat(model-toggle): add stopPropagation prop

### DIFF
--- a/ui/src/mixins/model-toggle.js
+++ b/ui/src/mixins/model-toggle.js
@@ -8,7 +8,8 @@ export default {
     value: {
       type: Boolean,
       default: void 0
-    }
+    },
+    stopPropagation: Boolean
   },
 
   data () {
@@ -29,6 +30,9 @@ export default {
 
   methods: {
     toggle (evt) {
+      // Stops the event propagation of the parent component
+      this.stopPropagation === true && evt !== void 0 && evt.stopPropagation()
+
       this[this.showing === true ? 'hide' : 'show'](evt)
     },
 

--- a/ui/src/mixins/model-toggle.json
+++ b/ui/src/mixins/model-toggle.json
@@ -4,6 +4,12 @@
       "type": "Boolean",
       "desc": "Model of the component defining shown/hidden state; Either use this property (along with a listener for 'input' event) OR use v-model directive",
       "category": "model"
+    },
+
+    "stopPropagation": {
+      "type": "Boolean",
+      "desc": "Stops the event propagation of the parent component, when it is true",
+      "category": "behavior"
     }
   },
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
If I want to place QMenu within QExpansionItem or within a selectable QItem I will need to propagate the parent component event, so I have added this new property: stopPropagation
Look: https://codepen.io/jvillanueva/pen/jOPbzjB