### PR TITLE
docs(QSelect): add fuzzy search example (#7974, #656)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-quasar": "^1.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^6.1.1",
+    "fuzzysort": "^1.1.4",
     "gray-matter": "^4.0.2",
     "markdown-it": "^10.0.0",
     "markdown-it-container": "^2.0.0",

--- a/docs/src/components/Codepen.vue
+++ b/docs/src/components/Codepen.vue
@@ -24,7 +24,8 @@ const cssResources = [
 
 const jsResources = [
   'https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js',
-  `https://cdn.jsdelivr.net/npm/quasar@${Quasar.version}/dist/quasar.umd.min.js`
+  `https://cdn.jsdelivr.net/npm/quasar@${Quasar.version}/dist/quasar.umd.min.js`,
+  `https://cdn.jsdelivr.net/npm/fuzzysort`
 ].join(';')
 
 export default {

--- a/docs/src/examples/QSelect/FuzzySearching.vue
+++ b/docs/src/examples/QSelect/FuzzySearching.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row">
+      <q-select
+        filled
+        v-model="model"
+        use-input
+        hide-selected
+        fill-input
+        input-debounce="0"
+        :options="filteringOptions"
+        @filter="filterFn"
+        :hint="hint"
+        style="width: 250px; padding-bottom: 32px"
+      >
+        <template v-slot:no-option>
+          <q-item>
+            <q-item-section class="text-grey">
+              No results
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
+    </div>
+  </div>
+</template>
+
+<script>
+// using "fuzzysort" library as filtering algorithm.
+import fuzzysort from 'fuzzysort'
+
+const stringOptions = [
+  'Google', 'Facebook', 'Twitter', 'Apple', 'Oracle'
+].reduce((acc, opt) => {
+  for (let i = 1; i <= 5; i++) {
+    acc.push(opt + ' ' + i)
+  }
+  return acc
+}, [])
+
+const mappedOptions = [ ...stringOptions ].map((item) => ({ label: item, value: item }))
+
+export default {
+  data () {
+    return {
+      hint: 'Fuzzy Searching (search for "ace")',
+      model: null,
+      options: stringOptions,
+      filteringOptions: [],
+      highlightClass: 'bg-orange-3'
+    }
+  },
+
+  methods: {
+    filterFn (val, update, abort) {
+      const options = mappedOptions
+      if (!options) return abort()
+      update(
+        () => {
+          if (val === '') this.filteringOptions = options
+          else {
+            this.filteringOptions = fuzzysort.go(val, options, {
+              key: 'label',
+              allowTypo: true,
+              limit: 50
+            }).map((item) => ({
+              value: item.obj.value,
+              label: fuzzysort.highlight(item, `<b class="${this.highlightClass}">`, '</b>')
+            }))
+          }
+        },
+        (ref) => {
+          if (val !== '' && ref.options.length > 0) {
+            ref.setOptionIndex(-1) // reset optionIndex in case there is something selected
+            ref.moveOptionSelection(1, true) // focus the first selectable option and do not update the input-value
+          }
+        }
+      )
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -158,6 +158,13 @@ More information: [native input attributes](https://developer.mozilla.org/en-US/
 
 <doc-example title="Selecting option after filtering" file="QSelect/InputFilterAfter" />
 
+### Fuzzy searching
+
+The following example shows how to configure q-select for fuzzy searching (also known as "approximate string matching").
+This example is using a 3rd party library [fuzzysort](https://github.com/farzher/fuzzysort) to implement fuzzy searching algorithm, you can always change the underlying algorithm as you wish.
+
+<doc-example title="Fuzzy searching" file="QSelect/FuzzySearching" />
+
 ## Create new values
 
 ::: tip


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Adding new example to q-select docs page. the example is using a third party library and for that, a new js resource was added to `jsResources` in Codepen.vue.
