### PR TITLE
fix(QEditor): allow to select single image for creating a link

### DIFF
--- a/ui/src/components/editor/editor-caret.js
+++ b/ui/src/components/editor/editor-caret.js
@@ -24,10 +24,10 @@ function getBlockElement (el, parent) {
   return getBlockElement(el.parentNode)
 }
 
-function isChildOf (el, parent, orSame = false) {
+function isChildOf (el, parent, orSame) {
   return !el || el === document.body
     ? false
-    : (orSame && el === parent) || (parent === document ? document.body : parent).contains(el.parentNode)
+    : (orSame === true && el === parent) || (parent === document ? document.body : parent).contains(el.parentNode)
 }
 
 function createRange (node, chars, range) {

--- a/ui/src/components/editor/editor-caret.js
+++ b/ui/src/components/editor/editor-caret.js
@@ -24,10 +24,10 @@ function getBlockElement (el, parent) {
   return getBlockElement(el.parentNode)
 }
 
-function isChildOf (el, parent) {
+function isChildOf (el, parent, orSame = false) {
   return !el || el === document.body
     ? false
-    : (parent === document ? document.body : parent).contains(el.parentNode)
+    : (orSame && el === parent) || (parent === document ? document.body : parent).contains(el.parentNode)
 }
 
 function createRange (node, chars, range) {
@@ -74,7 +74,7 @@ export class Caret {
       const sel = document.getSelection()
 
       // only when the selection in element
-      if (isChildOf(sel.anchorNode, this.el) && isChildOf(sel.focusNode, this.el)) {
+      if (isChildOf(sel.anchorNode, this.el, true) && isChildOf(sel.focusNode, this.el, true)) {
         return sel
       }
     }
@@ -295,7 +295,9 @@ export class Caret {
         const url = selection ? selection.toString() : ''
 
         if (!url.length) {
-          return
+          if (!this.range || !this.range.cloneContents().querySelector('img')) {
+            return
+          }
         }
 
         this.vm.editLinkUrl = urlRegex.test(url) ? url : 'https://'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Change to `isChildOf` is necessary, since when there's only `img` present in the editor and nothing else, `sel.anchorNode` and `sel.focusNode` are equal to `this.el`