### PR TITLE
fix: humanStorageSize (fix #9868)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Please make sure to read the Pull Request Guidelines:
-https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
+https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
 -->
 
 <!-- PULL REQUEST TEMPLATE -->

--- a/docs/src/pages/quasar-utils/formatter-utils.md
+++ b/docs/src/pages/quasar-utils/formatter-utils.md
@@ -47,7 +47,7 @@ import { format } from 'quasar'
 const { humanStorageSize } = format
 
 console.log( humanStorageSize(13087) )
-// 12.78 kB
+// 12.8 KiB
 ```
 
 ## Normalize Number to Interval

--- a/ui/src/utils/format.js
+++ b/ui/src/utils/format.js
@@ -8,7 +8,7 @@ export function humanStorageSize (bytes) {
     ++u
   }
 
-  return `${ bytes.toFixed(1) }${ units[ u ] }`
+  return `${ bytes.toFixed(1) } ${ units[ u ] }`
 }
 
 export function capitalize (str) {

--- a/ui/src/utils/format.js
+++ b/ui/src/utils/format.js
@@ -1,4 +1,4 @@
-const units = [ 'B', 'KB', 'MB', 'GB', 'TB', 'PB' ]
+const units = [ 'B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB' ]
 
 export function humanStorageSize (bytes) {
   let u = 0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (I guess not really)

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
- Adds a space between the value and the unit
- Changes the units to IEC style
- Adds units up to yobibyte according to https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
- Updates docs
- Updates PR template link (I know, it's not clean to put it here :sweat_smile:)

The icongenie [get-file-size.js](https://github.com/quasarframework/quasar/blob/3e61e24d175b1ce073bbdfc21e1107a869dcd8fc/icongenie/lib/utils/get-file-size.js) has a code duplicate.

fix #9868