### PR TITLE
fix(field validation): don't validate disabled components; guard calls to resetValidation; fix autofocus

### DIFF
--- a/ui/dev/src/pages/form/form.vue
+++ b/ui/dev/src/pages/form/form.vue
@@ -11,6 +11,7 @@
     <q-toggle v-model="greedy" label="Greedy" />
     <q-toggle v-model="loading" label="Loading" />
     <q-toggle v-model="customInput" label="Custom Input" />
+    <q-toggle v-model="titleIsDisabled" label="Disable Title QSelect" />
     <q-option-group class="q-mb-lg" inline v-model="autofocusEl" dense="dense" :options="autofocusEls" />
 
     <q-form
@@ -42,7 +43,7 @@
 
         <my-comp />
 
-        <!-- TODO vue3 <q-select
+        <q-select
           ref="title"
           name="title"
           v-model="title"
@@ -50,11 +51,12 @@
           :dark="dark"
           :color="dark ? 'yellow' : 'primary'"
           filled
+          :disable="titleIsDisabled"
           label="Title"
           :rules="[ val => !!val ]"
           :autofocus="autofocusEl === 4"
           clearable
-        /> -->
+        />
 
         <q-input
           ref="name"
@@ -189,7 +191,8 @@ export default {
       props: [ 'modelValue' ],
       render () {
         return h(QField, {
-          modelValue: this.modelValue
+          modelValue: this.modelValue,
+          stackLabel: true
         }, {
           control: () => this.modelValue || 'null'
         })
@@ -226,6 +229,8 @@ export default {
       modelAsync: null,
 
       accept: false,
+
+      titleIsDisabled: false,
 
       show: true,
       autofocus: true,

--- a/ui/src/components/dialog-plugin/DialogPlugin.js
+++ b/ui/src/components/dialog-plugin/DialogPlugin.js
@@ -145,7 +145,7 @@ export default defineComponent({
       ripple: false,
       ...(Object(props.ok) === props.ok ? props.ok : { flat: true }),
       disable: okDisabled.value,
-      'data-autofocus': props.focus === 'ok' && hasForm.value !== true,
+      'data-autofocus': (props.focus === 'ok' && hasForm.value !== true) || void 0,
       onClick: onOk
     }))
 
@@ -154,7 +154,7 @@ export default defineComponent({
       label: cancelLabel.value,
       ripple: false,
       ...(Object(props.cancel) === props.cancel ? props.cancel : { flat: true }),
-      'data-autofocus': props.focus === 'cancel' && hasForm.value !== true,
+      'data-autofocus': (props.focus === 'cancel' && hasForm.value !== true) || void 0,
       onClick: onCancel
     }))
 

--- a/ui/src/components/form/QForm.js
+++ b/ui/src/components/form/QForm.js
@@ -102,7 +102,7 @@ export default defineComponent({
       validateIndex++
 
       registeredComponents.forEach(comp => {
-        comp.resetValidation()
+        typeof comp.resetValidation === 'function' && comp.resetValidation()
       })
     }
 

--- a/ui/src/components/form/QFormChildMixin.js
+++ b/ui/src/components/form/QFormChildMixin.js
@@ -8,17 +8,33 @@ export default {
     }
   },
 
+  watch: {
+    disable (val) {
+      const $form = this.$.provides[ formKey ]
+      if ($form !== void 0) {
+        if (val === true) {
+          this.resetValidation()
+          $form.unbindComponent(this)
+        }
+        else {
+          $form.bindComponent(this)
+        }
+      }
+    }
+  },
+
   methods: {
-    validate () {}
+    validate () {},
+    resetValidation () {}
   },
 
   created () {
     const $form = this.$.provides[ formKey ]
-    $form !== void 0 && $form.bindComponent(this)
+    $form !== void 0 && this.disable !== true && $form.bindComponent(this)
   },
 
   beforeUnmount () {
     const $form = this.$.provides[ formKey ]
-    $form !== void 0 && $form.unbindComponent(this)
+    $form !== void 0 && this.disable !== true && $form.unbindComponent(this)
   }
 }

