### PR TITLE
fix(QPopupEdit): do not allow setting the value if it's invalid and not changed #8416

### DIFF
--- a/ui/src/components/popup-edit/QPopupEdit.js
+++ b/ui/src/components/popup-edit/QPopupEdit.js
@@ -81,10 +81,10 @@ export default Vue.extend({
 
   methods: {
     set () {
+      if (this.validate(this.value) !== true) {
+        return
+      }
       if (this.__hasChanged() === true) {
-        if (this.validate(this.value) === false) {
-          return
-        }
         this.$emit('save', this.value, this.initialValue)
       }
       this.__close()


### PR DESCRIPTION
#8416
