### PR TITLE
change quasar language at runtime works for en-US & de but not for  e…

### DIFF
--- a/docs/src/pages/options/quasar-language-packs.md
+++ b/docs/src/pages/options/quasar-language-packs.md
@@ -113,7 +113,6 @@ Example with a QSelect to dynamically change the Quasar components language:
     label="Quasar Language"
     dense
     borderless
-    emit-value
     map-options
     options-dense
     style="min-width: 150px"
@@ -135,13 +134,15 @@ export default {
 
   watch: {
     lang (lang) {
-      // dynamic import, so loading on demand only
-      import(
-        /* webpackInclude: /(de|en-us)\.js$/ */
-        'quasar/lang/' + lang
-        ).then(lang => {
-        this.$q.lang.set(lang.default)
-      })
+      this.$i18n.locale = lang.value;
+      // set quasar's language too!!
+      // eslint gives currently an warning
+      // see https://github.com/babel/babel-eslint/issues/799
+      // see workaround: https://github.com/babel/babel-eslint/issues/799#issuecomment-568195009
+      import(`quasar/lang/${lang.value}`).then(language => {
+        console.log(language.default);
+        this.$q.lang.set(language.default);
+      });
     }
   },
 


### PR DESCRIPTION
….g. nl or es

See my analysis:
https://forum.quasar-framework.org/topic/5561/change-quasar-language-at-runtime-works-for-en-us-de-but-not-for-others-e-g-nl-or-es/3

proposal is to take the watch/lang/import function from : https://medium.com/quasar-framework/adding-full-i18n-to-quasar-150da2d5bba4

When running on this my environment, I am getting a eslint warning, I have added the eslint issue and a workaround described in the issue against eslint

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
