### PR TITLE
fix(docs): emitValue is not a slot property of QPopupEdit

### DIFF
--- a/docs/src/examples/QPopupEdit/DefaultSlotParameters.vue
+++ b/docs/src/examples/QPopupEdit/DefaultSlotParameters.vue
@@ -7,12 +7,12 @@
           <q-input
             autofocus
             dense
+            v-model="scope.value"
             :model-value="scope.value"
             hint="Your nickname"
             :rules="[
               val => scope.validate(scope.value) || 'More than 5 chars required'
             ]"
-            @update:model-value="scope.emitValue"
           >
             <template v-slot:after>
               <q-btn

--- a/docs/src/pages/vue-components/popup-edit.md
+++ b/docs/src/pages/vue-components/popup-edit.md
@@ -43,7 +43,7 @@ You can also add two buttons with the `buttons` prop, "Cancel" and "Set" (the de
 The default slot's parameters are:
 
 ```js
-{ initialValue, value, emitValue, validate, set, cancel, updatePosition }
+{ initialValue, value, validate, set, cancel, updatePosition }
 ```
 
 ::: warning


### PR DESCRIPTION
Example was not working because it was using .emitValue on the scope which no longer exists.

@hawkeye64 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
