### PR TITLE
Expose QSelect.getEmitValue(opt)

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -331,7 +331,7 @@ export default Vue.extend({
   },
 
   methods: {
-    getEmitValue(opt) {
+    getEmitValue (opt) {
        return this.emitValue === true
          ? this.__getOptionValue(opt)
          : opt
@@ -411,7 +411,7 @@ export default Vue.extend({
         }
 
         if (isDeepEqual(this.__getOptionValue(this.innerValue), optValue) !== true) {
-          this.$emit('input', this.getEmitValue(opt))
+          this.$emit('input', this.emitValue === true ? optValue : opt)
         }
         return
       }
@@ -421,7 +421,7 @@ export default Vue.extend({
       this.__selectInputText()
 
       if (this.innerValue.length === 0) {
-        const val = this.getEmitValue(opt)
+        const val = this.emitValue === true ? optValue : opt
         this.$emit('add', { index: 0, value: val })
         this.$emit('input', this.multiple === true ? [ val ] : val)
         return
@@ -439,7 +439,7 @@ export default Vue.extend({
           return
         }
 
-        const val = this.getEmitValue(opt)
+        const val = this.emitValue === true ? optValue : opt
 
         this.$emit('add', { index: model.length, value: val })
         model.push(val)

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -331,6 +331,12 @@ export default Vue.extend({
   },
 
   methods: {
+    getEmitValue() {
+       return this.emitValue === true
+         ? this.__getOptionValue(opt)
+         : opt
+    },
+    
     removeAtIndex (index) {
       if (index > -1 && index < this.innerValue.length) {
         if (this.multiple === true) {
@@ -350,9 +356,7 @@ export default Vue.extend({
     },
 
     add (opt, unique) {
-      const val = this.emitValue === true
-        ? this.__getOptionValue(opt)
-        : opt
+      const val = this.getEmitValue()
 
       if (this.multiple !== true) {
         this.fillInput === true && this.updateInputValue(
@@ -407,7 +411,7 @@ export default Vue.extend({
         }
 
         if (isDeepEqual(this.__getOptionValue(this.innerValue), optValue) !== true) {
-          this.$emit('input', this.emitValue === true ? optValue : opt)
+          this.$emit('input', this.getEmitValue())
         }
         return
       }
@@ -417,7 +421,7 @@ export default Vue.extend({
       this.__selectInputText()
 
       if (this.innerValue.length === 0) {
-        const val = this.emitValue === true ? optValue : opt
+        const val = this.getEmitValue()
         this.$emit('add', { index: 0, value: val })
         this.$emit('input', this.multiple === true ? [ val ] : val)
         return
@@ -435,7 +439,7 @@ export default Vue.extend({
           return
         }
 
-        const val = this.emitValue === true ? optValue : opt
+        const val = this.getEmitValue()
 
         this.$emit('add', { index: model.length, value: val })
         model.push(val)

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -331,7 +331,7 @@ export default Vue.extend({
   },
 
   methods: {
-    getEmitValue() {
+    getEmitValue(opt) {
        return this.emitValue === true
          ? this.__getOptionValue(opt)
          : opt
@@ -356,7 +356,7 @@ export default Vue.extend({
     },
 
     add (opt, unique) {
-      const val = this.getEmitValue()
+      const val = this.getEmitValue(opt)
 
       if (this.multiple !== true) {
         this.fillInput === true && this.updateInputValue(
@@ -411,7 +411,7 @@ export default Vue.extend({
         }
 
         if (isDeepEqual(this.__getOptionValue(this.innerValue), optValue) !== true) {
-          this.$emit('input', this.getEmitValue())
+          this.$emit('input', this.getEmitValue(opt))
         }
         return
       }
@@ -421,7 +421,7 @@ export default Vue.extend({
       this.__selectInputText()
 
       if (this.innerValue.length === 0) {
-        const val = this.getEmitValue()
+        const val = this.getEmitValue(opt)
         this.$emit('add', { index: 0, value: val })
         this.$emit('input', this.multiple === true ? [ val ] : val)
         return
@@ -439,7 +439,7 @@ export default Vue.extend({
           return
         }
 
-        const val = this.getEmitValue()
+        const val = this.getEmitValue(opt)
 
         this.$emit('add', { index: model.length, value: val })
         model.push(val)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

Depending on the `emit-value` prop, `QSelect` emits a different value. I'm making a component wrapping `QSelect` and want to allow both `emit-value` and `multiple` to be chosen upon use of the wrapper component. Different actions need to be taken based on the `multiple` property. When `emit-value` is present as well, this adds an additional layer of complexity as the value could be in two formats, either the raw value or the specified option-value.

In order to fully rely on the behavior of `emit-value` I think it's good to expose a method that outputs the value that will be emitted in the end. This way the decision logic based on `emit-value` remains encapsulated in Quasar.

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)