### PR TITLE
feat(QRouteTab): add custom handling of navigation #7143

### DIFF
--- a/docs/src/examples/QTabs/RouterCustomNavigation.vue
+++ b/docs/src/examples/QTabs/RouterCustomNavigation.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-y-md" style="max-width: 600px">
+      <q-tabs
+        no-caps
+        class="bg-orange text-white shadow-2"
+      >
+        <q-route-tab :to="{ query: { tab: '1', noScroll: true } }" exact replace label="Activate in 2s" @click="navDelay" />
+        <q-route-tab :to="{ query: { tab: '2', noScroll: true } }" exact replace label="Do nothing" @click="navCancel" />
+        <q-route-tab :to="{ query: { tab: '3', noScroll: true } }" exact replace label="Navigate to the second tab" @click="navRedirect" />
+        <q-route-tab :to="{ query: { tab: '4', noScroll: true } }" exact replace label="Navigate immediatelly" @click="navPass" />
+      </q-tabs>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    navDelay (e, go) {
+      e.navigate = false // we cancel the default navigation
+
+      // console.log('triggering navigation in 2s')
+      setTimeout(() => {
+        // console.log('navigating as promised 2s ago')
+        go()
+      }, 2000)
+    },
+
+    navCancel (e) {
+      e.navigate = false // we cancel the default navigation
+    },
+
+    navRedirect (e, go) {
+      e.navigate = false // we cancel the default navigation
+
+      go({ query: { tab: '2', noScroll: true } })
+    },
+
+    navPass () {}
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/tabs.md
+++ b/docs/src/pages/vue-components/tabs.md
@@ -127,6 +127,12 @@ This component inherits everything from QTab, however it also has `router-link` 
 QRouteTab becomes "active" depending on your app's route and not due to the v-model. So the initial value of v-model or changing the v-model directly will not also change the route of your app.
 :::
 
+### Handling custom navigation
+
+The example below won't work with UMD version (so in Codepen/jsFiddle too) because it relies on the existence of Vue Router.
+
+<doc-example title="Custom navigation" file="QTabs/RouterCustomNavigation" no-edit />
+
 ## QTabs API
 
 <doc-api file="QTabs" />

--- a/docs/src/router/index.js
+++ b/docs/src/router/index.js
@@ -16,8 +16,10 @@ export default function () {
   const Router = new VueRouter({
     routes,
 
-    scrollBehavior (_, __, savedPosition) {
-      return savedPosition || { x: 0, y: 0 }
+    scrollBehavior (to, __, savedPosition) {
+      if (to.query === void 0 || to.query.noScroll !== true) {
+        return savedPosition || { x: 0, y: 0 }
+      }
     },
 
     // Leave these as is and change from quasar.conf.js instead!

--- a/ui/dev/src/pages/components/tabs-router.vue
+++ b/ui/dev/src/pages/components/tabs-router.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-y-md" style="max-width: 600px">
+      <q-tabs
+        no-caps
+        class="bg-orange text-white shadow-2"
+      >
+        <q-route-tab :to="{ query: { tab: '1', noScroll: true } }" replace label="Activate in 2s" @click="navDelay" />
+        <q-route-tab :to="{ query: { tab: '2', noScroll: true } }" replace label="Do nothing" @click="navCancel" />
+        <q-route-tab :to="{ query: { tab: '3', noScroll: true } }" replace label="Navigate to the second tab" @click="navRedirect" />
+        <q-route-tab :to="{ query: { tab: '4', noScroll: true } }" replace label="Navigate immediatelly" @click="navPass" />
+      </q-tabs>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    navDelay (e, go) {
+      e.navigate = false // we cancel the default navigation
+
+      // console.log('triggering navigation in 2s')
+      setTimeout(() => {
+        // console.log('navigating as promised 2s ago')
+        go()
+      }, 2000)
+    },
+
+    navCancel (e) {
+      e.navigate = false // we cancel the default navigation
+    },
+
+    navRedirect (e, go) {
+      e.navigate = false // we cancel the default navigation
+
+      go({ query: { tab: '2', noScroll: true } })
+    },
+
+    navPass () {}
+  }
+}
+</script>

--- a/ui/dev/src/pages/components/tabs.vue
+++ b/ui/dev/src/pages/components/tabs.vue
@@ -351,6 +351,16 @@
         <q-route-tab v-if="loose" key="14" :to="{ name: 'r.3' }" label="r.3 *" />
       </q-tabs>
 
+      <div class="q-text-subtitle2">Custom click action</div>
+      <q-tabs :dense="dense" class="test q-mt-sm">
+        <q-route-tab key="1" :to="{ name: 'r.1' }" label="r.1 - delay 2sec" @click="routeNavDelay" />
+        <q-route-tab key="2" :to="{ name: 'r.1.1' }" label="r.1.1 disabled - delay 2sec" disable @click="routeNavDelay" />
+        <q-route-tab key="3" :to="{ name: 'r.2' }" label="r.2 - passthrough" @click="routeNavPass" />
+        <q-route-tab key="4" :to="{ name: 'r.2' }" label="r.2 - delay 2sec" @click="routeNavDelay" />
+        <q-route-tab key="5" :to="{ name: 'r.2' }" label="r.2 - cancel" @click="routeNavCancel" />
+        <q-route-tab key="6" :to="{ name: 'r.3' }" label="r.3 - redirect to r.1.1" @click="routeNavChange" />
+      </q-tabs>
+
       <h4>Tabs model (respect model): {{ tabModel }}</h4>
       <q-tabs :dense="dense" :value="tabModel" @input="onChangeTab1" class="bg-grey-1 text-teal">
         <q-tab name="one" label="One" />
@@ -527,6 +537,24 @@ export default {
       else if (val !== 'four') {
         this.tabModel = val
       }
+    },
+
+    routeNavDelay (e, go) {
+      e.navigate = false
+
+      setTimeout(go, 2000)
+    },
+
+    routeNavPass () {},
+
+    routeNavCancel (e) {
+      e.navigate = false
+    },
+
+    routeNavChange (e, go) {
+      e.navigate = false
+
+      go({ name: 'r.1.1' })
     }
   }
 }

