### PR TITLE
feat(typescript): add iconMapFn typings

### DIFF
--- a/ui/types/globals.d.ts
+++ b/ui/types/globals.d.ts
@@ -1,5 +1,5 @@
 import { QuasarIconSet } from "./extras/icon-set";
-import { HasCapacitor, HasCordova, HasElectron } from "./feature-flag";
+import { HasCapacitor, HasCordova, HasElectron, HasSsr } from "./feature-flag";
 import { QuasarLanguage } from "./lang";
 
 // We cannot reference directly Capacitor/Cordova/Electron types
@@ -24,10 +24,18 @@ interface GlobalQuasarIconSet extends QuasarIconSet {
   set(iconSet: QuasarIconSet): void;
 }
 
+type GlobalQuasarIconMapFn = (
+  iconName: string
+) => { icon: string } | { cls: string; content?: string } | void;
+
 export interface QVueGlobals
   extends HasCapacitor<{ capacitor: any }>,
     HasCordova<{ cordova: GlobalsTypesHolder["cordova"] }>,
-    HasElectron<{ electron: GlobalsTypesHolder["electron"] }> {
+    HasElectron<{ electron: GlobalsTypesHolder["electron"] }>,
+    HasSsr<
+      { iconMapFn?: GlobalQuasarIconMapFn },
+      { iconMapFn: GlobalQuasarIconMapFn }
+    > {
   version: string;
   lang: GlobalQuasarLanguage;
   iconSet: GlobalQuasarIconSet;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
From the code, I understood `iconMapFn` like this: it normally exists without problems, but its type can also be `undefined` if SSR mode is used and people must check for its existence in that case.

@rstoenescu please provide insight if my guess is correct.
It could be a good idea to mention this quirk on docs too.