### PR TITLE
docs: Use negative instead of error in notify.type

### DIFF
--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -10,7 +10,7 @@
     "definition": {
       "type": {
         "type": "String",
-        "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'error', 'warning', 'info')",
+        "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info')",
         "examples": [ "negative", "custom-type" ],
         "addedIn": "v1.9.0"
       },
@@ -166,7 +166,7 @@
           "definition": {
             "type": {
               "type": "String",
-              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'error', 'warning', 'info')",
+              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info')",
               "examples": [ "negative", "custom-type" ],
               "addedIn": "v1.9.0"
             },
@@ -358,7 +358,7 @@
           "definition": {
             "type": {
               "type": "String",
-              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'error', 'warning', 'info')",
+              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info')",
               "examples": [ "negative", "custom-type" ],
               "addedIn": "v1.9.0"
             },
@@ -538,7 +538,7 @@
           "definition": {
             "type": {
               "type": "String",
-              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'error', 'warning', 'info')",
+              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info')",
               "examples": [ "negative", "custom-type" ],
               "addedIn": "v1.9.0"
             },


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

From v1.9.0, the type was added to Notify, but "error" is not supported. I think this means "negative" instead of "error".