### PR TITLE
fix: Morph animations not showing in q-dialog (fix #8091)

### DIFF
--- a/ui/src/utils/morph.js
+++ b/ui/src/utils/morph.js
@@ -413,7 +413,8 @@ export default function morph (_options) {
           elTo.style[prop] = options.style[prop]
         }
       }
-
+      // ensure that the element ends up on top while animating
+      elTo.style['zIndex'] = '10000'
       // we position the morphing element
       // if we use fixed position for the final element we need to adjust for scroll
       const documentScroll = elToNeedsFixedPosition === true


### PR DESCRIPTION
Fix morph not animating in a q-dialog

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app(https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
This is just one possible way to do it.  I'm happy with any other suggestions/possibilities you may think of, but I imagine users would generally expect this behavior rather than having the animation disappear if it's inside a `q-dialog`.

Thanks!
