### PR TITLE
feat(Styles & Identy -> Shadows) Inset shadow down

### DIFF
--- a/docs/src/pages/style/shadows.md
+++ b/docs/src/pages/style/shadows.md
@@ -10,7 +10,8 @@ The shadows are in accordance to Material Design specifications (24 levels of de
 | CSS Class Name | Description |
 | --- | --- |
 | `no-shadow` | Remove any shadow |
-| `inset-shadow` | Set an inset shadow |
+| `inset-shadow` | Set an inset shadow on top |
+| `inset-shadow-down` | Set an inset shadow on bottom |
 | `shadow-1` | Set a depth of 1 |
 | `shadow-2` | Set a depth of 2 |
 | `shadow-N` | Where `N` is an integer from 1 to 24. |

--- a/ui/dev/src/pages/css/shadows.vue
+++ b/ui/dev/src/pages/css/shadows.vue
@@ -13,10 +13,16 @@
       .shadow-up-{{ n }}
     </div>
     <p class="caption text-left">
-      Inset Shadow
+      Inset Shadow on top
     </p>
     <div class="flex inline shadow-box flex-center inset-shadow">
       .inset-shadow
+    </div>
+    <p class="caption text-left">
+      Inset Shadow on bottom
+    </p>
+    <div class="flex inline shadow-box flex-center inset-shadow-down">
+      .inset-shadow-down
     </div>
   </div>
 </template>

--- a/ui/src/css/core/elevation.sass
+++ b/ui/src/css/core/elevation.sass
@@ -11,6 +11,8 @@
   box-shadow: none !important
 .inset-shadow
   box-shadow: $inset-shadow !important
+.inset-shadow-down
+  box-shadow: $inset-shadow-down !important
 
 .z-marginals
   z-index: $z-marginals

--- a/ui/src/css/core/elevation.styl
+++ b/ui/src/css/core/elevation.styl
@@ -11,6 +11,8 @@ for $z in 1..24
   box-shadow: none !important
 .inset-shadow
   box-shadow: $inset-shadow !important
+.inset-shadow-down
+  box-shadow: $inset-shadow-down !important
 
 .z-marginals
   z-index: $z-marginals

--- a/ui/src/css/variables.sass
+++ b/ui/src/css/variables.sass
@@ -397,6 +397,7 @@ $z-max                : 9998 !default
 $shadow-color         : #000 !default
 $shadow-transition    : box-shadow .28s cubic-bezier(.4, 0, .2, 1) !default
 $inset-shadow         : 0 7px 9px -7px rgba($shadow-color, .7) inset !default
+$inset-shadow-down    : 0 -7px 9px -7px rgba($shadow-color, .7) inset !default
 
 $elevation-umbra      : rgba($shadow-color, .2) !default
 $elevation-penumbra   : rgba($shadow-color, .14) !default

--- a/ui/src/css/variables.styl
+++ b/ui/src/css/variables.styl
@@ -484,6 +484,7 @@ $z-max                ?= 9998
 $shadow-color         ?= black
 $shadow-transition    ?= box-shadow .28s cubic-bezier(.4, 0, .2, 1)
 $inset-shadow         ?= 0 7px 9px -7px rgba($shadow-color, .7) inset
+$inset-shadow-down    ?= 0 -7px 9px -7px rgba($shadow-color, .7) inset
 
 $elevation-umbra      ?= rgba($shadow-color, .2)
 $elevation-penumbra   ?= rgba($shadow-color, .14)


### PR DESCRIPTION
I am using inset-shadow to create an inner shadow...
![image](https://user-images.githubusercontent.com/9668277/101098676-13e9de00-35a2-11eb-9ee2-15f263bdba79.png)
...but would like the inner shadow to come in from the bottom only.

Solution:
In the `box-shadow`, use a negative value for the fourth and two length which defines the spread distance. This is often overlooked, but supported by all major browsers:

`box-shadow: 0 -7px 9px -7px rgba(0, 0, 0, 0.7) inset !important`

Result:
![image](https://user-images.githubusercontent.com/9668277/101098929-8b1f7200-35a2-11eb-9050-97af267c4e12.png)

Real usage case example:
![image](https://user-images.githubusercontent.com/9668277/101099342-3c260c80-35a3-11eb-9aa3-b992f0919137.png)
Using with `QExpansionItem` to create the idea of depth of the expanded area: `inset-shadow` in the top and `inset-shadow-down` in the bottom (Logout list item).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I didn't update all the documentation, just what I quickly thought needed to be updated.
`*` Need update `shadow-box` `width` and `height` in the doc.