### PR TITLE
Set a default rowsPerPage from rowsPerPageOptions

### DIFF
--- a/ui/src/components/table/table-pagination.js
+++ b/ui/src/components/table/table-pagination.js
@@ -137,6 +137,8 @@ export default {
   },
 
   created () {
+    this.innerPagination.rowsPerPage = this.rowsPerPageOptions[0]
+    
     this.$emit('update:pagination', { ...this.computedPagination })
   }
 }


### PR DESCRIPTION
There's no way to set a default rowsPerPage value without controling/syncing the pagination object.

The innerPagination object in QTable.js sets a default rowsPerPage value as 5 and it doesn't change when using custom rowsPerPageOptions array (For example when using [10, 20, 30, 0] in rowsPerPageOptions, QTable renders 5 rows per page by default). However, it should start with the first setting within the array.

There used to be a rowsPerPage param in QTable, but after the implementation of pagination object, this behaviour is neglected. But there are many cases that pagination object can not be used (in dynamically generated/multiple tables).

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
