### PR TITLE
Feature: Qstepper add properties to hide active and error icons (fixes #8640)

### DIFF
--- a/ui/dev/src/pages/components/stepper.vue
+++ b/ui/dev/src/pages/components/stepper.vue
@@ -15,6 +15,8 @@
       <q-toggle label="Global Navigation" v-model="globalNav" />
       <q-toggle label="Caption" v-model="caption" />
       <q-toggle label="Prefix" v-model="prefix" />
+      <q-toggle label="Hide active icon" v-model="hideActiveIcon" />
+      <q-toggle label="Hide error icon" v-model="hideErrorIcon" />
       <q-toggle label="Use 'done' prop" v-model="useDone" />
 
       <q-toggle label="Step 4 disable" v-model="stepDisable" />
@@ -35,6 +37,8 @@
         :flat="flat"
         :bordered="bordered"
         :header-nav="headerNav"
+        :hide-active-icon="hideActiveIcon"
+        :hide-error-icon="hideErrorIcon"
         :color="color"
         ref="stepper"
         v-model="step"
@@ -221,6 +225,8 @@ export default {
       globalNav: false,
       caption: false,
       prefix: false,
+      hideActiveIcon: false,
+      hideErrorIcon: false,
       useDone: false,
       headerNavStep: false,
 

--- a/ui/src/components/stepper/QStepper.js
+++ b/ui/src/components/stepper/QStepper.js
@@ -38,8 +38,10 @@ export default defineComponent({
     doneIcon: String,
     doneColor: String,
     activeIcon: String,
+    hideActiveIcon: Boolean,
     activeColor: String,
     errorIcon: String,
+    hideErrorIcon: Boolean,
     errorColor: String
   },
 

--- a/ui/src/components/stepper/QStepper.json
+++ b/ui/src/components/stepper/QStepper.json
@@ -67,6 +67,12 @@
       "category": "header"
     },
 
+    "hide-active-icon": {
+      "type": "Boolean",
+      "desc": "Don't show the active icon when a step is active. Instead the step 'icon' will be shown or the step 'prefix' if it is defined.",
+      "category": "header|behavior"
+    },
+
     "active-color": {
       "extends": "color",
       "category": "header"
@@ -75,6 +81,12 @@
     "error-icon": {
       "extends": "icon",
       "category": "header"
+    },
+
+    "hide-error-icon": {
+      "type": "Boolean",
+      "desc": "Don't show the error icon when a step has an error. Instead the step 'icon' will be shown or the step 'prefix' if it is defined.",
+      "category": "header|behavior"
     },
 
     "error-color": {

--- a/ui/src/components/stepper/QStepper.sass
+++ b/ui/src/components/stepper/QStepper.sass
@@ -54,6 +54,7 @@
         background: transparent !important
         span
           color: currentColor
+        .q-icon
           font-size: 24px
 
   &__header

--- a/ui/src/components/stepper/StepHeader.js
+++ b/ui/src/components/stepper/StepHeader.js
@@ -47,19 +47,19 @@ export default defineComponent({
 
     const hasPrefix = computed(() => {
       return props.step.prefix
-        && isActive.value === false
-        && isError.value === false
-        && isDone.value === false
+        && (props.stepper.hideActiveIcon || isActive.value === false)
+        && (props.stepper.hideErrorIcon || isError.value === false)
+        && (props.stepper.hideErrorIcon || isDone.value === false)
     })
 
     const icon = computed(() => {
-      if (isActive.value === true) {
+      if (!props.stepper.hideActiveIcon && isActive.value === true) {
         return props.step.activeIcon || props.stepper.activeIcon || $q.iconSet.stepper.active
       }
-      if (isError.value === true) {
+      if (!props.stepper.hideErrorIcon && isError.value === true) {
         return props.step.errorIcon || props.stepper.errorIcon || $q.iconSet.stepper.error
       }
-      if (isDisable.value === false && isDone.value === true) {
+      if (isDisable.value === false && isError.value === false && isDone.value === true) {
         return props.step.doneIcon || props.stepper.doneIcon || $q.iconSet.stepper.done
       }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

I was implementing a custom design for the QStepper in which I ran into a problem which I could not fix by overriding some CSS. When using a step prefix I wanted to keep that prefix visible, when editing a step but also when an error occured at that step. Currently the prefix label is removed when a step is either active, done or has an error. 

This PR introduces two properties that can be set to not show either the `active-icon` or the `error-icon`. That way the prefix remains rendered and can be styled accordingly by overriding css. Also this might be useful for people that do not want to redeclare the errorIcon/activeIcon for a step when they want this icon to be the same as the steps normal icon.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This is my first PR doing something with UI, so if I did something incorrectly, please advise :)

Edit: for a complete picture here is the example I was trying to replicate:
![image](https://user-images.githubusercontent.com/5757159/133563947-8b96dfb0-097c-4741-bba0-1a6337a96e54.png)

