### PR TITLE
feat(ui/go-back): support app exit on all or some pages, fix: #7228

### DIFF
--- a/app/types/configuration/framework-conf.d.ts
+++ b/app/types/configuration/framework-conf.d.ts
@@ -2,8 +2,13 @@ import {
   QuasarIconSets,
   QuasarLanguageCodes,
   DeepPartial,
-  QuasarPluginOptions
+  QuasarPluginOptions,
 } from "quasar";
+
+interface QuasarMobileFrameworkInnerConfiguration {
+  iosStatusBarPadding: boolean;
+  backButtonExit: boolean | "*" | string[];
+}
 
 interface QuasarFrameworkInnerConfiguration {
   brand: {
@@ -16,13 +21,8 @@ interface QuasarFrameworkInnerConfiguration {
     info: string;
     warning: string;
   };
-  capacitor: {
-    iosStatusBarPadding: boolean;
-  };
-  cordova: {
-    iosStatusBarPadding: boolean;
-    backButtonExit: boolean;
-  };
+  capacitor: QuasarMobileFrameworkInnerConfiguration;
+  cordova: QuasarMobileFrameworkInnerConfiguration;
   dark: boolean | "auto";
   loading: {
     delay: number;

--- a/docs/src/pages/quasar-cli/developing-capacitor-apps/configuring-capacitor.md
+++ b/docs/src/pages/quasar-cli/developing-capacitor-apps/configuring-capacitor.md
@@ -40,15 +40,15 @@ return {
 }
 ```
 
-Finally, you can also disable the back button hook (used for Dialogs):
+Finally, you can also disable or configure the back button hook (used for Dialogs):
 
 ```js
 return {
   framework: {
     config: {
       capacitor: {
-        // requires Quasar v1.9.3+
-        backButtonExit: true/false // Quasar handles app exit on mobile phone back button
+        // requires Quasar v1.9.3+ for true/false, v1.12.7+ for '*' wildcard and array values
+        backButtonExit: true/false/'*'/['login', 'home', 'my-page'] // Quasar handles app exit on mobile phone back button
       }
     }
   }

--- a/docs/src/pages/quasar-cli/developing-cordova-apps/configuring-cordova.md
+++ b/docs/src/pages/quasar-cli/developing-cordova-apps/configuring-cordova.md
@@ -29,7 +29,8 @@ return {
     config: {
       cordova: {
         iosStatusBarPadding: true/false, // add the dynamic top padding on iOS mobile devices
-        backButtonExit: true/false // Quasar handles app exit on mobile phone back button
+        // requires Quasar v1.12.7+ for '*' wildcard and array values
+        backButtonExit: true/false/'*'/['login', 'home', 'my-page'] // Quasar handles app exit on mobile phone back button
       }
     }
   }

--- a/docs/src/pages/vue-directives/go-back.md
+++ b/docs/src/pages/vue-directives/go-back.md
@@ -11,7 +11,10 @@ If you have no knowledge of [Vue Router](http://router.vuejs.org/), we highly re
 ## Cordova/Capacitor
 Quasar handles the back button for you by default, so it can hide any opened Dialogs **instead of the default behavior** which is to return to the previous page (which is not a nice user experience).
 
-Also, when on the home route (`/`) and user presses the back button on the phone/tablet, Quasar will make your app exit. Should you wish to disable this behavior, then you can do so by configuring quasar.conf.js:
+Also, when on the home route (`/`) and user presses the back button on the phone/tablet, Quasar will make your app exit. Should you wish to disable or configure this behavior, then you can do so via quasar.conf.js options:
+- `false` will disable the feature;
+- `'*'` will make your app exit on any page, if the history length is 0;
+- an array of strings (eg. `['login', 'home', 'my-page']`) will make your app exit when current path is included in that array (or on default `/`). The array automatically filters out non-strings or empty values and normalizes paths to match `#/<your-path>` format.
 
 ```js
 // for Cordova (only!):
@@ -19,7 +22,8 @@ return {
   framework: {
     config: {
       cordova: {
-        backButtonExit: true/false
+        // requires Quasar v1.12.7+ for '*' wildcard and array values
+        backButtonExit: true/false/'*'/['login', 'home', 'my-page'] // Quasar handles app exit on mobile phone back button
       }
     }
   }
@@ -31,7 +35,8 @@ return {
   framework: {
     config: {
       capacitor: {
-        backButtonExit: true/false
+        // requires Quasar v1.12.7+ for '*' wildcard and array values
+        backButtonExit: true/false/'*'/['login', 'home', 'my-page'] // Quasar handles app exit on mobile phone back button
       }
     }
   }
@@ -80,7 +85,7 @@ Then we use it:
 />
 ```
 
-This directive determines if the Platform is Cordova, and if so, it performs a `window.history.back()` call instead of a `$router.push('/')`.
+This directive determines if the Platform is Cordova or Capacitor, and if so, it performs a `window.history.back()` call instead of a `$router.push('/')`.
 
 ## Quirks
 Now you may think everything will work smoothly, but you must be careful about how your app is stacking up the window history. Remember, we started out by saying that the List page has a layout with multiple tabs, each one with its own route ("/list/shoes", "/list/hats"). If we'd use `to="/list/shoes"` and `to="/list/hats"` on your Tabs (read more about [QTabs](/vue-components/tabs)), then window history will build up when switching between the tabs.


### PR DESCRIPTION
Closes #7228

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Capacitor (Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
See related issue for motivation #7228
Has been tested on Capacitor v2 Android app, no Capacitor/Cordova specific code has been changed so there shouldn't be issues even with Capacitor v1, Capacitor on iOS and Cordova apps