### PR TITLE
feat(QSelect): improvements for QSelect #8169, #7898 (#8176)

### DIFF
--- a/ui/dev/src/pages/form/select-part-6-autocomplete.vue
+++ b/ui/dev/src/pages/form/select-part-6-autocomplete.vue
@@ -49,6 +49,8 @@
           </q-item>
         </template>
       </q-select>
+
+      <pre>{{name}} / {{city}} / {{country}}</pre>
     </div>
   </div>
 </template>

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -224,7 +224,7 @@ export default defineComponent({
 
   methods: {
     focus () {
-      if (this.showPopup !== void 0 && this.hasDialog === true) {
+      if (this.showPopup !== void 0) {
         this.showPopup()
         return
       }

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -255,6 +255,14 @@
       "extends": "tabindex"
     },
 
+    "autocomplete": {
+      "type": "String",
+      "desc": "Autocomplete attribute for field",
+      "examples": [ "autocomplete=\"country\"" ],
+      "category": "behavior",
+      "addedIn": "v1.14.8"
+    },
+
     "transition-show": {
       "extends": "transition",
       "desc": "Transition when showing the menu/dialog; One of Quasar's embedded transitions",

--- a/ui/src/components/select/QSelect.sass
+++ b/ui/src/components/select/QSelect.sass
@@ -6,9 +6,6 @@
     .q-field__control
       cursor: text
 
-  .q-field__native > span:first-child:empty:before
-    content: '\a0'
-
   .q-field__input
     min-width: 50px !important
 

--- a/ui/src/components/tabs/QRouteTab.json
+++ b/ui/src/components/tabs/QRouteTab.json
@@ -19,9 +19,7 @@
         "evt": {
           "type": "Object",
           "desc": "JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false",
-          "__exemption": [
-            "examples"
-          ]
+          "__exemption": [ "examples" ]
         },
         "navigateFn": {
           "type": "Function",

--- a/ui/src/mixins/virtual-scroll.js
+++ b/ui/src/mixins/virtual-scroll.js
@@ -238,7 +238,7 @@ export default {
 
   computed: {
     needsReset () {
-      return [ 'virtualScrollItemSize', 'virtualScrollHorizontal' ]
+      return [ 'virtualScrollItemSizeComputed', 'virtualScrollHorizontal' ]
         .map(p => this[ p ]).join(';')
     },
 
@@ -249,6 +249,10 @@ export default {
 
     colspanAttr () {
       return this.tableColspan !== void 0 ? this.tableColspan : 100
+    },
+
+    virtualScrollItemSizeComputed () {
+      return this.virtualScrollItemSize
     }
   },
 
@@ -496,7 +500,7 @@ export default {
     },
 
     __resetVirtualScroll (toIndex, fullReset) {
-      const defaultSize = this.virtualScrollItemSize
+      const defaultSize = this.virtualScrollItemSizeComputed
 
       if (fullReset === true || Array.isArray(this.virtualScrollSizes) === false) {
         this.virtualScrollSizes = []
@@ -563,7 +567,7 @@ export default {
       const onView = Math.ceil(Math.max(
         scrollViewSize === void 0 || scrollViewSize <= 0
           ? 10
-          : scrollViewSize / this.virtualScrollItemSize,
+          : scrollViewSize / this.virtualScrollItemSizeComputed,
         this.virtualScrollSliceSize / multiplier
       ))
 
@@ -571,7 +575,10 @@ export default {
         total: Math.ceil(onView * multiplier),
         start: Math.ceil(onView * this.virtualScrollSliceRatioBefore),
         center: Math.ceil(onView * (0.5 + this.virtualScrollSliceRatioBefore)),
-        end: Math.ceil(onView * (1 + this.virtualScrollSliceRatioBefore))
+        end: Math.ceil(onView * (1 + this.virtualScrollSliceRatioBefore)),
+        view: scrollViewSize === void 0 || scrollViewSize <= 0
+          ? 1
+          : Math.ceil(scrollViewSize / this.virtualScrollItemSizeComputed)
       }
     },
 
@@ -603,7 +610,7 @@ export default {
           class: 'q-virtual-scroll__content',
           key: 'content',
           ref: 'content',
-          attrs: { tabindex: -1 }
+          tabindex: -1
         }, content),
 
         tag === 'tbody'


### PR DESCRIPTION
- open options list on autofocus when using QMenu also (make it consistent with the case of QDialog)
- improve/fix autocomplete
- fix virtualScrollItemSize when not dense
- add PG_UP, PG_DOWN, HOME and END kbd navigation in list (HOME and END if there is no text in input)
- keep input in the base control when using QDialog to prevent visual changes
- prevent duplicate clicks due to propagation from label to input