### PR TITLE
Bump vue-router version to 3.1.6

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -104,7 +104,7 @@
     "url-loader": "3.0.0",
     "vue": "2.6.11",
     "vue-loader": "15.9.0",
-    "vue-router": "3.1.5",
+    "vue-router": "3.1.6",
     "vue-server-renderer": "2.6.11",
     "vue-style-loader": "4.1.2",
     "vue-template-compiler": "2.6.11",


### PR DESCRIPTION
3.1.6 includes a type change causing a compilation issue Type 'string | null | undefined' is not assignable to type 'string | undefined' when used with 3.1.5 from quasar

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X ] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
