### PR TITLE
fix(app): vuedevtools vuex tab does not work via `quasar build` (#7911)

### DIFF
--- a/app/bin/quasar-build
+++ b/app/bin/quasar-build
@@ -288,7 +288,7 @@ async function build () {
           await quasarConf.build.onPublish(opts)
         }
 
-        // run possible beforeBuild hooks
+        // run possible onPublish hooks
         await extensionRunner.runHook('onPublish', async hook => {
           log(`Extension(${hook.api.extId}): Running onPublish hook...`)
           await hook.fn(hook.api, opts)

--- a/app/lib/quasar-conf-file.js
+++ b/app/lib/quasar-conf-file.js
@@ -789,6 +789,7 @@ class QuasarConfFile {
       SERVER: false,
       DEV: this.ctx.dev,
       PROD: this.ctx.prod,
+      DEBUG: this.ctx.debug || this.ctx.dev,
       MODE: this.ctx.modeName,
       VUE_ROUTER_MODE: cfg.build.vueRouterMode,
       VUE_ROUTER_BASE: cfg.build.vueRouterBase,

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -341,7 +341,8 @@ module.exports = function (cfg, configName) {
         '**/.Thumbs.db',
         '**/*.sublime*',
         '**/.idea',
-        '**/.editorconfig'
+        '**/.editorconfig',
+        '**/.vscode'
       ]
 
       // avoid useless files to be copied

--- a/app/templates/store/default/index.js
+++ b/app/templates/store/default/index.js
@@ -23,8 +23,8 @@ export default function (/* { ssrContext } */) {
     },
 
     // enable strict mode (adds overhead!)
-    // for dev mode only
-    strict: process.env.DEV
+    // for dev mode and --debug builds only
+    strict: process.env.DEBUG
   })
 
   return Store

--- a/app/templates/store/ts/index.ts
+++ b/app/templates/store/ts/index.ts
@@ -25,8 +25,8 @@ export default store(function ({ Vue }) {
     },
 
     // enable strict mode (adds overhead!)
-    // for dev mode only
-    strict: !!process.env.DEV
+    // for dev mode and --debug builds only
+    strict: !!process.env.DEBUG
   });
 
   return Store;


### PR DESCRIPTION
This is missing the code from templates -> entry -> client-entry.js as the Vue.config no longer exists there