### PR TITLE
fix(QDrawer): Initialize lastDesktopState to prevent different behavior when started above or below breakpoint #6905

### DIFF
--- a/ui/dev/src/pages/layout/layout-keep-state-above.vue
+++ b/ui/dev/src/pages/layout/layout-keep-state-above.vue
@@ -1,0 +1,86 @@
+<template>
+  <q-layout view="hHh Lpr lFf">
+    <q-header elevated>
+      <q-toolbar>
+        <q-btn
+          flat
+          dense
+          round
+          icon="menu"
+          aria-label="Menu"
+          @click="leftDrawerOpen = !leftDrawerOpen"
+        />
+
+        <q-toolbar-title>
+          Quasar App
+        </q-toolbar-title>
+
+        <div>Quasar v{{ $q.version }}</div>
+
+        <q-btn
+          flat
+          dense
+          round
+          icon="settings"
+          aria-label="settings"
+          @click="rightDrawerOpen = !rightDrawerOpen"
+        />
+      </q-toolbar>
+    </q-header>
+
+    <q-drawer
+      v-model="leftDrawerOpen"
+      bordered
+      show-if-above
+    >
+      <q-list>
+        <q-item-label
+          header
+        >
+          Left drawer
+        </q-item-label>
+        <q-item-label
+          header
+        >
+          This should be shown after resizing, as it has the show-if-above property
+        </q-item-label>
+      </q-list>
+    </q-drawer>
+
+    <q-drawer
+      v-model="rightDrawerOpen"
+      bordered
+      side="right"
+    >
+      <q-list>
+        <q-item-label
+          header
+        >
+          Right drawer
+        </q-item-label>
+        <q-item-label
+          header
+        >
+          This should NOT be shown after resizing, as it DOES NOT HAVE the show-if-above property
+        </q-item-label>
+      </q-list>
+    </q-drawer>
+
+    <q-page-container>
+      <router-view />
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script>
+export default {
+  name: 'MainLayout',
+
+  data () {
+    return {
+      leftDrawerOpen: false,
+      rightDrawerOpen: false
+    }
+  }
+}
+</script>

--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -595,6 +595,8 @@ export default Vue.extend({
     this.$emit('on-layout', this.onLayout)
     this.$emit('mini-state', this.isMini)
 
+    this.lastDesktopState = this.showIfAbove === true
+
     const fn = () => {
       const action = this.showing === true ? 'show' : 'hide'
       this[`__${action}`](false, true)


### PR DESCRIPTION
The lastDesktopState should be:
- the current state when it changes from above to below breakpoint (in all cases)
- only when started below breakpoint then it should be true if showIfAbove and false else

Reproduction:
- start layout-keep-state-above below bp
- resize to above bp => right drawer shows
- resize to below bp => right drawer hides

- start layout-keep-state-above above bp
- resize to below bp => right stays hidden (lastDesktopState is set to false)
- resize to above bp => right stays hidden (lastDesktopState is false)