### PR TITLE
Chip RemoveIcon Prop

### DIFF
--- a/ui/src/components/chip/QChip.js
+++ b/ui/src/components/chip/QChip.js
@@ -34,6 +34,7 @@ export default Vue.extend({
 
     icon: String,
     iconRight: String,
+    iconRemove: String,
     label: [String, Number],
 
     color: String,
@@ -144,7 +145,7 @@ export default Vue.extend({
       this.removable === true && child.push(
         h(QIcon, {
           staticClass: 'q-chip__icon q-chip__icon--remove cursor-pointer',
-          props: { name: this.$q.iconSet.chip.remove },
+          props: { name: this.iconRemove || this.$q.iconSet.chip.remove },
           attrs: this.attrs,
           on: cache(this, 'non', {
             click: this.__onRemove,

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -170,7 +170,7 @@ export default Vue.extend({
     },
 
     fieldClass () {
-      return `q-select q-field--auto-height q-select--with${this.useInput !== true ? 'out' : ''}-input`
+      return `q-select q-field--auto-height q-select--with${this.useInput !== true ? 'out' : ''}-input q-select--with${this.useChips !== true ? 'out' : ''}-chips`
     },
 
     computedInputClass () {


### PR DESCRIPTION
Currently the only way to change the Remove icon on a Q-Chip is to set it like this:
`Vue.prototype.$q.iconSet.chip.remove = 'fas fa-times-circle'`
That sets it globally, but I added a prop so you can set it per instance.

**What kind of change does this PR introduce?**
- [x] Feature

**Does this PR introduce a breaking change?**
- [x] No
