### PR TITLE
Added information about Chrome devTools

### DIFF
--- a/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
@@ -66,25 +66,25 @@ HMR works with Browser Extension development but does work slightly differently 
 
 Browser extensions runs in three different environments (more on upcoming pages) and it requires various environments for debugging.
 
-### Chrome
+### With Chrome
 
 You can find following places to investigate the errors and outputs from the console in DevTools:
 
-1. Popup - right click on the page or on the extension icon  a choose `Inspect` pop-up for DevTools. 
+1. Popup - right click on the page or on the extension icon  a choose `Inspect` pop-up for DevTools.
 2. Background scripts (e.g.: background-hooks.js) open DevTools from `Manage extensions - background page`.
 3. Content scripts - page where your script is injected.
 4. Extension Errors - list of errors related to the extension (e.g. manifest configuration) are available in `Manage extension - Errors`.
-  
-[Popup](https://user-images.githubusercontent.com/37825539/106393529-ea113400-63f7-11eb-876c-aa10c90a4615.png) 
 
-[Background scripts, Content scripts and Extension Errors](https://user-images.githubusercontent.com/37825539/106393533-eed5e800-63f7-11eb-8a31-b60d51673801.png)
+![Popup](https://cdn.quasar.dev/img/bex-debug-popup.png)
+
+![Background scripts, Content scripts and Extension Errors](https://cdn.quasar.dev/img/bex-debug-bg.png)
 
 If your code changes are not propagated to the browser you can try to:
 	- Update or Reload extension - from the Extensions list (screenshots)
 	- Restart browser
 	- Restart dev process
 
-For more information visit [Debugging extensions](https://developer.chrome.com/docs/extensions/mv2/tut_debugging/)
+For more information, please visit [Debugging extensions](https://developer.chrome.com/docs/extensions/mv2/tut_debugging/).
 
 ## Building for Production
 ```bash

--- a/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
@@ -62,6 +62,30 @@ HMR works with Browser Extension development but does work slightly differently 
 **Chrome vs Firefox Nuances** - When developing your Browser Extension, you will often need to make changes to the files under the `src-bex` folder as well. This will be done when configuring hooks, setting up popups etc. Firefox will see these changes and automatically re-load the Browser Extension. Chrome on the other hand will not. When you have made these changes in Chrome, you will need to navigate to your Extension (see the Chrome section above) and click on the refresh icon in your Development Browser Extension.
 :::
 
+## Debugging
+
+Browser extensions runs in three different environments (more on upcoming pages) and it requires various environments for debugging.
+
+### Chrome
+
+You can find following places to investigate the errors and outputs from the console in DevTools:
+
+1. Popup - right click on the page or on the extension icon  a choose `Inspect` pop-up for DevTools. 
+2. Background scripts (e.g.: background-hooks.js) open DevTools from `Manage extensions - background page`.
+3. Content scripts - page where your script is injected.
+4. Extension Errors - list of errors related to the extension (e.g. manifest configuration) are available in `Manage extension - Errors`.
+  
+[Popup](https://drive.google.com/file/d/1MNI1ShmdBx_Dts9FVr_sfHnuMi73ge0O/view?usp=sharing) 
+
+[Background scripts, Content scripts and Extension Errors](https://drive.google.com/file/d/1kNRc9w2gdDOTmbnpR_3UPv-OmUf93ZLi/view?usp=sharing)
+
+If your code changes are not propagated to the browser you can try to:
+	- Update or Reload extension - from the Extensions list (screenshots)
+	- Restart browser
+	- Restart dev process
+
+For more information visit [Debugging extensions](https://developer.chrome.com/docs/extensions/mv2/tut_debugging/)
+
 ## Building for Production
 ```bash
 $ quasar build -m bex

--- a/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
+++ b/docs/src/pages/quasar-cli/developing-browser-extensions/build-commands.md
@@ -75,9 +75,9 @@ You can find following places to investigate the errors and outputs from the con
 3. Content scripts - page where your script is injected.
 4. Extension Errors - list of errors related to the extension (e.g. manifest configuration) are available in `Manage extension - Errors`.
   
-[Popup](https://drive.google.com/file/d/1MNI1ShmdBx_Dts9FVr_sfHnuMi73ge0O/view?usp=sharing) 
+[Popup](https://user-images.githubusercontent.com/37825539/106393529-ea113400-63f7-11eb-876c-aa10c90a4615.png) 
 
-[Background scripts, Content scripts and Extension Errors](https://drive.google.com/file/d/1kNRc9w2gdDOTmbnpR_3UPv-OmUf93ZLi/view?usp=sharing)
+[Background scripts, Content scripts and Extension Errors](https://user-images.githubusercontent.com/37825539/106393533-eed5e800-63f7-11eb-8a31-b60d51673801.png)
 
 If your code changes are not propagated to the browser you can try to:
 	- Update or Reload extension - from the Extensions list (screenshots)


### PR DESCRIPTION
When i was trying to debug background-hooks it took me few hours to find out why I can't see console.log in popup devTools despite the fact I was getting response from bridge.
 
I'm sure that information about `background page` devTools will help new users on the beginning.

I have doubt about placing it on this page because we are talking about environment which is described later. So, standalone page after DOM introduction would be more proper.
Images are uploaded to Google Drive (not visible here). I can provide .pptx with source screenshosts + description objects.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When i was trying to debug background-hooks it took me few hours to find out why I can't see console.log in popup devTools despite the fact I was getting response from bridge.
See commit information for further information about placing added information.
![chrome-debug-1](https://user-images.githubusercontent.com/37825539/106393529-ea113400-63f7-11eb-876c-aa10c90a4615.png)
![chrome-debug-2-3-4](https://user-images.githubusercontent.com/37825539/106393533-eed5e800-63f7-11eb-8a31-b60d51673801.png)
