### PR TITLE
docs(QUploader): Add Python Flask backend example for QUploader

### DIFF
--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -258,6 +258,7 @@ public class UploadRest {
 // html
 <q-uploader field-name="file" url="YOUR_URL_BACK/upload" with-credentials />
 ```
+
 ### Python/Flask
 
 ```python

--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -258,6 +258,35 @@ public class UploadRest {
 // html
 <q-uploader field-name="file" url="YOUR_URL_BACK/upload" with-credentials />
 ```
+### Python/Flask
+
+```python
+from flask import Flask, request
+from werkzeug import secure_filename
+from flask_cors import CORS
+import os
+
+app = Flask(__name__)
+
+# This is necessary because QUploader uses an AJAX request
+# to send the file
+cors = CORS()
+cors.init_app(app, resource={r"/api/*": {"origins": "*"}})
+
+@app.route('/upload', methods=['POST'])
+def upload():        
+    for fname in request.files:
+        f = request.files.get(fname)
+        print(f)
+        f.save('./uploads/%s' % secure_filename(fname))
+
+    return 'Okay!'
+
+if __name__ == '__main__':
+    if not os.path.exists('./uploads'):
+        os.mkdir('./uploads')
+    app.run(debug=True)
+```
 
 ## Supporting other services
 QUploader currently supports uploading through the HTTP protocol. But you can extend the component to support other services as well. Like Firebase for example. Here's how you can do it.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
I use Python/Flask for the backend of my application.  It would have saved me a fair bit of time to have an example like this in the QUploader documentation, and given the popularity of Flask, I think it would be useful to others in the future.  Thanks for considering and for building such an awesome framework!
