### PR TITLE
feat(utils/date): add arg opts.onlyDate in isBetweenDates

### DIFF
--- a/ui/src/utils/date.js
+++ b/ui/src/utils/date.js
@@ -14,10 +14,6 @@ const
   reverseToken = /(\[[^\]]*\])|d{1,4}|M{1,4}|m{1,2}|w{1,2}|Qo|Do|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]|([.*+:?^,\s${}()|\\]+)/g,
   regexStore = {}
 
-function toDate (date) {
-  return isDate(date) === true ? date : new Date(date)
-}
-
 function getRegexData (mask, dateLocale) {
   const
     days = '(' + dateLocale.days.join('|') + ')',
@@ -374,7 +370,7 @@ function getDayIdentifier (date) {
 }
 
 function getDateIdentifier (date, onlyDate /* = false */) {
-  const d = toDate(date)
+  const d = new Date(date)
   return onlyDate === true ? getDayIdentifier(d) : d.getTime()
 }
 

--- a/ui/src/utils/date.js
+++ b/ui/src/utils/date.js
@@ -14,6 +14,10 @@ const
   reverseToken = /(\[[^\]]*\])|d{1,4}|M{1,4}|m{1,2}|w{1,2}|Qo|Do|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]|([.*+:?^,\s${}()|\\]+)/g,
   regexStore = {}
 
+function toDate (date) {
+  return isDate(date) === true ? date : new Date(date)
+}
+
 function getRegexData (mask, dateLocale) {
   const
     days = '(' + dateLocale.days.join('|') + ')',
@@ -365,16 +369,23 @@ export function getWeekOfYear (date) {
   return 1 + Math.floor(weekDiff)
 }
 
+function getDayIdentifier (date) {
+  return date.getFullYear() * 10000 + date.getMonth() * 100 + date.getDate()
+}
+
+function getDateIdentifier (date, onlyDate /* = false */) {
+  const d = toDate(date)
+  return onlyDate === true ? getDayIdentifier(d) : d.getTime()
+}
+
 export function isBetweenDates (date, from, to, opts = {}) {
-  let
-    d1 = new Date(from).getTime(),
-    d2 = new Date(to).getTime(),
-    cur = new Date(date).getTime()
+  const
+    d1 = getDateIdentifier(from, opts.onlyDate),
+    d2 = getDateIdentifier(to, opts.onlyDate),
+    cur = getDateIdentifier(date, opts.onlyDate)
 
-  opts.inclusiveFrom && d1--
-  opts.inclusiveTo && d2++
-
-  return cur > d1 && cur < d2
+  return (cur > d1 || (opts.inclusiveFrom === true && cur === d1)) &&
+    (cur < d2 || (opts.inclusiveTo === true && cur === d2))
 }
 
 export function addToDate (date, mod) {

--- a/ui/types/utils/date.d.ts
+++ b/ui/types/utils/date.d.ts
@@ -29,7 +29,7 @@ export namespace date {
   function buildDate(options: BuildDateOptions, utc?: boolean): string;
   function getDayOfWeek(date: Date | number | string): number;
   function getWeekOfYear(date: Date | number | string): number;
-  function isBetweenDates(date: Date | number | string, from: Date | number | string, to: Date | number | string, opts?: { inclusiveFrom: boolean; inclusiveTo: boolean }): boolean;
+  function isBetweenDates(date: Date | number | string, from: Date | number | string, to: Date | number | string, opts?: { inclusiveFrom: boolean; inclusiveTo: boolean; onlyDate: boolean }): boolean;
   function addToDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function subtractFromDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function adjustDate(date: Date | number | string, options: ModifyDateOptions, utc?: boolean): Date;


### PR DESCRIPTION
The possibility of comparing dates without taking into account the hours, minutes, seconds and milliseconds was added. Taking into account the optimal conditions for this.
https://jsperf.com/datebetween/23

and just to ensure that it is correct only date and not time:
https://jsperf.com/datebetween/1
