### PR TITLE
fix(QLinearProgress): prevent all content to be mirrored when reversed #7261

### DIFF
--- a/ui/src/components/linear-progress/QLinearProgress.js
+++ b/ui/src/components/linear-progress/QLinearProgress.js
@@ -6,7 +6,10 @@ import ListenersMixin from '../../mixins/listeners.js'
 
 import { mergeSlot } from '../../utils/slot.js'
 
-function width (val) {
+function width (val, reverse) {
+  if (reverse === true) {
+    return { transform: `translateX(100%) scale3d(${-val},1,1)` }
+  }
   return { transform: `scale3d(${val},1,1)` }
 }
 
@@ -57,7 +60,7 @@ export default Vue.extend({
     },
 
     trackStyle () {
-      return width(this.buffer !== void 0 ? this.buffer : 1)
+      return width(this.buffer !== void 0 ? this.buffer : 1, this.reverse)
     },
 
     trackClass () {
@@ -67,7 +70,7 @@ export default Vue.extend({
     },
 
     modelStyle () {
-      return width(this.motion === true ? 1 : this.value)
+      return width(this.motion === true ? 1 : this.value, this.reverse)
     },
 
     modelClasses () {

--- a/ui/src/components/linear-progress/QLinearProgress.sass
+++ b/ui/src/components/linear-progress/QLinearProgress.sass
@@ -7,14 +7,16 @@
   color: $primary
   color: var(--q-color-primary)
 
-  &--reverse
-    transform: scale3d(-1, 1, 1)
-
   &__model, &__track
     transform-origin: 0 0
 
     &--with-transition
       transition: transform .3s
+
+  &--reverse
+    .q-linear-progress
+      &__model, &__track
+        transform-origin: 0 100%
 
   &__model
 


### PR DESCRIPTION
https://pdanpdan.github.io/quasar-docs/vue-components/linear-progress#Example--Reverse-progress-direction