### PR TITLE
feat(QField): on mobiles blur the field instead of focusing it when clear button is clicked #8136

### DIFF
--- a/ui/dev/src/pages/components/menu.vue
+++ b/ui/dev/src/pages/components/menu.vue
@@ -95,10 +95,10 @@
         <q-btn color="primary" label="Menu with select">
           <q-menu cover @show="log('@show cover')" @hide="log('@hide cover')" content-class="q-pa-md">
             <div class="column q-gutter-md">
-              <q-select v-model="selectModelS" :options="selectOptions" behavior="menu" filled label="Select single - menu" />
-              <q-select v-model="selectModelM" :options="selectOptions" behavior="menu" filled multiple label="Select multiple - menu" />
-              <q-select v-model="selectModelS" :options="selectOptions" behavior="dialog" filled label="Select single - dialog" />
-              <q-select v-model="selectModelM" :options="selectOptions" behavior="dialog" filled multiple label="Select multiple - dialog" />
+              <q-select v-model="selectModelS" :options="selectOptions" behavior="menu" filled label="Select single - menu" clearable />
+              <q-select v-model="selectModelM" :options="selectOptions" behavior="menu" filled multiple label="Select multiple - menu" clearable />
+              <q-select v-model="selectModelS" :options="selectOptions" behavior="dialog" filled label="Select single - dialog" clearable />
+              <q-select v-model="selectModelM" :options="selectOptions" behavior="dialog" filled multiple label="Select multiple - dialog" clearable />
             </div>
           </q-menu>
         </q-btn>

--- a/ui/dev/src/pages/form/input.vue
+++ b/ui/dev/src/pages/form/input.vue
@@ -78,6 +78,8 @@
 
       <q-input v-bind="props" v-model="email" type="email" label="eMail" placeholder="Write an email address" />
 
+      <q-input v-bind="props" type="date" v-model="date" label="Date" stack-label clearable />
+
       <q-input v-bind="props" v-model="text" label="Tooltip and menu">
         <q-icon slot="prepend" name="event">
           <q-tooltip>Tooltip</q-tooltip>
@@ -522,6 +524,7 @@ export default {
       invalid: '123',
       number: 1.1,
       email: 'a',
+      date: null,
 
       prefix: null,
       suffix: null,

--- a/ui/dev/src/pages/global/dialog.vue
+++ b/ui/dev/src/pages/global/dialog.vue
@@ -209,7 +209,7 @@
         </q-card-section>
 
         <q-card-section>
-          <q-input v-model="address" autofocus />
+          <q-input v-model="address" autofocus clearable />
         </q-card-section>
 
         <q-card-actions align="right" class="text-primary">
@@ -672,6 +672,7 @@
             v-model="select"
             :options="selectOptions"
             label="Select"
+            clearable
           />
         </q-card-section>
 
@@ -682,6 +683,7 @@
             v-model="select"
             :options="selectOptions"
             label="Select"
+            clearable
           />
           <q-select
             v-model="select"
@@ -689,15 +691,17 @@
             use-input
             label="Select - Use input"
             @filter="filterFn"
+            clearable
           />
-          <q-input v-model="text1" autofocus label="Text 1" />
-          <q-input v-model="text2" label="Text 2" />
-          <q-input v-model="text3" type="textarea" label="Text 3 - textarea" />
+          <q-input v-model="text1" autofocus label="Text 1" clearable />
+          <q-input v-model="text2" label="Text 2" clearable />
+          <q-input v-model="text3" type="textarea" label="Text 3 - textarea" clearable />
           <q-select
             v-model="selectMultiple"
             :options="selectOptions"
             multiple
             label="Select multiple"
+            clearable
           />
           <q-select
             v-model="selectMultiple"
@@ -706,6 +710,7 @@
             multiple
             label="Select multiple - Use input"
             @filter="filterFn"
+            clearable
           />
         </q-card-section>
       </q-card>

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -490,8 +490,14 @@ export default Vue.extend({
     __clearValue (e) {
       // prevent activating the field but keep focus on desktop
       stopAndPrevent(e)
-      const el = this.$refs.target || this.$el
-      el.focus()
+
+      if (this.$q.platform.is.mobile !== true) {
+        const el = this.$refs.target || this.$el
+        el.focus()
+      }
+      else if (this.$el.contains(document.activeElement) === true) {
+        document.activeElement.blur()
+      }
 
       if (this.type === 'file') {
         // do not let focus be triggered


### PR DESCRIPTION
It makes sense as it avoids:
- keyboard hiding/reopening
- native pickers (like date) showing