### PR TITLE
QDrawer - Backdrop - Color Opacity via GPU

### DIFF
--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -208,7 +208,8 @@ export default defineComponent({
     )
 
     const backdropStyle = computed(() => ({
-      backgroundColor: `rgba(0,0,0,${ flagBackdropBg.value * 0.4 })`
+      backgroundColor: "#000",
+      opacity: flagBackdropBg.value * 0.4
     }))
 
     const headerSlot = computed(() => (


### PR DESCRIPTION
In the old days, "rgba" was believed as a better implementation over "opacity"
(only the background color instead of everything in the DOM)
However, background / background-color property is using CPU instead of GPU.
https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/

For a element without children, rgba and opacity shall have the same effect.
But in terms of changing property, opacity is definitely the better option.
It can even request a GPU thread for its changing - ["will-change"](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: GPU Acceleration on Backdrop Element for QDrawer

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change