### PR TITLE
Fix formatting of Python/Flask example

### DIFF
--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -260,7 +260,8 @@ public class UploadRest {
 
 ### Python/Flask
 
-```python
+```
+// python
 from flask import Flask, request
 from werkzeug import secure_filename
 from flask_cors import CORS


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
I submitted this example last week.  I just saw that it did not render correctly when pushed into the production docs.  I guess quasar docs uses a different MarkDown processor from the one used on Github.  I built this change locally and can confirm that it renders properly now.  I apologize for the error in the first PR!
