### PR TITLE
fix(QTabPanels): remove default background color because it is already applied by the .q-light class #8602

### DIFF
--- a/ui/src/components/tab-panels/QTabPanel.sass
+++ b/ui/src/components/tab-panels/QTabPanel.sass
@@ -1,5 +1,2 @@
-.q-tab-panels
-  background: #fff
-
 .q-tab-panel
   padding: 16px

--- a/ui/src/components/tab-panels/QTabPanel.styl
+++ b/ui/src/components/tab-panels/QTabPanel.styl
@@ -1,5 +1,2 @@
-.q-tab-panels
-  background: #fff
-
 .q-tab-panel
   padding: 16px


### PR DESCRIPTION
#8602
