### PR TITLE
Pass current route in the btn mixin to router resolve

### DIFF
--- a/ui/src/mixins/btn.js
+++ b/ui/src/mixins/btn.js
@@ -97,7 +97,7 @@ export default {
       }
 
       if (this.hasRouterLink === true) {
-        attrs.href = this.$router.resolve(this.to).href
+        attrs.href = this.$router.resolve(this.to, this.$route).href
         attrs.role = 'link'
       }
       else {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

QRouteTab has the following code: 

```
        current = this.$route,
        { href, location, route } = this.$router.resolve(this.to, current, this.append),
```

It would be great to have the same for the btn when passing to `:to`.