### PR TITLE
fix(QBtnDropdown): remove spacing between main button and split when outline #8594

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.sass
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.sass
@@ -1,6 +1,7 @@
 .q-btn-dropdown
   &--split .q-btn-dropdown__arrow-container
-    border-left: 1px solid rgba(255,255,255,.3)
+    &:not(.q-btn--outline)
+      border-left: 1px solid rgba(255,255,255,.3)
 
     .q-btn__wrapper
       padding: 0 4px

--- a/ui/src/components/btn-dropdown/QBtnDropdown.styl
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.styl
@@ -1,6 +1,7 @@
 .q-btn-dropdown
   &--split .q-btn-dropdown__arrow-container
-    border-left: 1px solid rgba(255,255,255,.3)
+    &:not(.q-btn--outline)
+      border-left: 1px solid rgba(255,255,255,.3)
 
     .q-btn__wrapper
       padding: 0 4px


### PR DESCRIPTION
#8594
