### PR TITLE
fix(QEditor): fix broken isChildOf function #6769

### DIFF
--- a/ui/src/components/editor/editor-caret.js
+++ b/ui/src/components/editor/editor-caret.js
@@ -25,9 +25,9 @@ function getBlockElement (el, parent) {
 }
 
 function isChildOf (el, parent) {
-  return el === parent
+  return !el || el === document.body
     ? false
-    : (parent === document ? document.body : parent).contains(el)
+    : (parent === document ? document.body : parent).contains(el.parentNode)
 }
 
 const urlRegex = /^https?:\/\//


### PR DESCRIPTION
The original function was:

function isChildOf (el, parent) {
  if (!el) {
    return false
  }
  while ((el = el.parentNode)) {
    if (el === document.body) {
      return false
    }
    if (el === parent) {
      return true
    }
  }
  return false
}