### PR TITLE
feat(transitions): hide overflow on components that leave the transition; improve animation on Android by using same border radius #8341

### DIFF
--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -821,9 +821,7 @@ export default Vue.extend({
           staticClass: 'relative-position'
         }, [
           h('transition', {
-            props: {
-              name: 'q-transition--fade'
-            }
+            props: { name: 'q-transition--fade' }
           }, [
             h('div', {
               key: 'h-yr-' + this.headerSubtitle,
@@ -845,9 +843,7 @@ export default Vue.extend({
             staticClass: 'relative-position col'
           }, [
             h('transition', {
-              props: {
-                name: 'q-transition--fade'
-              }
+              props: { name: 'q-transition--fade' }
             }, [
               h('div', {
                 key: 'h-sub' + this.headerTitle,
@@ -900,9 +896,7 @@ export default Vue.extend({
           staticClass: 'relative-position overflow-hidden flex flex-center' + cls
         }, [
           h('transition', {
-            props: {
-              name: 'q-transition--jump-' + dir
-            }
+            props: { name: 'q-transition--jump-' + dir }
           }, [
             h('div', { key }, [
               h(QBtn, {
@@ -972,9 +966,7 @@ export default Vue.extend({
             staticClass: 'q-date__calendar-days-container relative-position overflow-hidden'
           }, [
             h('transition', {
-              props: {
-                name: 'q-transition--slide-' + this.monthDirection
-              }
+              props: { name: 'q-transition--slide-' + this.monthDirection }
             }, [
               h('div', {
                 key: this.viewMonthHash,

--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 
+import { onTransitionHideScroll } from '../../mixins/transition'
 import HistoryMixin from '../../mixins/history.js'
 import ModelToggleMixin from '../../mixins/model-toggle.js'
 import PortalMixin from '../../mixins/portal.js'
@@ -142,6 +143,18 @@ export default Vue.extend({
       }
 
       return on
+    },
+
+    onPortalTransition () {
+      return {
+        ...onTransitionHideScroll,
+        'before-enter' (el) {
+          el.setAttribute('data-q-portal-entering', true)
+        },
+        'after-enter' (el) {
+          el.removeAttribute('data-q-portal-entering')
+        }
+      }
     }
   },
 
@@ -342,7 +355,8 @@ export default Vue.extend({
         ] : null),
 
         h('transition', {
-          props: { name: this.transition }
+          props: { name: this.transition },
+          on: this.onPortalTransition
         }, [
           this.showing === true ? h('div', {
             ref: 'inner',

--- a/ui/src/components/dialog/QDialog.sass
+++ b/ui/src/components/dialog/QDialog.sass
@@ -48,16 +48,16 @@
       padding-left: 0 !important
 
     &--left, &--top
-      > div
+      &:not([data-q-portal-entering]) > div
         border-top-left-radius: 0
     &--right, &--top
-      > div
+      &:not([data-q-portal-entering]) > div
         border-top-right-radius: 0
     &--left, &--bottom
-      > div
+      &:not([data-q-portal-entering]) > div
         border-bottom-left-radius: 0
     &--right, &--bottom
-      > div
+      &:not([data-q-portal-entering]) > div
         border-bottom-right-radius: 0
 
     &--fullwidth

--- a/ui/src/components/dialog/QDialog.styl
+++ b/ui/src/components/dialog/QDialog.styl
@@ -48,16 +48,16 @@
       padding-left: 0 !important
 
     &--left, &--top
-      > div
+      &:not([data-q-portal-entering]) > div
         border-top-left-radius: 0
     &--right, &--top
-      > div
+      &:not([data-q-portal-entering]) > div
         border-top-right-radius: 0
     &--left, &--bottom
-      > div
+      &:not([data-q-portal-entering]) > div
         border-bottom-left-radius: 0
     &--right, &--bottom
-      > div
+      &:not([data-q-portal-entering]) > div
         border-bottom-right-radius: 0
 
     &--fullwidth

--- a/ui/src/css/core/transitions.sass
+++ b/ui/src/css/core/transitions.sass
@@ -151,3 +151,6 @@ $transition-easing: cubic-bezier(0.215, 0.61, 0.355, 1) // easeOutCubic
       transform: perspective(400px) rotate3d(1, 0, 0, 180deg)
     &-leave-to
       transform: perspective(400px) rotate3d(1, 0, 0, -180deg)
+
+  &--hide-scroll *
+    overflow: hidden !important

--- a/ui/src/css/core/transitions.styl
+++ b/ui/src/css/core/transitions.styl
@@ -151,3 +151,6 @@ $transition-easing = cubic-bezier(0.215, 0.61, 0.355, 1) // easeOutCubic
       transform: perspective(400px) rotate3d(1, 0, 0, 180deg)
     &-leave-to
       transform: perspective(400px) rotate3d(1, 0, 0, -180deg)
+
+  &--hide-scroll *
+    overflow: hidden !important

--- a/ui/src/mixins/panel.js
+++ b/ui/src/mixins/panel.js
@@ -1,5 +1,7 @@
 import Vue from 'vue'
 
+import { onTransitionHideScroll } from '../mixins/transition'
+
 import TouchSwipe from '../directives/TouchSwipe.js'
 
 import ListenersMixin from './listeners.js'
@@ -234,9 +236,8 @@ export const PanelParentMixin = {
       return this.animated === true
         ? [
           h('transition', {
-            props: {
-              name: this.panelTransition
-            }
+            props: { name: this.panelTransition },
+            on: onTransitionHideScroll
           }, content)
         ]
         : content

--- a/ui/src/mixins/transition.js
+++ b/ui/src/mixins/transition.js
@@ -1,3 +1,21 @@
+function hideScroll (el) {
+  if (el !== null && el !== void 0) {
+    el.classList.add('q-transition--hide-scroll')
+  }
+}
+
+function restoreScroll (el) {
+  if (el !== null && el !== void 0) {
+    el.classList.remove('q-transition--hide-scroll')
+  }
+}
+
+export const onTransitionHideScroll = {
+  'before-leave': hideScroll,
+  'after-leave': restoreScroll,
+  'leave-cancelled': restoreScroll
+}
+
 export default {
   props: {
     transitionShow: {


### PR DESCRIPTION
- prevents nasty scrollbars showing on transitions
- cannot be applied on QMenu/QTooltip because the smenu size would change
- improve animation on Android by using same border radius

#8341