### PR TITLE
QBanner avatar set aligned to top

### DIFF
--- a/ui/src/components/banner/QBanner.js
+++ b/ui/src/components/banner/QBanner.js
@@ -13,14 +13,20 @@ export default Vue.extend({
   props: {
     inlineActions: Boolean,
     dense: Boolean,
-    rounded: Boolean
+    rounded: Boolean,
+    avatarAlign: {
+      type: String,
+      validator: v => ['top', 'middle'].includes(v),
+      default: 'middle'
+    }
   },
 
   render (h) {
     const actions = slot(this, 'action')
     const child = [
       h('div', {
-        staticClass: 'q-banner__avatar col-auto row items-center'
+        staticClass: 'q-banner__avatar col-auto row items-center',
+        class: `self-${Object.create({top: 'start', middle: 'center'})[this.avatarAlign]}`
       }, slot(this, 'avatar')),
 
       h('div', {

--- a/ui/src/components/banner/QBanner.js
+++ b/ui/src/components/banner/QBanner.js
@@ -13,20 +13,14 @@ export default Vue.extend({
   props: {
     inlineActions: Boolean,
     dense: Boolean,
-    rounded: Boolean,
-    avatarAlign: {
-      type: String,
-      validator: v => ['top', 'middle'].includes(v),
-      default: 'middle'
-    }
+    rounded: Boolean
   },
 
   render (h) {
     const actions = slot(this, 'action')
     const child = [
       h('div', {
-        staticClass: 'q-banner__avatar col-auto row items-center',
-        class: `self-${Object.create({top: 'start', middle: 'center'})[this.avatarAlign]}`
+        staticClass: 'q-banner__avatar col-auto row items-center self-start'
       }, slot(this, 'avatar')),
 
       h('div', {


### PR DESCRIPTION
https://codepen.io/onurkose/pen/jOPxpyB?editable=true&editors=101

It usually centers itself when multiline messages used.  I propose to add avatar-align prop to QBanner and there'll be option to align the QAvatar to middle or top.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
