### PR TITLE
Update QBtnDropdown.json

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.json
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.json
@@ -93,7 +93,7 @@
       "values": [
         "top left", "top middle", "top right",
         "center left", "center middle", "center right",
-        "bottom left", "bottom center", "bottom right"
+        "bottom left", "bottom middle", "bottom right"
       ],
       "default": "bottom right",
       "examples": [ "top left", "bottom right" ],
@@ -106,7 +106,7 @@
       "values": [
         "top left", "top middle", "top right",
         "center left", "center middle", "center right",
-        "bottom left", "bottom center", "bottom right"
+        "bottom left", "bottom middle", "bottom right"
       ],
       "default": "top right",
       "examples": [ "top left", "bottom right" ],


### PR DESCRIPTION
Typo in options for dropdown menu position, specifically "menu-self" and "menu-anchor". The value "center" produces an error, converted to "middle".

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
