### PR TITLE
fix(preFetch): Call preFetch with class components #8915

### DIFF
--- a/app/templates/entry/client-prefetch.js
+++ b/app/templates/entry/client-prefetch.js
@@ -17,9 +17,12 @@ import { LoadingBar } from 'quasar'
 import { isRunningOnPWA } from './ssr-pwa'
 <% } %>
 
+// Class components return the component options (and the preFetch hook) inside __c property
 <% if (!ctx.mode.ssr || ctx.mode.pwa) { %>
 import App from 'app/<%= sourceFiles.rootComponent %>'
-let appPrefetch = typeof App.preFetch === 'function'
+let appPrefetch =
+  typeof App.preFetch === 'function' ||
+  (App.__c && typeof App.__c.preFetch === 'function');
 <% } %>
 
 function getMatchedComponents (to, router) {
@@ -61,6 +64,7 @@ export function addPreFetchHooks (router<%= store ? ', store' : '' %>, publicPat
         ))
       })
       .filter(m => {
+        // Class components return the component options (and the preFetch hook) inside __c property
         if (m.c && typeof m.c.preFetch === 'function') return true
         if (m.c && m.c.__c && typeof m.c.__c.preFetch === 'function') return true
         return false
@@ -72,12 +76,12 @@ export function addPreFetchHooks (router<%= store ? ', store' : '' %>, publicPat
     <% if (!ctx.mode.ssr) { %>
     if (appPrefetch === true) {
       appPrefetch = false
-      preFetchList.unshift(App.preFetch)
+      preFetchList.unshift(App.preFetch ? App.preFetch : App.__c.preFetch);
     }
     <% } else if (ctx.mode.pwa) { %>
     if (isRunningOnPWA === true && appPrefetch === true) {
       appPrefetch = false
-      preFetchList.unshift(App.preFetch)
+      preFetchList.unshift(App.preFetch ? App.preFetch : App.__c.preFetch);
     }
     <% } %>
 

--- a/app/templates/entry/client-prefetch.js
+++ b/app/templates/entry/client-prefetch.js
@@ -60,8 +60,14 @@ export function addPreFetchHooks (router<%= store ? ', store' : '' %>, publicPat
           m.path.indexOf('/:') > -1 // does it has params?
         ))
       })
-      .filter(m => m.c && typeof m.c.preFetch === 'function')
-      .map(m => m.c.preFetch)
+      .filter(m => {
+        if (m.c && typeof m.c.preFetch === 'function') return true
+        if (m.c && m.c.__c && typeof m.c.__c.preFetch === 'function') return true
+        return false
+      })
+      .map(m => {
+        return m.c.__c ? m.c.__c.preFetch : m.c.preFetch
+      })
 
     <% if (!ctx.mode.ssr) { %>
     if (appPrefetch === true) {

--- a/app/templates/entry/client-prefetch.js
+++ b/app/templates/entry/client-prefetch.js
@@ -63,15 +63,9 @@ export function addPreFetchHooks (router<%= store ? ', store' : '' %>, publicPat
           m.path.indexOf('/:') > -1 // does it has params?
         ))
       })
-      .filter(m => {
-        // Class components return the component options (and the preFetch hook) inside __c property
-        if (m.c && typeof m.c.preFetch === 'function') return true
-        if (m.c && m.c.__c && typeof m.c.__c.preFetch === 'function') return true
-        return false
-      })
-      .map(m => {
-        return m.c.__c ? m.c.__c.preFetch : m.c.preFetch
-      })
+      // Class components return the component options (and the preFetch hook) inside __c property
+      .filter(m => (m.c && typeof m.c.preFetch === 'function') || (m.c && m.c.__c && typeof m.c.__c.preFetch === 'function'))
+      .map(m => m.c.__c ? m.c.__c.preFetch : m.c.preFetch)
 
     <% if (!ctx.mode.ssr) { %>
     if (appPrefetch === true) {

--- a/app/templates/entry/server-entry.js
+++ b/app/templates/entry/server-entry.js
@@ -137,14 +137,17 @@ export default ssrContext => {
         redirectBrowser(url, router, reject, httpStatusCode)
       }
 
-      App.preFetch !== void 0 && matchedComponents.unshift(App)
-
+      // Class components return the component options (and the preFetch hook) inside __c property
+      if (typeof App.preFetch === 'function' || App.__c && typeof App.__c.preFetch === 'function') {
+        matchedComponents.unshift(App)
+      }
       // Call preFetch hooks on components matched by the route.
       // A preFetch hook dispatches a store action and returns a Promise,
       // which is resolved when the action is complete and store state has been
       // updated.
       matchedComponents
       .filter(c => {
+        // Class components return the component options (and the preFetch hook) inside __c property
         if (typeof c.preFetch === 'function') return true
         if (c.__c && typeof c.__c.preFetch === 'function') return true
         return false

--- a/app/templates/entry/server-entry.js
+++ b/app/templates/entry/server-entry.js
@@ -146,12 +146,8 @@ export default ssrContext => {
       // which is resolved when the action is complete and store state has been
       // updated.
       matchedComponents
-      .filter(c => {
-        // Class components return the component options (and the preFetch hook) inside __c property
-        if (typeof c.preFetch === 'function') return true
-        if (c.__c && typeof c.__c.preFetch === 'function') return true
-        return false
-      })
+      // Class components return the component options (and the preFetch hook) inside __c property
+      .filter(c => (typeof c.preFetch === 'function') || (c.__c && typeof c.__c.preFetch === 'function'))
       .reduce(
         (promise, c) => promise.then(() => hasRedirected === false && (c.__c ? c.__c : c).preFetch({
           <% if (store) { %>store,<% } %>

--- a/app/templates/entry/server-entry.js
+++ b/app/templates/entry/server-entry.js
@@ -144,9 +144,13 @@ export default ssrContext => {
       // which is resolved when the action is complete and store state has been
       // updated.
       matchedComponents
-      .filter(c => c && c.preFetch)
+      .filter(c => {
+        if (typeof c.preFetch === 'function') return true
+        if (c.__c && typeof c.__c.preFetch === 'function') return true
+        return false
+      })
       .reduce(
-        (promise, c) => promise.then(() => hasRedirected === false && c.preFetch({
+        (promise, c) => promise.then(() => hasRedirected === false && (c.__c ? c.__c : c).preFetch({
           <% if (store) { %>store,<% } %>
           ssrContext,
           currentRoute: router.currentRoute,


### PR DESCRIPTION
preFetch is now called when used inside @Options() in a class component. This fixes issue #8915.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
