### PR TITLE
fix(QBtn): do not remove tabindex from the focus target because it moves the activeElement to be the body of the document #7028

### DIFF
--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -245,7 +245,6 @@ export default Vue.extend({
       ) {
         blurTarget.setAttribute('tabindex', -1)
         blurTarget.focus()
-        blurTarget.removeAttribute('tabindex')
       }
 
       if (touchTarget === this.$el) {


### PR DESCRIPTION
Fixes the cascade close of menus and problems with refocusing of elements.

Ref #5888 - the initial markup will be without the negative tabindex, but after the first click there will be tabindex.
