### PR TITLE
build(ui-typescript): allow to reference API interfaces with `tsType`

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -316,6 +316,12 @@ function writeIndexDTS (apis) {
 
   Object.keys(extraInterfaces).forEach(name => {
     if (extraInterfaces[name] === void 0) {
+      // If we find the symbol as part of the generated Quasar API,
+      //  we don't need to import it from custom TS API patches
+      if (apis.some(definition => definition.name === name)) {
+        return
+      }
+
       writeLine(contents, `import { ${name} } from './api'`)
     }
     else {

--- a/ui/src/plugins/Cookies.json
+++ b/ui/src/plugins/Cookies.json
@@ -153,6 +153,7 @@
       },
       "returns": {
         "type": "Object",
+        "tsType": "Cookies",
         "desc": "Cookie object (like $q.cookies) for SSR usage purposes",
         "__exemption": [ "examples" ]
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Allow to reference API definitions with `tsType` option, this can be useful for recursive interfaces like `Cookies` plugin returning an object of type `Cookies` when using `parseSSR` method.