### PR TITLE
feat(ui) QList - inset-separator prop

### DIFF
--- a/ui/src/components/item/QItem.sass
+++ b/ui/src/components/item/QItem.sass
@@ -87,14 +87,29 @@
     > .q-item-type + .q-item-type,
     > .q-virtual-scroll__content > .q-item-type + .q-item-type
       border-top: 1px solid $separator-color
+  &--inset-separator
+    > .q-item-type + .q-item-type > .q-item__section--main::before,
+    > .q-virtual-scroll__content > .q-item-type + .q-item-type > .q-item__section--main::before
+      border-top: 1px solid $separator-color
+      content: ''
+      position: absolute
+      width: 100%
+      top: 0
   &--padding
     padding: 8px 0
+
+.q-list.q-list--inset-separator
+  overflow: hidden
 
 .q-list--dense > .q-item, .q-item--dense
   min-height: 32px
   padding: 2px 16px
 
 .q-list--dark.q-list--separator
+  > .q-item-type + .q-item-type,
+  > .q-virtual-scroll__content > .q-item-type + .q-item-type
+    border-top-color: $separator-dark-color
+.q-list--dark.q-list--inset-separator
   > .q-item-type + .q-item-type,
   > .q-virtual-scroll__content > .q-item-type + .q-item-type
     border-top-color: $separator-dark-color

--- a/ui/src/components/item/QItem.styl
+++ b/ui/src/components/item/QItem.styl
@@ -87,14 +87,29 @@
     > .q-item-type + .q-item-type,
     > .q-virtual-scroll__content > .q-item-type + .q-item-type
       border-top: 1px solid $separator-color
+  &--inset-separator
+    > .q-item-type + .q-item-type > .q-item__section--main::before,
+    > .q-virtual-scroll__content > .q-item-type + .q-item-type > .q-item__section--main::before
+      border-top: 1px solid $separator-color
+      content: ''
+      position: absolute
+      width: 100%
+      top: 0
   &--padding
     padding: 8px 0
+
+.q-list.q-list--inset-separator
+  overflow: hidden
 
 .q-list--dense > .q-item, .q-item--dense
   min-height: 32px
   padding: 2px 16px
 
 .q-list--dark.q-list--separator
+  > .q-item-type + .q-item-type,
+  > .q-virtual-scroll__content > .q-item-type + .q-item-type
+    border-top-color: $separator-dark-color
+.q-list--dark.q-list--inset-separator
   > .q-item-type + .q-item-type,
   > .q-virtual-scroll__content > .q-item-type + .q-item-type
     border-top-color: $separator-dark-color

--- a/ui/src/components/item/QList.js
+++ b/ui/src/components/item/QList.js
@@ -14,6 +14,7 @@ export default Vue.extend({
     bordered: Boolean,
     dense: Boolean,
     separator: Boolean,
+    insetSeparator: Boolean,
     padding: Boolean
   },
 
@@ -23,6 +24,7 @@ export default Vue.extend({
         (this.bordered === true ? ' q-list--bordered' : '') +
         (this.dense === true ? ' q-list--dense' : '') +
         (this.separator === true ? ' q-list--separator' : '') +
+        (this.insetSeparator === true ? ' q-list--inset-separator' : '') +
         (this.isDark === true ? ' q-list--dark' : '') +
         (this.padding === true ? ' q-list--padding' : '')
     }

--- a/ui/src/components/item/QList.json
+++ b/ui/src/components/item/QList.json
@@ -22,6 +22,12 @@
       "category": "content"
     },
 
+    "inset-separator": {
+      "type": "Boolean",
+      "desc": "Applies an inset separator between contained items",
+      "category": "content"
+    },
+
     "dark": {
       "extends": "dark"
     },


### PR DESCRIPTION
This feature implements the inset separator to `QList` items, similar to `<q-separator spaced inset="item" />`, but as a prop in `QList` and autogenerated by CSS like the prop `separator`. You do not need to add it manually or in a loop as in the example already existent in the documentation using `QSeparator` (List and List Items -> Usage -> QItemLabel).

Usage case - Example:
![Screenshot_20201204-032427_1](https://user-images.githubusercontent.com/9668277/101130436-37cd1400-35e2-11eb-81e9-88b34d620009.jpg)

I am not an expert in CSS, so this quick solution that I found I needed to put the `overflow: hidden` in `QList` when using `inset-separator`. See the changes in source code.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Discussion:
`overflow: hidden` in `.q-list` by default?