### PR TITLE
fix: #7014, where "quasar clean" can create an empty "dist" folder

### DIFF
--- a/app/lib/artifacts.js
+++ b/app/lib/artifacts.js
@@ -65,6 +65,8 @@ module.exports.cleanAll = function () {
   fse.removeSync(folder)
   log(`Cleaned build artifact: "${folder}"`)
 
-  fse.emptyDirSync(appPaths.resolve.app('dist'))
-  log(`Emptied dist folder`)
+  if (fs.existsSync('dist')) {
+    fse.emptyDirSync(appPaths.resolve.app('dist'))
+    log(`Emptied dist folder`)
+  }
 }

--- a/app/lib/artifacts.js
+++ b/app/lib/artifacts.js
@@ -65,8 +65,10 @@ module.exports.cleanAll = function () {
   fse.removeSync(folder)
   log(`Cleaned build artifact: "${folder}"`)
 
-  if (fs.existsSync('dist')) {
-    fse.emptyDirSync(appPaths.resolve.app('dist'))
+  const distFolder = appPaths.resolve.app('dist')
+
+  if (fs.existsSync(distFolder)) {
+    fse.emptyDirSync(distFolder)
     log(`Emptied dist folder`)
   }
 }


### PR DESCRIPTION
Only call emptyDirSync on "dist" if it exists
As a side-effect, emptyDirSync will create the folder if it does not exist.  Small annoyance for users who are not using the default "dist" directory for build artifacts.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
