### PR TITLE
Remove ZEIT Now as Deployment Option

### DIFF
--- a/docs/src/pages/quasar-cli/developing-ssr/deploying.md
+++ b/docs/src/pages/quasar-cli/developing-ssr/deploying.md
@@ -32,29 +32,3 @@ After installing PM2 on your server, your npm start script can look like this in
   "start": "pm2 start index.js"
 }
 ```
-
-## Deploying with Now.sh
-Deploying with [Now](https://zeit.co/now) is a breeze. All you need to do is to follow their [installation instructions](https://zeit.co/now#get-started). They recommend downloading "Now Desktop" but you can skip that and directly install the Now CLI:
-
-```bash
-$ npm install -g now
-$ now login
-```
-
-There are several ways to use the v1 of now's services:
-
-The robust way is to add the following file to `/dist/ssr/now.json` , and it should look like this:
-```
-{
-  "name": "Your Project Name",
-  "version": 1
-}
-```
-
-And then cd into the distributables folder and run `$ now`. If you do it this way, then you can also execute directly from a github repo, but we'll leave the details of setting that up to you.
-
-If you prefer, however, to set the version from the command line, you can also run `now -V 1`.
-
-At any rate, you might want to use a "now alias" or connect your domain to Now. And you're done!
-
-`Now.sh` will install the dependencies automatically then run `$ yarn start`. Your website will be up and running on an HTTPS connection in a matter of seconds!


### PR DESCRIPTION
This change removes ZEIT Now from the list of options as the 1.0 platform has been deprecated and it is not possible to run SSR Quasar on the 2.0 version.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
