### PR TITLE
fix: #8403 | Fix property names for BuildDateOptions

### DIFF
--- a/ui/types/utils/date.d.ts
+++ b/ui/types/utils/date.d.ts
@@ -3,15 +3,17 @@ interface DateOptions {
   seconds?: number;
   minutes?: number;
   hours?: number;
-  months?: number;
-  years?: number;
 }
 
 export interface BuildDateOptions extends DateOptions {
   date?: number;
+  month?: number;
+  year?: number;
 }
 export interface ModifyDateOptions extends DateOptions {
   days?: number;
+  months?: number;
+  years?: number;
 }
 
 export interface DateLocale {
@@ -32,7 +34,7 @@ export namespace date {
   function isBetweenDates(date: Date | number | string, from: Date | number | string, to: Date | number | string, opts?: { inclusiveFrom: boolean; inclusiveTo: boolean; onlyDate: boolean }): boolean;
   function addToDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function subtractFromDate(date: Date | number | string, options: ModifyDateOptions): Date;
-  function adjustDate(date: Date | number | string, options: ModifyDateOptions, utc?: boolean): Date;
+  function adjustDate(date: Date | number | string, options: BuildDateOptions, utc?: boolean): Date;
   function startOfDate(date: Date | number | string, option: DateUnitOptions, utc?: boolean): Date;
   function endOfDate(date: Date | number | string, option: DateUnitOptions, utc?: boolean): Date;
   function getMaxDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The typing is broken, because `adjustDate` and `buildDate` require e.g. `year` to be [settable](https://github.com/quasarframework/quasar/blob/6fc9be45dbad8674c1e3f7fc2ff935e1dbd1dcc5/ui/src/utils/date.js#L423) [(docs).](https://github.com/quasarframework/quasar/blob/vue3-work/docs/src/pages/quasar-utils/date-utils.md#set-datetime)
Currently this does not work, because only `years` is [allowed](https://github.com/quasarframework/quasar/blob/6fc9be45dbad8674c1e3f7fc2ff935e1dbd1dcc5/ui/types/utils/date.d.ts#L7).


Without this fix there will be a TSError, check out this example:
https://codesandbox.io/s/epic-hopper-12oko?file=/src/pages/Index.vue

Line 24 works, but results in this TSError.
Line 26 is "valid" TS but does not work, so this fixes the typing for `adjustDate` and `buildDate` to make line 24 valid TS.
![Screenshot_20210203_124151](https://user-images.githubusercontent.com/1855448/106742412-4bfeb300-661d-11eb-8fce-dbb5582b64f1.png)