### PR TITLE
feat(docs): Improves QOptionGroup

### DIFF
--- a/docs/src/examples/QOptionGroup/DisableCertainOptions.vue
+++ b/docs/src/examples/QOptionGroup/DisableCertainOptions.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="q-pa-lg">
+    <q-option-group
+      v-model="group"
+      :options="options"
+      color="green"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      group: 'op1',
+      options: [
+        {
+          label: 'Option 1',
+          value: 'op1'
+        },
+        {
+          label: 'Option 2',
+          value: 'op2',
+          disable: false
+        },
+        {
+          label: 'Option 3',
+          value: 'op3',
+          disable: true
+        },
+        {
+          label: 'Option 4',
+          value: 'op4',
+          disable: true
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/option-group.md
+++ b/docs/src/pages/vue-components/option-group.md
@@ -63,5 +63,6 @@ When dealing with a native form which has an `action` and a `method` (eg. when u
 
 <doc-example title="Native form" file="QOptionGroup/NativeForm" />
 
+
 ## QOptionGroup API
 <doc-api file="QOptionGroup" />

--- a/docs/src/pages/vue-components/option-group.md
+++ b/docs/src/pages/vue-components/option-group.md
@@ -63,6 +63,5 @@ When dealing with a native form which has an `action` and a `method` (eg. when u
 
 <doc-example title="Native form" file="QOptionGroup/NativeForm" />
 
-
 ## QOptionGroup API
 <doc-api file="QOptionGroup" />

--- a/docs/src/pages/vue-components/option-group.md
+++ b/docs/src/pages/vue-components/option-group.md
@@ -45,6 +45,14 @@ The model for checkboxes/toggles must be an array.
 
 <doc-example title="Disabled" file="QOptionGroup/Disable" />
 
+::: tip
+The objects within the `options` array can hold any of the props found in QToggle, QCheckbox or QRadio for instance `disable` or `leftLabel`. See below for an example.  
+:::
+
+### Disable Certain Options
+
+<doc-example title="Disable Certain Options" file="QOptionGroup/DisableCertainOptions" />
+
 ### Dark
 
 <doc-example title="On a dark background" file="QOptionGroup/Dark" dark />
@@ -54,6 +62,7 @@ The model for checkboxes/toggles must be an array.
 When dealing with a native form which has an `action` and a `method` (eg. when using Quasar with ASP.NET controllers), you need to specify the `name` property on QOptionGroup, otherwise formData will not contain it (if it should) - all value are converted to string (native behaviour, so do not use Object values):
 
 <doc-example title="Native form" file="QOptionGroup/NativeForm" />
+
 
 ## QOptionGroup API
 <doc-api file="QOptionGroup" />

--- a/ui/src/components/option-group/QOptionGroup.json
+++ b/ui/src/components/option-group/QOptionGroup.json
@@ -19,9 +19,9 @@
 
     "options": {
       "type": "Array",
-      "desc": "Array of objects with value and label props. The binary components will be created according to this array",
+      "desc": "Array of objects with value and label props. The binary components will be created according to this array. Props from QToggle, QCheckbox or QRadio can also be added as key/ value pairs to control the components singularly.",
       "examples": [
-        ":options=\"[ { label: 'Option 1', value: 'op1' }, { label: 'Option 2', value: 'op2' }, { label: 'Option 3', value: 'op3' } ]\""
+        ":options=\"[ { label: 'Option 1', value: 'op1' }, { label: 'Option 2', value: 'op2' }, { label: 'Option 3', value: 'op3', disable: true } ]\""
       ],
       "category": "model"
     },

--- a/ui/src/components/option-group/QOptionGroup.json
+++ b/ui/src/components/option-group/QOptionGroup.json
@@ -19,7 +19,7 @@
 
     "options": {
       "type": "Array",
-      "desc": "Array of objects with value and label props. The binary components will be created according to this array. Props from QToggle, QCheckbox or QRadio can also be added as key/ value pairs to control the components singularly.",
+      "desc": "Array of objects with value and label props. The binary components will be created according to this array; Props from QToggle, QCheckbox or QRadio can also be added as key/value pairs to control the components singularly",
       "examples": [
         ":options=\"[ { label: 'Option 1', value: 'op1' }, { label: 'Option 2', value: 'op2' }, { label: 'Option 3', value: 'op3', disable: true } ]\""
       ],


### PR DESCRIPTION
This improves the QOptionGroup docs to include an example and tip about adding key/value pairs as props of QToggle, QCheckbox and QRadio to singularly control each component.

Scott

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
