### PR TITLE
feat(QInfiniteScroll): add support for simultaneous directions #9159 #7782 #8577

### DIFF
--- a/ui/dev/src/pages/components/infinite-scroll-direction.vue
+++ b/ui/dev/src/pages/components/infinite-scroll-direction.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <div class="q-layout-padding">
+      <p class="caption">
+        Scroll down to see it in action.
+      </p>
+
+      <div class="row justify-between">
+        <q-toggle v-model="disable" label="Disable" class="q-mr-sm" />
+        <q-select v-model="direction" :options="directionOptions" label="Direction" dense style="width: 250px;" />
+      </div>
+
+      <div ref="scrollTarget" :style="styles">
+        <q-infinite-scroll @load="loadRef" :disable="disable" :direction="direction" v-if="active" :scroll-target="container ? $refs.scrollTarget : void 0">
+          <div v-for="(item, index) in itemsRef" :key="index" class="caption">
+            <q-chip square color="secondary" class="shadow-1">
+              {{ index + 1 }}
+            </q-chip>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+          </div>
+
+          <div slot="loading" class="row justify-center q-my-md">
+            <q-spinner color="primary" name="dots" :size="40" />
+          </div>
+        </q-infinite-scroll>
+        <div v-else style="height: 300vh">
+          Placeholder for scroll
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      itemsReverse: [{}, {}, {}, {}, {}],
+      itemsRef: [{}, {}, {}, {}, {}, {}],
+      itemsId: [{}, {}, {}, {}, {}],
+      disable: false,
+      container: false,
+      active: true,
+      direction: 'both',
+      directionOptions: [null, 'bottom', 'top', 'both', 'none']
+    }
+  },
+  computed: {
+    styles () {
+      return this.container ? 'height: 300px; border: 1px solid black; overflow: auto;' : ''
+    }
+  },
+  methods: {
+    loadReverse (index, done) {
+      console.log('load reverse called')
+      setTimeout(() => {
+        this.itemsReverse.splice(0, 0, {}, {}, {}, {}, {}, {}, {})
+        done()
+      }, 2500)
+    },
+
+    loadRef (index, done, direction) {
+      console.log('load ref called', direction)
+      setTimeout(() => {
+        this.itemsRef.push({}, {}, {}, {}, {}, {}, {})
+        done()
+      }, 2500)
+    },
+
+    loadId (index, done) {
+      console.log('load id called')
+      setTimeout(() => {
+        this.itemsId.push({}, {}, {}, {}, {}, {}, {})
+        done()
+      }, 2500)
+    }
+  }
+}
+</script>

