### PR TITLE
Docs page: Change search results to router links

### DIFF
--- a/docs/src/components/search-results/ResultPageContent.vue
+++ b/docs/src/components/search-results/ResultPageContent.vue
@@ -2,6 +2,8 @@
 q-item.app-search__result(
   :id="entry.id"
   :active="active"
+  :class="{'q-item--active': active}"
+  active-class=""
   :to="entry.to"
   @click="entry.onClick"
   @mouseenter="entry.onMouseenter"

--- a/docs/src/components/search-results/ResultPageContent.vue
+++ b/docs/src/components/search-results/ResultPageContent.vue
@@ -2,7 +2,7 @@
 q-item.app-search__result(
   :id="entry.id"
   :active="active"
-  clickable
+  :to="entry.to"
   @click="entry.onClick"
   @mouseenter="entry.onMouseenter"
 )

--- a/docs/src/components/search-results/ResultPageLink.vue
+++ b/docs/src/components/search-results/ResultPageLink.vue
@@ -2,6 +2,8 @@
 q-item.app-search__result(
   :id="entry.id"
   :active="active"
+  :class="{'q-item--active': active}"
+  active-class=""
   :to="entry.to"
   @click="entry.onClick"
   @mouseenter="entry.onMouseenter"

--- a/docs/src/components/search-results/ResultPageLink.vue
+++ b/docs/src/components/search-results/ResultPageLink.vue
@@ -2,7 +2,7 @@
 q-item.app-search__result(
   :id="entry.id"
   :active="active"
-  clickable
+  :to="entry.to"
   @click="entry.onClick"
   @mouseenter="entry.onMouseenter"
 )

--- a/docs/src/layouts/doc-layout/use-search.js
+++ b/docs/src/layouts/doc-layout/use-search.js
@@ -1,5 +1,4 @@
 import { ref, watch, onMounted, onBeforeUnmount, markRaw } from 'vue'
-import { useRouter } from 'vue-router'
 
 import { apiTypeToComponentMap } from 'components/AppSearchResults'
 import ResultEmpty from 'components/search-results/ResultEmpty'
@@ -39,8 +38,6 @@ export default function useSearch (scope, $q, $route) {
   const searchActiveId = ref(null)
   const searchInputRef = ref(null)
 
-  const $router = useRouter()
-
   function parseResults (hits) {
     if (hits.length === 0) {
       return { masterComponent: markRaw(ResultEmpty) }
@@ -67,6 +64,7 @@ export default function useSearch (scope, $q, $route) {
 
       const entry = {
         component: component.name,
+        to: hit.url,
         ...component.extractProps(hit),
 
         onMouseenter () {
@@ -75,7 +73,6 @@ export default function useSearch (scope, $q, $route) {
           }
         },
         onClick () {
-          $router.push(hit.url).catch(() => {})
           searchTerms.value = ''
           searchInputRef.value.blur()
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR converts the links in the documentation search box to router-links (using QItem `to` param), instead of programmatically changing the route in the `@click` handler. This for allows the links to be open in new tab and improves accessibility. 