### PR TITLE
fix(docs): Fixed misleading 'showing all options' for icon libraries

### DIFF
--- a/docs/src/pages/options/installing-icon-libraries.md
+++ b/docs/src/pages/options/installing-icon-libraries.md
@@ -29,14 +29,11 @@ extras: [
 
 Webfont icons are available through [@quasar/extras](https://github.com/quasarframework/quasar/tree/dev/extras) package. You don't need to import it in your app, just configure `/quasar.conf.js` as indicated above.
 
-Adding more than one set (showing all options):
+Adding more than one set:
 ```js
 extras: [
   'material-icons',
-  'material-icons-outlined',
-  'material-icons-round',
-  'material-icons-sharp',
-  'mdi-v3',
+  'mdi-v5',
   'ionicons-v4',
   'eva-icons',
   'fontawesome-v5',
@@ -45,6 +42,8 @@ extras: [
   'bootstrap-icons'
 ]
 ```
+
+For all available options, visit the [GitHub](https://github.com/quasarframework/quasar/tree/dev/extras#webfonts) repository.
 
 You're now ready to use the [QIcon](/vue-components/icon) component.
 
@@ -57,7 +56,7 @@ In case you follow this path, do not also add the icon sets that you want in `/q
 If you have a Fontawesome 5 Pro license and want to use it instead of the Fontawesome Free version, follow these instructions:
 
 1. Open the [Linked Accounts section](https://fontawesome.com/account) in Fontawesome's user account page to grab the npm TOKENID (login if necessary).
-2. Create or append TOKENID into the `.npmrc` file  (file path same as package.json):
+2. Create or append TOKENID into the `.npmrc` file (file path same as package.json):
   ```
   @fortawesome:registry=https://npm.fontawesome.com/
   //npm.fontawesome.com/:_authToken=TOKENID


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
The current documentation for installing icon libraries is some kind misleading as it lists some libraries and says "showing all option" instead it now points to the extras repo with the complete list, as it is done [here](https://next.quasar.dev/options/quasar-icon-sets#quasar-cli-way).