--- a/ui/dev/src/router/index.js
+++ b/ui/dev/src/router/index.js
@@ -16,7 +16,7 @@ Vue.use(VueRouter)
 
 export default function (/* { store, ssrContext } */) {
   const Router = new VueRouter({
-    scrollBehavior: () => ({ x: 0, y: 0 }),
+    scrollBehavior: to => (to.meta && to.meta.skipScroll === true ? false : { x: 0, y: 0 }),
     routes,
 
     // Leave these as they are and change in quasar.conf.js instead!

--- a/ui/dev/src/router/routes.js
+++ b/ui/dev/src/router/routes.js
@@ -38,18 +38,19 @@ const routes = [
     path: '/components/tabs',
     component: load('components/tabs'),
     children: [
-      { path: 'a' },
-      { path: 'a/a' },
-      { path: 'a/b' },
-      { path: 'b' },
-      { path: 'b/a' },
-      { path: 'c' },
+      { path: 'a', meta: { skipScroll: true } },
+      { path: 'a/a', meta: { skipScroll: true } },
+      { path: 'a/b', meta: { skipScroll: true } },
+      { path: 'b', meta: { skipScroll: true } },
+      { path: 'b/a', meta: { skipScroll: true } },
+      { path: 'c', meta: { skipScroll: true } },
       {
         path: 't',
         children: [
-          { path: ':id/a', name: 'ta' },
-          { path: ':id/b', name: 'tb' }
-        ]
+          { path: ':id/a', name: 'ta', meta: { skipScroll: true } },
+          { path: ':id/b', name: 'tb', meta: { skipScroll: true } }
+        ],
+        meta: { skipScroll: true }
       },
       {
         name: 'r',
@@ -60,14 +61,16 @@ const routes = [
             name: 'r.1',
             path: '1',
             children: [
-              { name: 'r.1.1', path: '1' },
-              { name: 'r.1.2', path: '2', redirect: { name: 'r' } },
-              { name: 'r.1.3', path: '3', redirect: { name: 'r.1.1' } }
-            ]
+              { name: 'r.1.1', path: '1', meta: { skipScroll: true } },
+              { name: 'r.1.2', path: '2', redirect: { name: 'r' }, meta: { skipScroll: true } },
+              { name: 'r.1.3', path: '3', redirect: { name: 'r.1.1' }, meta: { skipScroll: true } }
+            ],
+            meta: { skipScroll: true }
           },
-          { name: 'r.2', path: '2' },
-          { name: 'r.3', path: '3', redirect: { name: 'ta', params: { id: 2 } } }
-        ]
+          { name: 'r.2', path: '2', meta: { skipScroll: true } },
+          { name: 'r.3', path: '3', redirect: { name: 'ta', params: { id: 2 } }, meta: { skipScroll: true } }
+        ],
+        meta: { skipScroll: true }
       }
     ]
   },

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -141,14 +141,12 @@ export default Vue.extend({
       }
 
       const go = () => {
-        const res = this.$router[this.replace === true ? 'replace' : 'push'](this.to)
+        const { route } = this.$router.resolve(this.to, this.$route, this.append)
 
         // vue-router now throwing error if navigating
         // to the same route that the user is currently at
         // https://github.com/vuejs/vue-router/issues/2872
-        if (res !== void 0 && typeof res.catch === 'function') {
-          res.catch(noop)
-        }
+        this.$router[this.replace === true ? 'replace' : 'push'](route, void 0, noop)
       }
 
       this.$emit('click', e, go)

--- a/ui/src/components/btn/QBtn.json
+++ b/ui/src/components/btn/QBtn.json
@@ -51,5 +51,27 @@
         }
       }
     }
