### PR TITLE
feat(QTime): Add grid snapping to QTime with options

### DIFF
--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -282,14 +282,14 @@ export default Vue.extend({
 
     calculateSnappingGrid (inSel, count) {
       if (inSel === void 0) {
-        return void 0
+        return
       }
 
-      const snappingGrid = [...Array(count).keys()].map(inSel)
+      const snappingGrid = [ ...Array(count).keys() ].map(inSel)
 
       let consecutiveGaps = (count - 1) - snappingGrid.lastIndexOf(true)
       if (consecutiveGaps === -1) {
-        return void 0
+        return
       }
 
       for (let i = 0; i < count; i++) {
@@ -318,7 +318,8 @@ export default Vue.extend({
           }
 
           snappingGrid[i] = i
-        } else if (snappingGrid[i] === false) {
+        }
+        else if (snappingGrid[i] === false) {
           consecutiveGaps++
         }
       }

--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -210,6 +210,18 @@ export default Vue.extend({
         )
     },
 
+    hourSnappingGrid () {
+      return this.calculateSnappingGrid(this.hourInSelection, 24)
+    },
+
+    minuteSnappingGrid () {
+      return this.calculateSnappingGrid(this.minuteInSelection, 60)
+    },
+
+    secondSnappingGrid () {
+      return this.calculateSnappingGrid(this.secondInSelection, 60)
+    },
+
     positions () {
       let start, end, offset = 0, step = 1, inSel
 
@@ -266,6 +278,52 @@ export default Vue.extend({
         ...this.__getCurrentTime()
       })
       this.view = 'Hour'
+    },
+
+    calculateSnappingGrid (inSel, count) {
+      if (inSel === void 0) {
+        return void 0
+      }
+
+      const snappingGrid = [...Array(count).keys()].map(inSel)
+
+      let consecutiveGaps = (count - 1) - snappingGrid.lastIndexOf(true)
+      if (consecutiveGaps === -1) {
+        return void 0
+      }
+
+      for (let i = 0; i < count; i++) {
+        if (snappingGrid[i] === true) {
+          if (consecutiveGaps) {
+            if (consecutiveGaps > 1) {
+              const sideCount = Math.floor(consecutiveGaps / 2)
+
+              const previousVal = ((i - consecutiveGaps - 1) + count) % count
+              const previousValStart = ((i - consecutiveGaps) + count) % count
+              for (let j = 0, h = previousValStart; j < sideCount; j++, (h = (previousValStart + j + count) % count)) {
+                snappingGrid[h] = previousVal
+              }
+
+              const currentVal = i
+              const currentValStart = ((i - sideCount) + count) % count
+              for (let j = 0, h = currentValStart; j < sideCount; j++, (h = (currentValStart + j + count) % count)) {
+                snappingGrid[h] = currentVal
+              }
+            } else {
+              const previousPosition = ((i - 1) + count) % count
+              snappingGrid[previousPosition] = previousPosition
+            }
+
+            consecutiveGaps = 0
+          }
+
+          snappingGrid[i] = i
+        } else if (snappingGrid[i] === false) {
+          consecutiveGaps++
+        }
+      }
+
+      return snappingGrid
     },
 
     __getMask () {
@@ -387,12 +445,19 @@ export default Vue.extend({
         else if (this.isAM === false && val !== 12) {
           val += 12
         }
+
+        if (this.hourSnappingGrid !== void 0) {
+          val = this.hourSnappingGrid[val]
+        }
       }
       else {
-        val = Math.round(angle / 6)
+        val = Math.round(angle / 6) % 60
 
-        if (val === 60) {
-          val = 0
+        if (this.view === 'Minute' && this.minuteSnappingGrid !== void 0) {
+          val = this.minuteSnappingGrid[val]
+        }
+        else if (this.view === 'Second' && this.secondSnappingGrid !== void 0) {
+          val = this.secondSnappingGrid[val]
         }
       }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The current dragging (and clicking) behavior when using `*-options` for `options-fn` leads to confusing (from user's point of view) behavior. They may be dragging the cursor over the number, or clicking on the number, yet the time would not get selected.

![current-behavior](https://user-images.githubusercontent.com/2260539/90995424-db566380-e5b3-11ea-99e9-0698461ae38c.gif)

![current-behavior-still](https://user-images.githubusercontent.com/2260539/90995042-97169380-e5b2-11ea-9c19-9d32e7bbbba2.png)

Code-wise, this of course makes sense, for example on the above screenshot, the user is clearly dragging over the 29th minute, which is not allowed by `minute-options` and so no update is performed.

This PR adds snapping to the update function. It only activates if the developer had limited user selection. For both dragging and clicking, the computed value from the cursor position snaps to the nearest allowed value. More on implementation below. This is how it behaves with this PR:

![proposed-behavior](https://user-images.githubusercontent.com/2260539/90995071-b01f4480-e5b2-11ea-8a68-e5440bb34757.gif)

The implementation relies on mapping values after they were converted from degrees into time units (hours, minutes, seconds). The computed value contains an array with 24 elements for hours and 60 elements for minutes and seconds. Element index is the value obtained from cursor position and element value is the snapped to value.

For example, if we allow minutes to be set in increments of 5, our `minute-options` would be equal to `[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]`. The `minuteSnappingGrid` would then be `[0, 0, 0, 5, 5, 5, 5, 5, 10, 10, 10, 10, 10, 15, 15, 15, 15, 15, 20, 20, 20, 20, 20, 25, 25, 25, 25, 25, 30, 30, 30, 30, 30, 35, 35, 35, 35, 35, 40, 40, 40, 40, 40, 45, 45, 45, 45, 45, 50, 50, 50, 50, 50, 55, 55, 55, 55, 55, 0, 0]`. Now, if the user was to click on *4* minute sector on the clock dial, we would lookup the 4th element in the array, giving us the snapped value of *5*.

Use of `lastIndexOf()` guarantees that we always have at least one value to snap to (in case developer passes invalid `minute-options`, for example `['not a number', null, -10]`, or `options-fn` that always returns `false`).