### PR TITLE
fix(QTime): display 00 or 12 based in computedFormat24h

### DIFF
--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -261,7 +261,7 @@ export default Vue.extend({
           actualVal = val + offset,
           disable = inSel !== void 0 && inSel(actualVal) === false,
           label = this.view === 'Hour' && val === 0
-            ? (this.format24h === true ? '00' : '12')
+            ? (this.computedFormat24h === true ? '00' : '12')
             : val
 
         pos.push({ val: actualVal, index, disable, label })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Currently 00 vs 12 is based on direct `format24h` prop, generating a double 12 on languages which use 24h format

![image](https://user-images.githubusercontent.com/10036108/94457079-64187e80-01b4-11eb-85e1-8b694f523a62.png)
