### PR TITLE
Add shim-lang.d.ts for typescript

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -402,6 +402,7 @@ function writeIndexDTS (apis) {
   //  which by defaults would be ignored because inside node_modules
   //  and not directly referenced by any file
   writeLine(contents, 'import \'./shim-icon-set\'')
+  writeLine(contents, 'import \'./shim-lang\'')
 
   writeFile(resolvePath('index.d.ts'), contents.join(''))
 }

--- a/ui/types/shim-lang.d.ts
+++ b/ui/types/shim-lang.d.ts
@@ -1,0 +1,7 @@
+declare module "quasar/lang/*" {
+  // We know "quasar" will exists at runtime, we can safely ignore the TS error
+  // @ts-ignore
+  import { QuasarLanguage } from "quasar";
+  const lang: QuasarLanguage;
+  export default lang;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

We now have [shim-icon-set.d.ts](https://github.com/quasarframework/quasar/blob/vue3-work/ui/types/shim-icon-set.d.ts)
to make `import icons from "quasar/icon-set/material-icons";` works in typescript.
This PR implement a `shim-lang.d.ts` to make `import langCN from "quasar/lang/zh-CN";` works, too.