### PR TITLE
refactor(app): Remove deprecated zlib package to use from Node.js core (fix: #9942)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -112,8 +112,7 @@
     "webpack-chain": "6.5.1",
     "webpack-dev-server": "4.0.0-beta.3",
     "webpack-merge": "5.8.0",
-    "webpack-node-externals": "3.0.0",
-    "zlib": "1.0.5"
+    "webpack-node-externals": "3.0.0"
   },
   "engines": {
     "node": ">= 12.22.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Refactor
- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch
- The related issue is referenced in the PR's title

**Other information:**
Closes #9942.

See https://github.com/kkaefer/DEPRECATED-node-zlib/blob/d5fad4d243182eabc9a404d1a4c13e55bf567f8f/README.md#do-not-use--deprecated