### PR TITLE
fix(ssr): Give clientManifest.publicPath priority

### DIFF
--- a/ssr-helpers/create-renderer.js
+++ b/ssr-helpers/create-renderer.js
@@ -84,7 +84,7 @@ function ensureTrailingSlash (path) {
 function createRenderContext ({ clientManifest, publicPath }) {
   return {
     clientManifest,
-    publicPath: ensureTrailingSlash(publicPath || clientManifest.publicPath || '/'),
+    publicPath: ensureTrailingSlash(clientManifest.publicPath || publicPath || '/'),
     preloadFiles: (clientManifest.initial || []).map(normalizeFile),
     mapFiles: createMapper(clientManifest)
   }


### PR DESCRIPTION
In my project, which may be a snowflake, I serve pages relative to `/`, but I must serve the compiled assets from a subfolder `/somepath/`. To do this, I add `output.publicPath = '/somepath/`' to the webpack config. The resulting quasar.client-manifest.json file inlcudes `"publicPath": "/somepath"`. 

Unfortunately that setting is ignored, because the existing logic gives `build.publicPath` priority, which is never empty, as it defaults to `'/'`.

Cheers!

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (I don't believe so, since `publicPath` is never falsey. The resulting behavior would not change except for people who are experiencing this issue.

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x - ish] It's submitted to the `dev` branch and _not_ the `master` branch
- [n/a] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [n/a] It's been tested on a Cordova (iOS, Android) app
- [n/a] It's been tested on a Electron app
- [n/a] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

(This effects only SSR)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
