### PR TITLE
refactor: remove quasar typing import from tsconfig preset

### DIFF
--- a/app/tsconfig-preset.json
+++ b/app/tsconfig-preset.json
@@ -21,11 +21,6 @@
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"]
     },
-    // Forces quasar typings to be included, even if they aren't referenced directly
-    // Removing this would break `quasar/wrappers` imports if `quasar`
-    //  isn't referenced anywhere, because those typings are declared
-    //  into `@quasar/app` which is imported by `quasar` typings
-    "types": ["quasar"]
   },
   // Needed to avoid files copied into 'dist' folder (eg. a `.d.ts` file inside `src-ssr` folder)
   // to be evaluated by TS when their original files has been updated

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -270,6 +270,20 @@ function writeIndexDTS (apis) {
 
   addQuasarLangCodes(quasarTypeContents)
 
+  // TODO: (Qv3) remove this reference to q/app and
+  // rely on the shim provided by the starter kit with
+  // https://github.com/quasarframework/quasar-starter-kit/pull/162
+  // Existing projects which used `compilerOptions.types` as `["quasar", ... /* other packages types */]`
+  // due to this implementation may be able to remove that option and rely on default behaviour
+  // ----
+  // This line must be BEFORE ANY TS INSTRUCTION,
+  //  or it won't be interpreted as a TS compiler directive
+  //  but as a normal comment
+  // On Vue CLI projects `@quasar/app` isn't available,
+  //  we ignore the "missing package" error because it's the intended behaviour
+  writeLine(contents, '// @ts-ignore')
+  writeLine(contents, '/// <reference types="@quasar/app" />')
+  // ----
   writeLine(contents, 'import { App, Component, ComponentPublicInstance } from \'vue\'')
   writeLine(contents, 'import { LooseDictionary, ComponentConstructor, GlobalComponentConstructor } from \'./ts-helpers\'')
   writeLine(contents)

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -270,13 +270,6 @@ function writeIndexDTS (apis) {
 
   addQuasarLangCodes(quasarTypeContents)
 
-  // This line must be BEFORE ANY TS INSTRUCTION,
-  //  or it won't be interpreted as a TS compiler directive
-  //  but as a normal comment
-  // On Vue CLI projects `@quasar/app` isn't available,
-  //  we ignore the "missing package" error because it's the intended behaviour
-  writeLine(contents, '// @ts-ignore')
-  writeLine(contents, '/// <reference types="@quasar/app" />')
   writeLine(contents, 'import { App, Component, ComponentPublicInstance } from \'vue\'')
   writeLine(contents, 'import { LooseDictionary, ComponentConstructor, GlobalComponentConstructor } from \'./ts-helpers\'')
   writeLine(contents)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

~Users will need to create [this file](https://github.com/IlCallo/quasar-starter-kit/blob/import-quasar-typings-outside-tsconfig-preset/template/src/quasar.d.ts) into their own project to compensate these changes.
We could automatically generate it as we do with flags, but the same problems of feature flags will apply (you need to run `quasar dev/build` to generate it).~

~We could also keep this on hold until Qv3, but since every TS upgrade has breaking change upgrades anyway (but only at compile time), I think we can apply this now anyway or while upgrading TS to the next minor version and ask people to perform the needed steps manually~

**_We could also leave `/// <reference types="@quasar/app" />` into `quasar` typings as a fallback for existing projects, which almost certaintly already import something from quasar into their code, meaning the preset change won't affect them
We can then remove the reference when releasing Qv3_**

EDIT: updated the PR to remove the breaking change and postpone it to Qv3 release, left a comment into the code explaining the situation

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
See https://github.com/quasarframework/quasar-starter-kit/pull/162 as why this has been proposed
The main reason is to make TS automatically include `@types/*` packages again, which right now must be done by hand as we use `types` option

That PR should be merged and pushed into master before this one
This PR will then require a release of both `quasar` and `@quasar/app` packages

This PR spawned from some comments into #10277