### PR TITLE
Fix Line Awesome URL

### DIFF
--- a/docs/src/components/page-parts/umd/UmdTags.vue
+++ b/docs/src/components/page-parts/umd/UmdTags.vue
@@ -68,7 +68,7 @@ const cssMap = {
   'ionicons-v4': 'cdn.jsdelivr.net/npm/ionicons@^4.0.0/dist/css/ionicons.min.css',
   'eva-icons': 'cdn.jsdelivr.net/npm/eva-icons@^1.0.0/style/eva-icons.css',
   themify: 'themify.me/wp-content/themes/themify-v32/themify-icons/themify-icons.css',
-  'line-awesome': 'https://maxst.icons8.com/vue-static/landings/line-awesome/font-awesome-line-awesome/css/all.min.css',
+  'line-awesome': 'maxst.icons8.com/vue-static/landings/line-awesome/font-awesome-line-awesome/css/all.min.css',
   animate: 'cdn.jsdelivr.net/npm/animate.css@^3.5.2/animate.min.css'
 }
 


### PR DESCRIPTION
Having `https://` in Line Awesome URL results in duplicating it on the docs page when configuring UMD installation.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No