### PR TITLE
ThemeBuilder: capitalize color name, not color code

### DIFF
--- a/docs/src/components/page-parts/theming/ThemeBuilder.vue
+++ b/docs/src/components/page-parts/theming/ThemeBuilder.vue
@@ -12,7 +12,7 @@
           unelevated
         )
           .text-caption.text-weight-light
-            div.text-capitalize {{ color }}
+            .text-capitalize {{ color }}
             div {{ colors[color] }}
 
           q-menu(anchor="top left", self="top left")

--- a/docs/src/components/page-parts/theming/ThemeBuilder.vue
+++ b/docs/src/components/page-parts/theming/ThemeBuilder.vue
@@ -11,8 +11,8 @@
           glossy
           unelevated
         )
-          .text-caption.text-capitalize.text-weight-light
-            div {{ color }}
+          .text-caption.text-weight-light
+            div.text-capitalize {{ color }}
             div {{ colors[color] }}
 
           q-menu(anchor="top left", self="top left")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is a pretty simple change/fix to the Theme Builder.

It is currently "capitalizing" not only the color descriptions ("Primary", "Secondary", etc), but also the respective color codes. For example: it shows `#F2ff03`, instead of `#f2ff03`.

See more examples of the issue in the screenshot below:

![capitalize-color](https://user-images.githubusercontent.com/69181/75123868-11a93980-568a-11ea-9545-d7839505a920.png)

This PR fixes this issue.
