### PR TITLE
fix(portal): move portal element in the fullscreen element if it is a modal dialog #7187

### DIFF
--- a/ui/src/mixins/portal.js
+++ b/ui/src/mixins/portal.js
@@ -68,7 +68,17 @@ export default {
 
           if (
             this.__portal.$el.parentElement !== newParent &&
-            newParent.contains(this.$el) === true
+            (
+              // dialog plugin if the fullscreen element is not a child of it
+              (
+                this.$root !== void 0 &&
+                this.$root.$options.name === 'QGlobalDialog' &&
+                typeof this.__portal.$el.contains === 'function' &&
+                this.__portal.$el.contains(newParent) === false
+              ) ||
+              // other components if they are children of fullscreen element
+              newParent.contains(this.$el) === true
+            )
           ) {
             newParent.appendChild(this.__portal.$el)
           }


### PR DESCRIPTION
- menu, tooltip and dialog move if they are children of the fullscreen element
- dialog plugin moves if the fullscreen el is not its child

**This behavior should be discussed - concerns:**
- ~we might get in a loop where we move the dialog inside a children of the dialog that is fullscreen~ - solved
- does a modal non-plugin dialog belong to the place it is placed in HTML?
- ~should we also keep the seamless dialogs on screen?~ - no longer relevant - the question above is the solution