### PR TITLE
fix(build): "version" issue when directly connecting to 'src' folder

### DIFF
--- a/ui/build/script.build.js
+++ b/ui/build/script.build.js
@@ -21,6 +21,8 @@ console.log(` 📦 Building Quasar ${ green('v' + require('../package.json').ver
 
 createFolder('dist')
 
+require('./script.version.js')
+
 if (!type || type === 'js') {
   createFolder('dist/vetur')
   createFolder('dist/api')

--- a/ui/build/script.version.js
+++ b/ui/build/script.version.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+
+//  get version
+const version = require('../package.json').version
+
+// read in the template as text
+let template = fs.readFileSync(path.resolve(__dirname, './version/version.template'), 'utf-8')
+
+// do the replacement
+template = template.replace('__QUASAR_VERSION__', version)
+
+// write the file
+fs.writeFileSync(path.resolve(__dirname, '../src/version.js'), template, 'utf-8')

--- a/ui/build/version/version.template
+++ b/ui/build/version/version.template
@@ -1,0 +1,1 @@
+export const version = '__QUASAR_VERSION__'

--- a/ui/src/index.all.js
+++ b/ui/src/index.all.js
@@ -1,6 +1,7 @@
 import installQuasar from './install-quasar.js'
 import lang from './lang.js'
 import iconSet from './icon-set.js'
+import { version } from './version'
 
 import * as components from './components.js'
 import * as directives from './directives.js'
@@ -12,7 +13,7 @@ export * from './composables.js'
 export * from './utils.js'
 
 export const Quasar = {
-  version: __QUASAR_VERSION__,
+  version,
   install (app, opts, ssrContext) {
     installQuasar(
       app,

--- a/ui/src/index.umd.js
+++ b/ui/src/index.umd.js
@@ -7,9 +7,10 @@ import * as directives from './directives.js'
 import * as plugins from './plugins.js'
 import * as utils from './utils.js'
 import * as composables from './composables.js'
+import { version } from './version'
 
 export default {
-  version: __QUASAR_VERSION__,
+  version,
   install (app, opts) {
     installQuasar(app, {
       components,

--- a/ui/src/install-quasar.js
+++ b/ui/src/install-quasar.js
@@ -7,6 +7,7 @@ import History from './history.js'
 import Lang from './lang.js'
 import Body from './body.js'
 import IconSet from './icon-set.js'
+import { version } from './version'
 
 import { quasarKey } from './utils/private/symbols.js'
 import { globalConfig, globalConfigIsFrozen, freezeGlobalConfig } from './utils/private/global-config.js'
@@ -75,7 +76,7 @@ function prepareApp (app, uiOpts, pluginOpts) {
 export default __QUASAR_SSR_SERVER__
   ? function (parentApp, opts = {}, ssrContext) {
       const $q = {
-        version: __QUASAR_VERSION__,
+        version,
         config: opts.config || {}
       }
 
@@ -113,7 +114,7 @@ export default __QUASAR_SSR_SERVER__
       })
     }
   : function (parentApp, opts = {}) {
-    const $q = { version: __QUASAR_VERSION__ }
+    const $q = { version }
 
     if (globalConfigIsFrozen === false) {
       if (opts.config !== void 0) {

--- a/ui/src/version.js
+++ b/ui/src/version.js
@@ -1,0 +1,1 @@
+export const version = '2.1.0'

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -1,9 +1,10 @@
 import installQuasar from './install-quasar.js'
 import lang from './lang.js'
 import iconSet from './icon-set.js'
+import { version } from './version'
 
 export default {
-  version: __QUASAR_VERSION__,
+  version,
   install: installQuasar,
   lang,
   iconSet


### PR DESCRIPTION
When `yarn build` is run, a `version.js` file is created/updated with current version number. This is ideally a better solution than using the `@rollup/plugin-replace`.

Why is this better?

There is always a `version.js` file available always in the `src` folder.  For developers doing cutting edge development and connecting directly to the `src` folder they won't run into the `__QUASAR_VERSION__ undefined` issue.

Secondly, it's not a JSON file so won't pollute the dist stack.

From `quasar.umd.js`:
```js
  const version = '2.1.0';

  const quasarKey = '_q_';
  const timelineKey = '_q_t_';
  const stepperKey = '_q_s_';
  const layoutKey = '_q_l_';
// ...
```

The common and esm distributables are also similar.

I've submitted this PR so you have a choice of keeping the way it is or picking this PR as an alternative solution (and frankly, I think it's better because a dev can now import `vue-plugin` if needed).

If this PR is accepted, I can make similar changes to the UI kit.