### PR TITLE
fix: uncaught syntax error

### DIFF
--- a/docs/src/pages/quasar-cli/handling-process-env.md
+++ b/docs/src/pages/quasar-cli/handling-process-env.md
@@ -85,9 +85,11 @@ You can add your own definitions to `process.env` through `/quasar.conf.js` file
 
 build: {
   env: {
-    API: ctx.dev
+    API: JSON.stringify(
+      ctx.dev
       ? 'https://dev.api.com'
       : 'https://prod.api.com'
+    )
   }
 }
 ```
@@ -103,9 +105,11 @@ $ MY_API=api.com quasar build
 # then we pick it up in /quasar.conf.js
 build: {
   env: {
-    API: ctx.dev
+    API: JSON.stringify(
+      ctx.dev
       ? 'https://dev.' + process.env.MY_API
       : 'https://prod.' + process.env.MY_API
+    )
   }
 }
 ```


### PR DESCRIPTION
If we won't stringify the URL it will be treated like the code, not string (like `eval(process.env.API)`) and we'll get an error like
`Uncaught SyntaxError: Unexpected token ':'`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
