### PR TITLE
fix(QFab): add missing classes used in code

### DIFF
--- a/ui/src/components/fab/QFab.sass
+++ b/ui/src/components/fab/QFab.sass
@@ -11,6 +11,9 @@
   &--form-square
     border-radius: $generic-border-radius
 
+  &--form-rounded
+    border-radius: 50%
+
   &--opened
     .q-fab__actions
       opacity: 1

--- a/ui/src/components/fab/QFab.styl
+++ b/ui/src/components/fab/QFab.styl
@@ -11,6 +11,9 @@
   &--form-square
     border-radius: $generic-border-radius
 
+  &--form-rounded
+    border-radius: 50%
+
   &--opened
     .q-fab__actions
       opacity: 1


### PR DESCRIPTION
ref: Elevation prop for components (#6412)
Class injected by this code was missing:
  computed: {
    formClass () {
      return `q-fab--form-${this.square === true ? 'square' : 'rounded'}`
    },
