### PR TITLE
docs(electron): Replace deprecated 'remote' module with @electron/remote (#8806)

### DIFF
--- a/docs/src/pages/quasar-cli/developing-electron-apps/electron-accessing-files.md
+++ b/docs/src/pages/quasar-cli/developing-electron-apps/electron-accessing-files.md
@@ -28,9 +28,9 @@ We can use the userData directory, which is reserved specifically for our applic
 // electron-main or electron-preload
 
 import path from 'path'
-import { remote } from 'electron'
+import { app } from '@electron/remote'
 
-const filePath = path.join(remote.app.getPath('userData'), '/some.file')
+const filePath = path.join(app.getPath('userData'), '/some.file')
 ```
 
 If for some reason, you have important files that you are storing in the /public folder, you can access those too by following the code below. To understand why you need to access them this way, please read the "Using __dirname & __filename" section above.

--- a/docs/src/pages/quasar-cli/developing-electron-apps/frameless-electron-window.md
+++ b/docs/src/pages/quasar-cli/developing-electron-apps/frameless-electron-window.md
@@ -22,6 +22,9 @@ Then, in your `src-electron/main-process/electron-main.js` file, make some edits
 ```js
 // src-electron/main-process/electron-main.js
 
+import { initialize } from '@electron/remote/main' // <-- add this
+initialize() // <-- add this
+
 mainWindow = new BrowserWindow({
   width: 1000,
   height: 600,
@@ -32,8 +35,6 @@ mainWindow = new BrowserWindow({
     // ...
   }
 })
-
-require('@electron/remote/main').initialize() // <-- and add this
 ```
 
 Notice that we need to explicitly enable the remote module too. We'll be using it in the preload script to provide the renderer thread with the window minimize/maximize/close functionality.
@@ -45,7 +46,6 @@ Since we can't directly access Electron from within the renderer thread, we'll n
 // src-electron/main-process/electron-preload.js
 
 import { contextBridge } from 'electron'
-
 import { BrowserWindow } from '@electron/remote'
 
 contextBridge.exposeInMainWorld('myWindowAPI', {

--- a/docs/src/pages/quasar-cli/developing-electron-apps/frameless-electron-window.md
+++ b/docs/src/pages/quasar-cli/developing-electron-apps/frameless-electron-window.md
@@ -9,7 +9,15 @@ A nice combo is to use frameless Electron window along with [QBar](/vue-componen
 
 ## Main thread
 ### Setting frameless window
-In your `src-electron/main-process/electron-main.js` file we will make an edit to these lines:
+Firstly, install the `@electron/remote` dependency into your app.
+
+```bash
+$ yarn add @electron/remote
+// or:
+$ npm install @electron/remote
+```
+
+Then, in your `src-electron/main-process/electron-main.js` file, make some edits to these lines:
 
 ```js
 // src-electron/main-process/electron-main.js
@@ -24,6 +32,8 @@ mainWindow = new BrowserWindow({
     // ...
   }
 })
+
+require('@electron/remote/main').initialize() // <-- and add this
 ```
 
 Notice that we need to explicitly enable the remote module too. We'll be using it in the preload script to provide the renderer thread with the window minimize/maximize/close functionality.
@@ -34,9 +44,9 @@ Since we can't directly access Electron from within the renderer thread, we'll n
 ```js
 // src-electron/main-process/electron-preload.js
 
-import { contextBridge, remote } from 'electron'
+import { contextBridge } from 'electron'
 
-const { BrowserWindow } = remote
+import { BrowserWindow } from '@electron/remote'
 
 contextBridge.exposeInMainWorld('myWindowAPI', {
   minimize () {

--- a/docs/src/pages/quasar-cli/handling-process-env.md
+++ b/docs/src/pages/quasar-cli/handling-process-env.md
@@ -31,8 +31,8 @@ if (process.env.DEV) {
 // "quasar dev/build -m <mode>"
 // (defaults to 'spa' if -m parameter is not specified)
 if (process.env.MODE === 'electron') {
-  const { remote } = require('electron')
-  const win = remote.BrowserWindow.getFocusedWindow()
+  const { BrowserWindow } = require('@electron/remote')
+  const win = BrowserWindow.getFocusedWindow()
 
   if (win.isMaximized()) {
     win.unmaximize()


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Documentation

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `vue3-work` branch and _not_ the `master` branch
- The related issue is referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs).

**Other information:**
Closes #8806.

Deprecation Notice: https://github.com/electron/electron/issues/21408