### PR TITLE
fix(app/ts): Override noEmit for create-custom-sw chain

### DIFF
--- a/app/lib/webpack/pwa/create-custom-sw.js
+++ b/app/lib/webpack/pwa/create-custom-sw.js
@@ -104,6 +104,8 @@ module.exports = function (cfg, configName) {
         .options({
           onlyCompileBundledFiles: true,
           transpileOnly: false,
+          // While `noEmit: true` is needed in the tsconfig preset to prevent VSCode errors,
+          // it prevents emitting transpiled files when run into node context
           compilerOptions: {
             noEmit: false,
           }

--- a/app/lib/webpack/pwa/create-custom-sw.js
+++ b/app/lib/webpack/pwa/create-custom-sw.js
@@ -103,7 +103,10 @@ module.exports = function (cfg, configName) {
         .loader('ts-loader')
         .options({
           onlyCompileBundledFiles: true,
-          transpileOnly: false
+          transpileOnly: false,
+          compilerOptions: {
+            noEmit: false,
+          }
         })
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Build-related changes

**Does this PR introduce a breaking change?**

- No _(?)_

**The PR fulfills these requirements:**

- It's submitted to the ~~`dev`~~ `vue3-work` branch and _not_ the `master` branch

**Other information:**

To solve `Error: TypeScript emitted no output` error on compilation. _More context can be found on the `Quasar Insider` Discord server._