### PR TITLE
fix(#6768): Removed double quotes to allow resolving of Android Studi…

### DIFF
--- a/app/lib/helpers/open-ide.js
+++ b/app/lib/helpers/open-ide.js
@@ -118,7 +118,7 @@ function runWindows (mode, bin, target) {
         : appPaths.resolve.capacitor('android')
 
       open(folder, {
-        app: `"${studioPath}"`,
+        app: `${studioPath}`,
         wait: false
       })
 


### PR DESCRIPTION
The [open](https://github.com/sindresorhus/open) npm package was updated to 7.0.3, which fixed an internal issue regarding path resolutions with double quotes. Quasar upgraded to this version.

7.0.3 now adds the double quotes.