### PR TITLE
Fix: #7961 (prevent contents of .q-table__top from overlapping table contents on mobile Safari)

### DIFF
--- a/ui/src/components/table/QTable.sass
+++ b/ui/src/components/table/QTable.sass
@@ -44,6 +44,10 @@
     .q-table__middle
       flex: 1 1 auto
 
+    .q-table__top,
+    .q-table__bottom
+      flex: 0 0 auto
+
   &__container
     position: relative
 
@@ -60,7 +64,6 @@
 
   &__top
     padding: 12px 16px
-    flex-shrink: 0
     .q-table__control
       flex-wrap: wrap
 

--- a/ui/src/components/table/QTable.sass
+++ b/ui/src/components/table/QTable.sass
@@ -60,6 +60,7 @@
 
   &__top
     padding: 12px 16px
+    flex-shrink: 0
     .q-table__control
       flex-wrap: wrap
 

--- a/ui/src/components/table/QTable.styl
+++ b/ui/src/components/table/QTable.styl
@@ -44,6 +44,10 @@
     .q-table__middle
       flex: 1 1 auto
 
+    .q-table__top,
+    .q-table__bottom
+      flex: 0 0 auto
+
   &__container
     position: relative
 
@@ -60,7 +64,6 @@
 
   &__top
     padding: 12px 16px
-    flex-shrink: 0
     .q-table__control
       flex-wrap: wrap
 

--- a/ui/src/components/table/QTable.styl
+++ b/ui/src/components/table/QTable.styl
@@ -60,6 +60,7 @@
 
   &__top
     padding: 12px 16px
+    flex-shrink: 0
     .q-table__control
       flex-wrap: wrap
 


### PR DESCRIPTION
This PR fixes the height of `.q-table__top` on mobile Safari so that its contents don't overflow and overlap the table's contents.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I haven't tested in Cordova or Electron as I'm unfamiliar with the setup process for them. I believe the most relevant situation I haven't tested would be Cordova on iOS, and I don't have a Mac or an Apple developer account so I don't think I can test properly.