### PR TITLE
build(typescript): generate narrower types

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -41,6 +41,33 @@ function convertTypeVal (type, def, required) {
     return def.tsType
   }
 
+  if (def.values) {
+    const enums = def.values.map(v => {
+      if (v === '(Boolean) true' || v === true) {
+        return 'true'
+      }
+      else if (v === '(Boolean) false' || v === false) {
+        return 'false'
+      }
+      else if (v === '(CSS selector)') {
+        return 'string'
+      }
+      else if (v === '(DOM Element)') {
+        return 'Element'
+      }
+      else if (v === null) {
+        return 'null'
+      }
+      else if (typeof v === 'string') {
+        return `"${v}"`
+      }
+      else {
+        throw new Error(`Missing enumeration for ${v}`)
+      }
+    })
+    return enums.join(' | ')
+  }
+
   const t = type.trim()
 
   if (typeMap.has(t)) {
@@ -63,7 +90,7 @@ function convertTypeVal (type, def, required) {
 
 function getTypeVal (def, required) {
   return Array.isArray(def.type)
-    ? def.type.map(type => convertTypeVal(type, def, required)).join(' | ')
+    ? [...new Set(def.type.map(type => convertTypeVal(type, def, required)))].join(' | ')
     : convertTypeVal(def.type, def, required)
 }
 


### PR DESCRIPTION
## Summary

Generated type interfaces stand to benefit from narrower types.

Since components/plugins/etc already define `values` in their JSON defs when a prop can only be of a certain subset of values, we can include these in the type interface. This also helps with functions signatures that only accept certain values.

For a basic example, the `Dark` plugin interface in `index.d.ts` currently looks like
```ts
export interface Dark {
    /**
     * Is Dark mode active?
     */
    isActive : boolean
    /**
     * Dark mode configuration (not status)
     */
    mode : boolean | string
    /**
     * Set dark mode status
     * @param status Dark mode status
     */
    set (status : boolean | string): void
    /**
     * Toggle dark mode status
     */
    toggle (): void
}
```
a nicer dev experience would be to have an interface like the following that eliminates a 20 second lookup in the docs for what `string` values are valid.

```ts
export interface Dark {
    /**
     * Is Dark mode active?
     */
    isActive : boolean
    /**
     * Dark mode configuration (not status)
     */
    mode : boolean | 'auto'
    /**
     * Set dark mode status
     * @param status Dark mode status
     */
    set (status : boolean | 'auto'): void
    /**
     * Toggle dark mode status
     */
    toggle (): void
}
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
  - unless a component/plugin/etc.'s `json` def incorrectly defines `values`

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] ~When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)~
- [ ] ~It's been tested on a Cordova (iOS, Android) app~
- [ ] ~It's been tested on a Electron app~
- [ ] ~Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.~

**Other information:**
