### PR TITLE
fix(QField): set field as not focused when pressing clear #6906

### DIFF
--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -479,6 +479,8 @@ export default Vue.extend({
     },
 
     __clearValue (e) {
+      this.focused = false
+
       // prevent activating the field but keep focus on desktop
       stopAndPrevent(e)
       this.$el.focus()


### PR DESCRIPTION
If the QField is focusable it will refocus, else it will remain unfocused.