### PR TITLE
fix(QImg, QFile): avoid duplicate event listeners from passthrough and attrs

### DIFF
--- a/ui/src/components/file/QFile.js
+++ b/ui/src/components/file/QFile.js
@@ -12,6 +12,8 @@ import { humanStorageSize } from '../../utils/format.js'
 export default defineComponent({
   name: 'QFile',
 
+  inheritAttrs: false,
+
   props: {
     ...useFieldProps,
     ...useFormProps,

--- a/ui/src/components/img/QImg.js
+++ b/ui/src/components/img/QImg.js
@@ -64,7 +64,7 @@ export default defineComponent({
 
   emits: [ 'load', 'error' ],
 
-  setup (props, { slots, attrs, emit }) {
+  setup (props, { slots, emit }) {
     const naturalRatio = ref(props.initialRatio)
     const ratioStyle = useRatio(props, naturalRatio)
 
@@ -187,7 +187,6 @@ export default defineComponent({
 
       const data = {
         key: 'img_' + index,
-        ...attrs,
         class: imgClass.value,
         style: imgStyle.value,
         crossorigin: props.crossorigin,


### PR DESCRIPTION
@click at least was triggered twice
can be observed because demos of morph utils gallery do not work (click triggered twice)