### PR TITLE
feat(pwa) allow crossorigin: use-credentials on manifest meta tag

### DIFF
--- a/app/lib/quasar-conf-file.js
+++ b/app/lib/quasar-conf-file.js
@@ -704,6 +704,7 @@ class QuasarConfFile {
       cfg.pwa = merge({
         workboxPluginMode: 'GenerateSW',
         workboxOptions: {},
+        useCredentials: false,
         manifest: {
           name: this.pkg.productName || this.pkg.name || 'Quasar App',
           short_name: this.pkg.name || 'quasar-pwa',

--- a/app/lib/webpack/pwa/plugin.html-pwa.js
+++ b/app/lib/webpack/pwa/plugin.html-pwa.js
@@ -8,12 +8,13 @@ function makeTag (tagName, attributes) {
   }
 }
 
-function fillPwaTags (data, { pwa: { manifest, metaVariables, metaVariablesFn }}) {
+function fillPwaTags (data, { pwa: { manifest, metaVariables, metaVariablesFn, useCredentials }}) {
   data.headTags.push(
     // Add to home screen for Android and modern mobile browsers
     makeTag('link', {
       rel: 'manifest',
-      href: 'manifest.json'
+      href: 'manifest.json',
+      ...(useCredentials ? { crossorigin: 'use-credentials' } : {})
     })
   )
 

--- a/docs/src/pages/quasar-cli/developing-pwa/configuring-pwa.md
+++ b/docs/src/pages/quasar-cli/developing-pwa/configuring-pwa.md
@@ -196,7 +196,7 @@ Note that you don't need to edit your index.html file (generated from `/src/inde
 ::::
 
 ::: tip
-If your PWA is behind basic auth or requires an Authorization header, set quasar.conf.js > pwa > useCredentials to true to include `crossorigin="use-credentials"` on the manifest.json meta tag.
+(@quasar/app v2.1.10+) If your PWA is behind basic auth or requires an Authorization header, set quasar.conf.js > pwa > useCredentials to true to include `crossorigin="use-credentials"` on the manifest.json meta tag.
 ::::
 
 ## PWA Checklist

--- a/docs/src/pages/quasar-cli/developing-pwa/configuring-pwa.md
+++ b/docs/src/pages/quasar-cli/developing-pwa/configuring-pwa.md
@@ -195,6 +195,10 @@ Please read about the [manifest config](https://developer.mozilla.org/en-US/docs
 Note that you don't need to edit your index.html file (generated from `/src/index.template.html`) to link to the manifest file. Quasar CLI takes care of embedding the right things for you.
 ::::
 
+::: tip
+If your PWA is behind basic auth or requires an Authorization header, set quasar.conf.js > pwa > useCredentials to true to include `crossorigin="use-credentials"` on the manifest.json meta tag.
+::::
+
 ## PWA Checklist
 More info: [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist)
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I am deploying a PWA behind basic auth, the manifest.json meta tag needs `crossorigin="use-credentials"` set on it. Ref: https://github.com/koajs/basic-auth/issues/19#issuecomment-437050887