### PR TITLE
perf(QScrollArea): Simplify css rules for better performance

### DIFF
--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -391,7 +391,7 @@ export default defineComponent({
           tabindex: props.tabindex !== void 0 ? props.tabindex : void 0
         }, [
           h('div', {
-            class: 'q-scrollarea__content absolute',
+            class: 'q-scrollarea__content',
             style: mainStyle.value
           }, hMergeSlot(slots.default, [
             h(QResizeObserver, {

--- a/ui/src/components/scroll-area/QScrollArea.sass
+++ b/ui/src/components/scroll-area/QScrollArea.sass
@@ -1,5 +1,6 @@
 .q-scrollarea
   position: relative
+  display: flex
 
   &__bar,
   &__thumb
@@ -30,8 +31,7 @@
       opacity: .5
 
   &__content
-    min-height: 100%
-    min-width: 100%
+    flex: 1
 
   &--dark .q-scrollarea__thumb
     background: #fff


### PR DESCRIPTION
`position: absolute` for content area is not required
`min-height: 100%` and `min-width: 100%` is not required for flexbox flex-row

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: 
  - [x] CSS Performance Enhancement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
