### PR TITLE
fix(IE/Edge): hide clear and password reveal buttons in input fields #7213

### DIFF
--- a/ui/src/components/field/QField.sass
+++ b/ui/src/components/field/QField.sass
@@ -11,6 +11,10 @@ $field-transition-label-right-up: .324s cubic-bezier(.4,0,.2,1)
 .q-field
   font-size: $input-font-size
 
+  ::-ms-clear,
+  ::-ms-reveal
+    display: none
+
   &--with-bottom
     padding-bottom: 20px
 

--- a/ui/src/components/field/QField.styl
+++ b/ui/src/components/field/QField.styl
@@ -11,6 +11,10 @@ $field-transition-label-right-up = .324s cubic-bezier(.4,0,.2,1)
 .q-field
   font-size: $input-font-size
 
+  ::-ms-clear,
+  ::-ms-reveal
+    display: none
+
   &--with-bottom
     padding-bottom: 20px
 

--- a/ui/src/ie-compat/ie.sass
+++ b/ui/src/ie-compat/ie.sass
@@ -140,9 +140,6 @@
     &__prefix, &__suffix
       flex: 1 0 auto
 
-    ::-ms-clear
-      display: none
-
     &__bottom--stale
       .q-field__messages
         left: 12px

--- a/ui/src/ie-compat/ie.styl
+++ b/ui/src/ie-compat/ie.styl
@@ -146,9 +146,6 @@ ie_style = @block
     &__prefix, &__suffix
       flex: 1 0 auto
 
-    ::-ms-clear
-      display: none
-
     &__bottom--stale
       .q-field__messages
         left: 12px


### PR DESCRIPTION
The new Edge(chrome based) implements this.