### PR TITLE
fix(app): Added support for old behavior of nested env variables

### DIFF
--- a/app/lib/helpers/parse-build-env.js
+++ b/app/lib/helpers/parse-build-env.js
@@ -1,9 +1,7 @@
-const flat = require('flat')
-
 module.exports = function parseBuildEnv (envDefinitions, rootDefinitions) {
   const env = {}
 
-  const flatEnv = flat(envDefinitions)
+  const flatEnv = flattenObject(envDefinitions)
 
   for (const key in flatEnv) {
     env[`process.env.${key}`] = JSON.stringify(flatEnv[key])
@@ -14,4 +12,58 @@ module.exports = function parseBuildEnv (envDefinitions, rootDefinitions) {
   }
 
   return env
+}
+
+/**
+ * Flattens the object to a single level.
+ * Keys of the result will be the keypaths of the properties of the parameter.
+ * It will also preserve the original nested objects with their root keypath.
+ *
+ * @param {Object} obj
+ *
+ * @example
+ * flattenObject({
+ *   foo: 1,
+ *   bar: {
+ *     baz: 2,
+ *     qux: {
+ *       quux: {
+ *         quuz: 3
+ *       }
+ *     }
+ *   }
+ * })
+ * // Result:
+ * // foo: 1
+ * // bar: {baz: 2, qux: {…}, qux.quux: {…}, qux.quux.quuz: 3}
+ * // bar.baz: 2
+ * // bar.qux: {quux: {…}, quux.quuz: 3}
+ * // bar.qux.quux: {quuz: 3}
+ * // bar.qux.quux.quuz: 3
+ */
+const flattenObject = obj => {
+  const result = {}
+
+	for (const key in obj) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) continue
+
+    if(typeof obj[key] !== 'object') {
+      result[key] = obj[key]
+      continue
+    }
+
+    const flatObj = flattenObject(obj[key])
+
+    // Save the object itself to it's root key
+    result[key] = flatObj
+
+    // Save the child keys
+    for (const flatKey in flatObj) {
+      if (!Object.prototype.hasOwnProperty.call(flatObj, flatKey)) continue
+
+      result[`${key}.${flatKey}`] = flatObj[flatKey]
+    }
+  }
+
+	return result
 }

--- a/app/package.json
+++ b/app/package.json
@@ -68,7 +68,6 @@
     "express": "4.17.1",
     "fast-glob": "3.2.4",
     "file-loader": "6.2.0",
-    "flat": "^5.0.2",
     "fork-ts-checker-webpack-plugin": "4.1.6",
     "friendly-errors-webpack-plugin": "1.7.0",
     "fs-extra": "9.0.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**

Consider the following configuration for env.
```js
{
  foo: 1,
  bar: {
    baz: 2,
    qux: 3
  }
}
```

The following was working all the time.
```
process.env.foo => 1
process.env.bar.baz => 2
process.env.bar.qux => 2
```

But the following got broken after #8084:

```
process.env.bar => { baz: 2, qux: 3 }
```

This PR aims to preserve the old behavior to avoid breaking changes.

**Context:**
This issue was reported by multiple people that are using [@quasar/qenv](https://github.com/quasarframework/app-extension-qenv) and [@quasar/dotenv](https://github.com/quasarframework/app-extension-dotenv) app-extensions, to @hawkeye64, then we got in contact and I confirmed, investigated, and solved the issue.

**Implementation-wise details:**

'flat' dep got replaced with custom logic.
This custom logic preserves the original nested objects with their root keypath.