### PR TITLE
[docs] Setting up Translation Blocks in your SFCs fails on V2 (7367)

### DIFF
--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -68,7 +68,7 @@ return {
 Now you are ready to use it in your pages.
 
 ## Setting up Translation Blocks in your SFCs
-The following is an example recipe for using **vue-i18n** embedded `<i18n>` template components in your vue files with **vue-i18n-loader**, which you have to add in your `quasar.conf.js`. In this case the translations are stored in yaml format in the block.
+To use embedded `<i18n>` template components in your vue files with **vue-i18n-loader** you must ensure that the `@kazupon/vue-i18n-loader` and `yaml-loader` dependencies are added to your project using your package manager of choice. Then in your `quasar.conf.js` file change the webpack build options.
 
 ```js
 // quasar.conf.js
@@ -78,9 +78,10 @@ build: {
   extendWebpack (cfg) {
     cfg.module.rules.push({
       resourceQuery: /blockType=i18n/,
+      type: 'javascript/auto',
       use: [
-        {loader: '@kazupon/vue-i18n-loader'},
-        {loader: 'yaml-loader'}
+        { loader: '@kazupon/vue-i18n-loader' },
+        { loader: 'yaml-loader' }
       ]
     })
     ...

--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -68,7 +68,7 @@ return {
 Now you are ready to use it in your pages.
 
 ## Setting up Translation Blocks in your SFCs
-To use embedded `<i18n>` template components in your vue files with **vue-i18n-loader** you must ensure that the `@kazupon/vue-i18n-loader` and `yaml-loader` dependencies are added to your project using your package manager of choice. Then in your `quasar.conf.js` file change the webpack build options.
+To use embedded `<i18n>` template components in your vue files with **vue-i18n-loader** you must ensure that the `@intlify/vue-i18n-loader` and `yaml-loader` dependencies are added to your project using your package manager of choice. Then in your `quasar.conf.js` file change the webpack build options. In this case the translations are stored in yaml format in the block.
 
 ```js
 // quasar.conf.js


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
