### PR TITLE
fix/perf(VirtualScroll): prevent re-rendering of content items when both from and to changes #8344

### DIFF
--- a/ui/dev/src/pages/components/virtual-scroll-8-focus.vue
+++ b/ui/dev/src/pages/components/virtual-scroll-8-focus.vue
@@ -1,0 +1,44 @@
+<template>
+  <q-layout view="lHh LpR fFf">
+    <q-page-container>
+      <q-page>
+        <q-virtual-scroll
+          :items="rows"
+          virtual-scroll-item-size="72"
+          scroll-target="body"
+          class="sample-placeholder"
+        >
+          <template v-slot="{ item }">
+            <q-item :key="item.id">
+              <q-item-section>
+                <q-input v-model="item.text" />
+              </q-item-section>
+            </q-item>
+          </template>
+        </q-virtual-scroll>
+      </q-page>
+    </q-page-container>
+  </q-layout>
+</template>
+
+<style lang="sass">
+.sample-placeholder
+  .q-virtual-scroll__padding
+    background-image: url('data:image/svg+xml,%3Csvg width="64" height="64" viewBox="0 0 64 32" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M 8 16 c 4.418 0 8 -3.582 8 -8 s -3.582 -8 -8 -8 s -8 3.582 -8 8 s 3.582 8 8 8 z m 0 -2 c 3.314 0 6 -2.686 6 -6 s -2.686 -6 -6 -6 s -6 2.686 -6 6 s 2.686 6 6 6 z m 33.414 -6 l 5.95 -5.95 L 45.95 0.636 L 40 6.586 L 34.05 0.636 L 32.636 2.05 L 38.586 8 l -5.95 5.95 l 1.414 1.414 L 40 9.414 l 5.95 5.95 l 1.414 -1.414 L 41.414 8 z" fill="grey" fill-rule="evenodd"/%3E%3C/svg%3E')
+    background-size: auto var(--q-virtual-scroll-item-height, 50px)
+</style>
+
+<script>
+const virtualScrollElements = 1000
+
+export default {
+  data () {
+    return {
+      rows: Array(virtualScrollElements).fill(null).map((_, id) => ({
+        id: `k_${id + 1}`,
+        text: `text ${id + 1}`
+      }))
+    }
+  }
+}
+</script>

--- a/ui/dev/src/pages/form/select-part-2.vue
+++ b/ui/dev/src/pages/form/select-part-2.vue
@@ -459,11 +459,10 @@
             @blur="onBlur"
           >
             <template v-slot:option="scope">
-              <div>
+              <div :key="scope.index">
                 <q-item
                   v-bind="scope.itemProps"
                   v-on="scope.itemEvents"
-                  :key="scope.index"
                 >
                   <q-item-section>
                     <q-item-label>
@@ -505,11 +504,10 @@
             @virtual-scroll="onScroll"
           >
             <template v-slot:option="scope">
-              <div>
+              <div :key="scope.index">
                 <q-item
                   v-bind="scope.itemProps"
                   v-on="scope.itemEvents"
-                  :key="scope.index"
                 >
                   <q-item-section>
                     <q-item-label>

--- a/ui/src/components/virtual-scroll/QVirtualScroll.sass
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.sass
@@ -11,6 +11,7 @@
   &__padding
     background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) #{"/* rtl:ignore */"}
     background-size: 100% 50px #{"/* rtl:ignore */"}
+    background-size: var(--q-virtual-scroll-item-width, 100%) var(--q-virtual-scroll-item-height, 50px) #{"/* rtl:ignore */"}
 
     .q-table &
       tr
@@ -38,3 +39,4 @@
       &__padding
         background: linear-gradient(to left, rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) #{"/* rtl:ignore */"}
         background-size: 50px 100% #{"/* rtl:ignore */"}
+        background-size: var(--q-virtual-scroll-item-width, 50px) var(--q-virtual-scroll-item-height, 100%) #{"/* rtl:ignore */"}

--- a/ui/src/components/virtual-scroll/QVirtualScroll.styl
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.styl
@@ -11,6 +11,7 @@
   &__padding
     background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) /* rtl:ignore */
     background-size: 100% 50px /* rtl:ignore */
+    background-size: var(--q-virtual-scroll-item-width, 100%) var(--q-virtual-scroll-item-height, 50px) /* rtl:ignore */
 
     .q-table &
       tr
