### PR TITLE
feat(QSelect): improvements for QSelect #8169, #7898

### DIFF
--- a/ui/dev/src/pages/form/select-part-6-autocomplete.vue
+++ b/ui/dev/src/pages/form/select-part-6-autocomplete.vue
@@ -49,6 +49,8 @@
           </q-item>
         </template>
       </q-select>
+
+      <pre>{{name}} / {{city}} / {{country}}</pre>
     </div>
   </div>
 </template>

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -236,7 +236,7 @@ export default Vue.extend({
 
   methods: {
     focus () {
-      if (this.showPopup !== void 0 && this.hasDialog === true) {
+      if (this.showPopup !== void 0) {
         this.showPopup()
         return
       }

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -105,6 +105,8 @@ export default Vue.extend({
       default: 0
     },
 
+    autocomplete: String,
+
     transitionShow: String,
     transitionHide: String,
 
@@ -112,6 +114,11 @@ export default Vue.extend({
       type: String,
       validator: v => ['default', 'menu', 'dialog'].includes(v),
       default: 'default'
+    },
+
+    virtualScrollItemSize: {
+      type: [ Number, String ],
+      default: void 0
     }
   },
 
@@ -354,7 +361,7 @@ export default Vue.extend({
         // fires "change" instead of "input" on autocomplete.
         change: this.__onChange,
         keydown: this.__onTargetKeydown,
-        keyup: this.__onTargetKeyup,
+        keyup: this.__onTargetAutocomplete,
         keypress: this.__onTargetKeypress,
         focus: this.__selectInputText,
         click: e => {
@@ -365,6 +372,12 @@ export default Vue.extend({
       on.compositionstart = on.compositionupdate = on.compositionend = this.__onComposition
 
       return on
+    },
+
+    virtualScrollItemSizeComputed () {
+      return this.virtualScrollItemSize === void 0
+        ? (this.dense === true ? 24 : 48)
+        : this.virtualScrollItemSize
     }
   },
 
@@ -569,12 +582,14 @@ export default Vue.extend({
     __onTargetAutocomplete (e) {
       const { value } = e.target
 
-      e.target.value = ''
-
       if (e.keyCode !== void 0) {
         this.__onTargetKeyup(e)
         return
       }
+
+      e.target.value = ''
+      clearTimeout(this.inputTimer)
+      this.__resetInputValue()
 
       if (typeof value === 'string' && value.length > 0) {
         const needle = value.toLocaleLowerCase()
@@ -582,17 +597,33 @@ export default Vue.extend({
         let fn = opt => this.getOptionValue(opt).toLocaleLowerCase() === needle
         let option = this.options.find(fn)
 
-        if (option !== null) {
-          this.innerValue.indexOf(option) === -1 && this.toggleOption(option)
+        if (option !== void 0) {
+          if (this.innerValue.indexOf(option) === -1) {
+            this.toggleOption(option)
+          }
+          else {
+            this.hidePopup()
+          }
         }
         else {
           fn = opt => this.getOptionLabel(opt).toLocaleLowerCase() === needle
           option = this.options.find(fn)
 
-          if (option !== null) {
-            this.innerValue.indexOf(option) === -1 && this.toggleOption(option)
+          if (option !== void 0) {
+            if (this.innerValue.indexOf(option) === -1) {
+              this.toggleOption(option)
+            }
+            else {
+              this.hidePopup()
+            }
+          }
+          else {
+            this.filter(value, true)
           }
         }
+      }
+      else {
+        this.__clearValue(e)
       }
     },
 
@@ -653,6 +684,32 @@ export default Vue.extend({
         return
       }
 
+      // home, end - 36, 35
+      if (
+        (e.keyCode === 35 || e.keyCode === 36) &&
+        (typeof this.inputValue !== 'string' || this.inputValue.length === 0)
+      ) {
+        stopAndPrevent(e)
+        this.optionIndex = -1
+        this.moveOptionSelection(e.keyCode === 36 ? 1 : -1, this.multiple)
+      }
+
+      // pg up, pg down - 33, 34
+      if (
+        (e.keyCode === 33 || e.keyCode === 34) &&
+        this.virtualScrollSliceSizeComputed !== void 0
+      ) {
+        stopAndPrevent(e)
+        this.optionIndex = Math.max(
+          -1,
+          Math.min(
+            this.virtualScrollLength,
+            this.optionIndex + (e.keyCode === 33 ? -1 : 1) * this.virtualScrollSliceSizeComputed.view
+          )
+        )
+        this.moveOptionSelection(e.keyCode === 33 ? 1 : -1, this.multiple)
+      }
+
       // up, down
       if (e.keyCode === 38 || e.keyCode === 40) {
         stopAndPrevent(e)
@@ -670,6 +727,7 @@ export default Vue.extend({
       if (
         optionsLength > 0 &&
         this.useInput !== true &&
+        e.key !== void 0 &&
         e.key.length === 1 && // printable char
         e.altKey === e.ctrlKey && // not kbd shortcut
         (e.keyCode !== 32 || this.searchBuffer.length > 0) // space in middle of search
@@ -791,17 +849,9 @@ export default Vue.extend({
       return this.__getVirtualScrollEl()
     },
 
-    __getSelection (h, fromDialog) {
+    __getSelection (h) {
       if (this.hideSelected === true) {
-        return fromDialog === true || this.dialog !== true || this.hasDialog !== true
-          ? []
-          : [
-            h('span', {
-              domProps: {
-                textContent: this.inputValue
-              }
-            })
-          ]
+        return []
       }
 
       if (this.$scopedSlots['selected-item'] !== void 0) {
@@ -846,16 +896,16 @@ export default Vue.extend({
     },
 
     __getControl (h, fromDialog) {
-      const child = this.__getSelection(h, fromDialog)
+      const child = this.__getSelection(h)
       const isTarget = fromDialog === true || this.dialog !== true || this.hasDialog !== true
 
-      if (isTarget === true && this.useInput === true) {
-        child.push(this.__getInput(h, fromDialog))
+      if (this.useInput === true) {
+        child.push(this.__getInput(h, fromDialog, isTarget))
       }
-      else if (this.editable === true) {
-        isTarget === true && child.push(
+      // there can be only one (when dialog is opened the control in dialog should be target)
+      else if (this.editable === true && isTarget === true) {
+        child.push(
           h('div', {
-            // there can be only one (when dialog is opened the control in dialog should be target)
             ref: 'target',
             key: 'd_t',
             staticClass: 'no-outline',
@@ -871,15 +921,17 @@ export default Vue.extend({
           })
         )
 
-        this.qAttrs.autocomplete !== void 0 && child.push(
-          h('input', {
-            staticClass: 'q-select__autocomplete-input no-outline',
-            attrs: { autocomplete: this.qAttrs.autocomplete },
-            on: cache(this, 'autoinp', {
-              keyup: this.__onTargetAutocomplete
+        if (typeof this.autocomplete === 'string' && this.autocomplete.length > 0) {
+          child.push(
+            h('input', {
+              staticClass: 'q-select__autocomplete-input no-outline',
+              attrs: { autocomplete: this.autocomplete },
+              on: cache(this, 'autoinp', {
+                keyup: this.__onTargetAutocomplete
+              })
             })
-          })
-        )
+          )
+        }
       }
 
       if (this.nameProp !== void 0 && this.disable !== true && this.innerOptionsValue.length > 0) {
@@ -942,9 +994,9 @@ export default Vue.extend({
         : null
     },
 
-    __getInput (h, fromDialog) {
+    __getInput (h, fromDialog, isTarget) {
       const options = {
-        ref: 'target',
+        ref: isTarget === true ? 'target' : void 0,
         key: 'i_t',
         staticClass: 'q-field__input q-placeholder col',
         style: this.inputStyle,
@@ -957,6 +1009,7 @@ export default Vue.extend({
           id: this.targetUid,
           maxlength: this.maxlength, // this is converted to prop by QField
           tabindex: this.tabindex,
+          autocomplete: this.autocomplete,
           'data-autofocus': fromDialog === true ? false : this.autofocus,
           disabled: this.disable === true,
           readonly: this.readonly === true
@@ -966,7 +1019,6 @@ export default Vue.extend({
 
       if (fromDialog !== true && this.hasDialog === true) {
         options.staticClass += ' no-pointer-events'
-        options.attrs.readonly = true
       }
 
       return h('input', options)
@@ -1024,8 +1076,8 @@ export default Vue.extend({
       }
     },
 
-    filter (val) {
-      if (this.qListeners.filter === void 0 || this.focused !== true) {
+    filter (val, keepClosed) {
+      if (this.qListeners.filter === void 0 || (keepClosed !== true && this.focused !== true)) {
         return
       }
 
@@ -1057,7 +1109,7 @@ export default Vue.extend({
         'filter',
         val,
         (fn, afterFn) => {
-          if (this.focused === true && this.filterId === filterId) {
+          if ((keepClosed === true || this.focused === true) && this.filterId === filterId) {
             clearTimeout(this.filterId)
 
             typeof fn === 'function' && fn()
@@ -1069,7 +1121,10 @@ export default Vue.extend({
               this.innerLoading = false
 
               if (this.editable === true) {
-                if (this.menu === true) {
+                if (keepClosed === true) {
+                  this.menu === true && this.hidePopup()
+                }
+                else if (this.menu === true) {
                   this.__updateMenu(true)
                 }
                 else {
@@ -1113,12 +1168,7 @@ export default Vue.extend({
         click: e => {
           if (this.hasDialog !== true) {
             // label from QField will propagate click on the input (except IE)
-            if (
-              (this.useInput === true && e.target.classList.contains('q-field__input') !== true) ||
-              (this.useInput !== true && e.target.classList.contains('no-outline') === true)
-            ) {
-              return
-            }
+            prevent(e)
 
             if (this.menu === true) {
               this.__closeMenu()
@@ -1175,9 +1225,14 @@ export default Vue.extend({
         },
         on: cache(this, 'menu', {
           '&scroll': this.__onVirtualScrollEvt,
-          'before-hide': this.__closeMenu
+          'before-hide': this.__closeMenu,
+          show: this.__onMenuShow
         })
       }, child)
+    },
+
+    __onMenuShow () {
+      this.__setVirtualScrollSize()
     },
 
     __onDialogFieldFocus (e) {
@@ -1287,6 +1342,8 @@ export default Vue.extend({
       ) {
         this.$refs.target.focus()
       }
+
+      this.__setVirtualScrollSize()
     },
 
     __closeMenu () {

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -262,6 +262,14 @@
       "extends": "tabindex"
     },
 
+    "autocomplete": {
+      "type": "String",
+      "desc": "Autocomplete attribute for field",
+      "examples": [ "autocomplete=\"country\"" ],
+      "category": "behavior",
+      "addedIn": "v1.14.8"
+    },
+
     "transition-show": {
       "extends": "transition",
       "desc": "Transition when showing the menu/dialog; One of Quasar's embedded transitions",

--- a/ui/src/components/select/QSelect.sass
+++ b/ui/src/components/select/QSelect.sass
@@ -6,9 +6,6 @@
     .q-field__control
       cursor: text
 
-  .q-field__native > span:first-child:empty:before
-    content: '\a0'
-
   .q-field__input
     min-width: 50px !important
 

--- a/ui/src/components/select/QSelect.styl
+++ b/ui/src/components/select/QSelect.styl
@@ -6,9 +6,6 @@
     .q-field__control
       cursor: text
 
-  .q-field__native > span:first-child:empty:before
-    content: '\a0'
-
   .q-field__input
     min-width: 50px !important
 

--- a/ui/src/components/tabs/QRouteTab.json
+++ b/ui/src/components/tabs/QRouteTab.json
@@ -19,9 +19,7 @@
         "evt": {
           "type": "Object",
           "desc": "JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false",
-          "__exemption": [
-            "examples"
-          ]
+          "__exemption": [ "examples" ]
         },
         "navigateFn": {
           "type": "Function",

--- a/ui/src/mixins/virtual-scroll.js
+++ b/ui/src/mixins/virtual-scroll.js
@@ -230,7 +230,7 @@ export default {
 
   computed: {
     needsReset () {
-      return ['virtualScrollItemSize', 'virtualScrollHorizontal']
+      return ['virtualScrollItemSizeComputed', 'virtualScrollHorizontal']
         .map(p => this[p]).join(';')
     },
 
@@ -243,6 +243,10 @@ export default {
       return this.tableColspan !== void 0
         ? { colspan: this.tableColspan }
         : { colspan: 100 }
+    },
+
+    virtualScrollItemSizeComputed () {
+      return this.virtualScrollItemSize
     }
   },
 
@@ -489,7 +493,7 @@ export default {
     },
 
     __resetVirtualScroll (toIndex, fullReset) {
-      const defaultSize = this.virtualScrollItemSize
+      const defaultSize = this.virtualScrollItemSizeComputed
 
       if (fullReset === true || Array.isArray(this.virtualScrollSizes) === false) {
         this.virtualScrollSizes = []
@@ -556,7 +560,7 @@ export default {
       const onView = Math.ceil(Math.max(
         scrollViewSize === void 0 || scrollViewSize <= 0
           ? 10
-          : scrollViewSize / this.virtualScrollItemSize,
+          : scrollViewSize / this.virtualScrollItemSizeComputed,
         this.virtualScrollSliceSize / multiplier
       ))
 
@@ -564,7 +568,10 @@ export default {
         total: Math.ceil(onView * multiplier),
         start: Math.ceil(onView * this.virtualScrollSliceRatioBefore),
         center: Math.ceil(onView * (0.5 + this.virtualScrollSliceRatioBefore)),
-        end: Math.ceil(onView * (1 + this.virtualScrollSliceRatioBefore))
+        end: Math.ceil(onView * (1 + this.virtualScrollSliceRatioBefore)),
+        view: scrollViewSize === void 0 || scrollViewSize <= 0
+          ? 1
+          : Math.ceil(scrollViewSize / this.virtualScrollItemSizeComputed)
       }
     },
 


### PR DESCRIPTION
- open options list on autofocus when using QMenu also (make it consistent with the case of QDialog)
- improve/fix autocomplete
- fix virtualScrollItemSize when not dense
- add PG_UP, PG_DOWN, HOME and END kbd navigation in list (HOME and END if there is no text in input)
- keep input in the base control when using QDialog to prevent visual changes
- prevent duplicate clicks due to propagation from label to input

#8169, #7898