### PR TITLE
feat(QDate): disable months and years without available dates #6639

### DIFF
--- a/fastclick/node_modules/.yarn-integrity
+++ b/fastclick/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "darwin-x64-72",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "darwin-x64-72",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -60,7 +60,7 @@ export default Vue.extend({
       yearDirection: direction,
       startYear: inner.year - inner.year % yearsInterval,
       innerModel: inner,
-      extModel: external
+      extModel: external,
     }
   },
 
@@ -190,28 +190,25 @@ export default Vue.extend({
         : date => this.options.includes(date)
     },
 
-
-    isDisableMonths () {
-
+    months () {
       let res = [];
-      for (let month = 1; month <= 12; month++){
-        const prefix = this.innerModel.year + '/' + pad(month) + '/'
 
-        let disable = true;
-        for (let i = 1; i <= this.daysInMonth; i++) {
-          const day = prefix + pad(i)
+      for (let month = 1; month <= 12; month++) {
+        if (this.options !== void 0) {
 
-          if (this.options !== void 0 && this.isInSelection(day) !== true) {
+          const prefix = this.innerModel.year + '/' + pad(month) + '/'
+          let disable = true;
 
+          for (let i = 1; i <= 31; i++) {
+            const day = prefix + pad(i);
+            if (this.isInSelection(day) === true) disable = false;
           }
-          else {
-            disable = false;
-          }
+          res.push(disable);
         }
-        res.push(disable)
+        else res.push(false)
       }
-      return res;
 
+      return(res)
     },
 
     days () {
@@ -316,6 +313,10 @@ export default Vue.extend({
           descending === true ? -1 : 1
         )
       }
+    },
+
+    isDisableYear (year) {
+      console.log(this.computedLocale.months)
     },
 
     __getModels (val, mask, locale) {
@@ -559,15 +560,16 @@ export default Vue.extend({
 
     __getMonthsView (h) {
       const currentYear = this.innerModel.year === this.today.year
-      const disabledMonths = this.isDisableMonths;
 
-      const content = this.computedLocale.monthsShort.map((month, i) => {
+      console.log(this.months)
+      const content = this.months.map((disable, i) => {
         const active = this.innerModel.month === i + 1
+        const month = this.computedLocale.monthsShort[i];
 
         return h('div', {
           staticClass: 'q-date__months-item flex flex-center'
         }, [
-          disabledMonths[i] === true
+          disable === true
           ? h('div', {staticClass: 'text-grey'}, [ month ]) 
           : h(QBtn, {
             staticClass: currentYear === true && this.today.month === i + 1 ? 'q-date__today' : null,
@@ -596,6 +598,7 @@ export default Vue.extend({
         stop = start + yearsInterval,
         years = []
 
+      console.log(this.disabledYears)
       for (let i = start; i <= stop; i++) {
         const active = this.innerModel.year === i
 

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -190,6 +190,30 @@ export default Vue.extend({
         : date => this.options.includes(date)
     },
 
+
+    isDisableMonths () {
+
+      let res = [];
+      for (let month = 1; month <= 12; month++){
+        const prefix = this.innerModel.year + '/' + pad(month) + '/'
+
+        let disable = true;
+        for (let i = 1; i <= this.daysInMonth; i++) {
+          const day = prefix + pad(i)
+
+          if (this.options !== void 0 && this.isInSelection(day) !== true) {
+
+          }
+          else {
+            disable = false;
+          }
+        }
+        res.push(disable)
+      }
+      return res;
+
+    },
+
     days () {
       let date, endDay
 
@@ -271,7 +295,7 @@ export default Vue.extend({
       if (this.readonly === true) {
         return { 'aria-readonly': '' }
       }
-    }
+    },
   },
 
   methods: {
@@ -535,6 +559,7 @@ export default Vue.extend({
 
     __getMonthsView (h) {
       const currentYear = this.innerModel.year === this.today.year
+      const disabledMonths = this.isDisableMonths;
 
       const content = this.computedLocale.monthsShort.map((month, i) => {
         const active = this.innerModel.month === i + 1
@@ -542,7 +567,9 @@ export default Vue.extend({
         return h('div', {
           staticClass: 'q-date__months-item flex flex-center'
         }, [
-          h(QBtn, {
+          disabledMonths[i] === true
+          ? h('div', {staticClass: 'text-grey'}, [ month ]) 
+          : h(QBtn, {
             staticClass: currentYear === true && this.today.month === i + 1 ? 'q-date__today' : null,
             props: {
               flat: !active,

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -190,6 +190,34 @@ export default Vue.extend({
         : date => this.options.includes(date)
     },
 
+    years () {
+      let res = [];
+      const 
+        start = this.startYear,
+        stop = start + yearsInterval
+
+      for (let year = start; year <= stop; year++) {
+        if (this.options !== void 0) {
+
+          let disable = true;
+
+          for (let month = 1; month <= 12; month++) {
+            
+            const prefix = year + '/' + pad(month) + '/'
+
+            for (let i = 1; i <= 31; i++) {
+              const day = prefix + pad(i);
+              if(this.isInSelection(day) === true) disable = false;
+            }
+          }
+          res.push(disable)
+        }
+        else res.push(false);
+      }
+
+      return(res)
+    },
+
     months () {
       let res = [];
 
@@ -593,36 +621,34 @@ export default Vue.extend({
     },
 
     __getYearsView (h) {
-      const
-        start = this.startYear,
-        stop = start + yearsInterval,
-        years = []
 
-      console.log(this.disabledYears)
-      for (let i = start; i <= stop; i++) {
-        const active = this.innerModel.year === i
+      const years = this.years.map((disable, i) => {
+        const year = this.startYear + i;
+        const active = this.innerModel.year === i;
 
-        years.push(
+        return(
           h('div', {
             staticClass: 'q-date__years-item flex flex-center'
           }, [
-            h(QBtn, {
+            disable === true
+            ? h('div', {staticClass: 'text-grey'}, [ year ]) 
+            : h(QBtn, {
               key: 'yr' + i,
               staticClass: this.today.year === i ? 'q-date__today' : null,
               props: {
                 flat: !active,
-                label: i,
+                label: year,
                 dense: true,
                 unelevated: active,
                 color: active ? this.computedColor : null,
                 textColor: active ? this.computedTextColor : null,
                 tabindex: this.computedTabindex
               },
-              on: cache(this, 'yr#' + i, { click: () => { this.__setYear(i) } })
+              on: cache(this, 'yr#' + i, { click: () => { this.__setYear(year) } })
             })
           ])
         )
-      }
+      });
 
       return h('div', {
         staticClass: 'q-date__view q-date__years flex flex-center'

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -60,7 +60,7 @@ export default Vue.extend({
       yearDirection: direction,
       startYear: inner.year - inner.year % yearsInterval,
       innerModel: inner,
-      extModel: external,
+      extModel: external
     }
   },
 
@@ -343,10 +343,6 @@ export default Vue.extend({
       }
     },
 
-    isDisableYear (year) {
-      console.log(this.computedLocale.months)
-    },
-
     __getModels (val, mask, locale) {
       const external = __splitDate(
         val,
@@ -589,7 +585,6 @@ export default Vue.extend({
     __getMonthsView (h) {
       const currentYear = this.innerModel.year === this.today.year
 
-      console.log(this.months)
       const content = this.months.map((disable, i) => {
         const active = this.innerModel.month === i + 1
         const month = this.computedLocale.monthsShort[i];

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -191,52 +191,49 @@ export default Vue.extend({
     },
 
     years () {
-      let res = [];
-      const 
+      let res = []
+      const
         start = this.startYear,
         stop = start + yearsInterval
 
       for (let year = start; year <= stop; year++) {
         if (this.options !== void 0) {
-
-          let disable = true;
+          let disable = true
 
           for (let month = 1; month <= 12; month++) {
-            
             const prefix = year + '/' + pad(month) + '/'
 
             for (let i = 1; i <= 31; i++) {
-              const day = prefix + pad(i);
-              if(this.isInSelection(day) === true) disable = false;
+              const day = prefix + pad(i)
+              if (this.isInSelection(day) === true) disable = false
             }
           }
           res.push(disable)
         }
-        else res.push(false);
+        else res.push(false)
       }
 
-      return(res)
+      return (res)
     },
 
     months () {
-      let res = [];
+      let res = []
 
       for (let month = 1; month <= 12; month++) {
         if (this.options !== void 0) {
-
           const prefix = this.innerModel.year + '/' + pad(month) + '/'
-          let disable = true;
+          let disable = true
 
           for (let i = 1; i <= 31; i++) {
-            const day = prefix + pad(i);
-            if (this.isInSelection(day) === true) disable = false;
+            const day = prefix + pad(i)
+            if (this.isInSelection(day) === true) disable = false
           }
-          res.push(disable);
+          res.push(disable)
         }
         else res.push(false)
       }
 
-      return(res)
+      return (res)
     },
 
     days () {
@@ -320,7 +317,7 @@ export default Vue.extend({
       if (this.readonly === true) {
         return { 'aria-readonly': '' }
       }
-    },
+    }
   },
 
   methods: {
@@ -587,25 +584,25 @@ export default Vue.extend({
 
       const content = this.months.map((disable, i) => {
         const active = this.innerModel.month === i + 1
-        const month = this.computedLocale.monthsShort[i];
+        const month = this.computedLocale.monthsShort[i]
 
         return h('div', {
           staticClass: 'q-date__months-item flex flex-center'
         }, [
           disable === true
-          ? h('div', {staticClass: 'text-grey'}, [ month ]) 
-          : h(QBtn, {
-            staticClass: currentYear === true && this.today.month === i + 1 ? 'q-date__today' : null,
-            props: {
-              flat: !active,
-              label: month,
-              unelevated: active,
-              color: active ? this.computedColor : null,
-              textColor: active ? this.computedTextColor : null,
-              tabindex: this.computedTabindex
-            },
-            on: cache(this, 'month#' + i, { click: () => { this.__setMonth(i + 1) } })
-          })
+            ? h('div', { staticClass: 'text-grey' }, [ month ])
+            : h(QBtn, {
+              staticClass: currentYear === true && this.today.month === i + 1 ? 'q-date__today' : null,
+              props: {
+                flat: !active,
+                label: month,
+                unelevated: active,
+                color: active ? this.computedColor : null,
+                textColor: active ? this.computedTextColor : null,
+                tabindex: this.computedTabindex
+              },
+              on: cache(this, 'month#' + i, { click: () => { this.__setMonth(i + 1) } })
+            })
         ])
       })
 
@@ -616,34 +613,33 @@ export default Vue.extend({
     },
 
     __getYearsView (h) {
-
       const years = this.years.map((disable, i) => {
-        const year = this.startYear + i;
-        const active = this.innerModel.year === i;
+        const year = this.startYear + i
+        const active = this.innerModel.year === i
 
-        return(
+        return (
           h('div', {
             staticClass: 'q-date__years-item flex flex-center'
           }, [
             disable === true
-            ? h('div', {staticClass: 'text-grey'}, [ year ]) 
-            : h(QBtn, {
-              key: 'yr' + i,
-              staticClass: this.today.year === i ? 'q-date__today' : null,
-              props: {
-                flat: !active,
-                label: year,
-                dense: true,
-                unelevated: active,
-                color: active ? this.computedColor : null,
-                textColor: active ? this.computedTextColor : null,
-                tabindex: this.computedTabindex
-              },
-              on: cache(this, 'yr#' + i, { click: () => { this.__setYear(year) } })
-            })
+              ? h('div', { staticClass: 'text-grey' }, [ year ])
+              : h(QBtn, {
+                key: 'yr' + i,
+                staticClass: this.today.year === i ? 'q-date__today' : null,
+                props: {
+                  flat: !active,
+                  label: year,
+                  dense: true,
+                  unelevated: active,
+                  color: active ? this.computedColor : null,
+                  textColor: active ? this.computedTextColor : null,
+                  tabindex: this.computedTabindex
+                },
+                on: cache(this, 'yr#' + i, { click: () => { this.__setYear(year) } })
+              })
           ])
         )
-      });
+      })
 
       return h('div', {
         staticClass: 'q-date__view q-date__years flex flex-center'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Referencing _QDate.js_ file.

Added _months_ and _years_ to computed functions.  Both of these functions compute whether a month or year should be disabled.  Returns a list of boolean values representing each month/year.

___getMonthsView_ now maps through computed _months_.  If a month is disabled, function returns a label of that month, rather than a button.
___getYearsView_ now maps through computed _years_.  If a year is disabled, function returns a label of that month, rather than a button.


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Convincing Reason:  Specified in Issue #6639 

**Other information:**

As part of my final project for a college course, I was tasked with contributing to an Open Source project.  My experience with using Quasar for my own project has been positive and thought this would be a great project to contribute.  I found this issue to be interesting and decided to apply it to your extension.