### PR TITLE
Add no-route-dismiss behavior to q-menu component

### DIFF
--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -38,7 +38,8 @@ export default Vue.extend({
     persistent: Boolean,
     autoClose: Boolean,
     separateClosePopup: Boolean,
-
+    
+    noRouteDismiss: Boolean,
     noRefocus: Boolean,
     noFocus: Boolean,
 
@@ -101,7 +102,8 @@ export default Vue.extend({
     },
 
     hideOnRouteChange () {
-      return this.persistent !== true
+      return this.persistent !== true &&
+        this.noRouteDismiss !== true
     },
 
     onEvents () {

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -38,7 +38,7 @@ export default Vue.extend({
     persistent: Boolean,
     autoClose: Boolean,
     separateClosePopup: Boolean,
-    
+
     noRouteDismiss: Boolean,
     noRefocus: Boolean,
     noFocus: Boolean,

--- a/ui/src/components/menu/QMenu.json
+++ b/ui/src/components/menu/QMenu.json
@@ -77,7 +77,8 @@
     "no-route-dismiss": {
       "type": "Boolean",
       "desc": "Changing route app won't dismiss Manu; No need to set it if 'persistent' prop is also set",
-      "category": "behavior"
+      "category": "behavior",
+      "addedIn": "v1.13.0"
     },
 
     "auto-close": {

--- a/ui/src/components/menu/QMenu.json
+++ b/ui/src/components/menu/QMenu.json
@@ -74,6 +74,12 @@
       "category": "behavior"
     },
 
+    "no-route-dismiss": {
+      "type": "Boolean",
+      "desc": "Changing route app won't dismiss Manu; No need to set it if 'persistent' prop is also set",
+      "category": "behavior"
+    },
+
     "auto-close": {
       "type": "Boolean",
       "desc": "Allows any click/tap in the menu to close it; Useful instead of attaching events to each menu item that should close the menu on click/tap",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In my app click in any element in q-menu changes the URL, 
I needed to use persistent to avoid closing q-menu with every click. 
However now click outside it, doesn’t close the menu.
I need the ‘no-route-dismiss’ prop like in q-dialog, which will keep the q-menu functionality but just prevent it from closing when changing URL
