### PR TITLE
feat(ts): Introduce Volar support and event types

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -5,12 +5,13 @@ const { logError, writeFile } = require('./build.utils')
 const typeRoot = path.resolve(__dirname, '../types')
 const distRoot = path.resolve(__dirname, '../dist/types')
 const resolvePath = file => path.resolve(distRoot, file)
+const INDENT_SPACE_COUNT = 2
 const extraInterfaces = {}
 // eslint-disable-next-line no-useless-escape
 const toCamelCase = str => str.replace(/(-\w)/g, m => m[ 1 ].toUpperCase())
 
 function writeLine (fileContent, line = '', indent = 0) {
-  fileContent.push(`${ line.padStart(line.length + (indent * 4), ' ') }\n`)
+  fileContent.push(`${ line.padStart(line.length + (indent * INDENT_SPACE_COUNT), ' ') }\n`)
 }
 
 function writeLines (fileContent, lines = '', indent = 0) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const prettier = require('prettier')
 
 const { logError, writeFile } = require('./build.utils')
 const typeRoot = path.resolve(__dirname, '../types')
@@ -450,7 +451,10 @@ function writeIndexDTS (apis) {
   writeLine(contents, 'import \'./shim-icon-set\'')
   writeLine(contents, 'import \'./shim-lang\'')
 
-  writeFile(resolvePath('index.d.ts'), contents.join(''))
+  writeFile(
+    resolvePath('index.d.ts'),
+    prettier.format(contents.join(''), { parser: 'typescript' })
+  )
 }
 
 module.exports.generate = function (data) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -276,7 +276,7 @@ function writeIndexDTS (apis) {
   writeLine(contents, '// @ts-ignore')
   writeLine(contents, '/// <reference types="@quasar/app" />')
   writeLine(contents, 'import { App, Component, ComponentPublicInstance } from \'vue\'')
-  writeLine(contents, 'import { LooseDictionary, ComponentConstructor, PublicProps } from \'./ts-helpers\'')
+  writeLine(contents, 'import { LooseDictionary, ComponentConstructor, GlobalComponentConstructor } from \'./ts-helpers\'')
   writeLine(contents)
   writeLine(quasarTypeContents, 'export as namespace quasar')
   // We expose `ts-helpers` because they are needed by `@quasar/app` augmentations
@@ -422,13 +422,6 @@ function writeIndexDTS (apis) {
   }
 
   // Provide `GlobalComponents`, expected to be used for Volar
-  // Can't use `DefineComponent` because of the false prop inferring behavior, it doesn't pick up the required types when an interface is passed
-  // This will probably solve the problem as it moves the prop inferring behavior to `defineComponent` function: https://github.com/vuejs/vue-next/pull/4465
-  // GlobalComponentConstructor helper is kind of like the ComponentConstructor type helper, but simpler and keeps the Volar errors simpler,
-  // and also similar to the usage in official Vue packages: https://github.com/vuejs/vue-next/blob/d84d5ecdbdf709570122175d6565bb61fae877f2/packages/runtime-core/src/components/BaseTransition.ts#L258-L264 or https://github.com/vuejs/vue-router-next/blob/5dd5f47515186ce34efb9118dda5aad0bb773439/src/RouterView.ts#L160-L172 etc.
-  // TODO: Replace `GlobalComponentConstructor` with `DefineComponent` once https://github.com/vuejs/vue-next/pull/4465 gets merged
-  writeLine(contents, 'type GlobalComponentConstructor<Props = {}> = { new (): { $props: PublicProps & Props } }')
-  writeLine(contents)
   writeLine(contents, 'declare module \'@vue/runtime-core\' {')
   writeLine(contents, 'interface GlobalComponents {', 1)
 

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -289,6 +289,7 @@ function writeIndexDTS (apis) {
   writeLine(quasarTypeContents, 'export * from \'./extras\'')
   writeLine(quasarTypeContents, 'export * from \'./lang\'')
   writeLine(quasarTypeContents, 'export * from \'./api\'')
+  writeLine(quasarTypeContents)
 
   const injections = {}
 
@@ -432,10 +433,12 @@ function writeIndexDTS (apis) {
 
   writeLine(contents, '}', 1)
   writeLine(contents, '}')
+  writeLine(contents)
 
   addQuasarPluginOptions(contents, components, directives, plugins)
 
   quasarTypeContents.forEach(line => write(contents, line))
+  writeLine(contents)
 
   writeLine(contents, 'export const Quasar: { install: (app: App, options: Partial<QuasarPluginOptions>) => any } & QSingletonGlobals')
   writeLine(contents, 'export default Quasar')

--- a/ui/package.json
+++ b/ui/package.json
@@ -77,6 +77,7 @@
     "eslint-webpack-plugin": "^2.4.1",
     "json-beautify": "^1.1.1",
     "module-alias": "^2.2.2",
+    "prettier": "^2.4.1",
     "recast": "^0.18.5",
     "rimraf": "^3.0.1",
     "rollup": "^2.34.0",

--- a/ui/types/ts-helpers.d.ts
+++ b/ui/types/ts-helpers.d.ts
@@ -24,3 +24,14 @@ export type ComponentConstructor<Component extends ComponentPublicInstance<Props
 // https://github.com/vuejs/vue-next/blob/d84d5ecdbdf709570122175d6565bb61fae877f2/packages/runtime-core/src/apiDefineComponent.ts#L29-L31
 // TODO: This can be imported from vue directly once this PR gets merged: https://github.com/vuejs/vue-next/pull/2403
 export type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps;
+
+// Can't use `DefineComponent` because of the false prop inferring behavior, it doesn't pick up the required types when an interface is passed
+// This PR will probably solve the problem as it moves the prop inferring behavior to `defineComponent` function: https://github.com/vuejs/vue-next/pull/4465
+// GlobalComponentConstructor helper is kind of like the ComponentConstructor type helper, but simpler and keeps the Volar errors simpler,
+// and also similar to the usage in official Vue packages: https://github.com/vuejs/vue-next/blob/d84d5ecdbdf709570122175d6565bb61fae877f2/packages/runtime-core/src/components/BaseTransition.ts#L258-L264 or https://github.com/vuejs/vue-router-next/blob/5dd5f47515186ce34efb9118dda5aad0bb773439/src/RouterView.ts#L160-L172 etc.
+// TODO: This can be replaced with `DefineComponent` once this PR gets merged: https://github.com/vuejs/vue-next/pull/4465
+export type GlobalComponentConstructor<Props = {}> = {
+  new (): {
+    $props: PublicProps & Props
+  }
+}

--- a/ui/types/ts-helpers.d.ts
+++ b/ui/types/ts-helpers.d.ts
@@ -1,4 +1,4 @@
-import { ComponentOptions, ComponentPublicInstance, ComputedOptions, MethodOptions } from 'vue';
+import { ComponentOptions, ComponentPublicInstance, ComputedOptions, MethodOptions, VNodeProps, AllowedComponentProps, ComponentCustomProps } from 'vue';
 
 export type LooseDictionary = { [index in string]: any };
 
@@ -20,3 +20,7 @@ export type DeepPartial<T> = {
 // This type is compatible with the Vue private `ComponentPublicInstanceConstructor` type
 // https://github.com/vuejs/vue-next/blob/011dee8644bb52f5bdc6365c6e8404936d57e2cd/packages/runtime-core/src/componentPublicInstance.ts#L111
 export type ComponentConstructor<Component extends ComponentPublicInstance<Props, RawBindings, D, C, M> = ComponentPublicInstance<any>, Props = any, RawBindings = any, D = any, C extends ComputedOptions = ComputedOptions, M extends MethodOptions = MethodOptions > = { new(): Component } & ComponentOptions<Props, RawBindings, D, C, M>
+
+// https://github.com/vuejs/vue-next/blob/d84d5ecdbdf709570122175d6565bb61fae877f2/packages/runtime-core/src/apiDefineComponent.ts#L29-L31
+// TODO: This can be imported from vue directly once this PR gets merged: https://github.com/vuejs/vue-next/pull/2403
+export type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Type support improvements

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch

**Other information:**

I added some logic to provide components to the `GlobalComponents` interface in `@vue/runtime-core`. This is mainly for Volar support ATM, but it will soon be shipped officially(https://github.com/vuejs/vue-next/pull/3399), so it could become even more useful. Also, I extracted props definitions to separate interfaces, it's nice for reusability(_`h()`, `TSX`, or extending components_), it's a really common practice in Vue's and its official packages(e.g. `vue-router`) source code. (e.g. https://github.com/vuejs/vue-router-next/blob/5dd5f47515186ce34efb9118dda5aad0bb773439/src/RouterView.ts#L31-L35)

<details>
  <summary>Screenshots</summary>
        
  Component name auto completion:
  ![image](https://user-images.githubusercontent.com/6266078/135119634-f2ddb77c-915e-490b-8d2a-1fa69c2b78a9.png)

  Props auto completion:
  ![image](https://user-images.githubusercontent.com/6266078/135119810-1d021c45-ff34-4df4-b66c-65f57e66f3d6.png)

  Prop types and description:
  ![image](https://user-images.githubusercontent.com/6266078/135119891-9ad279e4-9295-4b9a-8d55-6dfaf92255b8.png)

  Required prop missing errors:
  ![image](https://user-images.githubusercontent.com/6266078/135119552-90623b74-c603-40f9-bc79-f45a21ca3934.png)

  Event auto completion:
  ![image](https://user-images.githubusercontent.com/6266078/135120122-be15dd0e-f004-4564-a10d-e6b5163a8b6a.png)

  Event description and payload types:
  ![image](https://user-images.githubusercontent.com/6266078/135119384-8a8841a0-c252-482a-9295-c1f1bbf134bc.png)

</details> 

See #10619 