### PR TITLE
DOC bad link for copy-webpack-plugin

### DIFF
--- a/docs/src/pages/quasar-cli/app-upgrade-guide.md
+++ b/docs/src/pages/quasar-cli/app-upgrade-guide.md
@@ -80,7 +80,7 @@ Following this guide should take you at most 5 minutes to complete.
 
 * The `webpack-html-plugin` package has been upgraded to v4; if you have tampered with the default config for it, please [review it](https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#400-2020-03-23)
 
-* The `copy-webpack-plugin` package has been upgraded to v6; if you have tampered with the default config for it, please [review it](https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#400-2020-03-23)
+* The `copy-webpack-plugin` package has been upgraded to v6; if you have tampered with the default config for it, please [review it](https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/CHANGELOG.md#600-2020-05-15)
 
 * If you're building with SSR mode, then custom publicPath can now be used, but it requires a small change to all your app.use() statements:
   ``` js


### PR DESCRIPTION
The link to the copy-webpack-plugin release notes was wrong (copy-pasted from the "webpack-html-plugin" juste above)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [X ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Just a big thanks for your work !