### PR TITLE
Fix: safe check for `$q` on component instance

### DIFF
--- a/ui/src/mixins/dark.js
+++ b/ui/src/mixins/dark.js
@@ -9,7 +9,7 @@ export default {
   computed: {
     isDark () {
       return this.dark === null
-        ? this.$q.dark.isActive
+        ? this.$q?.dark.isActive
         : this.dark
     }
   }


### PR DESCRIPTION
If I try to bundle some Quasar components in standalone UI components, so that devs can use the component regardless of their Vue environment (ideally we'd want them to just be able to import and use the component), this mixin is causing some issues because `$q` is undefined in that case.

It's fixed with a simple `?` safe check and I see no harm in adding this safety to line 12.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
