### PR TITLE
fix(typescript): add debounced.cancel() method to return type

### DIFF
--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -23,5 +23,5 @@ export function openURL(url: string): void;
 export function throttle<F extends (...args: any[]) => any>(
   fn: F,
   limit: number
-): F;
+): F & { cancel(): void };
 export function uid(): string;

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -11,7 +11,7 @@ export function debounce<F extends (...args: any[]) => any>(
   fn: F,
   wait?: number,
   immediate?: boolean
-): F;
+): F & { cancel(): void };
 export function exportFile(
   fileName: string,
   rawData: BlobPart,
@@ -23,5 +23,5 @@ export function openURL(url: string): void;
 export function throttle<F extends (...args: any[]) => any>(
   fn: F,
   limit: number
-): F & { cancel(): void };
+): F;
 export function uid(): string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] ~It's been tested on a Cordova (iOS, Android) app~
- [ ] ~It's been tested on a Electron app~
- [ ] ~Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.~

If adding a **new feature**, the PR's description includes:
- [ ] ~A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~

**Other information:**

The `debounce` utility function's typing does not include the cancel member in it's return type:

![error](https://user-images.githubusercontent.com/21686106/80271969-a6c3bf80-8719-11ea-9a57-c112f3c06886.png)

The current type is nice because the debounced function gets intellisense for the exact function signature+jsdoc comments. We can correct the error and keep intellisense with a type intersection.