### PR TITLE
fix(typescript) Fix typing for prefetch redirection function

### DIFF
--- a/app/types/prefetch.d.ts
+++ b/app/types/prefetch.d.ts
@@ -1,12 +1,12 @@
 import { HasSsrParam, HasStoreParam, PrefetchCallback } from "quasar";
 import Vue from "vue";
-import { Route } from "vue-router";
+import { RawLocation, Route } from "vue-router";
 
 declare module "quasar" {
   interface PreFetchOptions<TStore> extends HasSsrParam, HasStoreParam<TStore> {
     currentRoute: Route;
     previousRoute: Route;
-    redirect: (url: string) => void;
+    redirect: (url: RawLocation) => void;
   }
 
   // https://github.com/quasarframework/quasar/issues/6576#issuecomment-603787603


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The typing for the `redirect` function provided by the `prefetch` is not in line with the `vue-router` typing. As the `next()` function also accepts object locations. This is currently not possible when using quasar as the the parameter is forced to be a string.

![image](https://user-images.githubusercontent.com/7189039/83135226-d170b180-a0e5-11ea-8913-644bcd1bc877.png)

The fix allows both string and objects to be used, as RawLocation allows both types.
https://github.com/vuejs/vue-router/blob/v3.2.0/types/router.d.ts#L8