### PR TITLE
feat(ui): Sync core animation classes with animatecss

### DIFF
--- a/ui/dev/src/pages/components/transition-animatecss.vue
+++ b/ui/dev/src/pages/components/transition-animatecss.vue
@@ -6,9 +6,13 @@
       </q-card-section>
 
       <q-card-section>
-        <div class="caption">(only 4 anims showcased here)</div>
+        <div class="caption text-center text-italic">
+          (only 4 anims showcased here)
+        </div>
+
         <br />
-        <div class="row no-wrap">
+
+        <div class="row no-wrap q-col-gutter-sm">
           <q-select
             class="col"
             v-model="enter"
@@ -17,6 +21,7 @@
             stack-label
             label="CSS Enter Class"
           />
+
           <q-select
             class="col"
             v-model="leave"
@@ -24,6 +29,37 @@
             emit-value
             stack-label
             label="CSS Leave Class"
+          />
+        </div>
+
+        <br />
+
+        <div class="row no-wrap q-col-gutter-sm">
+          <q-select
+            class="col"
+            v-model="duration"
+            :options="durationOptions"
+            emit-value
+            stack-label
+            label="Animation Duration"
+          />
+
+          <q-select
+            class="col"
+            v-model="delay"
+            :options="delayOptions"
+            emit-value
+            stack-label
+            label="Animation Delay"
+          />
+
+          <q-select
+            class="col"
+            v-model="repeat"
+            :options="repeatOptions"
+            emit-value
+            stack-label
+            label="Animation Repeat"
           />
         </div>
       </q-card-section>
@@ -87,18 +123,41 @@ export default {
     return {
       enterSelectOptions: enter.map(generateOptions),
       leaveSelectOptions: leave.map(generateOptions),
+      durationOptions: ['faster', 'fast', 'default', 'slow', 'slower'],
+      delayOptions: ['default', '1s', '2s', '3s', '4s', '5s'],
+      repeatOptions: ['default', 1, 2, 3],
       enter: 'bounceInLeft',
       leave: 'bounceOutRight',
+      duration: 'default',
+      delay: 'default',
+      repeat: 'default',
       show: true,
       loremipsum: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
     }
   },
   computed: {
+    baseClasses () {
+      let classes = 'animated'
+
+      if (this.duration !== 'default') {
+        classes += ` ${this.duration}`
+      }
+
+      if (this.delay !== 'default') {
+        classes += ` delay-${this.delay}`
+      }
+
+      if (this.repeat !== 'default') {
+        classes += ` repeat-${this.repeat}`
+      }
+
+      return classes
+    },
     enterClass () {
-      return `animated ${this.enter}`
+      return `${this.baseClasses} ${this.enter}`
     },
     leaveClass () {
-      return `animated ${this.leave}`
+      return `${this.baseClasses} ${this.leave}`
     }
   }
 }

--- a/ui/dev/src/pages/components/transition-animatecss.vue
+++ b/ui/dev/src/pages/components/transition-animatecss.vue
@@ -13,8 +13,8 @@
         </div>
         <br>
         <div class="row no-wrap">
-          <q-select class="col" v-model="enter" :options="enterSelectOptions" stack-label label="CSS Enter Class" />
-          <q-select class="col" v-model="leave" :options="leaveSelectOptions" stack-label label="CSS Leave Class" />
+          <q-select class="col" v-model="enter" :options="enterSelectOptions" emit-value stack-label label="CSS Enter Class" />
+          <q-select class="col" v-model="leave" :options="leaveSelectOptions" emit-value stack-label label="CSS Leave Class" />
         </div>
       </q-card-section>
     </q-card>

--- a/ui/dev/src/pages/components/transition-animatecss.vue
+++ b/ui/dev/src/pages/components/transition-animatecss.vue
@@ -190,7 +190,7 @@ export default {
       }
 
       return `${classes} ${this.enter}`
-    },
+    }
   }
 }
 </script>

