### PR TITLE
fix(docs): css helper class "no-scrollbar" -> "hide-scrollbar"

### DIFF
--- a/docs/src/pages/style/other-helper-classes.md
+++ b/docs/src/pages/style/other-helper-classes.md
@@ -27,7 +27,7 @@ The list below is not complete. Also check the other CSS documentation pages lik
 | `overflow-auto` | Sets overflow to auto |
 | `overflow-hidden` | Sets overflow to hidden |
 | `overflow-hidden-y` | Sets overflow to hidden on the y-axis |
-| `no-scrollbar` | Removes the scrollbar |
+| `hide-scrollbar` | Removes the scrollbar |
 
 ## Size Related
 | Class Name | Description |


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**

In the current docs the css helper class `no-scrollbar` is mentioned. Since it did not work for me, and I found no such class in [visibility.sass](https://github.com/quasarframework/quasar/tree/dev/ui/src/css/core/visibility.sass) or its .styl equivalent, I think the docs should probably show the `hide-scrollbar` class instead.

Thank you for all your work! Cheers :)
