### PR TITLE
fix(QStepper): scope contracted prop only to the header to avoid propagating to child steppers #10191

### DIFF
--- a/ui/src/components/stepper/QStepper.js
+++ b/ui/src/components/stepper/QStepper.js
@@ -43,7 +43,6 @@ export default Vue.extend({
       return `q-stepper q-stepper--${this.vertical === true ? 'vertical' : 'horizontal'}` +
         (this.flat === true || this.isDark === true ? ' q-stepper--flat no-shadow' : '') +
         (this.bordered === true || (this.isDark === true && this.flat === false) ? ' q-stepper--bordered' : '') +
-        (this.contracted === true ? ' q-stepper--contracted' : '') +
         (this.isDark === true ? ' q-stepper--dark q-dark' : '')
     },
 
@@ -51,6 +50,7 @@ export default Vue.extend({
       return 'q-stepper__header row items-stretch justify-between' +
         ` q-stepper__header--${this.alternativeLabels === true ? 'alternative' : 'standard'}-labels` +
         (this.flat === false || this.bordered === true ? ' q-stepper__header--border' : '') +
+        (this.contracted === true ? ' q-stepper--contracted' : '') +
         (this.headerClass !== void 0 ? ` ${this.headerClass}` : '')
     }
   },

--- a/ui/src/components/stepper/QStepper.sass
+++ b/ui/src/components/stepper/QStepper.sass
@@ -90,6 +90,31 @@
         &:before, &:after
           display: none
 
+    &--contracted
+      min-height: 72px
+      &.q-stepper__header--alternative-labels
+        .q-stepper__tab
+          min-height: 72px
+          &:first-child
+            align-items: flex-start
+          &:last-child
+            align-items: flex-end
+      .q-stepper__tab
+        padding: 24px 0
+        &:first-child
+          .q-stepper__dot
+            transform: translateX(24px)
+        &:last-child
+          .q-stepper__dot
+            transform: translateX(-24px)
+        &:not(:last-child)
+          .q-stepper__dot:after
+            display: block !important
+      .q-stepper__dot
+        margin: 0
+      .q-stepper__label
+        display: none
+
   &__nav
     padding-top: 24px
 
@@ -184,29 +209,3 @@
           background: $separator-dark-color
         .q-stepper__label
           color: rgba(255,255,255,.54)
-
-  &--contracted
-    .q-stepper__header
-      min-height: 72px
-      &--alternative-labels
-        .q-stepper__tab
-          min-height: 72px
-          &:first-child
-            align-items: flex-start
-          &:last-child
-            align-items: flex-end
-      .q-stepper__tab
-        padding: 24px 0
-        &:first-child
-          .q-stepper__dot
-            transform: translateX(24px)
-        &:last-child
-          .q-stepper__dot
-            transform: translateX(-24px)
-    .q-stepper__tab:not(:last-child)
-      .q-stepper__dot:after
-        display: block !important
-    .q-stepper__dot
-      margin: 0
-    .q-stepper__label
-      display: none

--- a/ui/src/components/stepper/QStepper.styl
+++ b/ui/src/components/stepper/QStepper.styl
@@ -90,6 +90,31 @@
         &:before, &:after
           display: none
 
+    &--contracted
+      min-height: 72px
+      &.q-stepper__header--alternative-labels
+        .q-stepper__tab
+          min-height: 72px
+          &:first-child
+            align-items: flex-start
+          &:last-child
+            align-items: flex-end
+      .q-stepper__tab
+        padding: 24px 0
+        &:first-child
+          .q-stepper__dot
+            transform: translateX(24px)
+        &:last-child
+          .q-stepper__dot
+            transform: translateX(-24px)
+        &:not(:last-child)
+          .q-stepper__dot:after
+            display: block !important
+      .q-stepper__dot
+        margin: 0
+      .q-stepper__label
+        display: none
+
   &__nav
     padding-top: 24px
 
@@ -184,29 +209,3 @@
           background: $separator-dark-color
         .q-stepper__label
           color: rgba(255,255,255,.54)
-
-  &--contracted
-    .q-stepper__header
-      min-height: 72px
-      &--alternative-labels
-        .q-stepper__tab
-          min-height: 72px
-          &:first-child
-            align-items: flex-start
-          &:last-child
-            align-items: flex-end
-      .q-stepper__tab
-        padding: 24px 0
-        &:first-child
-          .q-stepper__dot
-            transform: translateX(24px)
-        &:last-child
-          .q-stepper__dot
-            transform: translateX(-24px)
-    .q-stepper__tab:not(:last-child)
-      .q-stepper__dot:after
-        display: block !important
-    .q-stepper__dot
-      margin: 0
-    .q-stepper__label
-      display: none


### PR DESCRIPTION
#10191