### PR TITLE
Adding nine patch support to Android splashscreen generation (featur request #7751)

### DIFF
--- a/docs/src/pages/icongenie/command-list.md
+++ b/docs/src/pages/icongenie/command-list.md
@@ -112,6 +112,14 @@ $ icongenie generate -h
                           Default: 0,0
                           Example: "--padding 10,5" means apply 10px padding to top
                             10px to bottom, 5px to left side and 5px to rightside
+                            
+    --nine-patch          Generate Nine Patch based splash screens for Android if 
+                          splashscreen-icon-ratio > 0. Specify which percentage of the
+                          splashscreen will be used for stretching as x%, y%
+                          Default: none
+                          Example: "--nine-patch 5,10" defines 5% of image width both left
+                          and right and 10% of image height both top and bottom as stretchable
+                          areas.
 
     --theme-color         Theme color to use for all generators requiring a color;
                           It gets overridden if any generator color is also specified;

--- a/docs/src/pages/icongenie/profile-files.md
+++ b/docs/src/pages/icongenie/profile-files.md
@@ -34,6 +34,7 @@ Full list of props that you can write for the `params` object:
 | filter | String | Optionally filter the assets by generators; when used, it can generate only one type of asset instead of all | `ico` |
 | quality | Number [1-12] | Quality of the generated files; higher quality means bigger filesize, slower; lower quality means smaller filesize, faster | `12` |
 | padding | Array [Number] | (v2.1+) Apply fixed padding to the icon image after trimming it; Syntax: [ <horiz_px>, <vert_px> ]; Default is: [0, 0] | `[10, 0]` / `[5,5]` |
+| ninePatch | Array [Number] | (v2.3+) Make Android splashscreens properly stretchable by defining percentages of width / height which will be marked as stretchable; Syntax: [ <horiz_percent>, <vert_percent> ]; Default is: unset | `[10, 0]` / `[5,5]` |
 | skipTrim | Boolean | (v2.2+) Do not trim the icon source file | |
 | themeColor | String [hex] | Theme color to use for all generators requiring a color; it gets overridden if any generator color is also specified | `ccc` / `e2b399` |
 | pngColor | String [hex] | Background color to use for the png generator, when "background: true" in the asset definition (like for the cordova/capacitor iOS icons) | `ccc` / `e2b399` |

--- a/icongenie/bin/icongenie-generate
+++ b/icongenie/bin/icongenie-generate
@@ -13,10 +13,11 @@ const argv = parseArgs(processArgv, {
     q: 'quality',
     h: 'help'
   },
-  boolean: [ 'h', 'skip-trim', 'nine-patch' ],
+  boolean: [ 'h', 'skip-trim' ],
   string: [
     'p', 'i', 'b', 'm', 'f', 'q',
     'padding',
+    'nine-patch',
     'theme-color',
     'png-color',
     'splashscreen-color',
@@ -100,8 +101,12 @@ if (argv.help) {
                             - lower quality  --> smaller filesize & faster to create
 
     --nine-patch          Generate Nine Patch based splash screens for Android if 
-                          splashscreen-icon-ratio > 0.  Only the icon will be kept unscaled,
-                          optional background images will probably get scaled by Android.
+                          splashscreen-icon-ratio > 0. Specify which percentage of the
+                          splashscreen will be used for stretching as x%, y%
+                          Default: none
+                          Example: "--nine-patch 5,10" defines 5% of image width both left
+                          and right and 10% of image height both top and bottom as stretchable
+                          areas.
 
     --skip-trim           Do not trim the icon source file
 

--- a/icongenie/bin/icongenie-generate
+++ b/icongenie/bin/icongenie-generate
@@ -17,6 +17,7 @@ const argv = parseArgs(processArgv, {
   string: [
     'p', 'i', 'b', 'm', 'f', 'q',
     'padding',
+    'platform',
     'nine-patch',
     'theme-color',
     'png-color',
@@ -91,6 +92,13 @@ if (argv.help) {
                             [all|${modes}]
                           Multiple can be specified, separated by ",":
                             spa,cordova
+
+    --platform            Limit cordova and capacitor asset generation to a mobile platform;
+                          Default: all
+                          Values: ios, android
+                          Example: "--platform android" generate icons and splashscreen for
+                          Android platform only.  Together with --icon one can use platform
+                          specific base icons
 
     --filter, -f          Filter the available generators; when used, it can
                           generate only one type of asset instead of all

--- a/icongenie/bin/icongenie-generate
+++ b/icongenie/bin/icongenie-generate
@@ -100,14 +100,6 @@ if (argv.help) {
                             - higher quality --> bigger filesize & slower to create
                             - lower quality  --> smaller filesize & faster to create
 
-    --nine-patch          Generate Nine Patch based splash screens for Android if 
-                          splashscreen-icon-ratio > 0. Specify which percentage of the
-                          splashscreen will be used for stretching as x%, y%
-                          Default: none
-                          Example: "--nine-patch 5,10" defines 5% of image width both left
-                          and right and 10% of image height both top and bottom as stretchable
-                          areas.
-
     --skip-trim           Do not trim the icon source file
 
     --padding             Apply fixed padding to the icon after trimming it;
@@ -115,6 +107,14 @@ if (argv.help) {
                           Default: 0,0
                           Example: "--padding 10,5" means apply 10px padding to top
                             10px to bottom, 5px to left side and 5px to rightside
+
+    --nine-patch          Generate Nine Patch based splash screens for Android if 
+                          splashscreen-icon-ratio > 0. Specify which percentage of the
+                          splashscreen will be used for stretching as x%, y%
+                          Default: none
+                          Example: "--nine-patch 5,10" defines 5% of image width both left
+                          and right and 10% of image height both top and bottom as stretchable
+                          areas.
 
     --theme-color         Theme color to use for all generators requiring a color;
                           It gets overridden if any generator color is also specified;

--- a/icongenie/bin/icongenie-generate
+++ b/icongenie/bin/icongenie-generate
@@ -13,7 +13,7 @@ const argv = parseArgs(processArgv, {
     q: 'quality',
     h: 'help'
   },
-  boolean: [ 'h', 'skip-trim' ],
+  boolean: [ 'h', 'skip-trim', 'nine-patch' ],
   string: [
     'p', 'i', 'b', 'm', 'f', 'q',
     'padding',
@@ -98,6 +98,10 @@ if (argv.help) {
     --quality             Quality of the files [1 - 12] (default: ${defaultParams.quality})
                             - higher quality --> bigger filesize & slower to create
                             - lower quality  --> smaller filesize & faster to create
+
+    --nine-patch          Generate Nine Patch based splash screens for Android if 
+                          splashscreen-icon-ratio > 0.  Only the icon will be kept unscaled,
+                          optional background images will probably get scaled by Android.
 
     --skip-trim           Do not trim the icon source file
 

--- a/icongenie/bin/icongenie-profile
+++ b/icongenie/bin/icongenie-profile
@@ -88,14 +88,6 @@ if (argv.help) {
                             - higher quality --> bigger filesize & slower to create
                             - lower quality  --> smaller filesize & faster to create
 
-    --nine-patch          Generate Nine Patch based splash screens for Android if 
-                          splashscreen-icon-ratio > 0. Specify which percentage of the
-                          splashscreen will be used for stretching as x%, y%
-                          Default: none
-                          Example: "--nine-patch 5,10" defines 5% of image width both left
-                          and right and 10% of image height both top and bottom as stretchable
-                          areas.
-
     --skip-trim           Do not trim the icon source file
 
     --padding             Apply fixed padding to the icon after trimming it;
@@ -104,6 +96,14 @@ if (argv.help) {
                           Example: "--padding 10,5" means apply 10px padding to top
                             10px to bottom, 5px to left side and 5px to rightside
 
+    --nine-patch          Generate Nine Patch based splash screens for Android if 
+                          splashscreen-icon-ratio > 0. Specify which percentage of the
+                          splashscreen will be used for stretching as x%, y%
+                          Default: none
+                          Example: "--nine-patch 5,10" defines 5% of image width both left
+                          and right and 10% of image height both top and bottom as stretchable
+                          areas.
+  
     --theme-color         Prefill the params.themeColor property;
                           Theme color to use for all generators requiring a color;
                           It gets overridden if any generator color is also specified;

--- a/icongenie/bin/icongenie-profile
+++ b/icongenie/bin/icongenie-profile
@@ -13,11 +13,12 @@ const argv = parseArgs(process.argv.slice(2), {
     q: 'quality',
     h: 'help'
   },
-  boolean: [ 'h', 'skip-trim', 'nine-patch' ],
+  boolean: [ 'h', 'skip-trim' ],
   string: [
     'o', 'a',
     'i', 'b', 'include', 'f', 'q',
     'padding',
+    'nine-patch',
     'theme-color',
     'png-color',
     'splashscreen-color',
@@ -88,8 +89,12 @@ if (argv.help) {
                             - lower quality  --> smaller filesize & faster to create
 
     --nine-patch          Generate Nine Patch based splash screens for Android if 
-                          splashscreen-icon-ratio > 0.  Only the icon will be kept unscaled,
-                          optional background images will probably get scaled by Android.
+                          splashscreen-icon-ratio > 0. Specify which percentage of the
+                          splashscreen will be used for stretching as x%, y%
+                          Default: none
+                          Example: "--nine-patch 5,10" defines 5% of image width both left
+                          and right and 10% of image height both top and bottom as stretchable
+                          areas.
 
     --skip-trim           Do not trim the icon source file
 

--- a/icongenie/bin/icongenie-profile
+++ b/icongenie/bin/icongenie-profile
@@ -18,6 +18,7 @@ const argv = parseArgs(process.argv.slice(2), {
     'o', 'a',
     'i', 'b', 'include', 'f', 'q',
     'padding',
+    'platform',
     'nine-patch',
     'theme-color',
     'png-color',

--- a/icongenie/bin/icongenie-profile
+++ b/icongenie/bin/icongenie-profile
@@ -13,7 +13,7 @@ const argv = parseArgs(process.argv.slice(2), {
     q: 'quality',
     h: 'help'
   },
-  boolean: [ 'h', 'skip-trim' ],
+  boolean: [ 'h', 'skip-trim', 'nine-patch' ],
   string: [
     'o', 'a',
     'i', 'b', 'include', 'f', 'q',
@@ -86,6 +86,10 @@ if (argv.help) {
                           Quality of the files [1 - 12] (default: ${defaultParams.quality})
                             - higher quality --> bigger filesize & slower to create
                             - lower quality  --> smaller filesize & faster to create
+
+    --nine-patch          Generate Nine Patch based splash screens for Android if 
+                          splashscreen-icon-ratio > 0.  Only the icon will be kept unscaled,
+                          optional background images will probably get scaled by Android.
 
     --skip-trim           Do not trim the icon source file
 

--- a/icongenie/lib/cmd/generate.js
+++ b/icongenie/lib/cmd/generate.js
@@ -28,6 +28,7 @@ function printBanner (assetsOf, params) {
  Background source file..... ${params.background ? green(params.background) : 'none'}
  Assets of.................. ${green(assetsOf)}
  Generator filter........... ${params.filter ? green(params.filter) : 'none'}
+ Capacitor/Cordova filter... ${params.platform ? green(params.platform) : 'none'}
  Svg color.................. ${green(params.svgColor)}
  Png color.................. ${green(params.pngColor)}
  Splashscreen color......... ${green(params.splashscreenColor)}
@@ -109,6 +110,12 @@ async function generateFromProfile (profile) {
     )
   }
 
+  if (params.platform) {
+    uniqueFiles = uniqueFiles.filter(
+      file => !file.platform || file.platform.endsWith(params.platform)
+    )
+  }
+
   if (uniqueFiles.length === 0) {
     warn(`No assets to generate! No mode/include specified, filter too specific or the respective Quasar mode(s) are not installed`)
     return Promise.resolve(0)
@@ -155,7 +162,7 @@ module.exports = function generate (argv) {
   profile.params = mergeObjects({}, profile.params)
   
   parseArgv(profile.params, [
-    'quality', 'filter', 'padding', 'ninePatch',
+    'quality', 'filter', 'padding', 'platform', 'ninePatch',
     'icon', 'background',
     'splashscreenIconRatio',
     // order matters:

--- a/icongenie/lib/cmd/generate.js
+++ b/icongenie/lib/cmd/generate.js
@@ -19,20 +19,21 @@ const validateProfileObject = require('../utils/validate-profile-object')
 
 function printBanner (assetsOf, params) {
   console.log(` Generating files with the following options:
- ==========================
- Quasar project folder..... ${green(appDir)}
- ${green(`Quality level............. ${params.quality}/12`)}
- Icon source file.......... ${green(params.icon)}
- Icon trimming............. ${params.skipTrim ? 'no' : green('yes')}
- Icon padding.............. ${green(`horizontal: ${params.padding[0]}; vertical: ${params.padding[1]}`)}
- Background source file.... ${params.background ? green(params.background) : 'none'}
- Assets of................. ${green(assetsOf)}
- Generator filter.......... ${params.filter ? green(params.filter) : 'none'}
- Svg color................. ${green(params.svgColor)}
- Png color................. ${green(params.pngColor)}
- Splashscreen color........ ${green(params.splashscreenColor)}
- Splashscreen icon ratio... ${green(params.splashscreenIconRatio)}%
- ==========================
+ ===========================
+ Quasar project folder...... ${green(appDir)}
+ ${green(`Quality level.............. ${params.quality}/12`)}
+ Icon source file........... ${green(params.icon)}
+ Icon trimming.............. ${params.skipTrim ? 'no' : green('yes')}
+ Icon padding............... ${green(`horizontal: ${params.padding[0]}; vertical: ${params.padding[1]}`)}
+ Background source file..... ${params.background ? green(params.background) : 'none'}
+ Assets of.................. ${green(assetsOf)}
+ Generator filter........... ${params.filter ? green(params.filter) : 'none'}
+ Svg color.................. ${green(params.svgColor)}
+ Png color.................. ${green(params.pngColor)}
+ Splashscreen color......... ${green(params.splashscreenColor)}
+ Splashscreen icon ratio.... ${green(params.splashscreenIconRatio)}%
+ Splash Nine Patch (Android) ${green(params.ninePatch)}
+ ===========================
 `)
 }
 

--- a/icongenie/lib/cmd/generate.js
+++ b/icongenie/lib/cmd/generate.js
@@ -32,7 +32,7 @@ function printBanner (assetsOf, params) {
  Png color.................. ${green(params.pngColor)}
  Splashscreen color......... ${green(params.splashscreenColor)}
  Splashscreen icon ratio.... ${green(params.splashscreenIconRatio)}%
- Splash Nine Patch (Android) ${green(params.ninePatch)}
+ Splash Nine Patch (Android) ${params.ninePatch ? green(`horizontal: ${params.ninePatch[0]}%, vertical: ${params.ninePatch[1]}%`) : 'no'}
  ===========================
 `)
 }
@@ -153,9 +153,9 @@ module.exports = function generate (argv) {
   }
 
   profile.params = mergeObjects({}, profile.params)
-
+  
   parseArgv(profile.params, [
-    'quality', 'filter', 'padding',
+    'quality', 'filter', 'padding', 'ninePatch',
     'icon', 'background',
     'splashscreenIconRatio',
     // order matters:

--- a/icongenie/lib/generators/splashscreen.js
+++ b/icongenie/lib/generators/splashscreen.js
@@ -25,17 +25,20 @@ module.exports = async function (file, opts, done) {
     // - if nine patch: extend image and add nine patch 'borders' to compositionArray
     if (file.ninePatchCheck) {
       if (opts.ninePatch) {
-        if (statSync(file.absoluteName).size > 0) {
-          warn(
-            "Nine Patch file generation requested, removing non-nine patch file " +
-              file.absoluteName
-          );
+        if (existsSync(file.absoluteName)) {
+          // zero sized files are from generate.js::ensureFileSync and can removed without notice
+          if (statSync(file.absoluteName).size > 0) {
+            warn(
+              "Nine Patch file generation requested, removing non-nine patch file " +
+                file.absoluteName
+            );
+          }
           unlinkSync(file.relativeName);
         }
         file.absoluteName = file.absoluteName.replace(".png", ".9.png");
         file.relativeName = file.relativeName.replace(".png", ".9.png");
 
-        // extend image by 2x2 with transparent 'border'
+        // extend image with 1 pixel transparent 'border'
         img.extend({
           top: 1,
           bottom: 1,
@@ -43,21 +46,38 @@ module.exports = async function (file, opts, done) {
           right: 1,
           background: { r: 0, g: 0, b: 0, alpha: 0 },
         });
-        // add black borders to each corner
+        // add black stretch markers to each corner, leaving corner pixel transparent
         ["northwest", "northeast", "southwest", "southeast"].forEach(
           (gravity) => {
-            compositionArray.unshift({
-              input: {
-                create: {
-                  width: Math.round(file.width*opts.ninePatch[0]/100),
-                  height: Math.round(file.height*opts.ninePatch[1]/100),
-                  channels: 4,
-                  background: { r: 0, g: 0, b: 0, alpha: 1 },
+            compositionArray.unshift(
+           
+              {
+                input: {
+                  create: {
+                    width:
+                      Math.round((file.width * opts.ninePatch[0]) / 100) + 1,
+                    height:
+                      Math.round((file.height * opts.ninePatch[1]) / 100) + 1,
+                    channels: 4,
+                    background: { r: 0, g: 0, b: 0, alpha: 1 },
+                  },
                 },
+                gravity: gravity,
+                blend: "dest-over",
               },
-              gravity: gravity,
-              blend: "dest-over",
-            });
+              {
+                input: {
+                  create: {
+                    width: 1,
+                    height: 1,
+                    channels: 4,
+                    background: { r: 0, g: 0, b: 0, alpha: 1 },
+                  },
+                },
+                gravity: gravity,
+                blend: "dest-out",
+              },
+            );
           }
         );
       } else {

--- a/icongenie/lib/generators/splashscreen.js
+++ b/icongenie/lib/generators/splashscreen.js
@@ -18,7 +18,7 @@ module.exports = async function (file, opts, done) {
       padding: opts.padding,
     });
 
-    const compositionArray = [{ input: await icon.toBuffer() }];
+    const compositionArray = [{ input: await icon.toBuffer(), blend: 'atop' }];
 
     // if this file is a possible nine patch:
     // - cleanup depending on --nine-patch command line option
@@ -48,8 +48,28 @@ module.exports = async function (file, opts, done) {
           right: 1,
           background: { r: 0, g: 0, b: 0, alpha: 1 },
         });
+
+         // clear corner pixels
+         ["northwest"].forEach(
+        //  ["northwest", "northeast", "southwest", "southeast"].forEach(
+          (gravity) => {
+            compositionArray.push({
+              input: {
+                create: {
+                  width: 1,
+                  height: 1,
+                  channels: 3,
+                  background: { r: 0, g: 0, b: 0, alpha: 0 },
+                },
+              },
+              gravity: gravity,
+              blend: "dest-out",
+            });
+          }
+        );
+
         // cut out non-stretchable areas
-        compositionArray.unshift(
+        compositionArray.push(
           {
             input: {
               create: {
@@ -80,23 +100,7 @@ module.exports = async function (file, opts, done) {
           }
         );
 
-        // clear corner pixels
-        ["northwest", "northeast", "southwest", "southeast"].forEach(
-          (gravity) => {
-            compositionArray.unshift({
-              input: {
-                create: {
-                  width: 1,
-                  height: 1,
-                  channels: 4,
-                  background: { r: 0, g: 0, b: 0, alpha: 1 },
-                },
-              },
-              gravity: gravity,
-              blend: "dest-out",
-            });
-          }
-        );
+       
       } else {
         const ninePatchAbsoluteName = file.absoluteName.replace(
           ".png",

--- a/icongenie/lib/generators/splashscreen.js
+++ b/icongenie/lib/generators/splashscreen.js
@@ -49,8 +49,8 @@ module.exports = async function (file, opts, done) {
             compositionArray.unshift({
               input: {
                 create: {
-                  width: Math.round((file.width - icon.options.width) / 2),
-                  height: Math.round((file.height - icon.options.height) / 2),
+                  width: Math.round(file.width*opts.ninePatch[0]/100),
+                  height: Math.round(file.height*opts.ninePatch[1]/100),
                   channels: 4,
                   background: { r: 0, g: 0, b: 0, alpha: 1 },
                 },

--- a/icongenie/lib/generators/splashscreen.js
+++ b/icongenie/lib/generators/splashscreen.js
@@ -1,33 +1,86 @@
-const getSquareIcon = require('../utils/get-square-icon')
+const { unlinkSync, existsSync, statSync } = require("fs");
+
+const getSquareIcon = require("../utils/get-square-icon");
+const { warn } = require("../utils/logger");
 
 module.exports = async function (file, opts, done) {
-  const size = Math.min(file.width, file.height)
+  const size = Math.min(file.width, file.height);
 
-  const img = opts.background
-    .clone()
-    .resize(file.width, file.height)
-    .flatten({
-      background: opts.splashscreenColor
-    })
+  const img = opts.background.clone().resize(file.width, file.height).flatten({
+    background: opts.splashscreenColor,
+  });
 
   if (opts.splashscreenIconRatio > 0) {
     const icon = getSquareIcon({
       file,
       icon: opts.icon,
-      size: Math.round(size * opts.splashscreenIconRatio / 100),
-      padding: opts.padding
-    })
+      size: Math.round((size * opts.splashscreenIconRatio) / 100),
+      padding: opts.padding,
+    });
 
-    const buffer = await icon.toBuffer()
+    const compositionArray = [{ input: await icon.toBuffer() }];
 
-    img.composite([
-      { input: buffer }
-    ])
+    // if this file is a possible nine patch:
+    // - cleanup depending on --nine-patch command line option
+    // - if nine patch: extend image and add nine patch 'borders' to compositionArray
+    if (file.ninePatchCheck) {
+      if (opts.ninePatch) {
+        if (statSync(file.absoluteName).size > 0) {
+          warn(
+            "Nine Patch file generation requested, removing non-nine patch file " +
+              file.absoluteName
+          );
+          unlinkSync(file.relativeName);
+        }
+        file.absoluteName = file.absoluteName.replace(".png", ".9.png");
+        file.relativeName = file.relativeName.replace(".png", ".9.png");
+
+        // extend image by 2x2 with transparent 'border'
+        img.extend({
+          top: 1,
+          bottom: 1,
+          left: 1,
+          right: 1,
+          background: { r: 0, g: 0, b: 0, alpha: 0 },
+        });
+        // add black borders to each corner
+        ["northwest", "northeast", "southwest", "southeast"].forEach(
+          (gravity) => {
+            compositionArray.unshift({
+              input: {
+                create: {
+                  width: Math.round((file.width - icon.options.width) / 2),
+                  height: Math.round((file.height - icon.options.height) / 2),
+                  channels: 4,
+                  background: { r: 0, g: 0, b: 0, alpha: 1 },
+                },
+              },
+              gravity: gravity,
+              blend: "dest-over",
+            });
+          }
+        );
+      } else {
+        const ninePatchAbsoluteName = file.absoluteName.replace(
+          ".png",
+          ".9.png"
+        );
+        if (existsSync(ninePatchAbsoluteName)) {
+          warn(
+            "Nine Patch file generation not requested, removing nine patch file " +
+              file.relativeName.replace(".png", ".9.png")
+          );
+          unlinkSync(ninePatchAbsoluteName);
+        }
+      }
+    }
+
+    img.composite(compositionArray);
   }
 
   img
     .png()
     .toFile(file.absoluteName)
     .then(() => opts.compression.png(file.absoluteName))
-    .then(done)
-}
+    .then(done);
+};

--- a/icongenie/lib/modes/quasar-app-v1/capacitor.js
+++ b/icongenie/lib/modes/quasar-app-v1/capacitor.js
@@ -6,7 +6,8 @@ function getAndroidIcons (entries) {
   entries.forEach(entry => {
     const icon = {
       generator: 'png',
-      folder: `src-capacitor/android/app/src/main/res/mipmap-${entry[0]}`
+      folder: `src-capacitor/android/app/src/main/res/mipmap-${entry[0]}`,
+      platform: 'capacitor-android'
     }
 
     list.push({
@@ -38,7 +39,8 @@ function getAndroidSplashscreen (entries) {
     const icon = {
       generator: 'splashscreen',
       name: 'splash.png',
-      ninePatchCheck: true
+      ninePatchCheck: true,
+      platform: 'capacitor-android'
     }
 
     list.push({
@@ -73,7 +75,8 @@ function getIosIcon (name) {
         ? parseFloat(size) * parseInt(multiplier,10)
         : parseFloat(size)
     ],
-    background: true
+    background: true,
+    platform: 'capacitor-ios'
   }
 }
 
@@ -97,7 +100,8 @@ module.exports = [
     folder: 'src-capacitor/android/app/src/main/res/drawable',
     sizes: [
       [ 480, 320 ]
-    ]
+    ],
+    platform: 'capacitor-android'
   },
 
   ...getAndroidSplashscreen([
@@ -137,20 +141,23 @@ module.exports = [
     generator: 'splashscreen',
     name: 'splash-2732x2732-1.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   },
 
   {
     generator: 'splashscreen',
     name: 'splash-2732x2732-2.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   },
 
   {
     generator: 'splashscreen',
     name: 'splash-2732x2732.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   }
 ]

--- a/icongenie/lib/modes/quasar-app-v1/capacitor.js
+++ b/icongenie/lib/modes/quasar-app-v1/capacitor.js
@@ -37,7 +37,8 @@ function getAndroidSplashscreen (entries) {
   entries.forEach(entry => {
     const icon = {
       generator: 'splashscreen',
-      name: 'splash.png'
+      name: 'splash.png',
+      ninePatchCheck: true
     }
 
     list.push({
@@ -92,6 +93,7 @@ module.exports = [
   {
     generator: 'splashscreen',
     name: 'splash.png',
+    ninePatchCheck: true,
     folder: 'src-capacitor/android/app/src/main/res/drawable',
     sizes: [
       [ 480, 320 ]

--- a/icongenie/lib/modes/quasar-app-v1/cordova.js
+++ b/icongenie/lib/modes/quasar-app-v1/cordova.js
@@ -18,6 +18,7 @@ function getAndroidSplashscreens (entries) {
     list.push({
       generator: 'splashscreen',
       name: `splash-land-${entry[0]}.png`,
+      ninePatchCheck: true,
       folder: 'src-cordova/res/screen/android',
       sizes: [
         [ entry[1], entry[2] ]
@@ -29,6 +30,7 @@ function getAndroidSplashscreens (entries) {
     list.push({
       generator: 'splashscreen',
       name: `splash-port-${entry[0]}.png`,
+      ninePatchCheck: true,
       folder: 'src-cordova/res/screen/android',
       sizes: [
         [ entry[2], entry[1] ]

--- a/icongenie/lib/modes/quasar-app-v2/capacitor.js
+++ b/icongenie/lib/modes/quasar-app-v2/capacitor.js
@@ -6,7 +6,8 @@ function getAndroidIcons (entries) {
   entries.forEach(entry => {
     const icon = {
       generator: 'png',
-      folder: `src-capacitor/android/app/src/main/res/mipmap-${entry[0]}`
+      folder: `src-capacitor/android/app/src/main/res/mipmap-${entry[0]}`,
+      platform: 'capacitor-android'
     }
 
     list.push({
@@ -38,7 +39,8 @@ function getAndroidSplashscreen (entries) {
     const icon = {
       generator: 'splashscreen',
       name: 'splash.png',
-      ninePatchCheck: true
+      ninePatchCheck: true,
+      platform: 'capacitor-android'
     }
 
     list.push({
@@ -73,7 +75,8 @@ function getIosIcon (name) {
         ? parseFloat(size) * parseInt(multiplier,10)
         : parseFloat(size)
     ],
-    background: true
+    background: true,
+    platform: 'capacitor-ios'
   }
 }
 
@@ -97,7 +100,8 @@ module.exports = [
     folder: 'src-capacitor/android/app/src/main/res/drawable',
     sizes: [
       [ 480, 320 ]
-    ]
+    ],
+    platform: 'capacitor-android'
   },
 
   ...getAndroidSplashscreen([
@@ -137,20 +141,23 @@ module.exports = [
     generator: 'splashscreen',
     name: 'splash-2732x2732-1.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   },
 
   {
     generator: 'splashscreen',
     name: 'splash-2732x2732-2.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   },
 
   {
     generator: 'splashscreen',
     name: 'splash-2732x2732.png',
     folder: 'src-capacitor/ios/App/App/Assets.xcassets/Splash.imageset',
-    sizes: [ 2732 ]
+    sizes: [ 2732 ],
+    platform: 'capacitor-ios'
   }
 ]

--- a/icongenie/lib/modes/quasar-app-v2/capacitor.js
+++ b/icongenie/lib/modes/quasar-app-v2/capacitor.js
@@ -37,7 +37,8 @@ function getAndroidSplashscreen (entries) {
   entries.forEach(entry => {
     const icon = {
       generator: 'splashscreen',
-      name: 'splash.png'
+      name: 'splash.png',
+      ninePatchCheck: true
     }
 
     list.push({
@@ -92,6 +93,7 @@ module.exports = [
   {
     generator: 'splashscreen',
     name: 'splash.png',
+    ninePatchCheck: true,
     folder: 'src-capacitor/android/app/src/main/res/drawable',
     sizes: [
       [ 480, 320 ]

--- a/icongenie/lib/modes/quasar-app-v2/cordova.js
+++ b/icongenie/lib/modes/quasar-app-v2/cordova.js
@@ -18,6 +18,7 @@ function getAndroidSplashscreens (entries) {
     list.push({
       generator: 'splashscreen',
       name: `splash-land-${entry[0]}.png`,
+      ninePatchCheck: true,
       folder: 'src-cordova/res/screen/android',
       sizes: [
         [ entry[1], entry[2] ]
@@ -29,6 +30,7 @@ function getAndroidSplashscreens (entries) {
     list.push({
       generator: 'splashscreen',
       name: `splash-port-${entry[0]}.png`,
+      ninePatchCheck: true,
       folder: 'src-cordova/res/screen/android',
       sizes: [
         [ entry[2], entry[1] ]

--- a/icongenie/lib/utils/parse-argv.js
+++ b/icongenie/lib/utils/parse-argv.js
@@ -124,6 +124,31 @@ function padding (value, argv) {
     : sizes
 }
 
+function ninePatch (value, argv) {
+  if (!value) {
+    argv.ninePatch = false;
+    return
+  }
+
+  const sizes = (Array.isArray(value) ? value : value.split(','))
+    .map(val => parseInt(val, 10))
+
+  if (sizes.length != 2) {
+    die(`Invalid number of nine patch sizes specified`)
+  }
+
+  sizes.forEach(size => {
+    if (isNaN(size)) {
+      die(`Invalid nine patch sizes specified (not numbers)`)
+    }
+    if (size < 0) {
+      die(`Invalid nine patch sizes specified (not all positive numbers)`)
+    }
+  })
+
+  argv.ninePatch = sizes;
+}
+
 function icon (value, argv) {
   if (!value) {
     warn(`No source icon file specified, so using the sample one`)
@@ -245,6 +270,7 @@ const parsers = {
   quality,
   filter,
   padding,
+  ninePatch,
   icon,
   background,
   splashscreenIconRatio,

--- a/icongenie/lib/utils/parse-argv.js
+++ b/icongenie/lib/utils/parse-argv.js
@@ -124,6 +124,13 @@ function padding (value, argv) {
     : sizes
 }
 
+function platform (value) {
+  if (value && !["ios", "android"].includes(value)) {
+    die(`Unknown platform value specified (${value})`)
+  }
+}
+
+
 function ninePatch (value, argv) {
   if (!value) {
     argv.ninePatch = false;
@@ -270,6 +277,7 @@ const parsers = {
   quality,
   filter,
   padding,
+  platform,
   ninePatch,
   icon,
   background,

--- a/icongenie/lib/utils/validate-profile-object.js
+++ b/icongenie/lib/utils/validate-profile-object.js
@@ -16,12 +16,15 @@ const baseParamsSchema = {
   filter: Joi.string().valid(...generatorsList),
   quality: Joi.number().integer().min(1).max(12),
 
-  ninePatch: Joi.boolean(),
   skipTrim: Joi.boolean(),
   padding: Joi.array().items(
     Joi.number().integer().min(0)
   ).min(1).max(2),
-
+  ninePatch: Joi.alternatives().try(
+    Joi.boolean(),
+    Joi.array().items(Joi.number().integer().min(0)).min(2).max(2)
+  ),
+  
   splashscreenIconRatio: Joi.number().integer().min(0).max(100)
 }
 
@@ -80,7 +83,7 @@ module.exports = function validateProfileObject (profileObject, generatingProfil
     params: getParamsSchema(generatingProfileFile),
     assets: assetsSchema
   })
-
+  
   const { error } = profileSchema.validate(profileObject)
   if (error) {
     console.error(` ${red('ERROR')}: Input parameters are not valid. Please correct them.`)

--- a/icongenie/lib/utils/validate-profile-object.js
+++ b/icongenie/lib/utils/validate-profile-object.js
@@ -16,6 +16,7 @@ const baseParamsSchema = {
   filter: Joi.string().valid(...generatorsList),
   quality: Joi.number().integer().min(1).max(12),
 
+  ninePatch: Joi.boolean(),
   skipTrim: Joi.boolean(),
   padding: Joi.array().items(
     Joi.number().integer().min(0)

--- a/icongenie/lib/utils/validate-profile-object.js
+++ b/icongenie/lib/utils/validate-profile-object.js
@@ -20,6 +20,7 @@ const baseParamsSchema = {
   padding: Joi.array().items(
     Joi.number().integer().min(0)
   ).min(1).max(2),
+  platform: Joi.string().valid("ios", "android"),
   ninePatch: Joi.alternatives().try(
     Joi.boolean(),
     Joi.array().items(Joi.number().integer().min(0)).min(2).max(2)

--- a/icongenie/package.json
+++ b/icongenie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quasar/icongenie",
-  "version": "2.3.3",
+  "version": "2.3.4-cc",
   "description": "A Quasar tool for generating all your Quasar App's icons and splashscreens",
   "bin": {
     "icongenie": "./bin/icongenie"

--- a/icongenie/samples/icongenie-profile.json
+++ b/icongenie/samples/icongenie-profile.json
@@ -90,6 +90,7 @@
     {
       "generator": "splashscreen",
       "name": "splash-land-xxxhdpi.png",
+      "ninePatchCheck": true,
       "folder": "src-cordova/res/screen/android",
       "sizes": [
         [ 1920, 1280 ]


### PR DESCRIPTION
Adds parameter --nine-patch which lets splashscreens for Android be generated
as 9-patch files if splashscreen-icon-ratio > 0.  Stretchable area must be defined in percentage
of width and height (e.g. --nine-patch 5,10 will result in 5% of image width left and 5%
of image width right, as well as 10% of image height both top and bottom to be stretchable)

Please see https://github.com/quasarframework/quasar/issues/7751 for a rationale.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
