### PR TITLE
QTime: set minutes/seconds to 0 by default after switching views

### DIFF
--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -379,9 +379,11 @@ export default Vue.extend({
     __goToNextView () {
       if (this.view === 'Hour') {
         this.view = 'Minute'
+        this.__setMinute(0)
       }
       else if (this.withSeconds && this.view === 'Minute') {
         this.view = 'Second'
+        this.__setSecond(0)
       }
     },
 


### PR DESCRIPTION
I have had complaints from clients that the QTime is not working logically. The problem is that very often, when the client is selecting the time, it is sharp such as 13:00, 16:00 or 20:00 (or if seconds are used, 13:00:00, 15:30:00, etc). Currently, when the hour is clicked, the minute selection becomes visible, and the minute is null (not selected) by default. At this point the client is practically ready and he/she is willing to click OK button. However, the minute (0) is still required to be selected, which creates unnecessary step for the client. 

Solution: after switching from hour view to minute view, we set the minute to 0 by default (and seconds as well, when entering from minute view to seconds view). This modification is added to this PR.

I don't see any reason why the minute/second should be null after selecting hour/minute.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
