### PR TITLE
feat(extras): add typings for iconsets, fix: #6711

### DIFF
--- a/app/types/ts-helpers.d.ts
+++ b/app/types/ts-helpers.d.ts
@@ -10,4 +10,3 @@ declare module "quasar" {
     devServer?: WebpackDevServerConfiguration;
   }
 }
-

--- a/extras/build/eva-icons.js
+++ b/extras/build/eva-icons.js
@@ -1,67 +1,48 @@
 const packageName = 'eva-icons'
+const iconSetName = 'Eva-Icons'
 
 // ------------
 
 const glob = require('glob')
 const { copySync } = require('fs-extra')
-const { readFileSync, writeFileSync } = require('fs')
-const { resolve, basename } = require('path')
+const { resolve } = require('path')
 
-let skipped = []
-const dist = resolve(__dirname, `../eva-icons/index.js`)
-const { parseSvgContent } = require('./utils')
+const skipped = []
+const distFolder = resolve(__dirname, `../eva-icons`)
+const { defaultNameMapper, extract, writeExports } = require('./utils')
 
 const svgFolder = resolve(__dirname, `../node_modules/${packageName}/`)
 const iconTypes = ['fill', 'outline']
 const iconNames = new Set()
 
-function extract (file) {
-  const name = ('eva-' + basename(file, '.svg')).replace(/(-\w)/g, m => m[1].toUpperCase())
-
-  if (iconNames.has(name)) {
-    return null
-  }
-
-  const content = readFileSync(file, 'utf-8')
-
-  try {
-    const { dPath, viewBox } = parseSvgContent(name, content)
-
-    iconNames.add(name)
-    return `export const ${name} = '${dPath}${viewBox}'`
-  }
-  catch (err) {
-    console.error(err)
-    skipped.push(name)
-    return null
-  }
-}
-
-function getBanner () {
-  const { version } = require(resolve(__dirname, `../node_modules/${packageName}/package.json`))
-  return `/* Eva-Icons v${version} */\n\n`
-}
-
 const svgExports = []
+const typeExports = []
 
 iconTypes.forEach(type => {
   const svgFiles = glob.sync(svgFolder + `/${type}/svg/*.svg`)
 
   svgFiles.forEach(file => {
-    svgExports.push(extract(file))
+    const name = defaultNameMapper(file, 'eva')
+  
+    if (iconNames.has(name)) {
+      return
+    }
+  
+    try {
+      const { svgDef, typeDef } = extract(file, name)
+      svgExports.push(svgDef)
+      typeExports.push(typeDef)
+  
+      iconNames.add(name)
+    }
+    catch(err) {
+      console.error(err)
+      skipped.push(name)
+    }
   })
 })
 
-if (svgExports.length === 0) {
-  console.log('WARNING. Eva-icons skipped completely')
-}
-else {
-  writeFileSync(dist, getBanner() + svgExports.filter(x => x !== null).join('\n'), 'utf-8')
-
-  if (skipped.length > 0) {
-    console.log(`eva-icons - skipped (${skipped.length}): ${skipped}`)
-  }
-}
+writeExports(iconSetName, packageName, distFolder, svgExports, typeExports, skipped)
 
 // then update webfont files
 

--- a/extras/build/ionicons-v4.js
+++ b/extras/build/ionicons-v4.js
@@ -1,63 +1,44 @@
 const packageName = 'ionicons'
+const iconSetName = 'Ionicons'
 
 // ------------
 
 const glob = require('glob')
 const { copySync } = require('fs-extra')
-const { readFileSync, writeFileSync } = require('fs')
-const { resolve, basename } = require('path')
+const { resolve } = require('path')
 
 let skipped = []
-const dist = resolve(__dirname, `../ionicons-v4/index.js`)
-const { parseSvgContent } = require('./utils')
+const distFolder = resolve(__dirname, `../ionicons-v4`)
+const { defaultNameMapper, extract, writeExports } = require('./utils')
 
 const svgFolder = resolve(__dirname, `../node_modules/${packageName}/dist/ionicons/svg/`)
 const svgFiles = glob.sync(svgFolder + '/*.svg')
 const iconNames = new Set()
 