--- a/ui/lang/index.json
+++ b/ui/lang/index.json
@@ -165,7 +165,7 @@
   },
   {
     "isoName": "sr",
-    "nativeName": "српски језик"
+    "nativeName": "srpski jezik"
   },
   {
     "isoName": "sv",

--- a/ui/lang/index.json
+++ b/ui/lang/index.json
@@ -165,7 +165,7 @@
   },
   {
     "isoName": "sr",
-    "nativeName": "srpski jezik"
+    "nativeName": "српски језик"
   },
   {
     "isoName": "sv",

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -8,6 +8,13 @@ import { getScrollTarget, getScrollHeight, getScrollPosition, setScrollPosition 
 import { listenOpts } from '../../utils/event.js'
 import { slot, uniqueSlot } from '../../utils/slot.js'
 
+const DIRECTIONS = {
+  none: 'none',
+  bottom: 'bottom',
+  top: 'top',
+  both: 'both'
+}
+
 export default Vue.extend({
   name: 'QInfiniteScroll',
 
@@ -31,13 +38,18 @@ export default Vue.extend({
     initialIndex: Number,
 
     disable: Boolean,
-    reverse: Boolean
+    reverse: Boolean,
+    direction: {
+      type: String,
+      default: null
+    }
   },
 
   data () {
     return {
       index: this.initialIndex || 0,
-      fetching: false,
+      fetchingTop: false,
+      fetchingBottom: false,
       working: true
     }
   },
@@ -58,12 +70,21 @@ export default Vue.extend({
 
     debounce (val) {
       this.__setDebounce(val)
+    },
+
+    direction (val) {
+      if (val === DIRECTIONS.none) {
+        this.stop()
+      }
+      else if (val && this.disable !== true) {
+        this.resume()
+      }
     }
   },
 
   methods: {
     poll () {
-      if (this.disable === true || this.fetching === true || this.working === false) {
+      if (this.disable === true || this.working === false || this.direction === DIRECTIONS.none) {
         return
       }
 
@@ -72,33 +93,48 @@ export default Vue.extend({
         scrollPosition = getScrollPosition(this.__scrollTarget),
         containerHeight = height(this.__scrollTarget)
 
-      if (this.reverse === false) {
-        if (scrollPosition + containerHeight + this.offset >= scrollHeight) {
-          this.trigger()
+      if (this.direction) {
+        if (this.direction === DIRECTIONS.bottom || this.direction === DIRECTIONS.both) {
+          if (scrollPosition + containerHeight + this.offset >= scrollHeight) {
+            this.trigger(DIRECTIONS.bottom)
+          }
+        }
+        if (this.direction === DIRECTIONS.top || this.direction === DIRECTIONS.both) {
+          if (scrollPosition < this.offset) {
+            this.trigger(DIRECTIONS.top)
+          }
         }
       }
       else {
-        if (scrollPosition < this.offset) {
-          this.trigger()
+        if (this.reverse === false) {
+          if (scrollPosition + containerHeight + this.offset >= scrollHeight) {
+            this.trigger(DIRECTIONS.bottom)
+          }
+        }
+        else {
+          if (scrollPosition < this.offset) {
+            this.trigger(DIRECTIONS.top)
+          }
         }
       }
     },
 
-    trigger () {
-      if (this.disable === true || this.fetching === true || this.working === false) {
+    trigger (direction) {
+      const isTop = direction === DIRECTIONS.top
+      if (this.disable === true || (isTop && this.fetchingTop === true) || (!isTop && this.fetchingBottom === true) || this.working === false || this.direction === DIRECTIONS.none) {
         return
       }
 
-      this.index++
-      this.fetching = true
+      this.index++ // TODO: in case direction === both index should be index range [number, number]?
+      this[isTop ? 'fetchingTop' : 'fetchingBottom'] = true
 
       const heightBefore = getScrollHeight(this.__scrollTarget)
 
       this.$emit('load', this.index, stop => {
-        if (this.working === true) {
-          this.fetching = false
+        if (this.working === true && (this.direction !== DIRECTIONS.none || !this.direction)) {
+          this[isTop ? 'fetchingTop' : 'fetchingBottom'] = false
           this.$nextTick(() => {
-            if (this.reverse === true) {
+            if ((this.reverse === true && !this.direction) || direction === DIRECTIONS.top) {
               const
                 heightAfter = getScrollHeight(this.__scrollTarget),
                 scrollPosition = getScrollPosition(this.__scrollTarget),
@@ -115,11 +151,11 @@ export default Vue.extend({
             }
           })
         }
-      })
+      }, direction)
     },
 
     reset () {
-      this.index = 0
+      this.index = 0 // TODO: do what with this?
     },
 
     resume () {
@@ -133,19 +169,20 @@ export default Vue.extend({
     stop () {
       if (this.working === true) {
         this.working = false
-        this.fetching = false
+        this.fetchingBottom = false
+        this.fetchingTop = false
         this.__scrollTarget.removeEventListener('scroll', this.poll, listenOpts.passive)
       }
     },
 
     updateScrollTarget () {
-      if (this.__scrollTarget && this.working === true) {
+      if (this.__scrollTarget && this.working === true && this.direction !== DIRECTIONS.none) {
         this.__scrollTarget.removeEventListener('scroll', this.poll, listenOpts.passive)
       }
 
       this.__scrollTarget = getScrollTarget(this.$el, this.scrollTarget)
 
-      if (this.working === true) {
+      if (this.working === true && this.direction !== DIRECTIONS.none) {
         this.__scrollTarget.addEventListener('scroll', this.poll, listenOpts.passive)
       }
     },
@@ -163,7 +200,7 @@ export default Vue.extend({
         ? this.immediatePoll
         : debounce(this.immediatePoll, isNaN(val) === true ? 100 : val)
 
-      if (this.__scrollTarget && this.working === true) {
+      if (this.__scrollTarget && this.working === true && this.direction !== DIRECTIONS.none) {
         if (oldPoll !== void 0) {
           this.__scrollTarget.removeEventListener('scroll', oldPoll, listenOpts.passive)
         }
@@ -179,12 +216,16 @@ export default Vue.extend({
 
     this.updateScrollTarget()
 
-    if (this.reverse === true) {
+    if (this.reverse === true || this.direction === DIRECTIONS.top || this.direction === DIRECTIONS.both) {
       const
         scrollHeight = getScrollHeight(this.__scrollTarget),
         containerHeight = height(this.__scrollTarget)
 
-      setScrollPosition(this.__scrollTarget, scrollHeight - containerHeight)
+      let scrollPos = scrollHeight - containerHeight
+      if (this.direction === DIRECTIONS.both) {
+        scrollPos = scrollPos / 2
+      }
+      setScrollPosition(this.__scrollTarget, scrollPos)
     }
 
     this.immediatePoll()
@@ -199,13 +240,23 @@ export default Vue.extend({
   render (h) {
     const child = uniqueSlot(this, 'default', [])
 
-    if (this.disable !== true && this.working === true) {
-      child[this.reverse === false ? 'push' : 'unshift'](
-        h('div', {
-          staticClass: 'q-infinite-scroll__loading',
-          class: this.fetching === true ? '' : 'invisible'
-        }, slot(this, 'loading'))
-      )
+    if (this.disable !== true && this.working === true && this.direction !== DIRECTIONS.none) {
+      const bottomLoading = h('div', {
+        staticClass: 'q-infinite-scroll__loading',
+        class: this.fetchingBottom === true ? '' : 'invisible'
+      }, slot(this, 'loading'))
+
+      const topLoading = h('div', {
+        staticClass: 'q-infinite-scroll__loading',
+        class: this.fetchingTop === true ? '' : 'invisible'
+      }, slot(this, 'loading'))
+
+      if (this.direction === DIRECTIONS.bottom || this.direction === DIRECTIONS.both || (!this.direction && this.reverse === false)) {
+        child.push(bottomLoading)
+      }
+      if (this.direction === DIRECTIONS.top || this.direction === DIRECTIONS.both || (!this.direction && this.reverse === true)) {
+        child.unshift(topLoading)
+      }
     }
 
     return h('div', {

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -125,7 +125,7 @@ export default Vue.extend({
         return
       }
 
-      this.index++ // TODO: in case direction === both index should be index range [number, number]?
+      this.index++ // in case direction === both, should index be index-range [number, number]?
       this[isTop ? 'fetchingTop' : 'fetchingBottom'] = true
 
       const heightBefore = getScrollHeight(this.__scrollTarget)
@@ -155,7 +155,7 @@ export default Vue.extend({
     },
 
     reset () {
-      this.index = 0 // TODO: do what with this?
+      this.index = 0
     },
 
     resume () {

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -77,7 +77,7 @@ export default Vue.extend({
         this.stop()
       }
       else if (val && this.disable !== true) {
-        this.resume()
+        this.$nextTick(() => this.resume())
       }
     }
   },

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.json
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.json
@@ -46,6 +46,14 @@
       "type": "Boolean",
       "desc": "Scroll area should behave like a messenger - starting scrolled to bottom and loading when reaching the top",
       "category": "behavior"
+    },
+
+    "direction": {
+      "type": "String",
+      "desc": "Direction in which to trigger loading. Overrides reverse",
+      "category": "behavior",
+      "examples": [ "bottom", "top", "both", "none" ],
+      "addedIn": "v1.15.22"
     }
   },
 
@@ -74,10 +82,15 @@
           "params": {
             "stop": {
               "type": "Boolean",
-              "desc": "Stops QInfiniteScroll if it's Boolean 'true'; Specify it in case there's nothing more to load"
+              "desc": "Stops QInfiniteScroll if it's Boolean 'true'; Specify it in case there's nothing more to load. Overrides direction"
             }
           },
           "returns": null
+        },
+        "direction": {
+          "type": "String",
+          "desc": "Direction that triggered load event",
+          "examples": [ "bottom", "top" ]
         }
       }
     }


### PR DESCRIPTION
feat(QInfiniteScroll): add support for simultaneous directions #9159 #7782 #8577
Does not introduce breaking changes
adds direction reactive property for controlling component that would replace both reverse prop and stop boolean in done function (have your direction compute to 'none' instead of passing true to the callback. Passing true to CB would override directions behavior so you can still pas direction and set stop boolean and it would work) if direction prop will later on change, then component will return requesting load events when reaching offset in said direction

efforts were done to avoid breaking changes and avoid changing existing code causing a bit of redundancy, both in code and in functionalities, that could possibly be merged but I preferred to avoid it for now. not sure if correct approach was taken

index is a property that would require a touch up to work accurately with direction === 'both' and might need to change to from-index and to-index duo. for now it was left as is with a note in comments 

This is first time contribution to quasar and to any open source project so I'm not sure i followed every protocol

Let me know what you think and if you have any requirements  

this was made for quasar v1 as i needed this functionality for existing project, can be easily ported to Quasar v2 if accepted

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
