### PR TITLE
Fix for Windows OS Incorrect Mousemove Event (fix: #10721)

### DIFF
--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -230,6 +230,15 @@ export default __QUASAR_SSR_SERVER__
               return
             }
 
+            if(ctx.lastEvt && ctx.lastEvt.clientX === evt.clientX && ctx.lastEvt.clientY === evt.clientY) {
+              // windows OS's bug for mousemove event
+              // mousemove event occurs even there is no movement after mousedown
+              // https://bugs.chromium.org/p/chromium/issues/detail?id=161464
+              // https://bugs.chromium.org/p/chromium/issues/detail?id=721341
+              // https://github.com/quasarframework/quasar/issues/10721
+              return
+            }
+
             ctx.lastEvt = evt
 
             const isMouseEvt = ctx.event.mouse === true

--- a/ui/src/directives/TouchPan.js
+++ b/ui/src/directives/TouchPan.js
@@ -231,7 +231,7 @@ export default __QUASAR_SSR_SERVER__
             }
 
             if(ctx.lastEvt && ctx.lastEvt.clientX === evt.clientX && ctx.lastEvt.clientY === evt.clientY) {
-              // windows OS's bug for mousemove event
+              // windows OS's bug for mousemove event (Blink Engine - Chrome & Edge)
               // mousemove event occurs even there is no movement after mousedown
               // https://bugs.chromium.org/p/chromium/issues/detail?id=161464
               // https://bugs.chromium.org/p/chromium/issues/detail?id=721341


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

fix #10721 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

// windows OS's bug for mousemove event (Blink Engine - Edge & Chrome, Windows Only)
// mousemove event occurs even there is no movement after mousedown
// https://bugs.chromium.org/p/chromium/issues/detail?id=161464
// https://bugs.chromium.org/p/chromium/issues/detail?id=721341
// https://github.com/quasarframework/quasar/issues/10721
