### PR TITLE
feat(app/ts): add Vuex typings, fix #8511, #8500

### DIFF
--- a/app/templates/entry/app.js
+++ b/app/templates/entry/app.js
@@ -61,6 +61,10 @@ export default async function (createAppFn<%= ctx.mode.ssr ? ', ssrContext' : ''
   const store = typeof createStore === 'function'
     ? await createStore({<%= ctx.mode.ssr ? 'ssrContext' : '' %>})
     : createStore
+
+
+  // obtain Vuex injection key in case we use TypeScript
+  const { storeKey } = await import('app/src/store/index');
   <% } %>
   const router = typeof createRouter === 'function'
     ? await createRouter({<%= ctx.mode.ssr ? 'ssrContext' + (store ? ',' : '') : '' %><%= store ? 'store' : '' %>})
@@ -89,7 +93,7 @@ export default async function (createAppFn<%= ctx.mode.ssr ? ', ssrContext' : ''
   // different depending on whether we are in a browser or on the server.
   return {
     app,
-    <%= store ? 'store,' : '' %>
+    <%= store ? 'store, storeKey,' : '' %>
     router
   }
 }

--- a/app/templates/entry/client-entry.js
+++ b/app/templates/entry/client-entry.js
@@ -69,7 +69,7 @@ const doubleSlashRE = /\/\//
 const addPublicPath = url => (publicPath + url).replace(doubleSlashRE, '/')
 <% } %>
 
-async function start ({ app, router<%= store ? ', store' : '' %> }<%= bootEntries.length > 0 ? ', bootFiles' : '' %>) {
+async function start ({ app, router<%= store ? ', store, storeKey' : '' %> }<%= bootEntries.length > 0 ? ', bootFiles' : '' %>) {
   <% if (ctx.mode.ssr && store && ssr.manualHydration !== true) { %>
   // prime the store with server-initialized state.
   // the state is determined during SSR and inlined in the page markup.
@@ -121,7 +121,7 @@ async function start ({ app, router<%= store ? ', store' : '' %> }<%= bootEntrie
   <% } %>
 
   app.use(router)
-  <% if (store) { %>app.use(store)<% } %>
+  <% if (store) { %>app.use(store, storeKey)<% } %>
 
   <% if (ctx.mode.ssr) { %>
     <% if (ctx.mode.pwa) { %>

--- a/app/templates/entry/server-entry.js
+++ b/app/templates/entry/server-entry.js
@@ -73,7 +73,7 @@ function redirectBrowser (url, router, reject, httpStatusCode) {
 // return a Promise that resolves to the app instance.
 export default ssrContext => {
   return new Promise(async (resolve, reject) => {
-    const { app, router<%= store ? ', store' : '' %> } = await createQuasarApp(createApp, ssrContext)
+    const { app, router<%= store ? ', store, storeKey' : '' %> } = await createQuasarApp(createApp, ssrContext)
 
     <% if (bootNames.length > 0) { %>
     let hasRedirected = false
@@ -106,7 +106,7 @@ export default ssrContext => {
     <% } %>
 
     app.use(router)
-    <% if (store) { %>app.use(store)<% } %>
+    <% if (store) { %>app.use(store, storeKey)<% } %>
 
     const url = ssrContext.url<% if (build.publicPath !== '/') { %>.replace(publicPath, '')<% } %>
     const { fullPath } = router.resolve(url)

--- a/app/templates/store/ts/index.ts
+++ b/app/templates/store/ts/index.ts
@@ -1,5 +1,10 @@
 import { store } from 'quasar/wrappers'
-import { createStore } from 'vuex'
+import { InjectionKey } from 'vue'
+import {
+  createStore,
+  Store as VuexStore,
+  useStore as vuexUseStore,
+} from 'vuex'
 
 // import example from './module-example'
 // import { ExampleStateInterface } from './module-example/state';
@@ -20,6 +25,16 @@ export interface StateInterface {
   example: unknown;
 }
 
+// provide typings for `this.$store`
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $store: VuexStore<StateInterface>
+  }
+}
+
+// provide typings for `useStore` helper
+export const storeKey: InjectionKey<VuexStore<StateInterface>> = Symbol();
+
 export default store(function (/* { ssrContext } */) {
   const Store = createStore<StateInterface>({
     modules: {
@@ -33,3 +48,7 @@ export default store(function (/* { ssrContext } */) {
 
   return Store
 })
+
+export function useStore() {
+  return vuexUseStore(storeKey)
+}

--- a/app/templates/store/ts/index.ts
+++ b/app/templates/store/ts/index.ts
@@ -33,7 +33,7 @@ declare module '@vue/runtime-core' {
 }
 
 // provide typings for `useStore` helper
-export const storeKey: InjectionKey<VuexStore<StateInterface>> = Symbol();
+export const storeKey: InjectionKey<VuexStore<StateInterface>> = Symbol('vuex-key')
 
 export default store(function (/* { ssrContext } */) {
   const Store = createStore<StateInterface>({

--- a/docs/src/pages/quasar-cli/prefetch-feature.md
+++ b/docs/src/pages/quasar-cli/prefetch-feature.md
@@ -260,7 +260,7 @@ interface StateInterface {
 }
 
 export default {
-  preFetch: preFetch<Store<StateInterface>>(({ store }) => {
+  preFetch: preFetch<StateInterface>(({ store }) => {
     // Do something with your newly-typed store parameter
   }),
 }


### PR DESCRIPTION
Closes #8511, #8500

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Static import of 'storeKey' wouldn't work, so I had to go for a dynamic import.
The key won't be present into JS codebases as it's not needed

I'm not sure if it's really needed on `server-entry.js` too, but better safe than sorry

I also fixed a docs code example which I didn't update during Qv2 migration 