### PR TITLE
fix(QBtnDropdown): do not pad left the dropdown icon if there is no label text #8293

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.sass
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.sass
@@ -5,7 +5,7 @@
     .q-btn__wrapper
       padding: 0 4px
 
-  &--simple .q-btn-dropdown__arrow
+  &--simple * + .q-btn-dropdown__arrow
     margin-left: 8px
   &__arrow
     transition: transform .28s

--- a/ui/src/components/btn-dropdown/QBtnDropdown.styl
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.styl
@@ -5,7 +5,7 @@
     .q-btn__wrapper
       padding: 0 4px
 
-  &--simple .q-btn-dropdown__arrow
+  &--simple * + .q-btn-dropdown__arrow
     margin-left: 8px
   &__arrow
     transition: transform .28s


### PR DESCRIPTION
#8293