### PR TITLE
fix(app): fix dart-sass outputStyle to work with postcss-rtl again #8162

### DIFF
--- a/app/lib/webpack/inject.style-rules.js
+++ b/app/lib/webpack/inject.style-rules.js
@@ -149,11 +149,11 @@ module.exports = function (chain, pref) {
     ...pref.stylusLoaderOptions
   })
   injectRule(chain, pref, 'scss', /\.scss$/, 'sass-loader', merge(
-    { sassOptions: {} },
+    { sassOptions: { outputStyle: /* required for RTL */ 'expanded' } },
     pref.scssLoaderOptions
   ))
   injectRule(chain, pref, 'sass', /\.sass$/, 'sass-loader', merge(
-    { sassOptions: { indentedSyntax: true } },
+    { sassOptions: { indentedSyntax: true, outputStyle: /* required for RTL */ 'expanded' } },
     pref.sassLoaderOptions
   ))
   injectRule(chain, pref, 'less', /\.less$/, 'less-loader', pref.lessLoaderOptions)


### PR DESCRIPTION
https://github.com/sass/dart-sass#javascript-api

It looks like `nested` was replaced by `expanded`

ref cabf6cadeea8c900c9a65e8e51f65bfe6003ba08