### PR TITLE
QPopupEdit.json update for API Docs

### DIFF
--- a/ui/src/components/popup-edit/QPopupEdit.json
+++ b/ui/src/components/popup-edit/QPopupEdit.json
@@ -244,7 +244,6 @@
     },
 
     "before-show": {
-      "extends": "before-show",
       "desc": "Emitted right before Popup gets shown"
     },
 
@@ -253,7 +252,6 @@
     },
 
     "before-hide": {
-      "extends": "before-hide",
       "desc": "Emitted right before Popup gets dismissed"
     },
 


### PR DESCRIPTION
`before-show` and `before-hide` events are shown to emit native js event in the docs when it does not.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
