### PR TITLE
fix(QTable): showing noResult message while loading

### DIFF
--- a/ui/src/components/table/table-bottom.js
+++ b/ui/src/components/table/table-bottom.js
@@ -19,9 +19,9 @@ export default {
       }
 
       if (this.nothingToDisplay === true) {
-        const message = this.filter
-          ? this.noResultsLabel || this.$q.lang.table.noResults
-          : (this.loading === true ? this.loadingLabel || this.$q.lang.table.loading : this.noDataLabel || this.$q.lang.table.noData)
+        const message = this.loading === true
+          ? this.loadingLabel || this.$q.lang.table.loading
+          : (this.filter ? this.noResultsLabel || this.$q.lang.table.noResults : this.noDataLabel || this.$q.lang.table.noData)
 
         const noData = this.$scopedSlots['no-data']
         const children = noData !== void 0


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR fixes this bug in QTable: https://jsfiddle.net/g6ucftj3/7/
While having 'filter' active the table shows 'No matching records found' ignoring the 'loading' state, whereas it should wait for loading state to finish and then show the aforementioned message.
