### PR TITLE
Added no-option-label prop for QSelect, issue #9463

### DIFF
--- a/docs/src/examples/QSelect/OptionNoneLabel.vue
+++ b/docs/src/examples/QSelect/OptionNoneLabel.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="q-pa-md" style="max-width: 300px">
+    <div class="q-gutter-md">
+      <q-select
+        filled
+        v-model="model"
+        :options="options"
+        label="No options"
+        no-option-label="Sorry, there are no options to show..."
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      model: null,
+      options: []
+    };
+  }
+};
+</script>

--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -118,6 +118,8 @@ Here is another example where we add a QToggle to each option. The possibilities
 
 By default, when there are no options, the menu won't appear. But you can customize this scenario and specify what the menu should display.
 
+<doc-example title="No options label" file="QSelect/OptionNoneLabel" />
+
 <doc-example title="No options slot" file="QSelect/OptionNoneSlot" />
 
 ### Lazy loading

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -56,6 +56,7 @@ export default Vue.extend({
     optionValue: [Function, String],
     optionLabel: [Function, String],
     optionDisable: [Function, String],
+    noOptionLabel: String,
 
     hideSelected: Boolean,
     hideDropdownIcon: Boolean,
@@ -1213,7 +1214,8 @@ export default Vue.extend({
         this.editable !== false && (
           this.dialog === true || // dialog always has menu displayed, so need to render it
           this.noOptions !== true ||
-          this.$scopedSlots['no-option'] !== void 0
+          this.$scopedSlots['no-option'] !== void 0 ||
+          this.noOptionLabel !== void 0
         )
       ) {
         return this[`__get${this.hasDialog === true ? 'Dialog' : 'Menu'}`](h)
@@ -1225,7 +1227,14 @@ export default Vue.extend({
         ? (
           this.$scopedSlots['no-option'] !== void 0
             ? this.$scopedSlots['no-option']({ inputValue: this.inputValue })
-            : null
+            : (this.noOptionLabel !== void 0 ? [h(QItem, {}, [
+              h(QItemSection, [
+                h(QItemLabel, {
+                  staticClass: 'text-grey',
+                  domProps: { textContent: this.noOptionLabel }
+                })
+              ])
+            ])] : null)
         )
         : this.__getOptions(h)
 
@@ -1318,7 +1327,14 @@ export default Vue.extend({
             ? (
               this.$scopedSlots['no-option'] !== void 0
                 ? this.$scopedSlots['no-option']({ inputValue: this.inputValue })
-                : null
+                : (this.noOptionLabel !== void 0 ? [h(QItem, {}, [
+                  h(QItemSection, [
+                    h(QItemLabel, {
+                      staticClass: 'text-grey',
+                      domProps: { textContent: this.noOptionLabel }
+                    })
+                  ])
+                ])] : null)
             )
             : this.__getOptions(h)
         ))
@@ -1418,7 +1434,7 @@ export default Vue.extend({
       if (this.qListeners.filter !== void 0) {
         this.filter(this.inputValue)
       }
-      else if (this.noOptions !== true || this.$scopedSlots['no-option'] !== void 0) {
+      else if (this.noOptions !== true || this.$scopedSlots['no-option'] !== void 0 || this.noOptionLabel !== void 0) {
         this.menu = true
       }
     },
@@ -1458,7 +1474,7 @@ export default Vue.extend({
         ? false
         : this.behavior !== 'menu' && (
           this.useInput === true
-            ? this.$scopedSlots['no-option'] !== void 0 || this.qListeners.filter !== void 0 || this.noOptions === false
+            ? this.$scopedSlots['no-option'] !== void 0 || this.noOptionLabel !== void 0 || this.qListeners.filter !== void 0 || this.noOptions === false
             : true
         )
 

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -77,6 +77,13 @@
       "category": "options"
     },
 
+    "no-option-label": {
+      "type": "String",
+      "desc": "Property which tells the user if there are no options available (overridden by no-options slot)",
+      "examples": "There are no options to show...",
+      "category": "options"
+    },
+
     "hide-selected": {
       "type": "Boolean",
       "desc": "Hides selection; Use the underlying input tag to hold the label (instead of showing it to the right of the input) of the selected option; Only works for non 'multiple' Selects",
@@ -317,7 +324,7 @@
 
   "scopedSlots": {
     "no-option": {
-      "desc": "What should the menu display after filtering options and none are left to be displayed; Suggestion: <div>",
+      "desc": "What should the menu display after filtering options and none are left to be displayed; Overrides no-option-label prop, if existing; Suggestion: <div>",
       "scope": {
         "inputValue": {
           "type": "String",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
