### PR TITLE
Bumped sharp version to >0.28 so it can be used on Apple M1/Silicon

### DIFF
--- a/icongenie/package.json
+++ b/icongenie/package.json
@@ -50,7 +50,7 @@
     "png2icons": "^2.0.1",
     "potrace": "^2.1.5",
     "read-chunk": "^3.2.0",
-    "sharp": "^0.25.2",
+    "sharp": "^0.28.3",
     "svgo": "^1.3.2",
     "untildify": "^4.0.0",
     "update-notifier": "^4.1.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
No breaking changes.
Just a version bump on Sharp, so @quasar/icongenie can be installed with no issues on any Apple computer with M1/Silicon chip.