### PR TITLE
docs():Fix typo and change an example in column wrapping

### DIFF
--- a/docs/src/examples/grid/RowColumnWrapping.vue
+++ b/docs/src/examples/grid/RowColumnWrapping.vue
@@ -3,16 +3,19 @@
 
     <div class="row">
       <div class="col-9">.col-9</div>
-      <div class="col-6">.col-6<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
+      <div class="col-4">.col-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
       <div class="col-5">.col-5<br>Subsequent columns continue along the new line.</div>
     </div>
 
     <div class="row">
-      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-
-      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+      <div class="col-2">.col-2</div>
+      <div class="col-3">.col-3</div>
+      <div class="col-4">.col-4</div>
+      <div class="col-5">.col-5</div>
+      <div class="col-6">.col-6</div>
+      <div class="col-5">.col-5</div>
+      <div class="col-4">.col-4</div>
+      <div class="col-3">.col-3</div>
     </div>
 
   </div>

--- a/docs/src/examples/grid/RowColumnWrapping.vue
+++ b/docs/src/examples/grid/RowColumnWrapping.vue
@@ -8,14 +8,11 @@
     </div>
 
     <div class="row">
-      <div class="col-2">.col-2</div>
-      <div class="col-3">.col-3</div>
-      <div class="col-4">.col-4</div>
-      <div class="col-5">.col-5</div>
-      <div class="col-6">.col-6</div>
-      <div class="col-5">.col-5</div>
-      <div class="col-4">.col-4</div>
-      <div class="col-3">.col-3</div>
+      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+
+      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+      <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
     </div>
 
   </div>


### PR DESCRIPTION
I tried to come up with a new example, that better demonstrates "column-wrapping". I found the second example confusing for new readers since it also requires knowledge about breakpoints, and to see the effect, you need to resize the browser window. Or you may not even know which rule is applied on the screen you are viewing the docs. So I tried to come up with something more intuitive :) Also fixed a typo.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
