### PR TITLE
Fix: #8764, Import from vue not @vue/composition-api

### DIFF
--- a/app/templates/app/ts-composition/component.vue
+++ b/app/templates/app/ts-composition/component.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent } from 'vue'
 export default defineComponent({
   // name: 'ComponentName'
 })

--- a/app/templates/app/ts-composition/layout.vue
+++ b/app/templates/app/ts-composition/layout.vue
@@ -85,7 +85,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, ref } from 'vue'
 export default defineComponent({
   // name: 'LayoutName',
 

--- a/app/templates/app/ts-composition/page.vue
+++ b/app/templates/app/ts-composition/page.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent } from 'vue'
 export default defineComponent({
   // name: 'PageName'
 })

--- a/app/templates/app/ts-options/component.vue
+++ b/app/templates/app/ts-options/component.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from 'vue'
+export default defineComponent({
   // name: 'ComponentName'
 })
 </script>

--- a/app/templates/app/ts-options/layout.vue
+++ b/app/templates/app/ts-options/layout.vue
@@ -85,8 +85,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from 'vue'
+export default defineComponent({
   // name: 'LayoutName',
 
   data (): { leftDrawer: boolean } {

--- a/app/templates/app/ts-options/page.vue
+++ b/app/templates/app/ts-options/page.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
+import { defineComponent } from 'vue'
+export default defineComponent({
   // name: 'PageName'
 })
 </script>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
Fixes #8764, import from vue (vue3 style) instead of `@vue/composition-api` (vue2 style)