### PR TITLE
feat(ui): Add min-height so badge can be used without label (indicator)

### DIFF
--- a/docs/src/examples/QBadge/Indicators.vue
+++ b/docs/src/examples/QBadge/Indicators.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="q-pa-md q-gutter-md">
+    <q-badge rounded color="yellow" />
+    <q-badge rounded color="green" />
+    <q-badge rounded color="red" />
+    <div class="q-gutter-md q-ml-none">
+      <q-btn round icon="notifications">
+        <q-badge floating color="red" rounded />
+      </q-btn>
+      <q-btn color="blue">
+        Notifications
+        <q-badge color="red" rounded floating />
+      </q-btn>
+    </div>
+    <div>
+      <q-badge color="blue" rounded class="q-mr-sm" />Status
+    </div>
+  </div>
+</template>

--- a/docs/src/pages/vue-components/badge.md
+++ b/docs/src/pages/vue-components/badge.md
@@ -22,5 +22,7 @@ The QBadge component allows you to create a small badge for adding information l
 
 <doc-example title="Rounded" file="QBadge/Round" />
 
+<doc-example title="Indicators" file="QBadge/Indicators" />
+
 ## QBadge API
 <doc-api file="QBadge" />

--- a/ui/dev/src/pages/components/badge.vue
+++ b/ui/dev/src/pages/components/badge.vue
@@ -15,6 +15,12 @@
         12 <q-icon name="warning" color="white" class="q-ml-xs" />
       </q-badge>
 
+      <q-badge color="yellow" rounded />
+
+      <q-badge color="green" rounded />
+
+      <q-badge color="red" rounded />
+
       <div class="text-h6">
         Badge <q-badge color="primary">
           v1.0.0+
@@ -110,6 +116,14 @@
         </q-badge>
       </q-btn>
 
+      <q-btn dense color="purple" round icon="email" class="q-ml-md">
+        <q-badge color="red" floating rounded />
+      </q-btn>
+
+      <q-btn dense round flat icon="email">
+        <q-badge color="red" floating rounded transparent />
+      </q-btn>
+
       <div class="text-h4">
         Title
         <q-badge transparent align="middle" color="orange">
@@ -187,6 +201,9 @@
       </div>
       <div>
         Some text <q-badge color="green" label="999+" rounded />
+      </div>
+      <div>
+        <q-badge color="blue" rounded class="q-mr-sm" />Some text
       </div>
     </div>
   </div>

--- a/ui/src/components/badge/QBadge.sass
+++ b/ui/src/components/badge/QBadge.sass
@@ -31,7 +31,3 @@
 
   &--rounded
     border-radius: 1em
-
-  &--indicator
-    min-height: 1em
-    min-width: 1em

--- a/ui/src/components/badge/QBadge.sass
+++ b/ui/src/components/badge/QBadge.sass
@@ -6,6 +6,7 @@
   border-radius: $generic-border-radius
   font-size: 12px
   line-height: 12px
+  min-height: 12px
   font-weight: normal
   vertical-align: baseline
 
@@ -30,3 +31,7 @@
 
   &--rounded
     border-radius: 1em
+
+  &--indicator
+    min-height: 1em
+    min-width: 1em

--- a/ui/src/components/badge/QBadge.styl
+++ b/ui/src/components/badge/QBadge.styl
@@ -5,6 +5,7 @@
   padding: 2px 6px
   border-radius: $generic-border-radius
   font-size: 12px
+  min-height: 12px
   line-height: 12px
   font-weight: normal
   vertical-align: baseline


### PR DESCRIPTION
- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

This PR allows badges to be used without a label, basically just by adding a single CSS attribute (`min-height`).  Previously there was no minimum height so when the badge is used without a label it's basically a flat line.   

This allows users to for example:
- Add an indeterminate "new" state indicator to avatars, buttons and any other components that badges are usually attached to.
- Add "dots" of any color

Docs have been updated with some basic usage
![image](https://user-images.githubusercontent.com/3470826/114556952-1bf90f00-9c61-11eb-98ba-89b674be7e0a.png)
