### PR TITLE
feat(TouchPan): add a modifier for preserving the cursor

### DIFF
--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -233,7 +233,9 @@ export default {
         const start = () => {
           handleEvent(evt, isMouseEvt)
 
-          document.documentElement.style.cursor = 'grabbing'
+          if (!modifiers.preserveCursor) {
+            document.documentElement.style.cursor = 'grabbing'
+          }
           isMouseEvt === true && document.body.classList.add('no-pointer-events--children')
           document.body.classList.add('non-selectable')
           clearSelection()
@@ -241,7 +243,9 @@ export default {
           ctx.styleCleanup = withDelayedFn => {
             ctx.styleCleanup = void 0
 
-            document.documentElement.style.cursor = ''
+            if (!modifiers.preserveCursor) {
+              document.documentElement.style.cursor = ''
+            }
             document.body.classList.remove('non-selectable')
 
             if (isMouseEvt === true) {

--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -233,7 +233,7 @@ export default {
         const start = () => {
           handleEvent(evt, isMouseEvt)
 
-          if (!modifiers.preserveCursor) {
+          if (modifiers.preserveCursor !== true) {
             document.documentElement.style.cursor = 'grabbing'
           }
           isMouseEvt === true && document.body.classList.add('no-pointer-events--children')
@@ -243,7 +243,7 @@ export default {
           ctx.styleCleanup = withDelayedFn => {
             ctx.styleCleanup = void 0
 
-            if (!modifiers.preserveCursor) {
+            if (modifiers.preserveCursor !== true) {
               document.documentElement.style.cursor = ''
             }
             document.body.classList.remove('non-selectable')

--- a/ui/src/directives/TouchPan.json
+++ b/ui/src/directives/TouchPan.json
@@ -149,6 +149,12 @@
       "desc": "Ignore initial mouse move direction (do not abort if the first mouse move is in an unaccepted direction)",
       "reactive": true
     },
+    
+    "preserveCursor": {
+      "type": "Boolean",
+      "desc": "Prevent the mouse cursor from automatically displaying as grabbing when panning",
+      "reactive": true
+    },
 
     "horizontal": {
       "type": "Boolean",

--- a/ui/src/directives/TouchPan.json
+++ b/ui/src/directives/TouchPan.json
@@ -153,7 +153,8 @@
     "preserveCursor": {
       "type": "Boolean",
       "desc": "Prevent the mouse cursor from automatically displaying as grabbing when panning",
-      "reactive": true
+      "reactive": true,
+      "addedIn": "v1.13.0"
     },
 
     "horizontal": {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

I often use the v-touch-pan directive for other functions besides panning (e.g. using v-touch-pan for a painting app), and so having the cursor change to grabbing isn't always the best for me. I tried using this.$nextTick, but there's sometimes still a short flicker of the cursor changing. It would be a lot easier if there was an option to disable Quasar from automatically changing the cursor when panning using v-touch-pan :)