### PR TITLE
Fix the mask  when reverse-fill - bug #8698

### DIFF
--- a/ui/src/mixins/mask.js
+++ b/ui/src/mixins/mask.js
@@ -487,7 +487,7 @@ export default {
 
         let valChar = val[valIndex]
 
-        if (typeof maskDef === 'string') {
+        if (typeof maskDef === 'string' && valIndex >= 0) {
           output = maskDef + output
           valChar === maskDef && valIndex--
         }

--- a/ui/src/mixins/mask.js
+++ b/ui/src/mixins/mask.js
@@ -482,12 +482,12 @@ export default {
 
       let valIndex = val.length - 1, output = ''
 
-      for (let maskIndex = mask.length - 1; maskIndex >= 0; maskIndex--) {
+      for (let maskIndex = mask.length - 1; maskIndex >= 0  && valIndex >= 0; maskIndex--) {
         const maskDef = mask[maskIndex]
 
         let valChar = val[valIndex]
 
-        if (typeof maskDef === 'string' && valIndex >= 0) {
+        if (typeof maskDef === 'string') {
           output = maskDef + output
           valChar === maskDef && valIndex--
         }


### PR DESCRIPTION
Fix the bug #8698, don't add a literal string to value when the value length is less then mask length.

**What kind of change does this PR introduce?** (check at least one)

- [ X ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ X ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ X ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ X ] It's been tested on a Cordova (iOS, Android) app
- [ X ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
