### PR TITLE
fix(QDrawer): only use drawer close directive on backdrop when it's open #7317

### DIFF
--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -656,7 +656,7 @@ export default Vue.extend({
             ? { backgroundColor: this.lastBackdropBg }
             : null,
           on: cache(this, 'bkdrop', { click: this.hide }),
-          directives: this.backdropCloseDirective
+          directives: this.showing === false ? void 0 : this.backdropCloseDirective
         })
       )
     }


### PR DESCRIPTION
- now that the TouchPan directive always emits the final event it should work as expected