### PR TITLE
HOTFIX: fix bug with q-parallax when using ssr

### DIFF
--- a/ui/src/components/parallax/QParallax.js
+++ b/ui/src/components/parallax/QParallax.js
@@ -148,6 +148,8 @@ export default Vue.extend({
       : this.$refs.media
 
     this.media.onload = this.media.onloadstart = this.media.loadedmetadata = this.__onResize
+    this.__onResize()
+    this.media.style.display = 'initial'
 
     if (window.IntersectionObserver !== void 0) {
       this.observer = new IntersectionObserver(entries => {

--- a/ui/src/components/parallax/QParallax.sass
+++ b/ui/src/components/parallax/QParallax.sass
@@ -12,3 +12,4 @@
     min-width: 100%
     min-height: 100%
     will-change: transform
+    display: none


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is how QParallax looks when activating SSR ("quasar dev -m ssr" latest chrome, mobile and desktop). I made the pull request to master because I think this fix should be considered a hotfix. correct me if i'm wrong :)

![image](https://user-images.githubusercontent.com/6235675/84201352-3b0a9b80-aaa8-11ea-8841-58b88d9902bb.png)


