### PR TITLE
Update input.md docs - adding example for vue-autonumeric as 3rd party mask processor

### DIFF
--- a/docs/src/pages/vue-components/input.md
+++ b/docs/src/pages/vue-components/input.md
@@ -255,6 +255,42 @@ moneyFormatForComponent: {
 }
 ```
 
+Alternatively, you can use the vue-autonumeric component for a variety of decimal numbers and currencies. See https://www.npmjs.com/package/vue-autonumeric for details. Check http://autonumeric.org/#/guide for options.
+
+```
+```html
+<q-field
+  filled
+  v-model="decimalNumber"
+  label="Decimal number, European format, vue-autonumeric component"
+  hint="Mask: ###.###,##"
+>
+  <template v-slot:control="{ id, floatingLabel, value, emitValue }">
+    <vue-autonumeric
+      ref="myDecimalNumber"
+      :id="id"
+      class="q-field__native text-right"
+      :options="autoNumericOptions"
+      :value="value"
+      @input="emitValue"
+      :placeholder="'####.###,##'"
+      v-show="floatingLabel"
+    />
+    </vue-autonumeric>
+  </template>
+</q-field>
+```
+
+```javascript
+autoNumericOptions: {
+  decimalCharacter: ",", // European decimal separator
+  decimalPlaces: 2, // 2 decimals places after separator
+  digitGroupSeparator: ".", // European thousands separator
+  // Many more options available - see docs for vue-autonumeric
+ },
+ ```
+
+
 ## Validation
 
 ### Internal validation


### PR DESCRIPTION
Add example about how to use vue-autonumeric as 3rd party mask processor.
Note that the existing example for v-money points to a package that is no longer actively maintained.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Suggest to update the q-input doc for this example on how to use vue-autonumeric. The existing example for v-money uses a component that is no longer actively maintained., and has significantly less features and downloads compared to vue-autonumeric.
