### PR TITLE
feat(QTable): New event - "row-contextmenu"

### DIFF
--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -1879,6 +1879,31 @@
       "addedIn": "v1.5.10"
     },
 
+    "row-contextmenu": {
+      "desc": "Emitted when user right clicks/long taps on a row; Is not emitted when using body/row/item scoped slots",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object",
+          "required": true,
+          "__exemption": [ "examples" ]
+        },
+
+        "row": {
+          "type": "Object",
+          "desc": "The row upon which user has right clicked/long tapped",
+          "__exemption": [ "examples" ]
+        },
+
+        "index": {
+          "type": "Number",
+          "desc": "Index of the row in the current page",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "addedIn": "v1.40.1"
+    },
+
     "request": {
       "desc": "Emitted when a server request is triggered",
       "params": {

--- a/ui/src/components/table/table-body.js
+++ b/ui/src/components/table/table-body.js
@@ -74,6 +74,13 @@ export default {
         }
       }
 
+      if (this.qListeners['row-contextmenu'] !== void 0) {
+        data.class['cursor-pointer'] = true
+        data.on.contextmenu = evt => {
+          this.$emit('row-contextmenu', evt, row, pageIndex)
+        }
+      }
+
       return h('tr', data, child)
     },
 


### PR DESCRIPTION
This pull request adds a `row-contextmenu` event to `QTable` which allows custom context menu per row to be implemented without a custom `body` slot.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
