### PR TITLE
feat(docs): Remove Content-Type header

### DIFF
--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -195,7 +195,6 @@ export default {
           url: 'http://localhost:4444/fileuploader/upload',
           method: 'POST',
           headers: [
-            { name: 'Content-Type', value: 'application/json-patch+json'},
             { name: 'Authorization', value: `Bearer ${token}` }
           ]
         })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**

`Content-Type` should not be set so the browser can generate the right header.
https://stackoverflow.com/a/39281156/8227702

This is working after a few hours of trying to figure out why my form isn't sending the right form data
```javascript
...
  async uploadFactory(files) {
      return new Promise((resolve) => {
        resolve({
          url: this.url,
          method: 'POST',
          headers: [
            { name: 'Authorization', value: `Bearer <token>` },
          ],
        });
      });
    }
...
```