--- a/ui/dev/src/pages/components/transition-animatecss.vue
+++ b/ui/dev/src/pages/components/transition-animatecss.vue
@@ -67,6 +67,22 @@
 
     <q-card style="margin-top: 25px" class="overflow-hidden">
       <q-card-section class="text-center">
+        <div class="text-h6">Continuous Enter</div>
+      </q-card-section>
+
+      <q-card-section>
+        <transition appear>
+          <div
+            v-if="showContinuous"
+            :class="continuousClasses"
+            v-html="loremipsum"
+          />
+        </transition>
+      </q-card-section>
+    </q-card>
+
+    <q-card style="margin-top: 25px" class="overflow-hidden">
+      <q-card-section class="text-center">
         <div class="text-h6">Single</div>
       </q-card-section>
 
@@ -125,14 +141,25 @@ export default {
       leaveSelectOptions: leave.map(generateOptions),
       durationOptions: ['faster', 'fast', 'default', 'slow', 'slower'],
       delayOptions: ['default', '1s', '2s', '3s', '4s', '5s'],
-      repeatOptions: ['default', 1, 2, 3],
+      repeatOptions: ['default', '1', '2', '3', 'infinite'],
       enter: 'bounceInLeft',
       leave: 'bounceOutRight',
       duration: 'default',
       delay: 'default',
       repeat: 'default',
       show: true,
+      showContinuous: true,
       loremipsum: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+    }
+  },
+  watch: {
+    // v-if hack to trigger animation
+    show () {
+      this.showContinuous = false
+
+      this.$nextTick(() => {
+        this.showContinuous = true
+      })
     }
   },
   computed: {
@@ -147,10 +174,6 @@ export default {
         classes += ` delay-${this.delay}`
       }
 
-      if (this.repeat !== 'default') {
-        classes += ` repeat-${this.repeat}`
-      }
-
       return classes
     },
     enterClass () {
@@ -158,7 +181,16 @@ export default {
     },
     leaveClass () {
       return `${this.baseClasses} ${this.leave}`
-    }
+    },
+    continuousClasses () {
+      let classes = this.baseClasses
+
+      if (this.repeat !== 'default') {
+        classes += this.repeat === 'infinite' ? ' infinite' : ` repeat-${this.repeat}`
+      }
+
+      return `${classes} ${this.enter}`
+    },
   }
 }
 </script>

--- a/ui/dev/src/pages/components/transition-animatecss.vue
+++ b/ui/dev/src/pages/components/transition-animatecss.vue
@@ -1,29 +1,37 @@
 <template>
-  <div class="q-layout-padding q-mx-auto" style="max-width: 600px;">
+  <div class="q-layout-padding q-mx-auto" style="max-width: 600px">
     <q-card style="margin-top: 25px">
       <q-card-section class="bg-primary text-center">
-        <q-btn push color="orange" @click="show = !show">
-          Toggle
-        </q-btn>
+        <q-btn push color="orange" @click="show = !show">Toggle</q-btn>
       </q-card-section>
 
       <q-card-section>
-        <div class="caption">
-          (only 4 anims showcased here)
-        </div>
-        <br>
+        <div class="caption">(only 4 anims showcased here)</div>
+        <br />
         <div class="row no-wrap">
-          <q-select class="col" v-model="enter" :options="enterSelectOptions" emit-value stack-label label="CSS Enter Class" />
-          <q-select class="col" v-model="leave" :options="leaveSelectOptions" emit-value stack-label label="CSS Leave Class" />
+          <q-select
+            class="col"
+            v-model="enter"
+            :options="enterSelectOptions"
+            emit-value
+            stack-label
+            label="CSS Enter Class"
+          />
+          <q-select
+            class="col"
+            v-model="leave"
+            :options="leaveSelectOptions"
+            emit-value
+            stack-label
+            label="CSS Leave Class"
+          />
         </div>
       </q-card-section>
     </q-card>
 
     <q-card style="margin-top: 25px" class="overflow-hidden">
       <q-card-section class="text-center">
