### PR TITLE
QDrawer: replace mouseout by mouseleave on examples

### DIFF
--- a/docs/src/examples/QDrawer/MiniMouseEvents.vue
+++ b/docs/src/examples/QDrawer/MiniMouseEvents.vue
@@ -14,7 +14,7 @@
 
         :mini="miniState"
         @mouseover="miniState = false"
-        @mouseout="miniState = true"
+        @mouseleave="miniState = true"
 
         :width="200"
         :breakpoint="500"

--- a/docs/src/examples/QDrawer/MiniToOverlay.vue
+++ b/docs/src/examples/QDrawer/MiniToOverlay.vue
@@ -14,7 +14,7 @@
 
         :mini="miniState"
         @mouseover="miniState = false"
-        @mouseout="miniState = true"
+        @mouseleave="miniState = true"
         mini-to-overlay
 
         :width="200"

--- a/docs/src/pages/layout/drawer.md
+++ b/docs/src/pages/layout/drawer.md
@@ -61,11 +61,11 @@ There are some CSS classes that will help you customize the drawer when dealing 
 
 You can also write your own CSS classes based on the fact that QLayoutDrawer has `q-drawer--standard` CSS class when in "normal" mode and `q-drawer--mini` when in "mini" mode. Also, when drawer is in "mobile" behavior, it gets `q-drawer--mobile` CSS class.
 
-#### Mouseover/mouseout trigger
+#### Mouseover/mouseleave trigger
 
 Consider using QItems with routing props (like `to`) below. For demoing purposes these props have not been added as it would break the UMD version.
 
-<doc-example title="Mini-mode with mouseover/mouseout trigger" file="QDrawer/MiniMouseEvents" />
+<doc-example title="Mini-mode with mouseover/mouseleave trigger" file="QDrawer/MiniMouseEvents" />
 
 #### Mini to overlay
 

--- a/ui/dev/src/pages/layout/layout.vue
+++ b/ui/dev/src/pages/layout/layout.vue
@@ -134,7 +134,7 @@
 
       <!--
         @mouseover="leftMini = false"
-        @mouseout="leftMini = true"
+        @mouseleave="leftMini = true"
         ...or
         @click.capture="e => {
           if (leftMini) {


### PR DESCRIPTION
On these QDrawer examples, where the mouse controls the "mini" state, the `mouseout` event is used
https://github.com/quasarframework/quasar/blob/dev/docs/src/examples/QDrawer/MiniToOverlay.vue#L17
https://github.com/quasarframework/quasar/blob/dev/docs/src/examples/QDrawer/MiniMouseEvents.vue#L17

This makes an event trigger whenever a person hovers different elements of the menu (that means, it gets triggered a lot). It'd be better to use the `mouseleave` event, which would trigger only once, when the person moves moves the pointer away from the entire QDrawer.

Difference between the two events from MDN (https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event):

> mouseleave and mouseout are similar but differ in that mouseleave does not bubble and mouseout does. This means that mouseleave is fired when the pointer has exited the element and all of its descendants, whereas mouseout is fired when the pointer leaves the element or leaves one of the element's descendants (even if the pointer is still within the element).


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**