### PR TITLE
feat(QTable): Adding middle click event. Requesting feedback on implementation.

### DIFF
--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -100,6 +100,7 @@ export default defineComponent({
     onRowClick: Function,
     onRowDblclick: Function,
     onRowContextmenu: Function,
+    onRowMiddleclick: Function,
 
     ...useDarkProps,
     ...useFullscreenProps,
@@ -444,6 +445,15 @@ export default defineComponent({
         data.class[ 'cursor-pointer' ] = true
         data.onContextmenu = evt => {
           emit('RowContextmenu', evt, row, pageIndex)
+        }
+      }
+
+      if (props.onRowMiddleclick !== void 0) {
+        data.class[ 'cursor-pointer' ] = true;
+        data.onAuxclick = evt => {
+          if (evt.button === 1) {
+            emit('RowMiddleclick', evt, row, pageIndex)
+          }
         }
       }
 

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -1861,6 +1861,30 @@
       }
     },
 
+    "row-middleclick": {
+      "desc": "Emitted when user middle-clicks on a row; Is not emitted when using body/row/item scoped slots",
+      "params": {
+        "evt": {
+          "type": "Object",
+          "desc": "JS event object",
+          "required": true,
+          "__exemption": [ "examples" ]
+        },
+
+        "row": {
+          "type": "Object",
+          "desc": "The row upon which user has middle-clicked.",
+          "__exemption": [ "examples" ]
+        },
+
+        "index": {
+          "type": "Number",
+          "desc": "Index of the row in the current page",
+          "__exemption": [ "examples" ]
+        }
+      }
+    },
+
     "request": {
       "desc": "Emitted when a server request is triggered",
       "params": {


### PR DESCRIPTION
Based on the discussion #10447, this will add middle click event on QTable so that you can mimic similar behavior like opening a URL in a new tab.

Here's where I need feedback on. There is not really a "middle click" event alone that's like `onclick` or `oncontextmenu`. 
There's two ways of implementing this:
1) 
```javascript
data.onClick = evt => {
  if (evt.button === 1) {
    //
  }
}
```
2) (the way it's currently implemented)
```javascript
data.onAuxclick= evt => {
  if (evt.button === 1) {
    //
  }
}
```

I used `auxclick` mainly because of what I was reading [here](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onauxclick):
> Note: Browser vendors are implementing this property as part of a plan to improve compatibility with regards to button behaviors. Specifically, event behavior is being updated so that click only fires for primary button clicks (e.g., left mouse button), while auxclick fires for non-primary button clicks. Historically, click has generally fired for the click of any device input button, although with browser behavior being somewhat inconsistent.

Auxclick in the GlobalEventHandler is marked as experimental, even though it's supported, but the [element auxclick](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event) should be fine to use. Would like some feedback on this implementation of "middle clicking". Specifically with auxclick and the `evt.button` vs `evt.which`, which I'm having trouble finding the difference. 

This also makes me wonder, would it be worth adding just an `auxclick` event in general that ignores if it's a middle click? This would add support for a mouse with multiple keys, not just left and right.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.