### PR TITLE
build: support ESM projects

### DIFF
--- a/app/bin/quasar-build
+++ b/app/bin/quasar-build
@@ -164,7 +164,7 @@ async function build () {
   }
   catch (e) {
     console.log(e)
-    warn(`⚠️  [FAIL] quasar.conf.js has JS errors`)
+    warn(`⚠️  [FAIL] ${quasarConfig.esmSafeFilename} has JS errors`)
     process.exit(1)
   }
 

--- a/app/bin/quasar-dev
+++ b/app/bin/quasar-dev
@@ -220,7 +220,7 @@ async function goLive () {
   }
   catch (e) {
     console.log(e)
-    warn(`⚠️  [FAIL] quasar.conf.js has JS errors`)
+    warn(`⚠️  [FAIL] ${quasarConfig.esmSafeFilename} has JS errors`)
     process.exit(1)
   }
 

--- a/app/bin/quasar-inspect
+++ b/app/bin/quasar-inspect
@@ -96,7 +96,7 @@ async function inspect () {
   }
   catch (e) {
     console.log(e)
-    warn(`⚠️ [FAIL] quasar.conf.js has JS errors`)
+    warn(`⚠️ [FAIL] ${quasarConfig.esmSafeFilename} has JS errors`)
     process.exit(1)
   }
 

--- a/app/lib/app-files-validations.js
+++ b/app/lib/app-files-validations.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const { green } = require('chalk')
 
 const appPaths = require('./app-paths')
+const esmCompat = require('./helpers/esm-compat')
 
 module.exports = function (cfg) {
   let file
@@ -60,9 +61,10 @@ ${green('Example:')}
     process.exit(1)
   }
 
-  file = appPaths.resolve.app('babel.config.js')
+  const babelConfigFilename = esmCompat('babel.config');
+  file = appPaths.resolve.app(babelConfigFilename)
   if (!fs.existsSync(file)) {
-    console.log(' ⚠️  Missing babel.config.js file...')
+    console.log(` ⚠️  Missing ${babelConfigFilename} file...`)
     console.log()
     process.exit(1)
   }

--- a/app/lib/app-paths.js
+++ b/app/lib/app-paths.js
@@ -1,11 +1,12 @@
-const fs = require('fs')
+const { existsSync } = require('fs')
 const { normalize, resolve, join, sep } = require('path')
 
 function getAppDir () {
   let dir = process.cwd()
 
   while (dir.length && dir[dir.length - 1] !== sep) {
-    if (fs.existsSync(join(dir, 'quasar.conf.js'))) {
+    // `esmCompat` uses this helper to obtain the app `package.json` so we cannot use it here
+    if (existsSync(join(dir, 'quasar.conf.js')) || existsSync(join(dir, 'quasar.conf.cjs'))) {
       return dir
     }
 

--- a/app/lib/helpers/esm-compat.js
+++ b/app/lib/helpers/esm-compat.js
@@ -1,0 +1,8 @@
+const appPaths = require("../app-paths");
+
+module.exports = function esmCompat(fileBase) {
+  const appPackageJson = require(appPaths.resolve.app("package.json"));
+  const fileExtension = appPackageJson.type === "module" ? "cjs" : "js";
+
+  return `${fileBase}.${fileExtension}`;
+};

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -7,6 +7,7 @@ const WebpackProgress = require('./plugin.progress')
 const BootDefaultExport = require('./plugin.boot-default-export')
 
 const appPaths = require('../app-paths')
+const esmCompat = require('../helpers/esm-compat');
 const injectStyleRules = require('./inject.style-rules')
 
 module.exports = function (cfg, configName) {
@@ -133,7 +134,7 @@ module.exports = function (cfg, configName) {
       .loader('babel-loader')
         .options({
           compact: false,
-          extends: appPaths.resolve.app('babel.config.js'),
+          extends: appPaths.resolve.app(esmCompat('babel.config')),
           plugins: cfg.framework.all !== true && configName !== 'Server' ? [
             [
               'transform-imports', {

--- a/app/lib/webpack/inject.style-rules.js
+++ b/app/lib/webpack/inject.style-rules.js
@@ -3,7 +3,8 @@ const merge = require('webpack-merge')
 
 const appPaths = require('../app-paths')
 const cssVariables = require('../helpers/css-variables')
-const postCssConfig = require(appPaths.resolve.app('.postcssrc.js'))
+const esmCompat = require('../helpers/esm-compat')
+const postCssConfig = require(appPaths.resolve.app(esmCompat('.postcssrc')))
 
 function injectRule (chain, pref, lang, test, loader, loaderOptions) {
   const baseRule = chain.module.rule(lang).test(test)

--- a/cli/lib/ensure-outside-project.js
+++ b/cli/lib/ensure-outside-project.js
@@ -5,7 +5,7 @@ module.exports = function () {
   let dir = process.cwd()
 
   while (dir.length && dir[dir.length - 1] !== sep) {
-    if (existsSync(join(dir, 'quasar.conf.js'))) {
+    if ((existsSync(join(dir, 'quasar.conf.js')) || existsSync(join(dir, 'quasar.conf.cjs'))) {
       const { fatal } = require('./logger')
       fatal(`⚠️  Error. This command must NOT be executed inside a Quasar project folder.`)
     }

--- a/cli/lib/get-project-root.js
+++ b/cli/lib/get-project-root.js
@@ -5,7 +5,7 @@ module.exports = function () {
   let dir = process.cwd()
 
   while (dir.length && dir[dir.length - 1] !== sep) {
-    if (existsSync(join(dir, 'quasar.conf.js'))) {
+    if (existsSync(join(dir, 'quasar.conf.js')) || existsSync(join(dir, 'quasar.conf.cjs'))) {
       return dir
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
No docs explaining how to take advantage of this yet.
In short:
- add `type: "module"` to your `package.json`
- change the extension of these files to `.cjs`: `quasar.conf.js`, `.postcssrc.js`, `babel.conf.js`, `.eslintrc.js` (optional) and `jest.config.js` (optional)

Some projects would need to delete their `yarn.lock` to force-update babel dependencies to use version `>=7.7.0` (previous versions doesn't support `.cjs` config file).
Updating `@quasar/babel-preset-app` would solve the problem.

I dunno if it could be useful for https://github.com/quasarframework/quasar/issues/5893
I actually did it for a project of mine for which I was forced to enable native ES modules due to some constraints, I didn't checked if it could solve that issue too