### PR TITLE
fix(app-extension) do not clear persistent conf on install

### DIFF
--- a/app/lib/app-extension/Extension.js
+++ b/app/lib/app-extension/Extension.js
@@ -153,7 +153,9 @@ module.exports = class Extension {
 
     const prompts = await this.__getPrompts()
 
+    const internal = extensionJson.getInternal(this.extId)
     extensionJson.set(this.extId, prompts)
+    extensionJson.setInternal(internal)
 
     // run extension install
     const hooks = await this.__runInstallScript(prompts)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I was trying to read previous values stored on the AE persistent conf, and realized they were getting cleared by the AE runner. IMO this shouldn't happen, so this is a PR to fix it.