### PR TITLE
feat(typescript): add typescript configuration into core

### DIFF
--- a/app/lib/quasar-config.js
+++ b/app/lib/quasar-config.js
@@ -339,6 +339,9 @@ class QuasarConfig {
     // make sure it exists
     cfg.supportIE = supportIE(cfg.supportIE, this.ctx)
 
+    // make sure it exists
+    cfg.supportTS = cfg.supportTS || false
+
     if (cfg.vendor.disable !== true) {
       cfg.vendor.add = cfg.vendor.add.length > 0
         ? new RegExp(cfg.vendor.add.filter(v => v).join('|'))

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -1,3 +1,4 @@
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const fs = require('fs')
 const path = require('path')
 const webpack = require('webpack')
@@ -145,6 +146,29 @@ module.exports = function (cfg, configName) {
             ]
           ] : []
         })
+
+  if (cfg.supportTS === true || cfg.supportTS.enable === true) {
+    chain.resolve.extensions.add('.ts').add('.tsx');
+    chain.module
+      .rule('typescript')
+      .test(/\.tsx?$/)
+      .use('ts-loader')
+      .loader('ts-loader')
+      .options({
+        // custom config is merged if present, but vue setup and type checking disable are always applied
+        ...(cfg.supportTS.tsLoaderConfig || {}),
+        appendTsSuffixTo: [/\.vue$/],
+        // Type checking is handled by fork-ts-checker-webpack-plugin
+        transpileOnly: true
+      });
+    chain
+      .plugin('ts-checker')
+      // https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options
+      .use(ForkTsCheckerWebpackPlugin, [
+        // custom config is merged if present, but vue option is always enabled
+        { ...(cfg.supportTS.tsCheckerConfig || {}), vue: true }
+      ]);
+  }
 
   chain.module.rule('images')
     .test(/\.(png|jpe?g|gif|svg)(\?.*)?$/)

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
     "bin",
     "lib",
     "templates",
-    "types"
+    "types",
+    "tsconfig-preset.json"
   ],
   "keywords": [
     "quasar",
@@ -70,6 +71,7 @@
     "express": "4.17.1",
     "fast-glob": "3.1.1",
     "file-loader": "^5.0.2",
+    "fork-ts-checker-webpack-plugin": "4.0.4",
     "friendly-errors-webpack-plugin": "1.7.0",
     "fs-extra": "8.1.0",
     "html-minifier": "4.0.0",
@@ -101,6 +103,8 @@
     "stylus": "0.54.7",
     "stylus-loader": "3.0.2",
     "terser-webpack-plugin": "2.3.4",
+    "ts-loader": "6.2.1",
+    "typescript": "3.8.2",
     "url-loader": "3.0.0",
     "vue": "2.6.11",
     "vue-loader": "15.9.0",

--- a/app/tsconfig-preset.json
+++ b/app/tsconfig-preset.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    // `baseUrl` must be placed on the extending configuration in devland, or paths won't be recognized
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    // Needed to address https://github.com/quasarframework/app-extension-typescript/issues/36
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es6",
+    // Quasar-defined webpack aliases
+    "paths": {
+      "src/*": ["src/*"],
+      "app/*": ["*"],
+      "components/*": ["src/components/*"],
+      "layouts/*": ["src/layouts/*"],
+      "pages/*": ["src/pages/*"],
+      "assets/*": ["src/assets/*"],
+      "boot/*": ["src/boot/*"]
+    }
+  },
+  // Needed to avoid files copied into 'dist' folder (eg. a `.d.ts` file inside `src-ssr` folder)
+  // to be evaluated by TS when their original files has been updated
+  "exclude": ["/dist", ".quasar", "node_modules"]
+}

