### PR TITLE
fix(app): Update postcss-loader option structure (fix: #9782)

### DIFF
--- a/app/lib/webpack/inject.style-rules.js
+++ b/app/lib/webpack/inject.style-rules.js
@@ -96,16 +96,18 @@ function injectRule (chain, pref, lang, test, loader, loaderOptions) {
         .loader('postcss-loader')
         .options({
           sourceMap: pref.sourceMap,
-          plugins: [
-            require('cssnano')({
-              preset: [ 'default', {
-                mergeLonghand: false,
-                convertValues: false,
-                cssDeclarationSorter: false,
-                reduceTransforms: false
-              } ]
-            })
-          ]
+          postcssOptions: {
+            plugins: [
+              require('cssnano')({
+                preset: [ 'default', {
+                  mergeLonghand: false,
+                  convertValues: false,
+                  cssDeclarationSorter: false,
+                  reduceTransforms: false
+                } ]
+              })
+            ]
+          }
         })
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Build-related changes

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- The related issue is referenced in the PR's title

**Other information:**
Fixes #9782.
This one got outdated, while the other usages of `postcss-loader` are using the correct structure. This change of structure is introduced in [`postcss-loader` v4](https://github.com/webpack-contrib/postcss-loader/releases/tag/v4.0.0).