### PR TITLE
fix(QSelect): prevent blurring on mobile when dialog is closing because it triggers click outside on parent menus

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -350,7 +350,10 @@ export default Vue.extend({
       }
 
       if (this.$q.platform.is.mobile === true) {
-        on.focus = ev => { ev.target.blur() }
+        on.focus = ev => {
+          // should not blur when the dialog is closing
+          this.dialog === true && ev.target.blur()
+        }
       }
 
       return on


### PR DESCRIPTION
ref https://discord.com/channels/415874313728688138/596275881907978240/710770404158996490