### PR TITLE
feat(QDate): support swipe gesture for switching between months

### DIFF
--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -1,5 +1,7 @@
 import Vue from 'vue'
 
+import TouchSwipe from '../../directives/TouchSwipe.js'
+
 import QBtn from '../btn/QBtn.js'
 import DateTimeMixin from '../../mixins/datetime.js'
 
@@ -19,6 +21,10 @@ export default Vue.extend({
   name: 'QDate',
 
   mixins: [ DateTimeMixin ],
+
+  directives: {
+    TouchSwipe
+  },
 
   props: {
     multiple: Boolean,
@@ -969,7 +975,14 @@ export default Vue.extend({
           }, this.daysOfWeek.map(day => h('div', { staticClass: 'q-date__calendar-item' }, [ h('div', [ day ]) ]))),
 
           h('div', {
-            staticClass: 'q-date__calendar-days-container relative-position overflow-hidden'
+            staticClass: 'q-date__calendar-days-container relative-position overflow-hidden',
+            directives: [{
+              name: 'touch-swipe',
+              value: this.__onDaysSwipe,
+              modifiers: {
+                horizontal: true
+              }
+            }]
           }, [
             h('transition', {
               props: {
@@ -1249,6 +1262,10 @@ export default Vue.extend({
           finalHash: this.__getDayHash(final)
         })
       }
+    },
+
+    __onDaysSwipe (evt) {
+      this.__goToMonth(evt.direction === 'left' ? 1 : -1)
     },
 
     __updateViewModel (year, month) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When using QDate on mobile, hitting the navigation arrow to switch between months may be difficult (in fact, you can see on the screencap below that we have hidden navigation arrows for year, as they are rarely used and would sometimes result in mis-taps on mobile). It is common for native calendar controls/inputs to allow swiping to switch between months.

In addition, there already is a sliding animation/transition between months and this feature complements it nicely.

You can see it in action here:

![ZMYwudRj1z](https://user-images.githubusercontent.com/2260539/109431319-dd372e80-79fd-11eb-8782-31764336f62a.gif)

If you believe this should be behind a `swipeable` property on QDate, I can add that and the corresponding documentation to this PR. I personally believe that this should be a default behavior on mobile.

