### PR TITLE
feat(QDrawer): Adding low-level public methods, backdrop-click event, and exposeRefs

### DIFF
--- a/ui/src/components/drawer/QDrawer.json
+++ b/ui/src/components/drawer/QDrawer.json
@@ -125,6 +125,35 @@
     }
   },
 
+  "methods": {
+    "_panningTo": {
+      "desc": "[low-level] set the panning of the QDrawer using custom gesture",
+      "params": {
+        "dx": {
+          "type": "Number",
+          "desc": "Movement X (in pixels) for QDrawer's panning",
+          "examples": [ 40, 200 ]
+        },
+        "flag": {
+          "type": "Number",
+          "desc": "Indicate the movement type - 0 | TOUCH_START | TOUCH_END",
+          "examples": [ 0, 32, 64 ]
+        }
+      }
+    },
+    
+    "_panningFinal": {
+      "desc": "[low-level] set the panning of the QDrawer using custom gesture",
+      "params": {
+        "flag": {
+          "type": "Number",
+          "desc": "Indicate the action and whether it resets to orginal position - QDRAWER_OPEN | QDRAWER_CLOSE | QDRAWER_RESET_POSITION",
+          "examples": [ 262144, 65536, 1310720 ]
+        }
+      }
+    }
+  },
+  
   "events": {
     "on-layout": {
       "desc": "Emitted when drawer toggles between occupying space on page or not",
@@ -157,6 +186,17 @@
         "state": {
           "type": "Boolean",
           "desc": "New state"
+        }
+      }
+    },
+
+    "backdrop-click": {
+      "desc": "Emitted when backdrop is clicked followed by closing the drawer - which can be cancelled using .cancel()",
+      "params": {
+        "options": {
+          "type": "Object",
+          "desc": "Providing the .cancel() method for cancelling the closing action",
+          "__exemption": [ "examples" ]
         }
       }
     }


### PR DESCRIPTION
Customize the drawer movement with own gesture detection (see #10746) :

1. A new low-level public method `_panningTo(dx, flag)` is added so that the progammers can use `_panningTo(80, TOUCH_START)` to pull the drawer.

> positive dx works with showing = false for opening the drawer
> negative dx works with showing = true for closing the drawer
> TOUCH_START / TOUCH_END are associated with the initial and final behavior of the drawer 
> (e.g. reseting position in final movement if required)

2. A new low-level public method `_panningFinal(flag)` is added so that the progammers can use `_panningFinal(QDRAWER_CLOSE | QDRAWER_RESET_POSITION)` to finalize the pulling.

> QDRAWER_OPEN: open the drawer
> QDRAWER_OPEN | QDRAWER_RESET_POSITION: reset the drawer position when it is opening
> QDRAWER_CLOSE: close the drawer
> QDRAWER_CLOSE | QDRAWER_RESET_POSITION: reset the drawer position when it is closing

3. All flags can be accessed from $q.consts
```
    const QDRAWER_OPEN = 0x00010000
    const QDRAWER_CLOSE = 0x00020000
    const QDRAWER_RESET_POSITION = 0x00040000
    const QDRAWER_CLOSE_OPPOSITE_DIRECTION = 0x00080000
    const TOUCH_START = 0x00000020
    const TOUCH_END = 0x00000040
```

4. Allow the ref values can be exposed to the QDrawer object if "`exposeRefs`" in config is `true`
(e.g. showing, flagContentPosition, size, stateDirection)

5. A new event `backdrop-click` is added to allow the developers to know whether the backdrop is clicked before closing. Developers can use ".cancel()" to prevent the closing. (see #10749)


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

* No impact to existing applications. (Fully backwards compatible)
* Update to the relevant document sections for `$q.consts` and `$q.config.exposeRefs`

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

* `$q.consts` and `$q.config.exposeRefs` to be added to Official Docs.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

* More functions and events shall be added to the UI components to let programmers to create custom behavior and actions.
* Let programmers to access the internal variables (e.g. size of drawer, current position of drawer's pulling)

**Other information:**
* The events and methods for the existing UIs shall be also reviewed to let developers to create custom behavior and actions.