### PR TITLE
[Feature] QUploaderBase.js adding the capture param

### DIFF
--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -32,7 +32,8 @@ export default Vue.extend({
     hideUploadBtn: Boolean,
 
     disable: Boolean,
-    readonly: Boolean
+    readonly: Boolean,
+    capture: String,
   },
 
   provide () {
@@ -296,6 +297,7 @@ export default Vue.extend({
             type: 'file',
             title: '', // try to remove default tooltip
             accept: this.accept,
+            capture: this.capture,            
             ...(this.multiple === true ? { multiple: true } : {})
           },
           on: cache(this, 'input', {


### PR DESCRIPTION
To force the Recorder Util this is needed.
eg. 
 :accept="'video/*'"
 :capture="'user'"
forces on Mobile a nice CamRecorder (was boolean, now needs a string)
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
