### PR TITLE
feat: new private composable useFocusHelper

### DIFF
--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -11,6 +11,7 @@ import { hMergeSlot, hDir } from '../../utils/render.js'
 import { stop, prevent, stopAndPrevent, listenOpts } from '../../utils/event.js'
 import { getTouchTarget } from '../../utils/touch.js'
 import { isKeyCode } from '../../utils/key-composition.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 const { passiveCapture } = listenOpts
 
@@ -303,10 +304,7 @@ export default defineComponent({
       }
 
       const child = [
-        h('span', {
-          class: 'q-focus-helper',
-          ref: blurTargetRef
-        })
+        useFocusHelper(blurTargetRef)
       ]
 
       if (props.loading === true && props.percentage !== void 0) {

--- a/ui/src/components/chip/QChip.js
+++ b/ui/src/components/chip/QChip.js
@@ -7,6 +7,7 @@ import Ripple from '../../directives/Ripple.js'
 import useQuasar from '../../composables/use-quasar.js'
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
 import useSize, { useSizeProps } from '../../composables/private/use-size.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 import { stopAndPrevent } from '../../utils/event.js'
 import { hMergeSlotSafely, hDir } from '../../utils/render.js'
@@ -130,7 +131,7 @@ export default defineComponent({
       const child = []
 
       isClickable.value === true && child.push(
-        h('div', { class: 'q-focus-helper' })
+        useFocusHelper()
       )
 
       hasLeftIcon.value === true && child.push(

--- a/ui/src/components/dialog-bottom-sheet/BottomSheet.js
+++ b/ui/src/components/dialog-bottom-sheet/BottomSheet.js
@@ -13,6 +13,7 @@ import QItemSection from '../item/QItemSection.js'
 
 import useQuasar from '../../composables/use-quasar.js'
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 export default defineComponent({
   name: 'BottomSheetPlugin',
@@ -75,7 +76,7 @@ export default defineComponent({
               e.keyCode === 13 && onOk(action)
             }
           }, [
-            h('div', { class: 'q-focus-helper' }),
+            useFocusHelper(),
 
             action.icon
               ? h(QIcon, { name: action.icon, color: action.color })

--- a/ui/src/components/item/QItem.js
+++ b/ui/src/components/item/QItem.js
@@ -3,6 +3,7 @@ import { h, defineComponent, ref, computed, getCurrentInstance } from 'vue'
 import useQuasar from '../../composables/use-quasar.js'
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
 import useRouterLink, { useRouterLinkProps } from '../../composables/private/use-router-link.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 import { hUniqueSlot } from '../../utils/render.js'
 import { stopAndPrevent } from '../../utils/event.js'
@@ -124,7 +125,7 @@ export default defineComponent({
       const child = hUniqueSlot(slots.default, [])
 
       isClickable.value === true && child.unshift(
-        h('div', { class: 'q-focus-helper', tabindex: -1, ref: blurTargetRef })
+        useFocusHelper(blurTargetRef)
       )
 
       return child

--- a/ui/src/components/stepper/StepHeader.js
+++ b/ui/src/components/stepper/StepHeader.js
@@ -5,6 +5,7 @@ import Ripple from '../../directives/Ripple.js'
 
 import useQuasar from '../../composables/use-quasar.js'
 import { hDir } from '../../utils/render.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 export default defineComponent({
   name: 'StepHeader',
@@ -124,7 +125,7 @@ export default defineComponent({
       }
 
       const child = [
-        h('div', { class: 'q-focus-helper', tabindex: -1, ref: blurRef }),
+        useFocusHelper(blurRef),
 
         h('div', { class: 'q-stepper__dot row flex-center q-stepper__line relative-position' }, [
           h('span', { class: 'row flex-center' }, [

--- a/ui/src/components/tabs/use-tab.js
+++ b/ui/src/components/tabs/use-tab.js
@@ -7,6 +7,7 @@ import Ripple from '../../directives/Ripple.js'
 import { hMergeSlot, hDir } from '../../utils/render.js'
 import { isKeyCode } from '../../utils/key-composition.js'
 import { tabsKey } from '../../utils/symbols.js'
+import useFocusHelper from '../../composables/private/use-focus-helper.js'
 
 let uid = 0
 
@@ -139,7 +140,7 @@ export default function (props, slots, emit, routerProps) {
     narrow === true && content.push(indicator)
 
     const node = [
-      h('div', { class: 'q-focus-helper', tabindex: -1, ref: blurTargetRef }),
+      useFocusHelper(blurTargetRef),
       h('div', { class: innerClass.value }, hMergeSlot(slots.default, content))
     ]
 

--- a/ui/src/composables/private/use-focus-helper.js
+++ b/ui/src/composables/private/use-focus-helper.js
@@ -1,0 +1,12 @@
+import { h } from 'vue'
+
+export default function (targetRef = void 0) {
+  return [
+    h('span', {
+      ref: targetRef,
+      ariaHidden: 'true',
+      tabindex: -1,
+      class: 'q-focus-helper'
+    })
+  ]
+}


### PR DESCRIPTION
I was able to convert everything, except for the QTree.js:528 where it has this `ref: el => { blurTargets[ m.key ] = el }`
I tested all changes in dev testing platform.
Using useFocusHelper will keep everything unified.