### PR TITLE
docs(vs-code-configuration): Remove deprecated extension

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -101,7 +101,6 @@ You can now edit files without violating the standard es-lint rules!
 - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 - [Import Cost](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)
 - [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
-- [Sass Lint](https://marketplace.visualstudio.com/items?itemName=glen-84.sass-lint)
 - [npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
 - [npm Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)


### PR DESCRIPTION
Remove the now deprecated Sass Lint extension. (https://marketplace.visualstudio.com/items?itemName=glen-84.sass-lint)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:
n/a

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch _(Is the vue3_work branch correct?)_
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
n/a