### PR TITLE
feat(app/quasar-info): Added eslint-plugin-quasar to local packages list

### DIFF
--- a/app/bin/quasar-info
+++ b/app/bin/quasar-info
@@ -76,6 +76,7 @@ print({ key: 'Important local packages', section: true })
   'quasar',
   '@quasar/app',
   '@quasar/extras',
+  'eslint-plugin-quasar',
   'vue',
   'vue-router',
   'vuex',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

If adding a **new feature**, the PR's description includes:
- A convincing reason for adding this feature

**Other information:**

[eslint-plugin-quasar](https://github.com/quasarframework/eslint-plugin-quasar) is the **Official** ESLint plugin for Quasar, so it's good to have it listed in `quasar-info` command.

Example Output:
```
$ quasar info

Operating System - Linux(4.19.84-microsoft-standard) - linux/x64
NodeJs - 12.16.2

Global packages
  NPM - 6.14.4
  yarn - 1.22.4
  @quasar/cli - 1.0.5
  cordova - Not installed

Important local packages
  quasar - 1.11.3 -- Build high-performance VueJS user interfaces (SPA, PWA, SSR, Mobile and Desktop) in record time
  @quasar/app - 1.8.8 -- Quasar Framework local CLI
  @quasar/extras - 1.8.1 -- Quasar Framework fonts, icons and animations
  eslint-plugin-quasar - 1.0.0 -- Official ESLint plugin for Quasar
  vue - 2.6.11 -- Reactive, component-oriented view layer for modern web interfaces.
  vue-router - 3.2.0 -- Official router for Vue.js 2
  vuex - 3.4.0 -- state management for Vue.js
  electron - Not installed
  electron-packager - Not installed
  electron-builder - Not installed
  @capacitor/core - Not installed
  @capacitor/cli - Not installed
  @capacitor/android - Not installed
  @capacitor/ios - Not installed
  @babel/core - 7.8.7 -- Babel compiler core.
  webpack - 4.43.0 -- Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.
  webpack-dev-server - 3.11.0 -- Serves a webpack app. Updates the browser on changes.
  workbox-webpack-plugin - 4.3.1 -- A plugin for your Webpack build process, helping you generate a manifest of local files that workbox-sw should precache.
  register-service-worker - 1.7.1 -- Script for registering service worker, with hooks
  typescript - 3.8.3 -- TypeScript is a language for application scale JavaScript development

Quasar App Extensions
  *None installed*

Networking
  Host - 75cd81f27e7e
  eth0 - 172.19.0.3
```

@hawkeye64's suggestion.