### PR TITLE
feat(QTree): General handler for clicking node

### DIFF
--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -487,7 +487,8 @@ export default Vue.extend({
           class: {
             'q-tree__node--link q-hoverable q-focusable': meta.link,
             'q-tree__node--selected': meta.selected,
-            'q-tree__node--disabled': meta.disabled
+            'q-tree__node--disabled': meta.disabled,
+            'q-tree__node--link': this.$attrs.handler
           },
           attrs: { tabindex: meta.link ? 0 : -1 },
           on: {

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -599,7 +599,7 @@ export default Vue.extend({
       else if (typeof node.handler === 'function') {
         node.handler(node)
       }
-      else if (typeof this.$attrs.handler === 'function') {
+      else if (typeof this.$attrs.handler === 'function' && !meta.selectable) {
         this.$attrs.handler(node)
       }
       else {

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -595,12 +595,14 @@ export default Vue.extend({
           this.$emit('update:selected', meta.key !== this.selected ? meta.key : null)
         }
       }
+      else if (typeof node.handler === 'function') {
+        node.handler(node)
+      }
+      else if (typeof this.$attrs.handler === 'function') {
+        this.$attrs.handler(node)
+      }
       else {
         this.__onExpandClick(node, meta, e, keyboard)
-      }
-
-      if (typeof node.handler === 'function') {
-        node.handler(node)
       }
     },
 

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -485,10 +485,10 @@ export default Vue.extend({
         h('div', {
           staticClass: 'q-tree__node-header relative-position row no-wrap items-center',
           class: {
-            'q-tree__node--link q-hoverable q-focusable': meta.link,
+            'q-tree__node--link': meta.link || this.$attrs.handler,
+            'q-hoverable q-focusable': meta.link || this.$attrs.handler,
             'q-tree__node--selected': meta.selected,
-            'q-tree__node--disabled': meta.disabled,
-            'q-tree__node--link': this.$attrs.handler
+            'q-tree__node--disabled': meta.disabled
           },
           attrs: { tabindex: meta.link ? 0 : -1 },
           on: {

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -599,7 +599,7 @@ export default Vue.extend({
       else if (typeof node.handler === 'function') {
         node.handler(node)
       }
-      else if (typeof this.$attrs.handler === 'function' && !meta.selectable) {
+      else if (typeof this.$attrs.handler === 'function') {
         this.$attrs.handler(node)
       }
       else {


### PR DESCRIPTION
A general handler for clicking node's header is introduced and preferred over expand click. Can be overridden by node handler.
```
<qtree
  :handler="generalNodeClick"
/>
```

With a general handler, it is not necessary to specify individual handler for each node in the data.


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
