### PR TITLE
Fix quasar-inspect always printing "undefined"

### DIFF
--- a/app/bin/quasar-inspect
+++ b/app/bin/quasar-inspect
@@ -105,7 +105,7 @@ async function inspect () {
     log(`Showing Webpack config for "${cfgEntry.name}" with depth of ${depth}`)
     console.log()
     console.log(
-      util.inspect(cfgEntry.webpackCfg, {
+      util.inspect(cfgEntry.webpack, {
         showHidden: true,
         depth: depth,
         colors: true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The actual Webpack config property was renamed from `webpackCfg` to `webpack` at some point, but the call to `util.inspect` was not updated. As such, it currently always prints `undefined` in place of any actual config.

On a related note: Showing the hidden (non-enumerable) properties seems to lead to a lot of verbosity that won't be relevant in most cases. How would you feel about a PR to change the default to `showHidden: false` and add a `-v`/`--verbose` flag to choose the previous behavior?