### PR TITLE
fix: using vueDevtools doesn't show tab vuex store #8461

### DIFF
--- a/app/templates/entry/app.js
+++ b/app/templates/entry/app.js
@@ -9,6 +9,11 @@
  *
  * Boot files are your "main.js"
  **/
+
+<% if (__vueDevtools !== false) { %>
+import vueDevtools from '@vue/devtools'
+<% } %>
+
 import Vue from 'vue'
 import './import-quasar.js'
 
@@ -31,9 +36,6 @@ import { Plugins } from '@capacitor/core'
 const { SplashScreen } = Plugins
 <% } %>
 
-<% if (__vueDevtools !== false) { %>
-import vueDevtools from '@vue/devtools'
-<% } %>
 
 export default async function (<%= ctx.mode.ssr ? 'ssrContext' : '' %>) {
   // create store and router instances


### PR DESCRIPTION
Fixes #8461 
Mode: capacitor or cordova.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Capacitor (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
