### PR TITLE
Update use-router-link.js

### DIFF
--- a/ui/src/composables/private/use-router-link.js
+++ b/ui/src/composables/private/use-router-link.js
@@ -148,7 +148,7 @@ export default function () {
   const linkClass = computed(() => (
     hasLink.value === true
       ? (
-          linkIsExactActive.value === true
+          linkIsExactActive.value === true || props.active
             ? ` ${ props.exactActiveClass } ${ props.activeClass }`
             : (
                 props.exact === true


### PR DESCRIPTION
We have this nice prop named "active" in q-item component but it became ineffective with v.2
It is really helpful to handle active state manually when vue-router's exact param is just not enough in certain situations (eg. parent > child links: navigating within child links while keeping the parent active)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
