### PR TITLE
feat(VirtualScroll): add ratio of items to render before and after the visible ones #7624

### DIFF
--- a/docs/src/pages/vue-components/virtual-scroll.md
+++ b/docs/src/pages/vue-components/virtual-scroll.md
@@ -18,7 +18,7 @@ There are currently two types of QVirtualScroll: "list" (using QItems) and "tabl
 
 ::: tip
 * To get the best performance while using large lists freeze the array you are passing in the `items` prop using `Object.freeze(items)`. This allows Vue to skip making the list "responsive" to changes.
-* The number of items that will be rendered will be calculated based on the `virtual-scroll-item-size` prop and the size of the window, but you can fit it to your needs using the `virtual-scroll-slice-size` prop.
+* The number of items that will be rendered will be calculated based on the `virtual-scroll-item-size` prop and the size of the scrollable area, but you can fit it to your needs using the `virtual-scroll-slice-size` prop.
 * Use the `virtual-scroll-item-size` to specify the size of elements (pixels of height, or width if horizontal). After an element is rendered on screen its size is updated automatically, but if you specify an element size close to the real size you'll get a better initial indication of the scroll position. Regardless if you will be using this property or not, QVirtualScroll will still work, but without it you may experience the scrollbar not following the mouse grab position while continuously scrolling (on desktop) or the actual scroll of the container getting slightly off by one or two elements when on mobile and continuously scrolling.
 :::
 

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -29,37 +29,55 @@
     },
 
     "virtual-scroll-slice-size": {
-      "type": "Number",
-      "desc": "Number of rows to render in the virtual list",
+      "type": [ "Number", "String" ],
+      "desc": "Minimum number of rows to render in the virtual list",
       "default": "30",
-      "examples": [ ":virtual-scroll-slice-size=\"60\"" ],
+      "examples": [ "virtual-scroll-slice-size=\"60\"" ],
       "category": "virtual-scroll",
       "addedIn": "v1.2.0"
     },
 
+    "virtual-scroll-slice-ratio-before": {
+      "type": [ "Number", "String" ],
+      "desc": "Ratio of number of rows in visible zone to render before it",
+      "default": "1",
+      "examples": [ "virtual-scroll-slice-ratio-before=\"0.3\"" ],
+      "category": "virtual-scroll",
+      "addedIn": "v1.14.7"
+    },
+
+    "virtual-scroll-slice-ratio-after": {
+      "type": [ "Number", "String" ],
+      "desc": "Ratio of number of rows in visible zone to render after it",
+      "default": "1",
+      "examples": [ "virtual-scroll-slice-ratio-after=\"2\"" ],
+      "category": "virtual-scroll",
+      "addedIn": "v1.14.7"
+    },
+
     "virtual-scroll-item-size": {
-      "type": "Number",
+      "type": [ "Number", "String" ],
       "desc": "Default size in pixels of a row; This value is used for rendering the initial table; Try to use a value close to the minimum size of a row",
       "default": "48 (24 if dense)",
-      "examples": [ ":virtual-scroll-item-size=\"48\"" ],
+      "examples": [ "virtual-scroll-item-size=\"48\"" ],
       "category": "virtual-scroll",
       "addedIn": "v1.2.0"
     },
 
     "virtual-scroll-sticky-size-start": {
-      "type": "Number",
+      "type": [ "Number", "String" ],
       "desc": "Size in pixels of the sticky header (if using one); A correct value will improve scroll precision",
       "default": "0",
-      "examples": [ ":virtual-scroll-sticky-size-start=\"48\"" ],
+      "examples": [ "virtual-scroll-sticky-size-start=\"48\"" ],
       "category": "virtual-scroll",
       "addedIn": "v1.2.0"
     },
 
     "virtual-scroll-sticky-size-end": {
-      "type": "Number",
+      "type": [ "Number", "String" ],
       "desc": "Size in pixels of the sticky footer part (if using one); A correct value will improve scroll precision",
       "default": "0",
-      "examples": [ ":virtual-scroll-sticky-size-end=\"48\"" ],
+      "examples": [ "virtual-scroll-sticky-size-end=\"48\"" ],
       "category": "virtual-scroll",
       "addedIn": "v1.2.0"
     },