-function extract (file) {
-  const name = ('ion-' + basename(file, '.svg')).replace(/(-\w)/g, m => m[1].toUpperCase())
-
-  if (iconNames.has(name)) {
-    return null
-  }
-
-  const content = readFileSync(file, 'utf-8')
-
-  try {
-    const { dPath, viewBox } = parseSvgContent(name, content)
-
-    iconNames.add(name)
-    return `export const ${name} = '${dPath}${viewBox}'`
-  }
-  catch (err) {
-    console.error(err)
-    skipped.push(name)
-    return null
-  }
-}
-
-function getBanner () {
-  const { version } = require(resolve(__dirname, `../node_modules/${packageName}/package.json`))
-  return `/* Ionicons v${version} */\n\n`
-}
-
 const svgExports = []
+const typeExports = []
 
 svgFiles.forEach(file => {
-  svgExports.push(extract(file))
+  const name = defaultNameMapper(file, 'ion')
+
+  if (iconNames.has(name)) {
+    return
+  }
+
+  try {
+    const { svgDef, typeDef } = extract(file, name)
+    svgExports.push(svgDef)
+    typeExports.push(typeDef)
+
+    iconNames.add(name)
+  }
+  catch(err) {
+    console.error(err)
+    skipped.push(name)
+  }
 })
 
-if (svgExports.length === 0) {
-  console.log('WARNING. Ionicons skipped completely')
-}
-else {
-  writeFileSync(dist, getBanner() + svgExports.filter(x => x !== null).join('\n'), 'utf-8')
-
-  if (skipped.length > 0) {
-    console.log(`ionicons - skipped (${skipped.length}): ${skipped}`)
-  }
-}
+writeExports(iconSetName, packageName, distFolder, svgExports, typeExports, skipped)
 
 // then update webfont files
 

--- a/extras/build/line-awesome.js
+++ b/extras/build/line-awesome.js
@@ -1,4 +1,5 @@
 const packageName = 'line-awesome'
+const iconSetName = 'Line Awesome'
 
 // ------------
 
@@ -8,56 +9,37 @@ const { readFileSync, writeFileSync } = require('fs')
 const { resolve, basename } = require('path')
 
 let skipped = []
-const dist = resolve(__dirname, `../line-awesome/index.js`)
-const { parseSvgContent } = require('./utils')
+const distFolder = resolve(__dirname, `../line-awesome`)
+const { defaultNameMapper, extract, writeExports } = require('./utils')
 
 const svgFolder = resolve(__dirname, `../node_modules/${packageName}/svg/`)
+const svgFiles = glob.sync(svgFolder + `/*.svg`)
 const iconNames = new Set()
 
-function extract (file) {
-  const name = ('la-' + basename(file, '.svg')).replace(/(-\w)/g, m => m[1].toUpperCase())
-
-  if (iconNames.has(name)) {
-    return null
-  }
-
-  const content = readFileSync(file, 'utf-8')
-
-  try {
-    const { dPath, viewBox } = parseSvgContent(name, content)
-
-    iconNames.add(name)
-    return `export const ${name} = '${dPath}${viewBox}'`
-  }
-  catch (err) {
-    console.error(err)
-    skipped.push(name)
-    return null
-  }
-}
-
-function getBanner () {
-  const { version } = require(resolve(__dirname, `../node_modules/${packageName}/package.json`))
-  return `/* Line Awesome v${version} */\n\n`
-}
-
 const svgExports = []
-const svgFiles = glob.sync(svgFolder + `/*.svg`)
+const typeExports = []
 
 svgFiles.forEach(file => {
-  svgExports.push(extract(file))
+  const name = defaultNameMapper(file, 'la')
+
+  if (iconNames.has(name)) {
+    return
+  }
+
+  try {
+    const { svgDef, typeDef } = extract(file, name)
+    svgExports.push(svgDef)
+    typeExports.push(typeDef)
+
+    iconNames.add(name)
+  }
+  catch(err) {
+    console.error(err)
+    skipped.push(name)
+  }
 })
 
-if (svgExports.length === 0) {
-  console.log('WARNING. Line Awesome skipped completely')
-}
-else {
-  writeFileSync(dist, getBanner() + svgExports.filter(x => x !== null).join('\n'), 'utf-8')
-
-  if (skipped.length > 0) {
-    console.log(`lineawesome - skipped (${skipped.length}): ${skipped}`)
-  }
-}
+writeExports(iconSetName, packageName, distFolder, svgExports, typeExports, skipped)
 
 // then update webfont files
 

--- a/extras/build/material-icons.js
+++ b/extras/build/material-icons.js
@@ -1,4 +1,5 @@
 const packageName = 'material-design-icons'
+const iconSetName = 'Google Material Design Icons'
 
 // ------------
 
@@ -8,57 +9,38 @@ const { copySync } = require('fs-extra')
 const { resolve } = require('path')
 
 let skipped = []
