### PR TITLE
fix: #8885 Use registered component if custom dialog component is a string.

### DIFF
--- a/ui/src/utils/private/global-dialog.js
+++ b/ui/src/utils/private/global-dialog.js
@@ -36,7 +36,9 @@ export default function (DefaultComponent, supportsCustomComponent, parentApp) {
     if (isCustom === true) {
       const { component, componentProps } = pluginProps
 
-      DialogComponent = component
+      DialogComponent = (typeof component === 'string')
+        ? parentApp.component(component)
+        : component
       props = componentProps
     }
     else {

--- a/ui/src/utils/private/global-dialog.js
+++ b/ui/src/utils/private/global-dialog.js
@@ -39,6 +39,7 @@ export default function (DefaultComponent, supportsCustomComponent, parentApp) {
       DialogComponent = (typeof component === 'string')
         ? parentApp.component(component)
         : component
+
       props = componentProps
     }
     else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Resolves #8885

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
