### PR TITLE
feat(app): AE Handlebars template compiler

### DIFF
--- a/app/lib/app-extension/InstallAPI.js
+++ b/app/lib/app-extension/InstallAPI.js
@@ -234,8 +234,10 @@ module.exports = class InstallAPI {
    *
    * @param {string} templatePath (relative path to folder to render in app)
    * @param {object} scope (optional; rendering scope variables)
+   * @param {object} options (optional); { templateCompiler: 'lodash' | 'handlebars' }
    */
-  render (templatePath, scope) {
+  render (templatePath, scope, options) {
+    const { templateCompiler } = options || {}
     const dir = getCallerPath()
     const source = path.resolve(dir, templatePath)
     const rawCopy = !scope || Object.keys(scope).length === 0
@@ -254,7 +256,8 @@ module.exports = class InstallAPI {
     this.__hooks.renderFolders.push({
       source,
       rawCopy,
-      scope
+      scope,
+      templateCompiler
     })
   }
 
@@ -266,11 +269,13 @@ module.exports = class InstallAPI {
    * @param {string} relativeTargetPath (file path relative to the root of the app -- including filename!)
    * @param {object} scope (optional; rendering scope variables)
    */
-  renderFile (relativeSourcePath, relativeTargetPath, scope) {
+  renderFile (relativeSourcePath, relativeTargetPath, scope, options) {
     const dir = getCallerPath()
     const sourcePath = path.resolve(dir, relativeSourcePath)
     const targetPath = appPaths.resolve.app(relativeTargetPath)
     const rawCopy = !scope || Object.keys(scope).length === 0
+    const { templateCompiler } = options || {}
+    console.log(templateCompiler)
 
     if (!fs.existsSync(sourcePath)) {
       warn()
@@ -288,7 +293,8 @@ module.exports = class InstallAPI {
       targetPath,
       rawCopy,
       scope,
-      overwritePrompt: true
+      overwritePrompt: true,
+      templateCompiler
     })
   }
 

--- a/app/package.json
+++ b/app/package.json
@@ -71,6 +71,7 @@
     "fork-ts-checker-webpack-plugin": "4.1.6",
     "friendly-errors-webpack-plugin": "1.7.0",
     "fs-extra": "9.0.1",
+    "handlebars": "^4.7.7",
     "html-minifier": "4.0.0",
     "html-webpack-plugin": "4.5.0",
     "inquirer": "7.3.3",

--- a/docs/src/pages/app-extensions/development-guide/install-api.md
+++ b/docs/src/pages/app-extensions/development-guide/install-api.md
@@ -155,6 +155,7 @@ Needs a relative path to the folder of the file calling render().
  *
  * @param {string} templatePath (relative path to folder to render in app)
  * @param {object} scope (optional; rendering scope variables)
+ * @param {object} options (optional; { templateCompiler: 'lodash' | 'handlebars' }
  */
 api.render('./path/to/a/template/folder')
 ```
@@ -215,6 +216,9 @@ const message = 'This is content when we don\'t have "Feature X"'
 
 Possibilities are limited only by your imagination.
 
+### Using Handlebars as template compiler <q-badge align="top" label="@quasar/app v3+" />
+
+If `templateCompiler` in `options` is set to `handlebars`, the source files will be rendered with the [Handlebars](https://handlebarsjs.com/) templating engine instead of lodash. Any .hbs extensions will also be stripped automatically.
 ## api.renderFile <q-badge align="top" label="@quasar/app v2+" />
 
 Similar with api.render() with the difference that this method renders a single file.
@@ -227,6 +231,7 @@ Similar with api.render() with the difference that this method renders a single 
  * @param {string} relativeSourcePath (file path relative to the folder from which the install script is called)
  * @param {string} relativeTargetPath (file path relative to the root of the app -- including filename!)
  * @param {object} scope (optional; rendering scope variables)
+ * @param {object} options (optional; { templateCompiler: 'lodash' | 'handlebars' }
  */
 api.renderFile('./path/to/a/template/filename', 'path/relative/to/app/root/filename', {
   prompts: api.prompts


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

With the lodash templating engine it is quite inconvenient to render pretty output due to the fact that the lodash templating seems to be replaced with whitespace in the rendered file. Also, with the JS syntax it is not self evident to render HTML.
Handlebars handles this much better.

In order not to break anything, I added an `options` argument to `render()` and `renderFile()` in which `templateCompiler` can be set to `handlebars`. Not providing the option will default to lodash.

For a better IDE experience the source files can have a .hbs extension which will be stripped upon rendering.