### PR TITLE
docs(QSelect): add info about multiple elements in an scoped slot option #8283

### DIFF
--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -106,6 +106,10 @@ If you use functions for custom props always check if the option is null. These 
 
 ### Customizing menu options
 
+::: warning
+The list of options is rendered using virtual scroll, so if you render more than one element for an option you must set a `q-virtual-scroll--with-prev` class on all elements except the first one.
+:::
+
 <doc-example title="Options slot" file="QSelect/OptionSlot" />
 
 Here is another example where we add a QToggle to each option. The possibilities are endless.


### PR DESCRIPTION
- also don't restrict docs pwa to portrait mode

#8283