### PR TITLE
feat(app-extension): ability to exclude ts or js files from rendering

### DIFF
--- a/app/lib/app-extension/Extension.js
+++ b/app/lib/app-extension/Extension.js
@@ -55,11 +55,16 @@ async function renderFile ({ sourcePath, targetPath, rawCopy, scope, overwritePr
   }
 }
 
-async function renderFolders ({ source, rawCopy, scope }) {
+async function renderFolders ({ source, rawCopy, scope, renderTypescript }) {
   const fglob = require('fast-glob')
 
   let overwrite
-  const files = fglob.sync(['**/*'], { cwd: source })
+  let files
+  if (typeof renderTypescript !== 'undefined') {
+    files = fglob.sync(['**/*', `!**/*.${renderTypescript ? 'js' : 'ts'}`], { cwd: source })
+  } else {
+    files = fglob.sync(['**/*'], { cwd: source })
+  }
 
   for (const rawPath of files) {
     const targetRelativePath = rawPath.split('/').map(name => {

--- a/app/lib/app-extension/InstallAPI.js
+++ b/app/lib/app-extension/InstallAPI.js
@@ -234,8 +234,9 @@ module.exports = class InstallAPI {
    *
    * @param {string} templatePath (relative path to folder to render in app)
    * @param {object} scope (optional; rendering scope variables)
+   * @param {boolean} renderTypescript (optional; render only ts files if true, only js files if false)
    */
-  render (templatePath, scope) {
+  render (templatePath, scope, renderTypescript) {
     const dir = getCallerPath()
     const source = path.resolve(dir, templatePath)
     const rawCopy = !scope || Object.keys(scope).length === 0
@@ -254,7 +255,8 @@ module.exports = class InstallAPI {
     this.__hooks.renderFolders.push({
       source,
       rawCopy,
-      scope
+      scope,
+      renderTypescript
     })
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

With the new typescript support, the app extensions will have to also support TS files.
If I am correct, this would require both a .js and .ts file in the app extension templates folder as there is no way to combine these two in a single source file.
The render() function renders all files in the template directory which places both js and ts files in the app, which will result in an error.

Excluding the files with fglob seemed to be the most simple solution, but I am not entirely sure if this is the best approach.

Let me know if this is accepted and I will update the docs accordingly.