--- a/ui/src/components/virtual-scroll/QVirtualScroll.sass
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.sass
@@ -2,6 +2,9 @@
   &:focus
     outline: 0
 
+  &__content
+    outline: none
+
   &__padding
     background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) #{"/* rtl:ignore */"}
     background-size: 100% 50px #{"/* rtl:ignore */"}

--- a/ui/src/components/virtual-scroll/QVirtualScroll.styl
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.styl
@@ -2,6 +2,9 @@
   &:focus
     outline: 0
 
+  &__content
+    outline: none
+
   &__padding
     background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) /* rtl:ignore */
     background-size: 100% 50px /* rtl:ignore */

--- a/ui/src/mixins/virtual-scroll.json
+++ b/ui/src/mixins/virtual-scroll.json
@@ -7,34 +7,52 @@
     },
 
     "virtual-scroll-slice-size": {
-      "type": "Number",
-      "desc": "Number of options to render in the virtual list",
+      "type": [ "Number", "String" ],
+      "desc": "Minimum number of items to render in the virtual list",
       "default": "30",
-      "examples": [ ":virtual-scroll-slice-size=\"60\"" ],
+      "examples": [ "virtual-scroll-slice-size=\"60\"" ],
       "category": "virtual-scroll"
     },
 
+    "virtual-scroll-slice-ratio-before": {
+      "type": [ "Number", "String" ],
+      "desc": "Ratio of number of items in visible zone to render before it",
+      "default": "1",
+      "examples": [ "virtual-scroll-slice-ratio-before=\"0.3\"" ],
+      "category": "virtual-scroll",
+      "addedIn": "v1.14.7"
+    },
+
+    "virtual-scroll-slice-ratio-after": {
+      "type": [ "Number", "String" ],
+      "desc": "Ratio of number of items in visible zone to render after it",
+      "default": "1",
+      "examples": [ "virtual-scroll-slice-ratio-after=\"2\"" ],
+      "category": "virtual-scroll",
+      "addedIn": "v1.14.7"
+    },
+
     "virtual-scroll-item-size": {
-      "type": "Number",
-      "desc": "Default size in pixels (height if vertical, width if horizontal) of an option; This value is used for rendering the initial list; Try to use a value close to the minimum size of an item",
+      "type": [ "Number", "String" ],
+      "desc": "Default size in pixels (height if vertical, width if horizontal) of an item; This value is used for rendering the initial list; Try to use a value close to the minimum size of an item",
       "default": "24",
-      "examples": [ ":virtual-scroll-item-size=\"48\"" ],
+      "examples": [ "virtual-scroll-item-size=\"48\"" ],
       "category": "virtual-scroll"
     },
 
     "virtual-scroll-sticky-size-start": {
-      "type": "Number",
+      "type": [ "Number", "String" ],
       "desc": "Size in pixels (height if vertical, width if horizontal) of the sticky part (if using one) at the start of the list; A correct value will improve scroll precision",
       "default": "0",
-      "examples": [ ":virtual-scroll-sticky-size-start=\"48\"" ],
+      "examples": [ "virtual-scroll-sticky-size-start=\"48\"" ],
       "category": "virtual-scroll"
     },
 
     "virtual-scroll-sticky-size-end": {
-      "type": "Number",
+      "type": [ "Number", "String" ],
       "desc": "Size in pixels (height if vertical, width if horizontal) of the sticky part (if using one) at the end of the list; A correct value will improve scroll precision",
       "default": "0",
-      "examples": [ ":virtual-scroll-sticky-size-end=\"48\"" ],
+      "examples": [ "virtual-scroll-sticky-size-end=\"48\"" ],
       "category": "virtual-scroll"
     },
 


### PR DESCRIPTION
- allow string or numbers for former numerical props
- fix losing focus when scrolling