### PR TITLE
feat(typescript): enhance prop typings for Array types

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -24,12 +24,16 @@ function write (fileContent, text = '') {
 }
 
 const typeMap = new Map([
-  ['Array', 'any[]'],
   ['Any', 'any'],
   ['Component', 'Vue'],
   ['String', 'string'],
   ['Boolean', 'boolean'],
   ['Number', 'number']
+])
+
+const fallbackComplexTypeMap = new Map([
+  ['Array', 'any[]'],
+  ['Object', 'LooseDictionary']
 ])
 
 function convertTypeVal (type, def, required) {
@@ -43,15 +47,15 @@ function convertTypeVal (type, def, required) {
     return typeMap.get(t)
   }
 
-  if (t === 'Object') {
+  if (fallbackComplexTypeMap.has(t)) {
     if (def.definition) {
       const propDefinitions = getPropDefinitions(def.definition, required, true)
       let lines = []
       propDefinitions.forEach(p => lines.push(...p.split('\n')))
-      return propDefinitions && propDefinitions.length > 0 ? `{\n        ${lines.join('\n        ')} }` : 'LooseDictionary'
+      return propDefinitions && propDefinitions.length > 0 ? `{\n        ${lines.join('\n        ')} }${t === 'Array' ? '[]' : ''}` : fallbackComplexTypeMap.get(t)
     }
 
-    return 'LooseDictionary'
+    return fallbackComplexTypeMap.get(t)
   }
 
   return t

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -98,7 +98,119 @@
       "type": "Array",
       "desc": "The column definitions (Array of Objects)",
       "examples": [ ":columns=\"tableColumns\"" ],
-      "category": "column"
+      "category": "column",
+      "definition": {
+        "name": {
+          "type": "String",
+          "desc": "Unique id, identifies column, (used by pagination.sortBy, 'body-cell-[name]' slot, ...)",
+          "required": true,
+          "examples": [ "desc" ]
+        },
+        "label": {
+          "type": "String",
+          "desc": "Label for header",
+          "required": true,
+          "examples": [ "Dessert (100g serving)" ]
+        },
+        "field": {
+          "type": [ "String", "Function" ],
+          "desc": "Row Object property to determine value for this column or function which maps to the required property",
+          "required": true,
+          "examples": [ "name", "row => row.some.nested.prop" ]
+        },
+        "required": {
+          "type": "Boolean",
+          "desc": "If we use visible-columns, this col will always be visible",
+          "default": false
+        },
+        "align": {
+          "type": "String",
+          "desc": "Horizontal alignment of cells in this column",
+          "default": "right",
+          "examples": [ "left", "right", "center" ]
+        },
+        "sortable": {
+          "type": "Boolean",
+          "desc": "Tell QTable you want this column sortable",
+          "default": false
+        },
+        "sort": {
+          "type": "Function",
+          "desc": "Compare function if you have some custom data or want a specific way to compare two rows",
+          "examples": ["(a, b, rowA, rowB) => parseInt(a, 10) - parseInt(b, 10)"],
+          "params": {
+            "a": {
+              "type": "Any",
+              "desc": "Value of the first comparison term",
+              "examples": [ 123, "abc" ]
+            },
+            "b": {
+              "type": "Any",
+              "desc": "Value of the second comparison term",
+              "examples": [ 123, "abc" ]
+            },
+            "rowA": {
+              "type": "Object",
+              "desc": "Full Row object in which is contained the first term",
+              "examples": [ "{ name: 'Potassium', value: 'K' }" ]
+            },
+            "rowB": {
+              "type": "Object",
+              "desc": "Full Row object in which is contained the second term",
+              "examples": [ "{ name: 'Fluorine', value: 'F' }" ]
+            }
+          },
+          "returns": {
+            "type": "Number",
+            "desc": "Comparison result of term 'a' with term 'b'. Less than 0 when 'a' should come first; greater than 0 if 'b' should come first; equal to 0 if their position must not be changed with respect to each other",
+            "examples": [ "-1", "0", "1" ]
+          }
+        },
+        "format": {
+          "type": "Function",
+          "desc": "Function you can apply to format your data",
+          "examples": [ "(val, row) => `${val}%`", "val => val ? /* Unicode checkmark checked */ '\u2611' : /* Unicode checkmark unchecked */ '\u2610'" ],
+          "params": {
+            "val": {
+              "type": "Any",
+              "desc": "Value of the cell",
+              "examples": [ 123, "abc" ]
+            },
+            "row": {
+              "type": "Object",
+              "desc": "Full Row object in which the cell is contained",
+              "examples": [ "{ name: 'Potassium', value: 'K' }" ]
+            }
+          },
+          "returns": {
+            "type": "Any",
+            "desc": "The resulting formatted value",
+            "examples": [ "20%" ]
+          }
+        },
+        "style": {
+          "type": "String",
+          "desc": "Style to apply on normal cells of the column",
+          "examples": [ "width: 500px" ]
+        },
+        "classes": {
+          "type": "String",
+          "desc": "Classes to add on normal cells of the column",
+          "examples": [ "my-special-class" ]
+        },
+        "headerStyle": {
+          "type": "String",
+          "desc": "Style to apply on header cells of the column",
+          "examples": [ "width: 500px" ],
+          "addedIn": "v1.3.0"
+        },
+        "headerClasses": {
+          "type": "String",
+          "desc": "Classes to add on header cells of the column",
+          "examples": [ "my-special-class" ],
+          "addedIn": "v1.3.0"
+        }
+      }
     },
 
     "visible-columns": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR leverage `definition` field when on an `Array` type to generate a matching TS interface, using the same code used for `Object` type definitions.

It also adds `QTable.columns` definitions, previously missing, used to test the feature (I noticed other occurrences only after completing the feature).

Affected props definitions: `BottomSheet.actions`, `QBtnToggle.options`, `QUploader.headers`, `QUploader.formFields`

These definitions aren't exported as top-level interfaces, but they can be referenced from the component interface via array notation (eg. `const columns: QTable['columns'] = [ ... ]`).