### PR TITLE
fix(a11y): set aria-hidden on the img tag inside QImg #6570

### DIFF
--- a/ui/src/components/img/QImg.js
+++ b/ui/src/components/img/QImg.js
@@ -228,7 +228,7 @@ export default Vue.extend({
         ? [
           h('img', {
             staticClass: 'absolute-full fit',
-            attrs: { src: this.url }
+            attrs: { src: this.url, 'aria-hidden': 'true' }
           })
         ]
         : void 0


### PR DESCRIPTION
All the a11y attributes are on the exterior tag, focus and right menu  is set there also, so there is no reason to expose the img to the screen reader.