### PR TITLE
Update app-internationalization.md

### DIFF
--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -168,10 +168,6 @@ export default {
     const { locale } = useI18n({ useScope: 'global' })
     const lang = ref(locale)
 
-    watch(lang, val => {
-      locale.value = val
-    })
-
     return {
       lang,
       langOptions: [

--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -146,8 +146,8 @@ export default {
 <template>
   <!-- ...... -->
   <q-select
-    v-model="lang"
-    :options="langOptions"
+    v-model="locale"
+    :options="localeOptions"
     label="Quasar Language"
     dense
     borderless
@@ -166,10 +166,9 @@ import { useI18n } from 'vue-i18n'
 export default {
   setup () {
     const { locale } = useI18n({ useScope: 'global' })
-    const lang = ref(locale)
 
     return {
-      lang,
+      locale,
       langOptions: [
         { value: 'en-US', label: 'English' },
         { value: 'de', label: 'German' }

--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -169,7 +169,7 @@ export default {
 
     return {
       locale,
-      langOptions: [
+      localeOptions: [
         { value: 'en-US', label: 'English' },
         { value: 'de', label: 'German' }
       ]


### PR DESCRIPTION
This watch statement is not needed, thus locale is being referenced by lang which is being changed with v-model.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
