### PR TITLE
no v-html

### DIFF
--- a/docs/src/examples/QSelect/OptionSlot.vue
+++ b/docs/src/examples/QSelect/OptionSlot.vue
@@ -20,7 +20,7 @@
               <q-icon :name="scope.opt.icon" />
             </q-item-section>
             <q-item-section>
-              <q-item-label v-html="scope.opt.label" />
+              <q-item-label>{{ scope.opt.label }}</q-item-label>
               <q-item-label caption>{{ scope.opt.description }}</q-item-label>
             </q-item-section>
           </q-item>


### PR DESCRIPTION
People tend to copy-paste so I suggest that v-html is only used in explicit examples where the user is aware of the consequences.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