-        <div class="text-h6">
-          Single
-        </div>
+        <div class="text-h6">Single</div>
       </q-card-section>
 
       <q-card-section>
@@ -39,9 +47,7 @@
 
     <q-card style="margin-top: 25px" class="overflow-hidden">
       <q-card-section class="text-center">
-        <div class="text-h6">
-          Group
-        </div>
+        <div class="text-h6">Group</div>
       </q-card-section>
 
       <q-card-section>
@@ -52,11 +58,7 @@
           class="group"
         >
           <template v-if="show">
-            <div
-              v-for="n in 3"
-              :key="n"
-              v-html="loremipsum"
-            />
+            <div v-for="n in 3" :key="n" v-html="loremipsum" />
           </template>
         </transition-group>
       </q-card-section>

--- a/ui/src/css/core/animations.sass
+++ b/ui/src/css/core/animations.sass
@@ -1,21 +1,68 @@
 /*
  * Animate.css additions
+ * Adapted from: https://github.com/animate-css/animate.css/blob/6828621a01e145119db6194dc9b4d37325b48aa5/source/_base.css
  */
 
+\:root
+  --animate-duration: #{$animate-duration}
+  --animate-delay: #{$animate-delay}
+  --animate-repeat: #{$animate-repeat}
+
 .animated
-  animation-duration: .3s
+  animation-duration: var(--animate-duration)
   animation-fill-mode: both
 
-.animated.infinite
-  animation-iteration-count: infinite
-.animated.hinge
-  animation-duration: 2s
+  &.infinite
+    animation-iteration-count: infinite
 
-.animated.flipOutX,
-.animated.flipOutY,
-.animated.bounceIn,
-.animated.bounceOut
-  animation-duration: .3s
+  // Last seen on v3.5.2
+  &.hinge
+    animation-duration: 2s
+
+  &.repeat-1
+    animation-iteration-count: var(--animate-repeat)
+
+  &.repeat-2
+    animation-iteration-count: calc(var(--animate-repeat) * 2)
+
+  &.repeat-3
+    animation-iteration-count: calc(var(--animate-repeat) * 3)
+
+  &.delay-1s
+    animation-delay: var(--animate-delay)
+
+  &.delay-2s
+    animation-delay: calc(var(--animate-delay) * 2)
+
+  &.delay-3s
+    animation-delay: calc(var(--animate-delay) * 3)
+
+  &.delay-4s
+    animation-delay: calc(var(--animate-delay) * 4)
+
+  &.delay-5s
+    animation-delay: calc(var(--animate-delay) * 5)
+
+  &.faster
+    animation-duration: calc(var(--animate-duration) / 2)
+
+  &.fast
+    animation-duration: calc(var(--animate-duration) * 0.8)
+
+  &.slow
+    animation-duration: calc(var(--animate-duration) * 2)
+
+  &.slower
+    animation-duration: calc(var(--animate-duration) * 3)
+
+@media print, (prefers-reduced-motion: reduce)
+  .animated
+    animation-duration: 1ms !important
+    transition-duration: 1ms !important
+    animation-iteration-count: 1 !important
+
+  .animated[class*='Out']
+    opacity: 0
 
 /*
  * Quasar animations

--- a/ui/src/css/core/animations.styl
+++ b/ui/src/css/core/animations.styl
@@ -1,21 +1,68 @@
 /*
  * Animate.css additions
+ * Adapted from: https://github.com/animate-css/animate.css/blob/6828621a01e145119db6194dc9b4d37325b48aa5/source/_base.css
  */
 
+:root
+  --animate-duration: $animate-duration
+  --animate-delay: $animate-delay
+  --animate-repeat: $animate-repeat
+
 .animated
-  animation-duration: .3s
+  animation-duration: var(--animate-duration)
   animation-fill-mode: both
 
-.animated.infinite
-  animation-iteration-count: infinite
-.animated.hinge
-  animation-duration: 2s
+  &.infinite
+    animation-iteration-count: infinite
 