--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -96,7 +96,7 @@ export default defineComponent({
     const inputAttrs = computed(() => {
       const attrs = {
         tabindex: 0,
-        'data-autofocus': props.autofocus,
+        'data-autofocus': props.autofocus === true || void 0,
         rows: props.type === 'textarea' ? 6 : void 0,
         'aria-label': props.label,
         name: nameProp.value,

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -975,7 +975,7 @@ export default defineComponent({
         maxlength: props.maxlength,
         tabindex: props.tabindex,
         autocomplete: props.autocomplete,
-        'data-autofocus': fromDialog === true ? false : props.autofocus,
+        'data-autofocus': (fromDialog !== true && props.autofocus === true) || void 0,
         disabled: props.disable === true,
         readonly: props.readonly === true,
         ...inputControlEvents.value

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -1,4 +1,4 @@
-import { h, ref, computed, watch, Transition, nextTick, onBeforeUnmount, onMounted, getCurrentInstance } from 'vue'
+import { h, ref, toRefs, computed, watch, Transition, nextTick, onBeforeUnmount, onMounted, getCurrentInstance } from 'vue'
 
 import { isRuntimeSsrPreHydration } from '../../plugins/Platform.js'
 
@@ -169,7 +169,7 @@ export default function (state) {
     hasError,
     computedErrorMessage,
     resetValidation
-  } = useValidate(state.focused, state.innerLoading)
+  } = useValidate(state.focused, state.innerLoading, toRefs(props).disable)
 
   const floatingLabel = state.floatingLabel !== void 0
     ? computed(() => props.stackLabel === true || state.focused.value === true || state.floatingLabel.value === true)
@@ -448,7 +448,7 @@ export default function (state) {
           ref: state.targetRef,
           class: 'q-field__native row',
           ...state.splitAttrs.attributes,
-          'data-autofocus': props.autofocus
+          'data-autofocus': props.autofocus === true || void 0
         }, slots.control(controlSlotScope.value))
       )
     }

--- a/ui/src/composables/private/use-validate.js
+++ b/ui/src/composables/private/use-validate.js
@@ -23,14 +23,14 @@ export const useValidateProps = {
   }
 }
 
-export default function (focused, innerLoading) {
+export default function (focused, innerLoading, disable) {
   const { props, proxy } = getCurrentInstance()
 
   const innerError = ref(false)
   const innerErrorMessage = ref(null)
   const isDirtyModel = ref(null)
 
-  useFormChild({ validate, requiresQForm: true })
+  useFormChild({ validate, resetValidation, requiresQForm: true, disable })
 
   let validateIndex = 0, unwatchRules
 

--- a/ui/src/composables/use-form-child.js
+++ b/ui/src/composables/use-form-child.js
@@ -1,8 +1,8 @@
-import { inject, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { inject, watch, onBeforeUnmount, getCurrentInstance } from 'vue'
 
 import { formKey } from '../utils/private/symbols.js'
 
-export default function ({ validate, requiresQForm }) {
+export default function ({ validate, resetValidation, requiresQForm, disable }) {
   const $form = inject(formKey, false)
 
   if ($form !== false) {
@@ -11,12 +11,22 @@ export default function ({ validate, requiresQForm }) {
     // export public method (so it can be used in QForm)
     Object.assign(vm.proxy, validate)
 
+    watch(disable, val => {
+      if (val === true) {
+        resetValidation()
+        $form.unbindComponent(vm.proxy)
+      }
+      else {
+        $form.bindComponent(vm.proxy)
+      }
+    })
+
     // register component to parent QForm
-    $form.bindComponent(vm.proxy)
+    disable.value !== true && $form.bindComponent(vm.proxy)
 
     onBeforeUnmount(() => {
       // unregister component
-      $form.unbindComponent(vm.proxy)
+      disable.value !== true && $form.unbindComponent(vm.proxy)
     })
   }
   else if (requiresQForm !== true) {


### PR DESCRIPTION
In the new QForm validation procedure the focus can no longer go to the first not valid component in document, but goes to the first registered one 