### PR TITLE
feat(QTable) Adding loading-icon and loading-icon-size

### DIFF
--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -82,6 +82,8 @@ export default Vue.extend({
     noDataLabel: String,
     noResultsLabel: String,
     loadingLabel: String,
+    loadingIcon: String,
+    loadingIconSize: String,
     selectedRowsLabel: Function,
     rowsPerPageLabel: String,
     paginationLabel: Function,

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -194,6 +194,25 @@
       "category": "content"
     },
 
+    "loading-icon": {
+      "type": "String",
+      "desc": "Override default icon to display when table is in loading state (see 'loading' prop)",
+      "examples": [
+        "hourglass_empty"
+      ],
+      "category": "content"
+    },
+
+    "loading-icon-size": {
+      "type": "String",
+      "desc": "Override default loading icon size (see 'loading-icon' prop)",
+      "default": "md",
+      "examples": [
+        "hourglass_empty"
+      ],
+      "category": "content"
+    },
+
     "selected-rows-label": {
       "type": "Function",
       "desc": "Text to display when user selected at least one row; For best performance, reference it from your scope and do not define it inline",

--- a/ui/src/components/table/table-bottom.js
+++ b/ui/src/components/table/table-bottom.js
@@ -25,11 +25,11 @@ export default {
 
         const noData = this.$scopedSlots['no-data']
         const children = noData !== void 0
-          ? [ noData({ message, icon: this.$q.iconSet.table.warning, filter: this.filter }) ]
+          ? [ noData({ message, icon: this.loadingIcon || this.$q.iconSet.table.warning, size: this.loadingIconSize, filter: this.filter }) ]
           : [
             h(QIcon, {
               staticClass: 'q-table__bottom-nodata-icon',
-              props: { name: this.$q.iconSet.table.warning }
+              props: { name: this.loadingIcon || this.$q.iconSet.table.warning, size: this.loadingIconSize }
             }),
             message
           ]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Reason: https://forum.quasar-framework.org/topic/7487/change-text-and-icon-for-a-table-in-loading-state
