### PR TITLE
fix: webpack-dev-server typings

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -51,7 +51,7 @@
     "@types/terser-webpack-plugin": "3.0.0",
     "@types/webpack": "4.41.26",
     "@types/webpack-bundle-analyzer": "3.8.0",
-    "@types/webpack-dev-server": "3.11.0",
+    "@types/webpack-dev-server": "3.11.2",
     "archiver": "5.0.2",
     "autoprefixer": "9.8.6",
     "browserslist": "^4.14.7",


### PR DESCRIPTION
@types/webpack-dev-server was exporting `.Config` which causes a bug during quasar dev command.
```
TS2694: Namespace '"/home/romain/Documents/ndfacile/stacks/admin/node_modules/http-proxy-middleware/dist/index"' has no exported member 'Config'.
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