-const dist = resolve(__dirname, `../material-icons/index.js`)
-const { parseSvgContent } = require('./utils')
+const distFolder = resolve(__dirname, `../material-icons`)
+const { extract, writeExports } = require('./utils')
 
 const svgFolder = resolve(__dirname, `../node_modules/${packageName}/`)
 const svgFiles = glob.sync(svgFolder + '/*/svg/production/ic_*_24px.svg')
 const iconNames = new Set()
 
-function extract (file) {
+const svgExports = []
+const typeExports = []
+
+svgFiles.forEach(file => {
   const name = ('mat_' + file.match(/ic_(.*)_24px\.svg/)[1])
     .replace(/(_\w)/g, m => m[1].toUpperCase())
 
   if (iconNames.has(name)) {
-    return null
+    return
   }
-
-  const content = readFileSync(file, 'utf-8')
 
   try {
-    const { dPath, viewBox } = parseSvgContent(name, content)
+    const { svgDef, typeDef } = extract(file, name)
+    svgExports.push(svgDef)
+    typeExports.push(typeDef)
 
     iconNames.add(name)
-    return `export const ${name} = '${dPath}${viewBox}'`
   }
-  catch (err) {
+  catch(err) {
     console.error(err)
     skipped.push(name)
-    return null
   }
-}
-
-function getBanner () {
-  const { version } = require(resolve(__dirname, `../node_modules/${packageName}/package.json`))
-  return `/* Google Material Design Icons v${version} */\n\n`
-}
-
-const svgExports = []
-
-svgFiles.forEach(file => {
-  svgExports.push(extract(file))
 })
 
-if (svgExports.length === 0) {
-  console.log('WARNING. Material-icons skipped completely')
-}
-else {
-  writeFileSync(dist, getBanner() + svgExports.filter(x => x !== null).join('\n'), 'utf-8')
-
-  if (skipped.length > 0) {
-    console.log(`material-icons - skipped (${skipped.length}): ${skipped}`)
-  }
-}
+writeExports(iconSetName, packageName, distFolder, svgExports, typeExports, skipped)
 
 copySync(
   resolve(__dirname, `../node_modules/${packageName}/LICENSE`),

--- a/extras/build/mdi-v5.js
+++ b/extras/build/mdi-v5.js
@@ -1,63 +1,44 @@
 const packageName = '@mdi/svg'
+const iconSetName = 'MDI'
 
 // ------------
 
 const glob = require('glob')
 const { copySync } = require('fs-extra')
-const { readFileSync, writeFileSync } = require('fs')
-const { resolve, basename } = require('path')
+const { resolve } = require('path')
 
-let skipped = []
-const dist = resolve(__dirname, `../mdi-v5/index.js`)
-const { parseSvgContent } = require('./utils')
+const skipped = []
+const distFolder = resolve(__dirname, `../mdi-v5`)
+const { defaultNameMapper, extract, writeExports } = require('./utils')
 
 const svgFolder = resolve(__dirname, `../node_modules/${packageName}/svg/`)
 const svgFiles = glob.sync(svgFolder + '/**/*.svg')
 const iconNames = new Set()
 
-function extract (file) {
-  const name = ('mdi-' + basename(file, '.svg')).replace(/(-\w)/g, m => m[1].toUpperCase())
-
-  if (iconNames.has(name)) {
-    return null
-  }
-
-  const content = readFileSync(file, 'utf-8')
-
-  try {
-    const { dPath, viewBox } = parseSvgContent(name, content)
-
-    iconNames.add(name)
-    return `export const ${name} = '${dPath}${viewBox}'`
-  }
-  catch (err) {
-    console.error(err)
-    skipped.push(name)
-    return null
-  }
-}
-
-function getBanner () {
-  const { version } = require(resolve(__dirname, `../node_modules/${packageName}/package.json`))
-  return `/* MDI v${version} */\n\n`
-}
-
 const svgExports = []
+const typeExports = []
 
 svgFiles.forEach(file => {
-  svgExports.push(extract(file))
+  const name = defaultNameMapper(file, 'mdi')
+
+  if (iconNames.has(name)) {
+    return
+  }
+
+  try {
+    const { svgDef, typeDef } = extract(file, name)
+    svgExports.push(svgDef)
+    typeExports.push(typeDef)
+
+    iconNames.add(name)
+  }
+  catch(err) {
+    console.error(err)
+    skipped.push(name)
+  }
 })
 
-if (svgExports.length === 0) {
-  console.log('WARNING. MDI skipped completely')
-}
-else {
-  writeFileSync(dist, getBanner() + svgExports.filter(x => x !== null).join('\n'), 'utf-8')
-
-  if (skipped.length > 0) {
-    console.log(`mdi - skipped (${skipped.length}): ${skipped}`)
-  }
-}
+writeExports(iconSetName, packageName, distFolder, svgExports, typeExports, skipped)
 
 // then update webfont files
 

--- a/extras/build/utils/index.js
+++ b/extras/build/utils/index.js
@@ -1,6 +1,9 @@
 const xmldom = require('xmldom')
 const Parser = new xmldom.DOMParser()
 
+const { resolve, basename } = require('path')
+const { readFileSync, writeFileSync } = require('fs')
+
 const typeExceptions = [ 'g', 'svg', 'defs', 'style' ]
 
 function getAttributes (el, list) {
@@ -85,7 +88,7 @@ function parseDom (el, allPaths) {
   })
 }
 
-module.exports.parseSvgContent = (name, content) => {
+function parseSvgContent(name, content) {
   const dom = Parser.parseFromString(content, 'text/xml')
 
   const viewBox = dom.documentElement.getAttribute('viewBox')
@@ -108,5 +111,46 @@ module.exports.parseSvgContent = (name, content) => {
   return {
     dPath,
     viewBox: viewBox !== '0 0 24 24' ? `|${viewBox}` : ''
+  }
+}
+
+function getBanner(iconSetName, versionOrPackageName) {
+  const version = 
+    versionOrPackageName.match(/^\d/)
+    ? versionOrPackageName
+    : require(resolve(__dirname, `../../node_modules/${versionOrPackageName}/package.json`)).version
+  
+  return `/* ${iconSetName} v${version} */\n\n`
+}
+
+module.exports.defaultNameMapper = (filePath, prefix) => {
+  return (prefix + '-' + basename(filePath, '.svg')).replace(/(-\w)/g, m => m[1].toUpperCase());
+}
+
+module.exports.extract = (filePath, name) => {
+  const content = readFileSync(filePath, 'utf-8')
+
+  const {dPath, viewBox} = parseSvgContent(name, content)
+
+  return {
+    svgDef: `export const ${name} = '${dPath}${viewBox}'`,
+    typeDef: `export declare const ${name}: string;`
+  }
+}
+
+module.exports.writeExports = (iconSetName, versionOrPackageName, distFolder, svgExports, typeExports, skipped) => {
+  if (svgExports.length === 0) {
+    console.log(`WARNING. ${iconSetName} skipped completely`)
+  }
+  else {
+    const banner = getBanner(iconSetName, versionOrPackageName);
+    const distIndex = `${distFolder}/index`
+  
+    writeFileSync(`${distIndex}.js`, banner + svgExports.join('\n'), 'utf-8')
+    writeFileSync(`${distIndex}.d.ts`, banner + typeExports.join('\n'), 'utf-8')
+  
+    if (skipped.length > 0) {
+      console.log(`${iconSetName} - skipped (${skipped.length}): ${skipped}`)
+    }
   }
 }

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -370,8 +370,9 @@ function writeIndexDTS (apis) {
   writeLine(contents, `import './vue'`)
   // If `@quasar/app` package is present, this works as "reference" and its types are added to compilation
   // If it's not (Vue CLI projects) the shim serves as a fallback avoiding TS errors
-  writeLine(contents, `import './shim-quasar-app.d.ts'`)
+  writeLine(contents, `import './shim-quasar-app'`)
   writeLine(contents, `import '@quasar/app'`)
+  writeLine(contents, `import './shim-icon-set'`)
 
   writeFile(resolvePath('index.d.ts'), contents.join(''))
 }

--- a/ui/types/shim-icon-set.d.ts
+++ b/ui/types/shim-icon-set.d.ts
@@ -1,0 +1,7 @@
+declare module "quasar/icon-set/*" {
+  // We know "quasar" will exists at runtime, we can safely ignore the TS error
+  // @ts-ignore
+  import { QuasarIconSet } from "quasar";
+  const iconSet: QuasarIconSet;
+  export default iconSet;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Running the build command on my machine removes al webfonts and complains about a missing `update.sh`, so I just updated and tested the build code, but without committing the `yarn build` result.

I refactored a bit the SVG generation code to make easier to manage both JS exports and TS declarations, abstracting away code into `utils` where possible.
It can be refined further, but I think this is already an good step ahead.

Closes #6711 