### PR TITLE
GPU Accelerated QDrawer Rendering

### DIFF
--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -208,7 +208,8 @@ export default defineComponent({
     )
 
     const backdropStyle = computed(() => ({
-      backgroundColor: `rgba(0,0,0,${ flagBackdropBg.value * 0.4 })`
+      backgroundColor: "#000",
+      opacity: flagBackdropBg.value * 0.4
     }))
 
     const headerSlot = computed(() => (
@@ -248,9 +249,19 @@ export default defineComponent({
     })
 
     const style = computed(() => {
+
+      const isDrawerAtRight = ($q.lang.rtl === true ? rightSide.value !== true : rightSide.value);
+
+      //flagContentPosition {right tab, hidden}: 200width => transformx 215px => right: -200px = -215px + 15px
+      //flagContentPosition {right tab, shown}: 200width => transformx 0 => right: 15px = 0px + 15px
+      //flagContentPosition {left tab, shown}: 200width => transformx 0 => left: 0px
+      //flagContentPosition {left tab, hidden}: 200width => transformx -200px => left:-200px
+
       const style = {
         width: `${ size.value }px`,
-        transform: `translateX(${ flagContentPosition.value }px)`
+        left: isDrawerAtRight?"auto" : `${ flagContentPosition.value }px`,
+        right: !isDrawerAtRight?"auto" : `${ - flagContentPosition.value + $layout.scrollbarWidth.value }px`,
+        transform: 'initial' //reset the css rule for transform
       }
 
       return belowBreakpoint.value === true


### PR DESCRIPTION
- changed from background-color rgba to static backgroundcolor with varying opacity
- changed from transform:translateX to left/right property

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Currently the css for QDrawer's panel and backdrop is not fully utilized the GPU rendering

varying the alpha channel in `backgroundColor`'s `rgba` and `transform:translateX(xxxx)` were believed faster but in fact the GPU acceleration would perform much better in `opacity` and `left/right` for modern web browser engines.

* background / background-color property is using CPU instead of GPU.
   https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/

* being able for using `will-change` optimization
 https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Faster Rendering with GPU Acceleration

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
For those existing plugin modifying the QDrawer's behavior should be reviewed due to the property name changed.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

in long term, `will-change` might be required immediately before the start of grabbing to let the GPU prepare the changes much effectively.