### PR TITLE
feat(app v3): Add typescript support for app extensions

### DIFF
--- a/app/lib/app-extension/Extension.js
+++ b/app/lib/app-extension/Extension.js
@@ -125,7 +125,8 @@ module.exports = class Extension {
 
   isInstalled () {
     try {
-      require.resolve(this.packageName  + '/src/index', {
+      const pkgSrc = this.__getPkgSrc()
+      require.resolve(`${this.packageName}/${pkgSrc}/index`, {
         paths: [ appPaths.appDir ]
       })
     }
@@ -301,11 +302,18 @@ module.exports = class Extension {
     )
   }
 
+  __getPkgSrc () {
+    const pkg = require.resolve(this.packageName + `/package.json`, {
+      paths: [ appPaths.appDir ]
+    })
+    return require(pkg).main.split('/')[0]
+  }
+
   __getScript (scriptName, fatalError) {
     let script
-
+    const pkgSrc = this.__getPkgSrc()
     try {
-      script = require.resolve(this.packageName + '/src/' + scriptName, {
+      script = require.resolve(`${this.packageName}/${pkgSrc}/${scriptName}`, {
         paths: [ appPaths.appDir ]
       })
     }

--- a/app/types/app-extension.d.ts
+++ b/app/types/app-extension.d.ts
@@ -1,0 +1,61 @@
+import { IResolve } from './app-paths'
+
+export interface IndexAPI {
+  ctx: Record<string, unknown>
+  extId: string
+  prompts: Record<string, unknown>
+  resolve: IResolve,
+  appDir: string,
+  // __hooks: IndexAPIHooks,
+  getPersistentConf: () => Record<string, unknown>,
+  setPersistentConf: (cfg: Record<string, unknown>) => void,
+  mergePersistentConf: (cfg: Record<string, unknown>) => void,
+  compatibleWith: (packageName: string, semverCondition?: string) => void,
+  hasPackage: (packageName: string, semverCondition?: string) => boolean,
+  hasExtension: (extId: string) => boolean,
+  getPackageVersion: (packageName: string) => string|undefined
+  extendQuasarConf: (fn: Function) => void,
+  chainWebpack: (fn: Function) => void,
+  extendWebpack: (fn: Function) => void,
+  chainWebpackMainElectronProcess: (fn: Function) => void,
+  extendWebpackMainElectronProcess: (fn: Function) => void,
+  chainWebpackWebserver: (fn: Function) => void,
+  extendWebpackWebserver: (fn: Function) => void,
+  registerCommand: (commandName: string, fn: Function) => void,
+  registerDescribeApi: (name: string, relativePath: string) => void,
+  beforeDev: (fn: Function) => void,
+  afterDev: (fn: Function) => void,
+  beforeBuild: (fn: Function) => void,
+  afterBuild: (fn: Function) => void,
+  onPublish: (fn: Function) => void,
+}
+
+export interface InstallAPI {
+  extId: string
+  prompts: Record<string, unknown>
+  resolve: IResolve,
+  appDir: string,
+  getPersistentConf: () => Record<string, unknown>,
+  setPersistentConf: (cfg: Record<string, unknown>) => void,
+  mergePersistentConf: (cfg: Record<string, unknown>) => void,
+  compatibleWith: (packageName: string, semverCondition?: string) => void,
+  hasPackage: (packageName: string, semverCondition?: string) => boolean,
+  hasExtension: (extId: string) => boolean,
+  getPackageVersion: (packageName: string) => string|undefined,
+  extendPackageJson: (extPkg: object | string) => void,
+  extendJsonFile: (file: string, newData: object) => void,
+  render: (templatePath: string, scope?: object) => void,
+  renderFile: (relativeSourcePath: string, relativeTargetPath: string, scope?: object) => void,
+  onExitLog: (msg: string) => void
+}
+
+export interface UninstallAPI {
+  extId: string
+  prompts: Record<string, unknown>
+  resolve: IResolve,
+  appDir: string,
+  getPersistentConf: () => Record<string, unknown>,
+  hasExtension: (extId: string) => boolean,
+  removePath: (__path: string) => void,
+  onExitLog: (msg: string) => void,
+} 

--- a/app/types/app-paths.d.ts
+++ b/app/types/app-paths.d.ts
@@ -1,0 +1,24 @@
+export interface IResolve {
+  cli: (dir: string) => string,
+  app: (dir: string) => string,
+  src: (dir: string) => string,
+  pwa: (dir: string) => string,
+  ssr: (dir: string) => string,
+  cordova: (dir: string) => string,
+  capacitor: (dir: string) => string,
+  electron: (dir: string) => string,
+  bex: (dir: string) => string,
+}
+
+export interface QuasarAppPaths {
+  cliDir: string,
+  appDir: string,
+  srcDir: string,
+  pwaDir: string,
+  ssrDir: string,
+  cordovaDir: string,
+  capacitorDir: string,
+  electronDir: string,
+  bexDir: string,
+  resolve: IResolve
+} 

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -17,4 +17,5 @@ export * from "./boot";
 export * from "./configuration";
 export * from "./route";
 export * from "./ssrmiddleware";
+export * from "./app-extension";
 import "./wrappers";

--- a/app/types/wrappers.d.ts
+++ b/app/types/wrappers.d.ts
@@ -31,7 +31,7 @@ declare module "quasar/wrappers" {
 
   function store(callback: StoreCallback): StoreCallback;
 
-  function ssrmiddleware(
+  function ssrMiddleware(
     callback: SsrMiddlewareCallback
   ): SsrMiddlewareCallback;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

https://github.com/quasarframework/quasar/issues/7329

PR is submitted to the vue3-work branch and it could be merged into dev, but AE TS support will require Quasar v2 (that is, the changes I made to the starter-kits are based on Quasar v2). The only internal change is that it looks up the source folder from `main` in package.json instead of assuming that it is `src`. Thus, a TS AE can have `"main": "dist/index.js"` in order for Quasar to use it correctly.

It also provides types for the API.