### PR TITLE
fix(Bex): ES6 module export on background.js #6744

### DIFF
--- a/app/templates/bex/js/background.js
+++ b/app/templates/bex/js/background.js
@@ -1,12 +1,10 @@
 // Background code goes here
-
-export default function attachGlobalBackgroundHooks (chrome) {
-  chrome.browserAction.onClicked.addListener((tab) => { // eslint-disable-line no-unused-vars
-    // Opens our extension in a new browser window.
-    chrome.tabs.create({
-      url: chrome.extension.getURL('www/index.html')
-    }, (newTab) => { // eslint-disable-line no-unused-vars
-      // Tab opened.
-    })
+chrome.browserAction.onClicked.addListener((tab) => { // eslint-disable-line no-unused-vars
+  // Opens our extension in a new browser window.
+  // Only if a popup isn't defined in the manifest.
+  chrome.tabs.create({
+    url: chrome.extension.getURL('www/index.html')
+  }, (newTab) => { // eslint-disable-line no-unused-vars
+    // Tab opened.
   })
-}
+})


### PR DESCRIPTION
Remove old code which relied on an export. This file is now linked directly in the manifest file and as such should not contain ES6 style module imports.