### PR TITLE
fix(QStep): headerNav=false, current step shouldn't be clickable #7284

### DIFF
--- a/ui/src/components/stepper/StepHeader.js
+++ b/ui/src/components/stepper/StepHeader.js
@@ -48,7 +48,7 @@ export default Vue.extend({
 
       return this.isDisable === false &&
         this.stepper.headerNav &&
-        (this.isActive === true || nav)
+        nav
     },
 
     hasPrefix () {


### PR DESCRIPTION
I've tested QStepper and QCarousel and this doesn't seem to have any negative effects. I've looked back in the git history it seems it's always been like this. 