### PR TITLE
fix(docs): Try to fix tab-to-search with "title" attr

### DIFF
--- a/docs/src/index.template.html
+++ b/docs/src/index.template.html
@@ -12,7 +12,7 @@
     <meta property="og:image" content="https://cdn.quasar.dev/logo/512/quasar-logo.png" />
     <meta property="og:site_name" content="Quasar Framework" />
 
-    <link type="application/opensearchdescription+xml" rel="search" href="https://cdn.quasar.dev/other/search_manifest.xml">
+    <link type="application/opensearchdescription+xml" rel="search" title="Quasar docs" href="https://cdn.quasar.dev/other/search_manifest.xml">
     <link rel="icon" type="image/svg+xml" href="https://cdn.quasar.dev/logo/svg/quasar-logo.svg">
     <link rel="icon" type="image/png" sizes="128x128" href="https://cdn.quasar.dev/app-icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="https://cdn.quasar.dev/app-icons/favicon-96x96.png">


### PR DESCRIPTION
MDN says that it's required and it must match the "shortname" in xml description file. It's kinda weird because I didn't need it for testing, but since tab to search doesn't work on `quasar.dev` on any machine I tried, let's try if this fixes it.

see [here](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for more details

Btw. If I add the site manually in `chrome://settings/searchEngines` (which is very tedious), Everything works fine, so I really have no idea what's wrong here. I've seen some other tips to do, but most of them seems fairly outdated (like - "don't serve the xml over https", which is nonsense)