--- a/app/types/configuration/conf.d.ts
+++ b/app/types/configuration/conf.d.ts
@@ -86,6 +86,14 @@ interface BaseQuasarConfiguration {
    * @default false
    */
   supportIE?: boolean;
+  /**
+   * Add support for TypeScript.
+   *
+   * @default false
+   */
+  supportTS?:
+    | boolean
+    | { enabled: boolean; tsLoaderConfig: object; tsCheckerConfig: object };
   /** Add variables that you can use in index.template.html. */
   htmlVariables?: { [index: string]: string };
   /**

--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -220,6 +220,10 @@ const cli = [
       {
         name: 'Supporting IE',
         path: 'supporting-ie'
+      },
+      {
+        name: 'Supporting TypeScript',
+        path: 'supporting-ts'
       }
     ]
   },

--- a/docs/src/pages/quasar-cli/cli-documentation/supporting-ts.md
+++ b/docs/src/pages/quasar-cli/cli-documentation/supporting-ts.md
@@ -1,0 +1,87 @@
+---
+title: Supporting TypeScript
+desc: How to enable support for TypeScript in a Quasar app.
+related:
+  - /quasar-cli/quasar-conf-js
+---
+
+If you are building a medium/large web-app, you might want to use TypeScript and its features. This support is not added by default to your project, but it can be easily integrated.
+
+::: danger Attention Windows Developer
+It is strongly recommended to use Yarn instead of NPM when developing on a Windows machine, to avoid many problems.
+:::
+
+## Installation of TypeScript Support
+
+In order to support TypeScript, you'll need to edit `/quasar.conf.js`:
+
+```js
+module.exports = function (ctx) {
+  return {
+    supportTS: true,
+    ....
+  }
+}
+```
+
+Then create `/tsconfig.json` file at the root of you project with this content:
+
+```json
+{
+  "extends": "@quasar/app/tsconfig-preset",
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}
+```
+
+Now you can start using TypeScript into your project!
+
+::: tip
+Remember that you must change the extension of your JavaScript files to `.ts` to be allowed to write TypeScript code inside them. To write TS code into your components, instead, change the script opening tag like so `<script lang="ts">`.
+:::
+
+::: warning
+If you enable the `supportTS` flag but fail to add the `tsconfig.json` file, the application will break at compile time!  
+:::
+
+## Provide a custom configuration for TypeScript webpack loaders
+
+Behind the curtains, Quasar uses `ts-loader` and `fork-ts-checker-webpack-plugin` to manage TS files. If you ever need to provide a custom configuration for these piaces of software, you can do so providing an object to `supportTS` property like so:
+
+```js
+module.exports = function (ctx) {
+  return {
+    supportTS: {
+      enable: true,
+      tsLoaderConfig: {
+        // `appendTsSuffixTo: [/\.vue$/]` and `transpileOnly: true` are added by default and cannot be overriden
+        ...
+      },
+      tsCheckerConfig: {
+        // `vue: true` is added by default and cannot be overriden
+        ...
+      }
+    },
+    ....
+  }
+}
+```
+
+### Linting setup
+
+If you setup TypeScript linting and want `fork-ts-checker-webpack-plugin` to take it into account, you should provide use `tsCheckerConfig` accordingly:
+
+```js
+module.exports = function (ctx) {
+  return {
+    supportTS: {
+      enable: true,
+      tsCheckerConfig: {
+        eslint: true
+      }
+    },
+    ....
+  }
+}
+```

--- a/docs/src/pages/quasar-cli/quasar-conf-js.md
+++ b/docs/src/pages/quasar-cli/quasar-conf-js.md
@@ -113,6 +113,7 @@ Let's take each option one by one:
 | extras | Array | What to import from [@quasar/extras](https://github.com/quasarframework/quasar/tree/dev/extras) package. Example: _['material-icons', 'roboto-font', 'ionicons-v4']_ |
 | vendor | Object | Add/remove files/3rd party libraries to/from vendor chunk: { add: [...], remove: [...] }. |
 | supportIE | Boolean | Add support for IE11+. |
+| supportTS | Boolean/Object | Add support for TypeScript. |
 | htmlVariables | Object | Add variables that you can use in index.template.html. |
 | framework | Object/String | What Quasar components/directives/plugins to import, what Quasar language pack to use, what Quasar icon set to use for Quasar components. |
 | animations | Object/String | What [CSS animations](/options/animations) to import. Example: _['bounceInLeft', 'bounceOutRight']_ |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
`tsconfig-preset.json` should be extended by the actual `tsconfig.json` into the generated project

It could be a good idea to allow usage of 'withLinter' value to `supportTS` property (or something similar which adds `{ eslint: true }` to TSChecker configuration) to cover the common scenario of ESLint integration.

Current way to handle it:
```js
supportTS: {
  enable: true,
  tsChecker: {
    eslint: true
  }
}
```

Possible ways to make it shorter:
`supportTS: 'withLint'`
or
`supportTS: { enable: true, enableLint: true }`