### PR TITLE
feat(QDate): Improve range selection; add day slot for content, fix small years #5434, #7076, #7290, #8037, #8658, #8918, #8926

### DIFF
--- a/docs/src/examples/QDate/DaySlot.vue
+++ b/docs/src/examples/QDate/DaySlot.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md">
+      <q-date
+        class="day-slot--example"
+        v-model="date"
+        range
+        multiple
+        :events="eventsFn"
+        :event-color="eventDetailsFn"
+      >
+        <template v-slot:day="day">
+          <small v-if="day.fill === true" class="text-grey-5">
+            {{ day.i }}
+          </small>
+          <div v-else-if="day.event" class="day-slot__events--example absolute-full">
+            <div
+              v-for="({ color, label }, index) in day.event"
+              :key="index"
+              :class="'bg-' + color"
+            >
+              <q-tooltip
+                :content-class="'day-slot__tooltip--example q-px-md q-py-sm rounded-borders bg-' + color + '-1 text-subtitle2 text-' + color"
+                anchor="bottom right"
+                self="top left"
+                :offset="[ 4, 4 ]"
+              >
+                <span class="text-grey-10">{{ label }}</span>
+              </q-tooltip>
+            </div>
+          </div>
+        </template>
+      </q-date>
+    </div>
+  </div>
+</template>
+
+<style lang="sass">
+.day-slot__events--example
+  border-radius: 50%
+  mix-blend-mode: overlay
+
+  > div
+    position: absolute
+    left: 0
+    right: 0
+    height: 50%
+
+  > div:first-child
+    top: 0
+    border-top-left-radius: 15px
+    border-top-right-radius: 15px
+
+  > div:last-child
+    bottom: 0
+    border-bottom-left-radius: 15px
+    border-bottom-right-radius: 15px
+
+  > div:first-child:last-child
+    height: 100%
+
+.day-slot--example
+  .q-btn--unelevated
+    .day-slot__events--example
+      border: 2px solid transparent
+
+  .q-date__calendar-item--fill
+    visibility: visible
+    cursor: not-allowed
+
+.day-slot__tooltip--example
+  border: 2px solid currentColor
+</style>
+
+<script>
+export default {
+  data () {
+    return {
+      date: [ { from: '2020/12/28', to: '2021/01/02' } ]
+    }
+  },
+
+  methods: {
+    eventsFn (date) {
+      const parts = date.split('/')
+      return [ 1, 3 ].indexOf(parts[2] % 6) > -1
+    },
+
+    eventDetailsFn (date) {
+      const parts = date.split('/')
+      return parts[2] % 6 === 1
+        ? [
+          {
+            color: 'red',
+            label: `Event on ${date}`
+          }
+        ]
+        : [
+          {
+            color: 'orange',
+            label: `Task on ${date}`
+          },
+          {
+            color: 'green',
+            label: `Recurring event on ${date}`
+          }
+        ]
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QDate/Input.vue
+++ b/docs/src/examples/QDate/Input.vue
@@ -4,11 +4,7 @@
       <template v-slot:append>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy ref="qDateProxy" transition-show="scale" transition-hide="scale">
-            <q-date v-model="date">
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date" @input="() => $refs.qDateProxy.hide()" />
           </q-popup-proxy>
         </q-icon>
       </template>

--- a/docs/src/examples/QDate/InputFull.vue
+++ b/docs/src/examples/QDate/InputFull.vue
@@ -4,11 +4,7 @@
       <template v-slot:prepend>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-date v-model="date" mask="YYYY-MM-DD HH:mm">
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date" mask="YYYY-MM-DD HH:mm" />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -16,11 +12,7 @@
       <template v-slot:append>
         <q-icon name="access_time" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-time v-model="date" mask="YYYY-MM-DD HH:mm" format24h>
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-time>
+            <q-time v-model="date" mask="YYYY-MM-DD HH:mm" format24h />
           </q-popup-proxy>
         </q-icon>
       </template>

--- a/docs/src/examples/QDate/IntervalSelection.vue
+++ b/docs/src/examples/QDate/IntervalSelection.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row">
+      <div class="row items-start shadow-2">
+        <q-date
+          ref="start"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMStart"
+          :navigation-min-year-month="selectionStarted ? defaultYMStart : void 0"
+          :navigation-max-year-month="selectionStarted ? defaultYMStart : void 0"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('start', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+
+        <q-date
+          ref="end"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMEnd"
+          :navigation-min-year-month="selectionStarted ? defaultYMEnd : void 0"
+          :model-navigation="false"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('end', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const ym2hash = ({ year, month }) => `${year}/${month > 9 ? '' : '0'}${month}`
+
+export default {
+  data () {
+    return {
+      defaultYMStart: '2020/03',
+      defaultYMEnd: '2020/04',
+
+      selectedDates: null,
+
+      selectionStarted: false
+    }
+  },
+
+  methods: {
+    onSelectionStart (from) {
+      this.selectionStarted = true
+
+      this.defaultYMStart = ym2hash(from)
+      this.defaultYMEnd = ym2hash({
+        year: from.month === 12 ? from.year + 1 : from.year,
+        month: from.month === 12 ? 1 : from.month + 1
+      })
+
+      this.$refs.start.setEditingRange(from, from)
+      this.$refs.end.setEditingRange(from, from)
+    },
+
+    onSelectionChange ({ from, to }) {
+      this.$refs.start.setEditingRange(from, to, 'from')
+      this.$refs.end.setEditingRange(from, to, 'to')
+    },
+
+    onSelectionEnd () {
+      this.selectionStarted = false
+
+      this.$refs.start.setEditingRange()
+      this.$refs.end.setEditingRange()
+    },
+
+    syncCalendars (selectionEnd, yearMonth) {
+      if (selectionEnd === 'start') {
+        const start = ym2hash(yearMonth)
+
+        if (this.selectionStarted !== true) {
+          this.defaultYMStart = start
+        }
+
+        if (start >= this.defaultYMEnd) {
+          const end = ym2hash({
+            year: yearMonth.month === 12 ? yearMonth.year + 1 : yearMonth.year,
+            month: yearMonth.month === 12 ? 1 : yearMonth.month + 1
+          })
+
+          if (this.selectionStarted !== true) {
+            this.defaultYMEnd = end
+          }
+
+          this.$refs.end.setCalendarTo(...end.split('/'))
+        }
+      }
+      else if (selectionEnd === 'end') {
+        const end = ym2hash(yearMonth)
+
+        if (this.selectionStarted !== true) {
+          this.defaultYMEnd = end
+        }
+
+        if (this.defaultYMStart >= end) {
+          const start = ym2hash({
+            year: yearMonth.month === 1 ? yearMonth.year - 1 : yearMonth.year,
+            month: yearMonth.month === 1 ? 12 : yearMonth.month - 1
+          })
+
+          if (this.selectionStarted !== true) {
+            this.defaultYMEnd = start
+          }
+
+          this.$refs.start.setCalendarTo(...start.split('/'))
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QDate/IntervalSelectionConstrained.vue
+++ b/docs/src/examples/QDate/IntervalSelectionConstrained.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row">
+      <div class="row items-start shadow-2">
+        <q-date
+          ref="start"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMStart"
+          :navigation-min-year-month="selectionStarted ? defaultYMStart : void 0"
+          :navigation-max-year-month="selectionStarted ? defaultYMStart : void 0"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('start', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+
+        <q-date
+          ref="end"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMEnd"
+          :navigation-min-year-month="selectionStarted ? defaultYMEnd : void 0"
+          :model-navigation="false"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('end', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+      </div>
+
+      <ul style="max-width: 350px">
+        <li>Click once to start selection mode</li>
+        <li>Click again to select the range</li>
+        <li>The selected range must be at least 3 days and at most 14 days</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { date } from 'quasar'
+
+const { addToDate, formatDate } = date
+const ym2hash = ({ year, month }) => `${year}/${month > 9 ? '' : '0'}${month}`
+const date2hash = ({ year, month, day }) => `${year}/${month > 9 ? '' : '0'}${month}/${day > 9 ? '' : '0'}${day}`
+
+export default {
+  data () {
+    return {
+      defaultYMStart: '2020/03',
+      defaultYMEnd: '2020/04',
+
+      selectedDates: null,
+
+      selectionStarted: false,
+
+      selectionMin: null,
+      selectionMax: null
+    }
+  },
+
+  methods: {
+    onSelectionStart (from) {
+      this.selectionStarted = date2hash(from)
+
+      this.defaultYMStart = ym2hash(from)
+      this.defaultYMEnd = ym2hash({
+        year: from.month === 12 ? from.year + 1 : from.year,
+        month: from.month === 12 ? 1 : from.month + 1
+      })
+
+      const selectionMin = formatDate(addToDate(date2hash(from), { days: 2 }), 'YYYY/MM/DD')
+
+      this.selectionMin = selectionMin
+      this.selectionMax = formatDate(addToDate(date2hash(from), { days: 13 }), 'YYYY/MM/DD')
+
+      const toSplit = selectionMin.split('/')
+      const to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+
+      this.$refs.start.setEditingRange(from, to)
+      this.$refs.end.setEditingRange(from, to)
+    },
+
+    onSelectionChange ({ from, to }) {
+      if (date2hash(to) < this.selectionMin) {
+        const toSplit = this.selectionMin.split('/')
+        to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+      }
+      else if (date2hash(to) > this.selectionMax) {
+        const toSplit = this.selectionMax.split('/')
+        to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+      }
+
+      this.$refs.start.setEditingRange(from, to, 'from')
+      this.$refs.end.setEditingRange(from, to, 'to')
+    },
+
+    onSelectionEnd ({ from, to }) {
+      if (date2hash(to) === this.selectionStarted) {
+        const tmp = to
+        to = from
+        from = tmp
+      }
+
+      if (date2hash(to) < this.selectionMin) {
+        this.selectedDates = { from: date2hash(from), to: this.selectionMin }
+      }
+      else if (date2hash(to) > this.selectionMax) {
+        this.selectedDates = { from: date2hash(from), to: this.selectionMax }
+      }
+
+      this.selectionStarted = false
+
+      this.$refs.start.setEditingRange()
+      this.$refs.end.setEditingRange()
+    },
+
+    syncCalendars (selectionEnd, yearMonth) {
+      if (selectionEnd === 'start') {
+        const start = ym2hash(yearMonth)
+
+        if (this.selectionStarted === false) {
+          this.defaultYMStart = start
+        }
+
+        if (start >= this.defaultYMEnd) {
+          const end = ym2hash({
+            year: yearMonth.month === 12 ? yearMonth.year + 1 : yearMonth.year,
+            month: yearMonth.month === 12 ? 1 : yearMonth.month + 1
+          })
+
+          if (this.selectionStarted === false) {
+            this.defaultYMEnd = end
+          }
+
+          this.$refs.end.setCalendarTo(...end.split('/'))
+        }
+      }
+      else if (selectionEnd === 'end') {
+        const end = ym2hash(yearMonth)
+
+        if (this.selectionStarted === false) {
+          this.defaultYMEnd = end
+        }
+
+        if (this.defaultYMStart >= end) {
+          const start = ym2hash({
+            year: yearMonth.month === 1 ? yearMonth.year - 1 : yearMonth.year,
+            month: yearMonth.month === 1 ? 12 : yearMonth.month - 1
+          })
+
+          if (this.selectionStarted === false) {
+            this.defaultYMEnd = start
+          }
+
+          this.$refs.start.setCalendarTo(...start.split('/'))
+        }
+      }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QDate/WeekSelection.vue
+++ b/docs/src/examples/QDate/WeekSelection.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row items-start">
+      <q-date
+        :value="selectedWeek"
+        minimal
+        @input="selectWeek"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { date } from 'quasar'
+
+const {
+  getDayOfWeek,
+  addToDate,
+  formatDate
+} = date
+
+export default {
+  data () {
+    return {
+      selectedWeek: { from: '2020/03/08', to: '2020/03/14' }
+    }
+  },
+
+  methods: {
+    selectWeek (date) {
+      const dayOfWeek = getDayOfWeek(date)
+      const start = addToDate(date, { days: dayOfWeek === 7 ? 0 : -dayOfWeek })
+      const end = addToDate(start, { days: 6 })
+
+      this.selectedWeek = { from: formatDate(start, 'YYYY/MM/DD'), to: formatDate(end, 'YYYY/MM/DD') }
+    }
+  }
+}
+</script>

--- a/docs/src/examples/QTime/Input.vue
+++ b/docs/src/examples/QTime/Input.vue
@@ -5,11 +5,7 @@
         <template v-slot:append>
           <q-icon name="access_time" class="cursor-pointer">
             <q-popup-proxy transition-show="scale" transition-hide="scale">
-              <q-time v-model="time">
-                <div class="row items-center justify-end">
-                  <q-btn v-close-popup label="Close" color="primary" flat />
-                </div>
-              </q-time>
+              <q-time v-model="time" />
             </q-popup-proxy>
           </q-icon>
         </template>
@@ -23,11 +19,7 @@
                 v-model="timeWithSeconds"
                 with-seconds
                 format24h
-              >
-                <div class="row items-center justify-end">
-                  <q-btn v-close-popup label="Close" color="primary" flat />
-                </div>
-              </q-time>
+              />
             </q-popup-proxy>
           </q-icon>
         </template>

--- a/docs/src/examples/QTime/InputFull.vue
+++ b/docs/src/examples/QTime/InputFull.vue
@@ -4,11 +4,7 @@
       <template v-slot:prepend>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-date v-model="date" mask="YYYY-MM-DD HH:mm">
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date" mask="YYYY-MM-DD HH:mm" />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -16,11 +12,7 @@
       <template v-slot:append>
         <q-icon name="access_time" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-time v-model="date" mask="YYYY-MM-DD HH:mm" format24h>
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-time>
+            <q-time v-model="date" mask="YYYY-MM-DD HH:mm" format24h />
           </q-popup-proxy>
         </q-icon>
       </template>

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -47,7 +47,7 @@ Notice in the examples below that the model is an Object (single selection) or a
 ::: tip TIPS
 * Clicking on an already selected day will deselect it.
 * The user's current editing range can also be set programmatic through the `setEditingRange` method (check the API card).
-* There are two useful events in regards to the current editing range: `range-start` and `range-end` (check the API card).
+* There are three useful events in regards to the current editing range: `range-start`, `range-change` and `range-end` (check the API card).
 :::
 
 ::: warning
@@ -134,6 +134,12 @@ The first example is using an array and the second example is using a function.
 
 <doc-example title="Event color" file="QDate/EventColor" overflow />
 
+### Day scoped slot
+
+You can use the `day` scoped slot to render custom event markers or tooltips specific to each day.
+
+<doc-example title="Day slot" file="QDate/DaySlot" overflow />
+
 ### Limiting options
 
 * You can use the `options` prop to limit user selection to certain times.
@@ -156,6 +162,18 @@ In the example below the navigation is restricted between 2020/07 and 2020/09.
 You can use the default slot for adding buttons:
 
 <doc-example title="With additional buttons" file="QDate/AdditionalButtons" overflow />
+
+* Use 2 components to allow easy interval selection
+
+<doc-example title="Interval selection" file="QDate/IntervalSelection" overflow />
+
+* Adjust the selection to match a fixed interval
+
+<doc-example title="Week selection" file="QDate/WeekSelection" overflow />
+
+* Limit the minimum and maximum selection length
+
+<doc-example title="Constrained interval selection" file="QDate/IntervalSelectionConstrained" overflow />
 
 ### With QSplitter and QTabPanels
 

--- a/ui/dev/src/pages/form/date-day-slot.vue
+++ b/ui/dev/src/pages/form/date-day-slot.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md">
+      <q-date
+        class="day-slot--example"
+        v-model="date"
+        range
+        multiple
+        :events="eventsFn"
+        :event-color="eventDetailsFn"
+      >
+        <template v-slot:day="day">
+          <small v-if="day.fill === true" class="text-grey-5">
+            {{ day.i }}
+          </small>
+          <div v-else-if="day.event" class="day-slot__events--example absolute-full">
+            <div
+              v-for="({ color, label }, index) in day.event"
+              :key="index"
+              :class="'bg-' + color"
+            >
+              <q-tooltip
+                :content-class="'day-slot__tooltip--example q-px-md q-py-sm rounded-borders bg-' + color + '-1 text-subtitle2 text-' + color"
+                anchor="bottom right"
+                self="top left"
+                :offset="[ 4, 4 ]"
+              >
+                <span class="text-grey-10">{{ label }}</span>
+              </q-tooltip>
+            </div>
+          </div>
+        </template>
+      </q-date>
+    </div>
+  </div>
+</template>
+
+<style lang="sass">
+.day-slot__events--example
+  border-radius: 50%
+  mix-blend-mode: overlay
+
+  > div
+    position: absolute
+    left: 0
+    right: 0
+    height: 50%
+
+  > div:first-child
+    top: 0
+    border-top-left-radius: 15px
+    border-top-right-radius: 15px
+
+  > div:last-child
+    bottom: 0
+    border-bottom-left-radius: 15px
+    border-bottom-right-radius: 15px
+
+  > div:first-child:last-child
+    height: 100%
+
+.day-slot--example
+  .q-btn--unelevated
+    .day-slot__events--example
+      border: 2px solid transparent
+
+  .q-date__calendar-item--fill
+    visibility: visible
+    cursor: not-allowed
+
+.day-slot__tooltip--example
+  border: 2px solid currentColor
+</style>
+
+<script>
+export default {
+  data () {
+    return {
+      date: [{ from: '2020/12/28', to: '2021/01/02' }]
+    }
+  },
+
+  methods: {
+    eventsFn (date) {
+      const parts = date.split('/')
+      return [ 1, 3 ].indexOf(parts[2] % 6) > -1
+    },
+
+    eventDetailsFn (date) {
+      const parts = date.split('/')
+      return parts[2] % 6 === 1
+        ? [
+          {
+            color: 'red',
+            label: `Event on ${date}`
+          }
+        ]
+        : [
+          {
+            color: 'orange',
+            label: `Task on ${date}`
+          },
+          {
+            color: 'green',
+            label: `Recurring event on ${date}`
+          }
+        ]
+    }
+  }
+}
+</script>

--- a/ui/dev/src/pages/form/date-interval-selection-constrained.vue
+++ b/ui/dev/src/pages/form/date-interval-selection-constrained.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row">
+      <div class="row items-start shadow-2">
+        <q-date
+          ref="start"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMStart"
+          :navigation-min-year-month="selectionStarted ? defaultYMStart : void 0"
+          :navigation-max-year-month="selectionStarted ? defaultYMStart : void 0"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('start', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+
+        <q-date
+          ref="end"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMEnd"
+          :navigation-min-year-month="selectionStarted ? defaultYMEnd : void 0"
+          :model-navigation="false"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('end', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+      </div>
+
+      <ul style="max-width: 350px">
+        <li>Click once to start selection mode</li>
+        <li>Click again to select the range</li>
+        <li>The selected range must be at least 3 days and at most 14 days</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { date } from 'quasar'
+
+const { addToDate, formatDate } = date
+const ym2hash = ({ year, month }) => `${year}/${month > 9 ? '' : '0'}${month}`
+const date2hash = ({ year, month, day }) => `${year}/${month > 9 ? '' : '0'}${month}/${day > 9 ? '' : '0'}${day}`
+
+export default {
+  data () {
+    return {
+      defaultYMStart: '2020/03',
+      defaultYMEnd: '2020/04',
+
+      selectedDates: null,
+
+      selectionStarted: false,
+
+      selectionMin: null,
+      selectionMax: null
+    }
+  },
+
+  methods: {
+    onSelectionStart (from) {
+      this.selectionStarted = date2hash(from)
+
+      this.defaultYMStart = ym2hash(from)
+      this.defaultYMEnd = ym2hash({
+        year: from.month === 12 ? from.year + 1 : from.year,
+        month: from.month === 12 ? 1 : from.month + 1
+      })
+
+      const selectionMin = formatDate(addToDate(date2hash(from), { days: 2 }), 'YYYY/MM/DD')
+
+      this.selectionMin = selectionMin
+      this.selectionMax = formatDate(addToDate(date2hash(from), { days: 13 }), 'YYYY/MM/DD')
+
+      const toSplit = selectionMin.split('/')
+      const to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+
+      this.$refs.start.setEditingRange(from, to)
+      this.$refs.end.setEditingRange(from, to)
+    },
+
+    onSelectionChange ({ from, to }) {
+      if (date2hash(to) < this.selectionMin) {
+        const toSplit = this.selectionMin.split('/')
+        to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+      }
+      else if (date2hash(to) > this.selectionMax) {
+        const toSplit = this.selectionMax.split('/')
+        to = { year: toSplit[0], month: toSplit[1], day: toSplit[2] }
+      }
+
+      this.$refs.start.setEditingRange(from, to, 'from')
+      this.$refs.end.setEditingRange(from, to, 'to')
+    },
+
+    onSelectionEnd ({ from, to }) {
+      if (date2hash(to) === this.selectionStarted) {
+        const tmp = to
+        to = from
+        from = tmp
+      }
+
+      if (date2hash(to) < this.selectionMin) {
+        this.selectedDates = { from: date2hash(from), to: this.selectionMin }
+      }
+      else if (date2hash(to) > this.selectionMax) {
+        this.selectedDates = { from: date2hash(from), to: this.selectionMax }
+      }
+
+      this.selectionStarted = false
+
+      this.$refs.start.setEditingRange()
+      this.$refs.end.setEditingRange()
+    },
+
+    syncCalendars (selectionEnd, yearMonth) {
+      if (selectionEnd === 'start') {
+        const start = ym2hash(yearMonth)
+
+        if (this.selectionStarted === false) {
+          this.defaultYMStart = start
+        }
+
+        if (start >= this.defaultYMEnd) {
+          const end = ym2hash({
+            year: yearMonth.month === 12 ? yearMonth.year + 1 : yearMonth.year,
+            month: yearMonth.month === 12 ? 1 : yearMonth.month + 1
+          })
+
+          if (this.selectionStarted === false) {
+            this.defaultYMEnd = end
+          }
+
+          this.$refs.end.setCalendarTo(...end.split('/'))
+        }
+      }
+      else if (selectionEnd === 'end') {
+        const end = ym2hash(yearMonth)
+
+        if (this.selectionStarted === false) {
+          this.defaultYMEnd = end
+        }
+
+        if (this.defaultYMStart >= end) {
+          const start = ym2hash({
+            year: yearMonth.month === 1 ? yearMonth.year - 1 : yearMonth.year,
+            month: yearMonth.month === 1 ? 12 : yearMonth.month - 1
+          })
+
+          if (this.selectionStarted === false) {
+            this.defaultYMEnd = start
+          }
+
+          this.$refs.start.setCalendarTo(...start.split('/'))
+        }
+      }
+    }
+  }
+}
+</script>

--- a/ui/dev/src/pages/form/date-interval-selection.vue
+++ b/ui/dev/src/pages/form/date-interval-selection.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row">
+      <div class="row items-start shadow-2">
+        <q-date
+          ref="start"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMStart"
+          :navigation-min-year-month="selectionStarted ? defaultYMStart : void 0"
+          :navigation-max-year-month="selectionStarted ? defaultYMStart : void 0"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('start', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+
+        <q-date
+          ref="end"
+          v-model="selectedDates"
+          range
+          :default-year-month="defaultYMEnd"
+          :navigation-min-year-month="selectionStarted ? defaultYMEnd : void 0"
+          :model-navigation="false"
+          minimal
+          flat
+          @navigation="(yearMonth) => { syncCalendars('end', yearMonth) }"
+          @range-start="onSelectionStart"
+          @range-change="onSelectionChange"
+          @range-end="onSelectionEnd"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const ym2hash = ({ year, month }) => `${year}/${month > 9 ? '' : '0'}${month}`
+
+export default {
+  data () {
+    return {
+      defaultYMStart: '2020/03',
+      defaultYMEnd: '2020/04',
+
+      selectedDates: null,
+
+      selectionStarted: false
+    }
+  },
+
+  methods: {
+    onSelectionStart (from) {
+      this.selectionStarted = true
+
+      this.defaultYMStart = ym2hash(from)
+      this.defaultYMEnd = ym2hash({
+        year: from.month === 12 ? from.year + 1 : from.year,
+        month: from.month === 12 ? 1 : from.month + 1
+      })
+
+      this.$refs.start.setEditingRange(from, from)
+      this.$refs.end.setEditingRange(from, from)
+    },
+
+    onSelectionChange ({ from, to }) {
+      this.$refs.start.setEditingRange(from, to, 'from')
+      this.$refs.end.setEditingRange(from, to, 'to')
+    },
+
+    onSelectionEnd () {
+      this.selectionStarted = false
+
+      this.$refs.start.setEditingRange()
+      this.$refs.end.setEditingRange()
+    },
+
+    syncCalendars (selectionEnd, yearMonth) {
+      if (selectionEnd === 'start') {
+        const start = ym2hash(yearMonth)
+
+        if (this.selectionStarted !== true) {
+          this.defaultYMStart = start
+        }
+
+        if (start >= this.defaultYMEnd) {
+          const end = ym2hash({
+            year: yearMonth.month === 12 ? yearMonth.year + 1 : yearMonth.year,
+            month: yearMonth.month === 12 ? 1 : yearMonth.month + 1
+          })
+
+          if (this.selectionStarted !== true) {
+            this.defaultYMEnd = end
+          }
+
+          this.$refs.end.setCalendarTo(...end.split('/'))
+        }
+      }
+      else if (selectionEnd === 'end') {
+        const end = ym2hash(yearMonth)
+
+        if (this.selectionStarted !== true) {
+          this.defaultYMEnd = end
+        }
+
+        if (this.defaultYMStart >= end) {
+          const start = ym2hash({
+            year: yearMonth.month === 1 ? yearMonth.year - 1 : yearMonth.year,
+            month: yearMonth.month === 1 ? 12 : yearMonth.month - 1
+          })
+
+          if (this.selectionStarted !== true) {
+            this.defaultYMEnd = start
+          }
+
+          this.$refs.start.setCalendarTo(...start.split('/'))
+        }
+      }
+    }
+  }
+}
+</script>

--- a/ui/dev/src/pages/form/date-part1-basic.vue
+++ b/ui/dev/src/pages/form/date-part1-basic.vue
@@ -22,8 +22,8 @@
           :style="style"
           @input="inputLog"
           flat bordered
-          navigation-min-year-month="2018/05"
-          navigation-max-year-month="2019/03"
+          :navigation-min-year-month="navigationMinYM"
+          :navigation-max-year-month="navigationMaxYM"
         >
           <div class="row items-center justify-end q-gutter-sm">
             <q-btn label="Cancel" color="primary" flat />
@@ -135,25 +135,61 @@
       </div>
 
       <div class="text-h6">
+        Day slot
+      </div>
+      <div class="q-gutter-md">
+        <q-date
+          class="day-slot--example"
+          v-model="date"
+          v-bind="props"
+          :events="eventMultiFn"
+          :event-color="eventMultiDetailsFn"
+          :style="style"
+        >
+          <template v-slot:day="day">
+            <small v-if="day.fill === true" class="text-grey-5">
+              {{ day.i }}
+            </small>
+            <div v-else-if="day.event" class="day-slot__events--example absolute-full">
+              <div
+                v-for="({ color, label }, index) in day.event"
+                :key="index"
+                :class="'bg-' + color"
+              >
+                <q-tooltip
+                  :content-class="'day-slot__tooltip--example q-px-md q-py-sm rounded-borders bg-' + color + '-1 text-subtitle2 text-' + color"
+                  anchor="bottom right"
+                  self="top left"
+                  :offset="[ 4, 4 ]"
+                >
+                  <span class="text-grey-10">{{ label }}</span>
+                </q-tooltip>
+              </div>
+            </div>
+          </template>
+        </q-date>
+      </div>
+
+      <div class="text-h6">
         Limited options
       </div>
       <div class="q-gutter-md">
         <q-date
-          v-model="date"
+          v-model="dateLimited"
           v-bind="props"
           :options="options"
           :style="style"
         />
 
         <q-date
-          v-model="date"
+          v-model="dateLimited"
           v-bind="props"
           :options="optionsFn"
           :style="style"
         />
 
         <q-date
-          v-model="date"
+          v-model="dateLimited"
           v-bind="props"
           :options="optionsFn2"
           :style="style"
@@ -214,7 +250,6 @@
           :mask="mask"
           :locale="localeComputed"
           v-bind="props"
-          calendar="gregorian"
           :style="style"
         />
 
@@ -333,6 +368,43 @@
   </div>
 </template>
 
+<style lang="sass">
+.day-slot__events--example
+  border-radius: 50%
+  mix-blend-mode: overlay
+
+  > div
+    position: absolute
+    left: 0
+    right: 0
+    height: 50%
+
+  > div:first-child
+    top: 0
+    border-top-left-radius: 15px
+    border-top-right-radius: 15px
+
+  > div:last-child
+    bottom: 0
+    border-bottom-left-radius: 15px
+    border-bottom-right-radius: 15px
+
+  > div:first-child:last-child
+    height: 100%
+
+.day-slot--example
+  .q-btn--unelevated
+    .day-slot__events--example
+      border: 2px solid transparent
+
+  .q-date__calendar-item--fill
+    visibility: visible
+    cursor: not-allowed
+
+.day-slot__tooltip--example
+  border: 2px solid currentColor
+</style>
+
 <script>
 import languages from 'quasar/lang/index.json'
 
@@ -357,12 +429,15 @@ export default {
 
       date: '2018/11/03',
       dateParse: 'Month: Aug, Day: 28th, Year: 2018',
+      dateLimited: '2018/08/23',
       dateNeg: '-13/11/03',
-      dateFrom: '2012/06/18',
-      dateTo: '2015/04/10',
       nullDate: null,
       nullDate2: null,
+
       defaultYearMonth: '1986/02',
+
+      navigationMinYM: '2018/05',
+      navigationMaxYM: '2019/03',
 
       persian: false,
 
@@ -419,13 +494,21 @@ export default {
     persian (val) {
       if (val === true) {
         this.date = '1397/08/12'
+        this.dateLimited = '1397/08/10'
+        this.dateParse = 'Month: Aug, Day: 12th, Year: 1397'
         this.nullDate = undefined
         this.defaultYearMonth = '1364/11'
+        this.navigationMinYM = '1396/05'
+        this.navigationMaxYM = '1397/10'
       }
       else {
         this.date = '2018/11/03'
+        this.dateLimited = '2018/08/23'
+        this.dateParse = 'Month: Aug, Day: 28th, Year: 2018'
         this.nullDate = null
         this.defaultYearMonth = '1986/02'
+        this.navigationMinYM = '2018/05'
+        this.navigationMaxYM = '2019/03'
       }
     }
   },
@@ -436,6 +519,32 @@ export default {
 
     eventColor (date) {
       return date[9] % 2 === 0 ? 'teal' : 'orange'
+    },
+
+    eventMultiFn (date) {
+      const parts = date.split('/')
+      return [ 1, 3 ].indexOf(parts[2] % 6) > -1
+    },
+
+    eventMultiDetailsFn (date) {
+      const parts = date.split('/')
+      return parts[2] % 6 === 1
+        ? [
+          {
+            color: 'red',
+            label: `Event on ${date}`
+          }
+        ]
+        : [
+          {
+            color: 'orange',
+            label: `Task on ${date}`
+          },
+          {
+            color: 'green',
+            label: `Recurring event on ${date}`
+          }
+        ]
     },
 
     optionsFn (date) {

--- a/ui/dev/src/pages/form/date-part2-multiple-range.vue
+++ b/ui/dev/src/pages/form/date-part2-multiple-range.vue
@@ -18,7 +18,7 @@
 
       <div>Multiple + Range {{ daysRange || 'none ' }}:</div>
       <div class="row no-wrap">
-        <q-date ref="daysRange" v-model="daysRange" multiple today-btn range @input="onInput" @range-start="onRangeStart" @range-end="onRangeEnd" :no-unset="noUnset" />
+        <q-date ref="daysRange" v-model="daysRange" multiple today-btn range day-as-range @input="onInput" @range-start="onRangeStart" @range-end="onRangeEnd" :no-unset="noUnset" />
         <div class="q-gutter-sm q-ml-sm">
           <q-btn label="setEditingRange(from)" @click="setRangeFrom" no-caps />
           <q-btn label="setEditingRange(from, to)" @click="setRangeFromTo" no-caps />
@@ -52,9 +52,10 @@ export default {
       daysRange: [
         { from: '2020/08/12', to: '2020/08/16' },
         '2020/08/02',
+        { from: '2020/08/03', to: '2020/08/03' },
+        { from: '2020/08/07', to: '2020/08/05' },
         '2020/08/10',
-        { from: '2020/08/27', to: '2020/09/15' }
-        // '2021/09/11',
+        { from: '2020/08/27', to: '2020/10/15' }
       ]
     }
   },

--- a/ui/dev/src/pages/form/date-time-timezone.vue
+++ b/ui/dev/src/pages/form/date-time-timezone.vue
@@ -4,11 +4,7 @@
       <template v-slot:prepend>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-date v-model="date1" mask="YYYY-MM-DD HH:mm:ssZ">
-              <div class="row items-center justify-end q-gutter-sm">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date1" mask="YYYY-MM-DD HH:mm:ssZ" />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -16,11 +12,7 @@
       <template v-slot:append>
         <q-icon name="access_time" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-time v-model="date1" mask="YYYY-MM-DD HH:mm:ssZ" format24h with-seconds>
-              <div class="row items-center justify-end q-gutter-sm">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-time>
+            <q-time v-model="date1" mask="YYYY-MM-DD HH:mm:ssZ" format24h with-seconds />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -30,11 +22,7 @@
       <template v-slot:prepend>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-date v-model="date2" mask="YYYY-MM-DD HH:mm ZZ">
-              <div class="row items-center justify-end q-gutter-sm">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date2" mask="YYYY-MM-DD HH:mm ZZ" />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -42,11 +30,7 @@
       <template v-slot:append>
         <q-icon name="access_time" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-time v-model="date2" mask="YYYY-MM-DD HH:mm ZZ" format24h>
-              <div class="row items-center justify-end q-gutter-sm">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-time>
+            <q-time v-model="date2" mask="YYYY-MM-DD HH:mm ZZ" format24h />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -56,11 +40,7 @@
       <template v-slot:prepend>
         <q-icon name="event" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-date v-model="date3" mask="YYYY-MM-DD HH:mm">
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-date>
+            <q-date v-model="date3" mask="YYYY-MM-DD HH:mm" />
           </q-popup-proxy>
         </q-icon>
       </template>
@@ -68,11 +48,7 @@
       <template v-slot:append>
         <q-icon name="access_time" class="cursor-pointer">
           <q-popup-proxy transition-show="scale" transition-hide="scale">
-            <q-time v-model="date3" mask="YYYY-MM-DD HH:mm" format24h>
-              <div class="row items-center justify-end">
-                <q-btn v-close-popup label="Close" color="primary" flat />
-              </div>
-            </q-time>
+            <q-time v-model="date3" mask="YYYY-MM-DD HH:mm" format24h />
           </q-popup-proxy>
         </q-icon>
       </template>

--- a/ui/dev/src/pages/form/date-week-selection.vue
+++ b/ui/dev/src/pages/form/date-week-selection.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="q-pa-md">
+    <div class="q-gutter-md row items-start">
+      <q-date
+        :value="selectedWeek"
+        minimal
+        @input="selectWeek"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { date } from 'quasar'
+
+const {
+  getDayOfWeek,
+  addToDate,
+  formatDate
+} = date
+
+export default {
+  data () {
+    return {
+      selectedWeek: { from: '2020/03/08', to: '2020/03/14' }
+    }
+  },
+
+  methods: {
+    selectWeek (date) {
+      const dayOfWeek = getDayOfWeek(date)
+      const start = addToDate(date, { days: dayOfWeek === 7 ? 0 : -dayOfWeek })
+      const end = addToDate(start, { days: 6 })
+
+      this.selectedWeek = { from: formatDate(start, 'YYYY/MM/DD'), to: formatDate(end, 'YYYY/MM/DD') }
+    }
+  }
+}
+</script>

--- a/ui/src/components/date/QDate.json
+++ b/ui/src/components/date/QDate.json
@@ -96,6 +96,15 @@
       "category": "model"
     },
 
+    "model-navigation": {
+      "type": [ "String", "Boolean" ],
+      "desc": "On which end of the range to navigate the calendar when the model changes; Use `false` to skip navigation",
+      "values": [ "from", "to", "(Boolean) false" ],
+      "default": "from",
+      "category": "behavior",
+      "addedIn": "v1.14.8"
+    },
+
     "navigation-min-year-month": {
       "type": "String",
       "desc": "Lock user from navigating below a specific year+month (in YYYY/MM format); This prop is not used to correct the model; You might want to also use 'default-year-month' prop",
@@ -156,6 +165,13 @@
       "addedIn": "v1.13.0"
     },
 
+    "day-as-range": {
+      "type": "Boolean",
+      "desc": "Model single days as a range (object) instead of string",
+      "category": "model|selection",
+      "addedIn": "v1.15.2"
+    },
+
     "emit-immediately": {
       "type": "Boolean",
       "desc": "Emit model when user browses month and year too; ONLY for single selection (non-multiple, non-range)",
@@ -167,6 +183,129 @@
     "default": {
       "desc": "This is where additional buttons can go",
       "addedIn": "v1.2.8"
+    }
+  },
+
+  "scopedSlots": {
+    "day": {
+      "desc": "Override default day content slot; Suggestion: tooltips and / or multiple event markers",
+      "scope": {
+        "i": {
+          "type": "Number",
+          "desc": "The day number in month",
+          "examples": [ 23 ]
+        },
+        "day": {
+          "type": "String",
+          "desc": "Full date in YYYY/MM/DD form",
+          "examples": [ "2020/05/20" ]
+        },
+        "fill": {
+          "type": "Boolean",
+          "desc": "The day does not belong to the currently displayed month / year (no QBtn and hidden by default)"
+        },
+        "in": {
+          "type": "Boolean",
+          "desc": "The day is selectable (QBtn is not disabled)"
+        },
+        "today": {
+          "type": "Boolean",
+          "desc": "The day is today"
+        },
+        "selected": {
+          "type": "Boolean",
+          "desc": "The day is selected"
+        },
+        "unelevated": {
+          "type": "Boolean",
+          "desc": "The day is selected"
+        },
+        "flat": {
+          "type": "Boolean",
+          "desc": "The day is not selected"
+        },
+        "classes": {
+          "type": "String",
+          "desc": "The classes applied to the day",
+          "__exemption": "examples"
+        },
+        "color": {
+          "type": "String",
+          "desc": "The color of the QBtn used for the day",
+          "examples": [ "primary" ]
+        },
+        "textColor": {
+          "type": "String",
+          "desc": "The text color of the QBtn used for the day",
+          "examples": [ "orange-2" ]
+        },
+        "event": {
+          "type": [ "Boolean", "String", "Any" ],
+          "desc": "Boolean false if there is no event for the day; The event-color or the value returned by the event-color function",
+          "examples": [ "red" ]
+        },
+        "range": {
+          "type": "Object",
+          "desc": "The range this day belongs to",
+          "definition": {
+            "from": {
+              "type": "Object",
+              "desc": "Object of properties of the range starting point (only if range)",
+              "definition": {
+                "year": {
+                  "type": "Number",
+                  "desc": "The year",
+                  "__exemption": [
+                    "examples"
+                  ]
+                },
+                "month": {
+                  "type": "Number",
+                  "desc": "The month",
+                  "__exemption": [
+                    "examples"
+                  ]
+                },
+                "day": {
+                  "type": "Number",
+                  "desc": "The day of month",
+                  "__exemption": [
+                    "examples"
+                  ]
+                }
+              }
+            },
+            "to": {
+              "type": "Object",
+              "desc": "Object of properties of the range ending point (only if range)",
+              "definition": {
+                "year": {
+                  "type": "Number",
+                  "desc": "The year",
+                  "__exemption": [
+                    "examples"
+                  ]
+                },
+                "month": {
+                  "type": "Number",
+                  "desc": "The month",
+                  "__exemption": [
+                    "examples"
+                  ]
+                },
+                "day": {
+                  "type": "Number",
+                  "desc": "The day of month",
+                  "__exemption": [
+                    "examples"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "addedIn": "v1.14.8"
     }
   },
 
@@ -304,6 +443,61 @@
         }
       },
       "addedIn": "v1.13.0"
+    },
+
+    "range-change": {
+      "desc": "User has changed a range selection",
+      "params": {
+        "range": {
+          "type": "Object",
+          "desc": "Definition of the range",
+          "definition": {
+            "from": {
+              "type": "Object",
+              "desc": "Definition of date from where the range begins",
+              "definition": {
+                "year": {
+                  "type": "Number",
+                  "desc": "The year",
+                  "__exemption": [ "examples" ]
+                },
+                "month": {
+                  "type": "Number",
+                  "desc": "The month",
+                  "__exemption": [ "examples" ]
+                },
+                "day": {
+                  "type": "Number",
+                  "desc": "The day of month",
+                  "__exemption": [ "examples" ]
+                }
+              }
+            },
+            "to": {
+              "type": "Object",
+              "desc": "Definition of date to where the range ends",
+              "definition": {
+                "year": {
+                  "type": "Number",
+                  "desc": "The year",
+                  "__exemption": [ "examples" ]
+                },
+                "month": {
+                  "type": "Number",
+                  "desc": "The month",
+                  "__exemption": [ "examples" ]
+                },
+                "day": {
+                  "type": "Number",
+                  "desc": "The day of month",
+                  "__exemption": [ "examples" ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "addedIn": "v1.14.8"
     },
 
     "range-end": {
@@ -459,6 +653,13 @@
               "__exemption": [ "examples" ]
             }
           }
+        },
+        "modelNavigation": {
+          "type": [ "String", "Boolean" ],
+          "desc": "On which end of the range to navigate the calendar; Use `false` to skip navigation",
+          "values": [ "from", "to", "(Boolean) false" ],
+          "default": "from",
+          "addedIn": "v1.14.8"
         }
       }
     }

--- a/ui/src/components/date/QDate.sass
+++ b/ui/src/components/date/QDate.sass
@@ -102,6 +102,12 @@
 
     &--fill
       visibility: hidden
+      min-height: 32px
+
+      &.q-date
+        &__range, &__range-from, &__range-to
+          &:before
+            opacity: .05
 
   &__range, &__range-from, &__range-to
 
@@ -114,7 +120,9 @@
       left: 0
       right: 0
       opacity: .3
+      pointer-events: none
 
+  &__range
     &:nth-child(7n-6)
       &:before
         border-top-left-radius: 0
@@ -127,10 +135,15 @@
 
   &__range-from
     &:before
-      left: 50%
+      left: calc(50% - 15px)
+      border-top-left-radius: $button-rounded-border-radius
+      border-bottom-left-radius: $button-rounded-border-radius
+
   &__range-to
     &:before
-      right: 50%
+      right: calc(50% - 15px)
+      border-top-right-radius: $button-rounded-border-radius
+      border-bottom-right-radius: $button-rounded-border-radius
 
   &__edit-range
     &:after

--- a/ui/src/components/date/QDate.styl
+++ b/ui/src/components/date/QDate.styl
@@ -102,6 +102,12 @@
 
     &--fill
       visibility: hidden
+      min-height: 32px
+
+      &.q-date
+        &__range, &__range-from, &__range-to
+          &:before
+            opacity: .05
 
   &__range, &__range-from, &__range-to
 
@@ -114,7 +120,9 @@
       left: 0
       right: 0
       opacity: .3
+      pointer-events: none
 
+  &__range
     &:nth-child(7n-6)
       &:before
         border-top-left-radius: 0
@@ -127,10 +135,15 @@
 
   &__range-from
     &:before
-      left: 50%
+      left: calc(50% - 15px)
+      border-top-left-radius: $button-rounded-border-radius
+      border-bottom-left-radius: $button-rounded-border-radius
+
   &__range-to
     &:before
-      right: 50%
+      right: calc(50% - 15px)
+      border-top-right-radius: $button-rounded-border-radius
+      border-bottom-right-radius: $button-rounded-border-radius
 
   &__edit-range
     &:after

--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -4,7 +4,7 @@ import QBtn from '../btn/QBtn.js'
 import TouchPan from '../../directives/TouchPan.js'
 
 import { slot } from '../../utils/slot.js'
-import { formatDate, __splitDate } from '../../utils/date.js'
+import { formatDate, __splitDate, __safeCreateDate } from '../../utils/date.js'
 import { position } from '../../utils/event.js'
 import { pad } from '../../utils/format.js'
 import cache from '../../utils/cache.js'
@@ -850,7 +850,7 @@ export default Vue.extend({
           pad(date.minute) +
           (this.withSeconds === true ? ':' + pad(date.second) : '')
         : formatDate(
-          new Date(
+          __safeCreateDate(
             date.year,
             date.month === null ? null : date.month - 1,
             date.day,

--- a/ui/src/utils/date.js
+++ b/ui/src/utils/date.js
@@ -151,10 +151,20 @@ function getRegexData (mask, dateLocale) {
   return res
 }
 
+export function __safeCreateDate (...args) {
+  const d = new Date(...args)
+
+  if (args.length > 1 && args[0] >= 0 && args[0] <= 99) {
+    d.setFullYear(args[0])
+  }
+
+  return d
+}
+
 export function extractDate (str, mask, dateLocale) {
   const d = __splitDate(str, mask, dateLocale)
 
-  const date = new Date(
+  const date = __safeCreateDate(
     d.year,
     d.month === null ? null : d.month - 1,
     d.day,
@@ -262,7 +272,7 @@ export function __splitDate (str, mask, dateLocale, calendar, defaultModel) {
       }
 
       const maxDay = calendar !== 'persian'
-        ? (new Date(date.year, date.month, 0)).getDate()
+        ? (__safeCreateDate(date.year, date.month, 0)).getDate()
         : jalaaliMonthLength(date.year, date.month)
 
       if (date.day > maxDay) {
@@ -321,7 +331,7 @@ function formatTimezone (offset, delimeter = '') {
 
 function setMonth (date, newMonth /* 1-based */) {
   const
-    test = new Date(date.getFullYear(), newMonth, 0, 0, 0, 0, 0),
+    test = __safeCreateDate(date.getFullYear(), newMonth, 0, 0, 0, 0, 0),
     days = test.getDate()
 
   date.setMonth(newMonth - 1, Math.min(days, date.getDate()))
@@ -363,13 +373,13 @@ export function getDayOfWeek (date) {
 
 export function getWeekOfYear (date) {
   // Remove time components of date
-  const thursday = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const thursday = __safeCreateDate(date.getFullYear(), date.getMonth(), date.getDate())
 
   // Change date to Thursday same week
   thursday.setDate(thursday.getDate() - ((thursday.getDay() + 6) % 7) + 3)
 
   // Take January 4th as it is always in week 1 (see ISO 8601)
-  const firstThursday = new Date(thursday.getFullYear(), 0, 4)
+  const firstThursday = __safeCreateDate(thursday.getFullYear(), 0, 4)
 
   // Change date to Thursday same week
   firstThursday.setDate(firstThursday.getDate() - ((firstThursday.getDay() + 6) % 7) + 3)
@@ -490,10 +500,12 @@ export function getMinDate (date /*, ...args */) {
 }
 
 function getDiff (t, sub, interval) {
-  return (
-    (t.getTime() - t.getTimezoneOffset() * MILLISECONDS_IN_MINUTE) -
-    (sub.getTime() - sub.getTimezoneOffset() * MILLISECONDS_IN_MINUTE)
-  ) / interval
+  return Math.floor(
+    (
+      (t.getTime() - t.getTimezoneOffset() * MILLISECONDS_IN_MINUTE) -
+      (sub.getTime() - sub.getTimezoneOffset() * MILLISECONDS_IN_MINUTE)
+    ) / interval
+  )
 }
 
 export function getDateDiff (date, subtract, unit = 'days') {
@@ -595,7 +607,7 @@ export function isSameDate (date, date2, unit) {
 }
 
 export function daysInMonth (date) {
-  return (new Date(date.getFullYear(), date.getMonth() + 1, 0)).getDate()
+  return (__safeCreateDate(date.getFullYear(), date.getMonth() + 1, 0)).getDate()
 }
 
 function getOrdinal (n) {


### PR DESCRIPTION
- add modelNavigation prop
- add range-change event
- fix cached function when changing from persian to gregorian calendars
- fix viewModel as text
- add more examples
- fix processing of years between 0 and 99

#5434, #7076, #7290, #8037, #8658, #8918, #8926
