### PR TITLE
fix: add undeclared dependencies and resolve others (fix #8286, fix #7581)

### DIFF
--- a/app/lib/ssr/webpack.directives.js
+++ b/app/lib/ssr/webpack.directives.js
@@ -54,7 +54,7 @@ module.exports = function () {
   chain.module.rule('node')
     .test(/\.node$/)
     .use('node-loader')
-      .loader('node-loader')
+      .loader(require.resolve('node-loader'))
 
   chain.resolve.modules
     .merge(resolveModules)

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -196,7 +196,7 @@ module.exports = function (cfg, configName) {
             extensions: {
               vue: {
                 enabled: true,
-                compiler: '@vue/compiler-sfc'
+                compiler: require.resolve('@vue/compiler-sfc')
               }
             }
           }

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -125,7 +125,7 @@ module.exports = function (cfg, configName) {
     })
 
   vueRule.use('vue-loader')
-    .loader('vue-loader')
+    .loader(require.resolve('vue-loader'))
     .options(
       merge(
         {},
@@ -164,7 +164,7 @@ module.exports = function (cfg, configName) {
         ))
         .end()
       .use('babel-loader')
-        .loader('babel-loader')
+        .loader(require.resolve('babel-loader'))
           .options({
             compact: false,
             extends: appPaths.resolve.app('babel.config.js')
@@ -176,7 +176,7 @@ module.exports = function (cfg, configName) {
       .rule('typescript')
       .test(/\.ts$/)
       .use('ts-loader')
-        .loader('ts-loader')
+        .loader(require.resolve('ts-loader'))
         .options({
           // custom config is merged if present, but vue setup and type checking disable are always applied
           ...(cfg.supportTS.tsLoaderConfig || {}),
@@ -209,7 +209,7 @@ module.exports = function (cfg, configName) {
     .test(/\.(png|jpe?g|gif|svg|webp|avif|ico)(\?.*)?$/)
     .type('javascript/auto')
     .use('url-loader')
-      .loader('url-loader')
+      .loader(require.resolve('url-loader'))
       .options({
         esModule: false,
         limit: 10000,
@@ -221,7 +221,7 @@ module.exports = function (cfg, configName) {
     .test(/\.(woff2?|eot|ttf|otf)(\?.*)?$/)
     .type('javascript/auto')
     .use('url-loader')
-      .loader('url-loader')
+      .loader(require.resolve('url-loader'))
       .options({
         esModule: false,
         limit: 10000,
@@ -233,7 +233,7 @@ module.exports = function (cfg, configName) {
     .test(/\.(mp4|webm|ogg|mp3|wav|flac|aac)(\?.*)?$/)
     .type('javascript/auto')
     .use('url-loader')
-      .loader('url-loader')
+      .loader(require.resolve('url-loader'))
       .options({
         esModule: false,
         limit: 10000,

--- a/app/lib/webpack/electron/create-node-chain.js
+++ b/app/lib/webpack/electron/create-node-chain.js
@@ -53,7 +53,7 @@ module.exports = (nodeType, cfg, configName) => {
   chain.module.rule('node')
     .test(/\.node$/)
     .use('node-loader')
-      .loader('node-loader')
+      .loader(require.resolve('node-loader'))
 
   chain.resolve.modules
     .merge(resolveModules)

--- a/app/lib/webpack/inject.node-babel.js
+++ b/app/lib/webpack/inject.node-babel.js
@@ -8,7 +8,7 @@ module.exports = function (cfg, chain) {
         .add(/node_modules/)
         .end()
       .use('babel-loader')
-        .loader('babel-loader')
+        .loader(require.resolve('babel-loader'))
           .options({
             extends: appPaths.resolve.app('babel.config.js')
           })

--- a/app/lib/webpack/inject.node-typescript.js
+++ b/app/lib/webpack/inject.node-typescript.js
@@ -7,7 +7,7 @@ module.exports = function (cfg, chain) {
       .rule('typescript')
       .test(/\.ts$/)
       .use('ts-loader')
-        .loader('ts-loader')
+        .loader(require.resolve('ts-loader'))
         .options({
           // While `noEmit: true` is needed in the tsconfig preset to prevent VSCode errors,
           // it prevents emitting transpiled files when run into node context

--- a/app/lib/webpack/inject.style-rules.js
+++ b/app/lib/webpack/inject.style-rules.js
@@ -50,7 +50,7 @@ function injectRule (chain, pref, lang, test, loader, loaderOptions) {
   function create (rule, modules) {
     if (pref.isServerBuild === true) {
       rule.use('null-loader')
-        .loader('null-loader')
+        .loader(require.resolve('null-loader'))
       return
     }
 
@@ -61,7 +61,7 @@ function injectRule (chain, pref, lang, test, loader, loaderOptions) {
     }
     else {
       rule.use('vue-style-loader')
-        .loader('vue-style-loader')
+        .loader(require.resolve('vue-style-loader'))
         .options({
           sourceMap: pref.sourceMap
         })
@@ -86,14 +86,14 @@ function injectRule (chain, pref, lang, test, loader, loaderOptions) {
     }
 
     rule.use('css-loader')
-      .loader('css-loader')
+      .loader(require.resolve('css-loader'))
       .options(cssLoaderOptions)
 
     if (!pref.extract && pref.minify) {
       // needs to be applied separately,
       // otherwise it messes up RTL
       rule.use('cssnano')
-        .loader('postcss-loader')
+        .loader(require.resolve('postcss-loader'))
         .options({
           sourceMap: pref.sourceMap,
           postcssOptions: {
@@ -149,12 +149,17 @@ function injectRule (chain, pref, lang, test, loader, loaderOptions) {
     }
 
     rule.use('postcss-loader')
-      .loader('postcss-loader')
+      .loader(require.resolve('postcss-loader'))
       .options({ postcssOptions: postCssOpts })
 
     if (loader) {
+      let resolvedLoader = loader
+      try {
+        resolvedLoader = require.resolve(loader)
+      } catch (err) { }
+
       rule.use(loader)
-        .loader(loader)
+        .loader(resolvedLoader)
         .options({
           sourceMap: pref.sourceMap,
           ...loaderOptions

--- a/app/lib/webpack/pwa/create-custom-sw.js
+++ b/app/lib/webpack/pwa/create-custom-sw.js
@@ -88,7 +88,7 @@ module.exports = function (cfg, configName) {
         ))
         .end()
       .use('babel-loader')
-        .loader('babel-loader')
+        .loader(require.resolve('babel-loader'))
           .options({
             compact: false,
             extends: appPaths.resolve.app('babel.config.js')
@@ -103,7 +103,7 @@ module.exports = function (cfg, configName) {
       .rule('typescript')
       .test(/\.ts$/)
       .use('ts-loader')
-        .loader('ts-loader')
+        .loader(require.resolve('ts-loader'))
         .options({
           onlyCompileBundledFiles: true,
           transpileOnly: false,

--- a/app/lib/webpack/ssr/webserver.js
+++ b/app/lib/webpack/ssr/webserver.js
@@ -82,7 +82,7 @@ module.exports = function (cfg, configName) {
   chain.module.rule('node')
     .test(/\.node$/)
     .use('node-loader')
-      .loader('node-loader')
+      .loader(require.resolve('node-loader'))
 
   chain.resolve.modules
     .merge(resolveModules)

--- a/app/package.json
+++ b/app/package.json
@@ -119,13 +119,21 @@
   },
   "peerDependencies": {
     "stylus-loader": "^6.1.0",
-    "less-loader": "^10.0.1"
+    "less-loader": "^10.0.1",
+    "vue": "^3.1.5",
+    "vue-router": "^4.0.10"
   },
   "peerDependenciesMeta": {
     "stylus-loader": {
       "optional": true
     },
     "less-loader": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    },
+    "vue-router": {
       "optional": true
     }
   },

--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     "url": "https://donate.quasar.dev"
   },
   "dependencies": {
+    "@babel/core": "^7.9.0",
     "@quasar/babel-preset-app": "2.0.1",
     "@quasar/fastclick": "1.1.4",
     "@quasar/ssr-helpers": "2.1.1",
@@ -55,7 +56,9 @@
     "@vue/server-renderer": "3.1.5",
     "archiver": "5.3.0",
     "autoprefixer": "10.3.1",
+    "babel-loader": "^8.0.6",
     "browserslist": "^4.12.0",
+    "loader-utils": "^2.0.0",
     "chalk": "4.1.1",
     "chokidar": "3.5.2",
     "ci-info": "3.2.0",
@@ -113,6 +116,18 @@
     "webpack-dev-server": "4.0.0-beta.3",
     "webpack-merge": "5.8.0",
     "webpack-node-externals": "3.0.0"
+  },
+  "peerDependencies": {
+    "stylus-loader": "^6.1.0",
+    "less-loader": "^10.0.1"
+  },
+  "peerDependenciesMeta": {
+    "stylus-loader": {
+      "optional": true
+    },
+    "less-loader": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 12.22.1",

--- a/app/package.json
+++ b/app/package.json
@@ -121,7 +121,8 @@
     "stylus-loader": "^6.1.0",
     "less-loader": "^10.0.1",
     "vue": "^3.1.5",
-    "vue-router": "^4.0.10"
+    "vue-router": "^4.0.10",
+    "eslint": "^7.14.0"
   },
   "peerDependenciesMeta": {
     "stylus-loader": {
@@ -134,6 +135,9 @@
       "optional": true
     },
     "vue-router": {
+      "optional": true
+    },
+    "eslint": {
       "optional": true
     }
   },

--- a/app/tsconfig-preset.json
+++ b/app/tsconfig-preset.json
@@ -20,12 +20,7 @@
       "pages/*": ["src/pages/*"],
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"]
-    },
-    // Forces quasar typings to be included, even if they aren't referenced directly
-    // Removing this would break `quasar/wrappers` imports if `quasar`
-    //  isn't referenced anywhere, because those typings are declared
-    //  into `@quasar/app` which is imported by `quasar` typings
-    "types": ["quasar"]
+    }
   },
   // Needed to avoid files copied into 'dist' folder (eg. a `.d.ts` file inside `src-ssr` folder)
   // to be evaluated by TS when their original files has been updated

--- a/docs/quasar.conf.js
+++ b/docs/quasar.conf.js
@@ -44,13 +44,13 @@ module.exports = function (ctx) {
 
         chain.module.rule('pug')
           .test(/\.pug$/)
-          .use('pug-loader').loader('pug-plain-loader')
+          .use('pug-loader').loader(require.resolve('pug-plain-loader'))
 
         const rule = chain.module.rule('md')
           .test(/\.md$/)
 
         rule.use('v-loader')
-          .loader('vue-loader')
+          .loader(require.resolve('vue-loader'))
           .options({
             ...(
               isServer === true

--- a/docs/src/pages/app-extensions/tips-and-tricks/chain-webpack.md
+++ b/docs/src/pages/app-extensions/tips-and-tricks/chain-webpack.md
@@ -52,7 +52,7 @@ const chainWebpack = function (ctx, chain) {
     .pre()
 
   rule.use('v-loader')
-    .loader('vue-loader')
+    .loader(require.resolve('vue-loader'))
     .options({
       productionMode: ctx.prod,
       transformAssetUrls: {
@@ -64,7 +64,7 @@ const chainWebpack = function (ctx, chain) {
     })
 
   rule.use('ware-loader')
-    .loader('ware-loader')
+    .loader(require.resolve('ware-loader'))
     .options({
       raw: true,
       middleware: function (source) {

--- a/docs/src/pages/quasar-cli/handling-webpack.md
+++ b/docs/src/pages/quasar-cli/handling-webpack.md
@@ -39,7 +39,7 @@ build: {
         .add((/[\\/]node_modules[\\/]/))
         .end()
       .use('eslint-loader')
-        .loader('eslint-loader')
+        .loader(require.resolve('eslint-loader'))
   }
 }
 ```
@@ -171,7 +171,7 @@ build: {
     chain.module.rule('json')
       .test(/\.json$/)
       .use('json-loader')
-        .loader('json-loader')
+        .loader(require.resolve('json-loader'))
   }
 }
 ```
@@ -212,7 +212,7 @@ build: {
     chain.module.rule('pug')
       .test(/\.pug$/)
       .use('pug-plain-loader')
-        .loader('pug-plain-loader')
+        .loader(require.resolve('pug-plain-loader'))
   }
 }
 ```

--- a/ui/package.json
+++ b/ui/package.json
@@ -88,6 +88,9 @@
   "dependencies": {
     "core-js": "^3.6.5"
   },
+  "peerDependencies": {
+    "vue": "^3.1.5"
+  },
   "vetur": {
     "tags": "dist/vetur/quasar-tags.json",
     "attributes": "dist/vetur/quasar-attributes.json"

--- a/ui/package.json
+++ b/ui/package.json
@@ -85,6 +85,9 @@
     "tslib": "^2.0.3",
     "uglify-es": "^3.3.9"
   },
+  "dependencies": {
+    "core-js": "^3.6.5"
+  },
   "vetur": {
     "tags": "dist/vetur/quasar-tags.json",
     "attributes": "dist/vetur/quasar-attributes.json"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**

Fixes #8286
Fixes #7581
Ref https://github.com/quasarframework/quasar-starter-kit/pull/159

In order to not rely on unpredictable hoisting this PR makes a few changes.

- `require.resolve` Webpack loaders
See https://github.com/yarnpkg/berry/tree/b605eaf5785dc91d0f5248da67ec9f34460900ca/packages/yarnpkg-doctor#no-unqualified-webpack-config

- Declare dependencies
See https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

- `types` in `tsconfig.json`
Using the `types` option in `tsconfig.json` disables the default behaviour of loading all visible types in the global scope, this PR avoids using it and instead uses a triple-slash directive to avoid disabling that behaviour
https://www.typescriptlang.org/tsconfig#types
https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-

- Making `vue` and `vue-router` peer dependencies
`vue` is currently a dependency of `@quasar/app` while it's undeclared in `quasar` and the starter-kit, this is problematic as it relies on hoisting to place the correct `vue` version in an accessible location for all of them and any other dependency that might need access to it. Hoisting is an implementation detail and does not guarantee this to happen.
For example when using workspaces one workspace might use `vue@2` while the other uses `vue@3`, which one getting hoisted to the root is undefined.
To solve this `vue` is changed to be a peer dependency which correctly reflects the intent that one workspace (quasar project) uses one version of `vue`