### PR TITLE
(feat) Platform.js additional info about display-mode

### DIFF
--- a/ui/src/plugins/Platform.js
+++ b/ui/src/plugins/Platform.js
@@ -57,6 +57,10 @@ const hasTouch = isSSR === false
   ? 'ontouchstart' in window || window.navigator.maxTouchPoints > 0
   : false
 
+const asPwa = isSSR === false
+  ? window.matchMedia('(display-mode: standalone)').matches
+  : false
+
 function applyIosCorrection (is) {
   iosCorrection = { is: { ...is } }
 
@@ -295,6 +299,9 @@ export const client = isSSR === false
     },
     within: {
       iframe: window.self !== window.top
+    },
+    as: {
+      pwa: asPwa
     }
   }
   : ssrClient


### PR DESCRIPTION
if a spa app is started from added to homescreen (with a manifest "display-mode": standalone)
this $q.platform.as.pwa gets true. Works nice on iOs and Android. In our case no needs for getting the other
matches (and also respect performance). 
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
