### PR TITLE
fix(VirtualScroll): flatten content in padVirtualScroll to allow keys to work

### DIFF
--- a/ui/src/components/virtual-scroll/use-virtual-scroll.js
+++ b/ui/src/components/virtual-scroll/use-virtual-scroll.js
@@ -244,7 +244,7 @@ export function useVirtualScroll ({
   props, emit, $q, vm, virtualScrollLength, getVirtualScrollTarget, getVirtualScrollEl,
   virtualScrollItemSizeComputed // optional
 }) {
-  let prevScrollStart, prevToIndex, prevAlignRange, localScrollViewSize, virtualScrollSizesAgg = [], virtualScrollSizes
+  let prevScrollStart, prevToIndex, localScrollViewSize, virtualScrollSizesAgg = [], virtualScrollSizes
 
   const vsId = 'qvs_' + id++
 
@@ -655,7 +655,7 @@ export function useVirtualScroll ({
         ref: contentRef,
         id: vsId,
         tabindex: -1
-      }, content),
+      }, content.flat()),
 
       tag === 'tbody'
         ? h(tag, {


### PR DESCRIPTION
Unfortunately the problem with keys (from vue2) is still present, and even worse, so we must keep the workaround with changing from and to in different ticks/renders