### PR TITLE
perf(QDrawer): Render visual changes with GPU and remove unnecessary reflow/repaint css

### DIFF
--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -204,11 +204,12 @@ export default defineComponent({
 
     const backdropClass = computed(() =>
       'fullscreen q-drawer__backdrop'
-      + (showing.value === false && flagPanning.value === false ? ' hidden' : '')
+      + (showing.value === false && flagPanning.value === false ? ' no-pointer-events' : '')
     )
 
     const backdropStyle = computed(() => ({
-      backgroundColor: `rgba(0,0,0,${ flagBackdropBg.value * 0.4 })`
+      backgroundColor: "#000",
+      opacity: flagBackdropBg.value * 0.4
     }))
 
     const headerSlot = computed(() => (
@@ -265,13 +266,13 @@ export default defineComponent({
 
     const classes = computed(() =>
       `q-drawer q-drawer--${ props.side }`
-      + (flagMiniAnimate.value === true ? ' q-drawer--mini-animate' : '')
       + (props.bordered === true ? ' q-drawer--bordered' : '')
       + (isDark.value === true ? ' q-drawer--dark q-dark' : '')
+      + (flagMiniAnimate.value === true ? ' q-drawer--mini-animate' : '')
       + (
         flagPanning.value === true
           ? ' no-transition'
-          : (showing.value === true ? '' : ' q-layout--prevent-focus')
+          : (showing.value === true ? '' : ' no-pointer-events')
       )
       + (
         belowBreakpoint.value === true


### PR DESCRIPTION
perf(QDrawer): Render visual changes with GPU and remove unnecessary reflow/repaint css

- changed from background-color `rgba` to static backgroundColor with varying `opacity` (GPU acceleration for `opacity` property)
- removed all `visibility` changes since QDrawer & Backdrop (controlled by `translateX` and `opacity`) are already visually disappeared - just use `no-pointer-events`

Currently the css for QDrawer's panel and backdrop is not fully utilized the GPU rendering

varying the alpha channel in backgroundColor's rgba was believed faster but in fact the GPU acceleration would perform much better in opacity for modern web browser engines.

background / background-color property is using CPU instead of GPU.
https://www.smashingmagazine.com/2016/12/gpu-animation-doing-it-right/

being able for using will-change optimization
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

visiblity hidden is not required since `opacity` is zero or out of screen due to `translateX`
`no-pointer-events` is required for backdrop if `opacity: 0` is using

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Performance Enhancement for GPU Rendering

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
