### PR TITLE
fix(icongenie): Deprecated media feature (fix #8118)

### DIFF
--- a/docs/src/index.template.html
+++ b/docs/src/index.template.html
@@ -19,16 +19,16 @@
     <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.quasar.dev/app-icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="https://cdn.quasar.dev/app-icons/favicon-16x16.png">
     <link rel="icon" type="image/ico" href="https://cdn.quasar.dev/app-icons/favicon.ico">
-    <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-828x1792.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1125x2436.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1242x2688.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-750x1334.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1242x2208.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-640x1136.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1536x2048.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1668x2224.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1668x2388.png">
-    <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-2048x2732.png">
+    <link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-828x1792.png">
+    <link rel="apple-touch-startup-image" media="(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1125x2436.png">
+    <link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1242x2688.png">
+    <link rel="apple-touch-startup-image" media="(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-750x1334.png">
+    <link rel="apple-touch-startup-image" media="(width: 414px) and (height: 736px) and (-webkit-device-pixel-ratio: 3)" href="https://cdn.quasar.dev/app-icons/apple-launch-1242x2208.png">
+    <link rel="apple-touch-startup-image" media="(width: 320px) and (height: 568px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-640x1136.png">
+    <link rel="apple-touch-startup-image" media="(width: 768px) and (height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1536x2048.png">
+    <link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1668x2224.png">
+    <link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-1668x2388.png">
+    <link rel="apple-touch-startup-image" media="(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="https://cdn.quasar.dev/app-icons/apple-launch-2048x2732.png">
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-6317975-6"></script>
     <script>

--- a/docs/src/pages/icongenie/profile-files.md
+++ b/docs/src/pages/icongenie/profile-files.md
@@ -71,7 +71,7 @@ Some examples for `assets` from which you can extract the syntax for every type 
     "sizes": [
       [ 1668, 2388 ]
     ],
-    "tag": "<link rel=\"apple-touch-startup-image\" media=\"(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)\" href=\"icons/{name}\">"
+    "tag": "<link rel=\"apple-touch-startup-image\" media=\"(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)\" href=\"icons/{name}\">"
   },
 
   {

--- a/docs/src/pages/quasar-cli/developing-pwa/app-icons-pwa.md
+++ b/docs/src/pages/quasar-cli/developing-pwa/app-icons-pwa.md
@@ -61,23 +61,23 @@ The required HTML code that goes into `/src/index.template.html` to reference th
 <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png">
 <!-- iPhone XR -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-828x1792.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-828x1792.png">
 <!-- iPhone X, XS -->
-<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1125x2436.png">
+<link rel="apple-touch-startup-image" media="(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1125x2436.png">
 <!-- iPhone XS Max -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2688.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2688.png">
 <!-- iPhone 8, 7, 6s, 6 -->
-<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-750x1334.png">
+<link rel="apple-touch-startup-image" media="(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-750x1334.png">
 <!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2208.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 736px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2208.png">
 <!-- iPhone 5 -->
-<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-640x1136.png">
+<link rel="apple-touch-startup-image" media="(width: 320px) and (height: 568px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-640x1136.png">
 <!-- iPad Mini, Air, 9.7" -->
-<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1536x2048.png">
+<link rel="apple-touch-startup-image" media="(width: 768px) and (height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1536x2048.png">
 <!-- iPad Pro 10.5" -->
-<link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2224.png">
+<link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2224.png">
 <!-- iPad Pro 11" -->
-<link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2388.png">
+<link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2388.png">
 <!-- iPad Pro 12.9" -->
-<link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-2048x2732.png">
+<link rel="apple-touch-startup-image" media="(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-2048x2732.png">
 ```

--- a/docs/src/pages/quasar-cli/developing-ssr/app-icons-ssr.md
+++ b/docs/src/pages/quasar-cli/developing-ssr/app-icons-ssr.md
@@ -78,23 +78,23 @@ And the corresponding HTML code to go into `/src/index.template.html` file (noti
 
 ```html
 <!-- iPhone XR -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-828x1792.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-828x1792.png">
 <!-- iPhone X, XS -->
-<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1125x2436.png">
+<link rel="apple-touch-startup-image" media="(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1125x2436.png">
 <!-- iPhone XS Max -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2688.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2688.png">
 <!-- iPhone 8, 7, 6s, 6 -->
-<link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-750x1334.png">
+<link rel="apple-touch-startup-image" media="(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-750x1334.png">
 <!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->
-<link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2208.png">
+<link rel="apple-touch-startup-image" media="(width: 414px) and (height: 736px) and (-webkit-device-pixel-ratio: 3)" href="icons/apple-launch-1242x2208.png">
 <!-- iPhone 5 -->
-<link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-640x1136.png">
+<link rel="apple-touch-startup-image" media="(width: 320px) and (height: 568px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-640x1136.png">
 <!-- iPad Mini, Air, 9.7" -->
-<link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1536x2048.png">
+<link rel="apple-touch-startup-image" media="(width: 768px) and (height: 1024px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1536x2048.png">
 <!-- iPad Pro 10.5" -->
-<link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2224.png">
+<link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1112px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2224.png">
 <!-- iPad Pro 11" -->
-<link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2388.png">
+<link rel="apple-touch-startup-image" media="(width: 834px) and (height: 1194px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-1668x2388.png">
 <!-- iPad Pro 12.9" -->
-<link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-2048x2732.png">
+<link rel="apple-touch-startup-image" media="(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)" href="icons/apple-launch-2048x2732.png">
 ```

--- a/icongenie/lib/modes/quasar-app-v1/pwa.js
+++ b/icongenie/lib/modes/quasar-app-v1/pwa.js
@@ -51,15 +51,15 @@ module.exports = [
   },
 
   ...[
-    [ 828, 1792, '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone XR -->' ],
-    [ 1125, 2436, '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone X, XS -->' ],
-    [ 1242, 2688, '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone XS Max -->' ],
-    [ 750, 1334, '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 8, 7, 6s, 6 -->' ],
-    [ 1242, 2208, '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->' ],
-    [ 640, 1136, '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 5 -->' ],
-    [ 1536, 2048, '(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Mini, Air, 9.7" -->' ],
-    [ 1668, 2224, '(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 10.5" -->' ],
-    [ 1668, 2388, '(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 11" -->' ],
-    [ 2048, 2732, '(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 12.9" -->' ]
+    [ 828, 1792, '(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone XR -->' ],
+    [ 1125, 2436, '(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone X, XS -->' ],
+    [ 1242, 2688, '(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone XS Max -->' ],
+    [ 750, 1334, '(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 8, 7, 6s, 6 -->' ],
+    [ 1242, 2208, '(width: 414px) and (height: 736px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->' ],
+    [ 640, 1136, '(width: 320px) and (height: 568px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 5 -->' ],
+    [ 1536, 2048, '(width: 768px) and (height: 1024px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Mini, Air, 9.7" -->' ],
+    [ 1668, 2224, '(width: 834px) and (height: 1112px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 10.5" -->' ],
+    [ 1668, 2388, '(width: 834px) and (height: 1194px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 11" -->' ],
+    [ 2048, 2732, '(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 12.9" -->' ]
   ].map(getAppleLaunch)
 ]

--- a/icongenie/lib/modes/quasar-app-v2/pwa.js
+++ b/icongenie/lib/modes/quasar-app-v2/pwa.js
@@ -51,15 +51,15 @@ module.exports = [
   },
 
   ...[
-    [ 828, 1792, '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone XR -->' ],
-    [ 1125, 2436, '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone X, XS -->' ],
-    [ 1242, 2688, '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone XS Max -->' ],
-    [ 750, 1334, '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 8, 7, 6s, 6 -->' ],
-    [ 1242, 2208, '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->' ],
-    [ 640, 1136, '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 5 -->' ],
-    [ 1536, 2048, '(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Mini, Air, 9.7" -->' ],
-    [ 1668, 2224, '(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 10.5" -->' ],
-    [ 1668, 2388, '(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 11" -->' ],
-    [ 2048, 2732, '(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 12.9" -->' ]
+    [ 828, 1792, '(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone XR -->' ],
+    [ 1125, 2436, '(width: 375px) and (height: 812px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone X, XS -->' ],
+    [ 1242, 2688, '(width: 414px) and (height: 896px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone XS Max -->' ],
+    [ 750, 1334, '(width: 375px) and (height: 667px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 8, 7, 6s, 6 -->' ],
+    [ 1242, 2208, '(width: 414px) and (height: 736px) and (-webkit-device-pixel-ratio: 3)', '<!-- iPhone 8 Plus, 7 Plus, 6s Plus, 6 Plus -->' ],
+    [ 640, 1136, '(width: 320px) and (height: 568px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPhone 5 -->' ],
+    [ 1536, 2048, '(width: 768px) and (height: 1024px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Mini, Air, 9.7" -->' ],
+    [ 1668, 2224, '(width: 834px) and (height: 1112px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 10.5" -->' ],
+    [ 1668, 2388, '(width: 834px) and (height: 1194px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 11" -->' ],
+    [ 2048, 2732, '(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)', '<!-- iPad Pro 12.9" -->' ]
   ].map(getAppleLaunch)
 ]

--- a/icongenie/samples/icongenie-profile.json
+++ b/icongenie/samples/icongenie-profile.json
@@ -26,7 +26,7 @@
       "sizes": [
         [ 1668, 2388 ]
       ],
-      "tag": "<link rel=\"apple-touch-startup-image\" media=\"(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)\" href=\"statics/icons/{name}\">"
+      "tag": "<link rel=\"apple-touch-startup-image\" media=\"(width: 1024px) and (height: 1366px) and (-webkit-device-pixel-ratio: 2)\" href=\"statics/icons/{name}\">"
     },
 
     {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Closes #8118

Although [the spec](https://www.w3.org/TR/mediaqueries-4/#mf-deprecated) is still technically a [CR](https://www.w3.org/2020/Process-20200915/#RecsCR), rather than an [REC](https://www.w3.org/2020/Process-20200915/#RecsW3C),
universal implementation by the browsers suggests it will maintain reliability for the foreseeable future.

This change would encourage the use of the non-deprecated @&#8203;media features '[height](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/height)' and '[width](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/width)'
to write CSS that passes [w3 validation](https://validator.w3.org/).