### PR TITLE
fix: vite minifying css warning

### DIFF
--- a/ui/src/components/expansion-item/QExpansionItem.sass
+++ b/ui/src/components/expansion-item/QExpansionItem.sass
@@ -66,6 +66,7 @@
   &--expanded .q-textarea--autogrow textarea
     animation: q-expansion-done 0s
 
+/* needed for compilation */
 @keyframes q-expansion-done
   0%
-    --q-exp-done: 1 /* needed for compilation */
+    --q-exp-done: 1

--- a/ui/src/components/expansion-item/QExpansionItem.sass
+++ b/ui/src/components/expansion-item/QExpansionItem.sass
@@ -68,4 +68,4 @@
 
 @keyframes q-expansion-done
   0%
-    --q-exp-done: 1 // needed for compilation
+    --q-exp-done: 1 /* needed for compilation */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:`

Warning when building a vite application with quasar. With this change the warning does not appear anymore as the comment is now changed to fit the standards.
```
warnings when minifying css:
 > <stdin>:1893:20: warning: Comments in CSS use "/* ... */" instead of "//"
    1893 │     --q-exp-done: 1 // needed for compilation;
         ╵                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