@@ -38,3 +39,4 @@
       &__padding
         background: linear-gradient(to left, rgba(255,255,255,0), rgba(255,255,255,0) 20%, rgba(128, 128, 128, .03) 20%, rgba(128, 128, 128, .08) 50%, rgba(128, 128, 128, .03) 80%, rgba(255,255,255,0) 80%, rgba(255,255,255,0)) /* rtl:ignore */
         background-size: 50px 100% /* rtl:ignore */
+        background-size: var(--q-virtual-scroll-item-width, 50px) var(--q-virtual-scroll-item-height, 100%) /* rtl:ignore */

--- a/ui/src/mixins/virtual-scroll.js
+++ b/ui/src/mixins/virtual-scroll.js
@@ -634,6 +634,9 @@ export default {
 
     __padVirtualScroll (h, tag, content) {
       const paddingSize = this.virtualScrollHorizontal === true ? 'width' : 'height'
+      const style = {
+        ['--q-virtual-scroll-item-' + paddingSize]: this.virtualScrollItemSizeComputed + 'px'
+      }
 
       return [
         tag === 'tbody'
@@ -644,7 +647,7 @@ export default {
           }, [
             h('tr', [
               h('td', {
-                style: { [paddingSize]: `${this.virtualScrollPaddingBefore}px` },
+                style: { [paddingSize]: `${this.virtualScrollPaddingBefore}px`, ...style },
                 attrs: this.colspanAttr
               })
             ])
@@ -653,7 +656,7 @@ export default {
             staticClass: 'q-virtual-scroll__padding',
             key: 'before',
             ref: 'before',
-            style: { [paddingSize]: `${this.virtualScrollPaddingBefore}px` }
+            style: { [paddingSize]: `${this.virtualScrollPaddingBefore}px`, ...style }
           }),
 
         h(tag, {
@@ -671,7 +674,7 @@ export default {
           }, [
             h('tr', [
               h('td', {
-                style: { [paddingSize]: `${this.virtualScrollPaddingAfter}px` },
+                style: { [paddingSize]: `${this.virtualScrollPaddingAfter}px`, ...style },
                 attrs: this.colspanAttr
               })
             ])
@@ -680,7 +683,7 @@ export default {
             staticClass: 'q-virtual-scroll__padding',
             key: 'after',
             ref: 'after',
-            style: { [paddingSize]: `${this.virtualScrollPaddingAfter}px` }
+            style: { [paddingSize]: `${this.virtualScrollPaddingAfter}px`, ...style }
           })
       ]
     },

--- a/ui/src/mixins/virtual-scroll.js
+++ b/ui/src/mixins/virtual-scroll.js
@@ -403,29 +403,13 @@ export default {
       )
     },
 
-    __calcAlignRange (alignEnd, toIndex) {
-      if (alignEnd !== void 0) {
-        return alignEnd
-      }
-
-      if (toIndex > this.prevToIndex) {
-        return 'start'
-      }
-
-      return toIndex === this.prevToIndex && this.prevAlignRange !== void 0
-        ? this.prevAlignRange
-        : 'end'
-    },
-
     __setVirtualScrollSliceRange (scrollEl, scrollDetails, toIndex, offset, align) {
       const alignForce = typeof align === 'string' && align.indexOf('-force') > -1
       const alignEnd = alignForce === true ? align.replace('-force', '') : align
-      const alignRange = this.__calcAlignRange(alignEnd, toIndex)
-
-      this.prevAlignRange = alignRange
+      const alignRange = alignEnd !== void 0 ? alignEnd : 'start'
 
       let
-        from = Math.max(0, Math.ceil(toIndex - this.virtualScrollSliceSizeComputed[alignRange])),
+        from = Math.max(0, toIndex - this.virtualScrollSliceSizeComputed[alignRange]),
         to = from + this.virtualScrollSliceSizeComputed.total
 
       if (to > this.virtualScrollLength) {
@@ -435,10 +419,6 @@ export default {
 
       this.prevScrollStart = scrollDetails.scrollStart
 
-      if (this.$refs.content !== void 0 && this.$refs.content.contains(document.activeElement)) {
-        this.$refs.content.focus()
-      }
-
       const rangeChanged = from !== this.virtualScrollSliceRange.from || to !== this.virtualScrollSliceRange.to
 
       if (rangeChanged === false && alignEnd === void 0) {
@@ -447,14 +427,46 @@ export default {
         return
       }
 
+      const { activeElement } = document
+      if (
+        rangeChanged === true &&
+        this.$refs.content !== void 0 &&
+        this.$refs.content !== activeElement &&
+        this.$refs.content.contains(activeElement) === true
+      ) {
+        const onBlurFn = () => {
+          this.$refs.content.focus()
+        }
+
+        activeElement.addEventListener('blur', onBlurFn, true)
+
+        requestAnimationFrame(() => {
+          activeElement.removeEventListener('blur', onBlurFn, true)
+        })
+      }
+
       setOverflowAnchor(this.id, toIndex - from + 1)
 
       const sizeBefore = alignEnd !== void 0 ? this.virtualScrollSizes.slice(from, toIndex).reduce(sumFn, 0) : 0
 
       if (rangeChanged === true) {
-        this.virtualScrollSliceRange = { from, to }
+        // vue key matching algorithm works only if
+        // the array of VNodes changes on only one of the ends
+        // so we first change one end and then the other
+
+        const tempTo = to >= this.virtualScrollSliceRange.from && from <= this.virtualScrollSliceRange.to
+          ? this.virtualScrollSliceRange.to
+          : to
+        this.virtualScrollSliceRange = { from, to: tempTo }
         this.virtualScrollPaddingBefore = sumSize(this.virtualScrollSizesAgg, this.virtualScrollSizes, 0, from)
-        this.virtualScrollPaddingAfter = sumSize(this.virtualScrollSizesAgg, this.virtualScrollSizes, to, this.virtualScrollLength)
+        this.virtualScrollPaddingAfter = sumSize(this.virtualScrollSizesAgg, this.virtualScrollSizes, this.virtualScrollSliceRange.to, this.virtualScrollLength)
+
+        requestAnimationFrame(() => {
+          if (this.virtualScrollSliceRange.to !== to && this.prevScrollStart === scrollDetails.scrollStart) {
+            this.virtualScrollSliceRange = { from: this.virtualScrollSliceRange.from, to }
+            this.virtualScrollPaddingAfter = sumSize(this.virtualScrollSizesAgg, this.virtualScrollSizes, to, this.virtualScrollLength)
+          }
+        })
       }
 
       requestAnimationFrame(() => {
@@ -538,7 +550,7 @@ export default {
     },
 
     __resetVirtualScroll (toIndex, fullReset) {
-      const defaultSize = this.virtualScrollItemSizeComputed
+      const defaultSize = 1 * this.virtualScrollItemSizeComputed
 
       if (fullReset === true || Array.isArray(this.virtualScrollSizes) === false) {
         this.virtualScrollSizes = []
@@ -602,21 +614,21 @@ export default {
       this.__scrollViewSize = scrollViewSize
 
       const multiplier = 1 + this.virtualScrollSliceRatioBefore + this.virtualScrollSliceRatioAfter
-      const onView = Math.ceil(Math.max(
-        scrollViewSize === void 0 || scrollViewSize <= 0
-          ? 10
-          : scrollViewSize / this.virtualScrollItemSizeComputed,
-        this.virtualScrollSliceSize / multiplier
-      ))
+      const view = scrollViewSize === void 0 || scrollViewSize <= 0
+        ? 1
+        : Math.ceil(scrollViewSize / this.virtualScrollItemSizeComputed)
+      const baseSize = Math.max(
+        10,
+        view,
+        Math.ceil(this.virtualScrollSliceSize / multiplier)
+      )
 
       this.virtualScrollSliceSizeComputed = {
-        total: Math.ceil(onView * multiplier),
-        start: Math.ceil(onView * this.virtualScrollSliceRatioBefore),
-        center: Math.ceil(onView * (0.5 + this.virtualScrollSliceRatioBefore)),
-        end: Math.ceil(onView * (1 + this.virtualScrollSliceRatioBefore)),
-        view: scrollViewSize === void 0 || scrollViewSize <= 0
-          ? 1
-          : Math.ceil(scrollViewSize / this.virtualScrollItemSizeComputed)
+        total: Math.ceil(baseSize * multiplier),
+        start: Math.ceil(baseSize * this.virtualScrollSliceRatioBefore),
+        center: Math.ceil(baseSize * (0.5 + this.virtualScrollSliceRatioBefore)),
+        end: Math.ceil(baseSize * (1 + this.virtualScrollSliceRatioBefore)),
+        view
       }
     },
 


### PR DESCRIPTION
Vue key matching algorithm works only if the array of VNodes changes on only one of the ends so we first change one end and then the other.

Only refocus on container if the active element is blurred while scrolling.

#8344