+  },
+
+  "events": {
+    "click": {
+      "desc": "Emitted when component is clicked (activated)",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false",
+          "__exemption": [
+            "examples"
+          ]
+        },
+        "navigateFn": {
+          "type": "Function",
+          "desc": "Call this function to navigate to the route of the tab",
+          "params": {},
+          "returns": null
+        }
+      },
+      "addedIn": "v1.12.8"
+    }
   }
 }

--- a/ui/src/components/btn/QBtn.json
+++ b/ui/src/components/btn/QBtn.json
@@ -70,8 +70,7 @@
           "params": {},
           "returns": null
         }
-      },
-      "addedIn": "v1.12.8"
+      }
     }
   }
 }

--- a/ui/src/components/tabs/QRouteTab.js
+++ b/ui/src/components/tabs/QRouteTab.js
@@ -3,6 +3,7 @@ import Vue from 'vue'
 import QTab from './QTab.js'
 import { RouterLinkMixin } from '../../mixins/router-link.js'
 import { isSameRoute, isIncludedRoute } from '../../utils/router.js'
+import { stop, stopAndPrevent, noop } from '../../utils/event.js'
 
 export default Vue.extend({
   name: 'QRouteTab',
@@ -24,10 +25,62 @@ export default Vue.extend({
     }
   },
 
+  computed: {
+    onEvents () {
+      return {
+        input: stop,
+        ...this.qListeners,
+        focusin: this.__onFocusin,
+        focusout: this.__onFocusout,
+        '!click': this.__activate, // we need capture to intercept before vue-router
+        keydown: this.__onKeydown
+      }
+    }
+  },
+
   methods: {
     __activate (e, keyboard) {
       if (this.disable !== true) {
-        this.__checkActivation(true)
+        if (
+          e !== void 0 && (
+            e.ctrlKey === true ||
+            e.shiftKey === true ||
+            e.altKey === true ||
+            e.metaKey === true
+          )
+        ) {
+          // if it has meta keys, let vue-router link
+          // handle this by its own
+          this.__checkActivation(true)
+        }
+        else {
+          // we use programatic navigation instead of letting vue-router handle it
+          // so we can check for activation when the navigation is complete
+          e !== void 0 && stopAndPrevent(e)
+
+          const go = (to = this.to, append = this.append, replace = this.replace) => {
+            const { route } = this.$router.resolve(to, this.$route, append)
+            const checkFn = to === this.to && append === this.append && replace === this.replace
+              ? this.__checkActivation
+              : noop
+
+            // vue-router now throwing error if navigating
+            // to the same route that the user is currently at
+            // https://github.com/vuejs/vue-router/issues/2872
+            this.$router[replace === true ? 'replace' : 'push'](
+              route,
+              () => { checkFn(true) },
+              err => {
+                if (err && err.name === 'NavigationDuplicated') {
+                  checkFn(true)
+                }
+              }
+            )
+          }
+
+          this.qListeners.click !== void 0 && this.$emit('click', e, go)
+          e.navigate !== false && go()
+        }
       }
 
       if (keyboard === true) {
@@ -43,6 +96,7 @@ export default Vue.extend({
         current = this.$route,
         { href, location, route } = this.$router.resolve(this.to, current, this.append),
         redirected = route.redirectedFrom !== void 0,
+        isSameRouteCheck = isSameRoute(current, route),
         checkFunction = this.exact === true ? isSameRoute : isIncludedRoute,
         params = {
           name: this.name,
@@ -52,12 +106,27 @@ export default Vue.extend({
           priorityHref: href.length
         }
 
-      checkFunction(current, route) && this.__activateRoute({ ...params, redirected })
-      redirected === true && checkFunction(current, {
-        path: route.redirectedFrom,
-        ...location
-      }) && this.__activateRoute(params)
-      this.isActive && this.__activateRoute()
+      if (isSameRouteCheck === true || (this.exact !== true && isIncludedRoute(current, route) === true)) {
+        this.__activateRoute({
+          ...params,
+          redirected,
+          // if it's an exact match give higher priority
+          // even if the tab is not marked as exact
+          exact: this.exact === true || isSameRouteCheck === true
+        })
+      }
+
+      if (
+        redirected === true &&
+        checkFunction(current, {
+          path: route.redirectedFrom,
+          ...location
+        }) === true
+      ) {
+        this.__activateRoute(params)
+      }
+
+      this.isActive === true && this.__activateRoute()
     }
   },
 

--- a/ui/src/components/tabs/QRouteTab.json
+++ b/ui/src/components/tabs/QRouteTab.json
@@ -10,5 +10,49 @@
       "required": true,
       "category": "general"
     }
+  },
+
+  "events": {
+    "click": {
+      "desc": "Emitted when component is clicked (activated)",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false",
+          "__exemption": [
+            "examples"
+          ]
+        },
+        "navigateFn": {
+          "type": "Function",
+          "desc": "Call this function to navigate to the route of the tab or to a new route",
+          "params": {
+            "to": {
+              "type": [ "String", "Object" ],
+              "desc": "Equivalent to Vue Router <router-link> 'to' property",
+              "examples": [
+                "/home/dashboard",
+                "{ name: 'my-route-name' }"
+              ],
+              "default": "Tab's 'to' property"
+            },
+
+            "append": {
+              "type": "Boolean",
+              "desc": "Equivalent to Vue Router <router-link> 'append' property",
+              "default": "Tab's 'append' property"
+            },
+
+            "replace": {
+              "type": "Boolean",
+              "desc": "Equivalent to Vue Router <router-link> 'replace' property",
+              "default": "Tab's 'replace' property"
+            }
+          },
+          "returns": null
+        }
+      },
+      "addedIn": "v1.12.8"
+    }
   }
 }

--- a/ui/src/components/tabs/QTabs.js
+++ b/ui/src/components/tabs/QTabs.js
@@ -307,12 +307,12 @@ export default Vue.extend({
           ? `translate3d(0,${oldPos.top - newPos.top}px,0) scale3d(1,${newPos.height ? oldPos.height / newPos.height : 1},1)`
           : `translate3d(${oldPos.left - newPos.left}px,0,0) scale3d(${newPos.width ? oldPos.width / newPos.width : 1},1,1)`
 
-        // allow scope updates to kick in
+        // allow scope updates to kick in (QRouteTab needs more time)
         this.$nextTick(() => {
           this.animateTimer = setTimeout(() => {
             newEl.style.transition = 'transform .25s cubic-bezier(.4, 0, .2, 1)'
             newEl.style.transform = 'none'
-          }, 30)
+          }, 70)
         })
       }
 

--- a/ui/src/mixins/btn.js
+++ b/ui/src/mixins/btn.js
@@ -28,8 +28,10 @@ export default {
 
   props: {
     type: String,
+
     to: [ Object, String ],
     replace: Boolean,
+    append: Boolean,
 
     label: [ Number, String ],
     icon: String,

--- a/ui/src/mixins/btn.json
+++ b/ui/src/mixins/btn.json
@@ -31,6 +31,13 @@
       "category": "router"
     },
 
+    "append": {
+      "type": "Boolean",
+      "desc": "Equivalent to Vue Router <router-link> 'append' property",
+      "category": "router",
+      "addedIn": "v1.12.8"
+    },
+
     "label":{
       "type": [ "String", "Number" ],
       "desc": "The text that will be shown on the button",


### PR DESCRIPTION
https://pdanpdan.github.io/quasar-docs/vue-components/tabs#Handling-custom-navigation

- improve route tab matching
- add use of append for both QBtn and QRoute Tab
- always use functional navigation for QRouteTab to check for activation after navigation and in case of duplicated navigation