-.animated.flipOutX,
-.animated.flipOutY,
-.animated.bounceIn,
-.animated.bounceOut
-  animation-duration: .3s
+  // Last seen on v3.5.2
+  &.hinge
+    animation-duration: 2s
+
+  &.repeat-1
+    animation-iteration-count: var(--animate-repeat)
+
+  &.repeat-2
+    animation-iteration-count: calc(var(--animate-repeat) * 2)
+
+  &.repeat-3
+    animation-iteration-count: calc(var(--animate-repeat) * 3)
+
+  &.delay-1s
+    animation-delay: var(--animate-delay)
+
+  &.delay-2s
+    animation-delay: calc(var(--animate-delay) * 2)
+
+  &.delay-3s
+    animation-delay: calc(var(--animate-delay) * 3)
+
+  &.delay-4s
+    animation-delay: calc(var(--animate-delay) * 4)
+
+  &.delay-5s
+    animation-delay: calc(var(--animate-delay) * 5)
+
+  &.faster
+    animation-duration: calc(var(--animate-duration) / 2)
+
+  &.fast
+    animation-duration: calc(var(--animate-duration) * 0.8)
+
+  &.slow
+    animation-duration: calc(var(--animate-duration) * 2)
+
+  &.slower
+    animation-duration: calc(var(--animate-duration) * 3)
+
+@media print, (prefers-reduced-motion: reduce)
+  .animated
+    animation-duration: 1ms !important
+    transition-duration: 1ms !important
+    animation-iteration-count: 1 !important
+
+  .animated[class*='Out']
+    opacity: 0
 
 /*
  * Quasar animations

--- a/ui/src/css/variables.sass
+++ b/ui/src/css/variables.sass
@@ -12,6 +12,10 @@ $space-xl   : (x: ($space-x-base * 3), y: ($space-y-base * 3)) !default
 // sorry for long line; we need .sass and it doesn't support multi-line list
 $spaces: ('none': $space-none, 'xs': $space-xs, 'sm': $space-sm, 'md': $space-md, 'lg': $space-lg, 'xl': $space-xl) !default
 
+$animate-duration : 1s
+$animate-delay    : 1s
+$animate-repeat   : 1
+
 // Max width at which point
 // current size ends
 $breakpoint-xs: 599px !default

--- a/ui/src/css/variables.styl
+++ b/ui/src/css/variables.styl
@@ -18,6 +18,10 @@ $spaces ?= {
   xl: $space-xl
 }
 
+$animate-duration ?= 1s
+$animate-delay    ?= 1s
+$animate-repeat   ?= 1
+
 // Max width at which point
 // current size ends
 $breakpoint-xs ?= 599px


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature (_for `quasar` and `ui/dev` app_)
- Bugfix (_for `ui/dev` app_)
- Code style update (_for `ui/dev` app_)

**Does this PR introduce a breaking change?**

- Yes, but it depends on the aim.

Our updating policy for animate.css is not 100% clear to me, so I need some feedback on this. They updated the default value of `animation-duration` to `1s` and removed `animated.hinge` class. Logically, if there are some users that are using these or relying on the current `.3s` duration, this will be a breaking change technically.
So, since these are small and additive(_in a positive way for UX_) changes, we can either prepare a small migrate guide and ship this in the next minor version, or we can change the default values to match with old values and ship it as is, and leave the other changes to the next major version.

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and **not** the `master` branch

**Other information:**

From https://discordapp.com/channels/415874313728688138/596275881907978240/772097608365375509:
> `@b0otable#7831`:
> I can't seem to get some of the other options in animate.css to work
> ```html
> <transition
>   appear
>   enter-active-class="animated fadeInUpBig delay-4s"
>   leave-active-class="animated fadeOut"
>   >
>   <div class="text-caption"> (scroll down for more info!) </div>
> </transition>
> ````
> I can get the text to come in, but it flashes super quick and doesn't delay
> Am I misunderstanding the docs?
