### PR TITLE
Fix #10161 and improve code completion

### DIFF
--- a/app/lib/quasar-conf-file.js
+++ b/app/lib/quasar-conf-file.js
@@ -714,7 +714,6 @@ class QuasarConfFile {
       }
 
       cfg.build.gzip = merge({
-        filename: '[path].gz[query]',
         algorithm: 'gzip',
         test: new RegExp('\\.(' + ext.join('|') + ')$'),
         threshold: 10240,

--- a/app/package.json
+++ b/app/package.json
@@ -47,6 +47,7 @@
     "@quasar/ssr-helpers": "2.1.1",
     "@types/cordova": "0.0.34",
     "@types/express": "4.17.13",
+    "@types/compression-webpack-plugin": "9.0.0",
     "@types/webpack-bundle-analyzer": "4.4.1",
     "@types/webpack-dev-server": "4.1.0",
     "@vue/compiler-sfc": "3.2.19",

--- a/app/types/configuration/build.d.ts
+++ b/app/types/configuration/build.d.ts
@@ -2,6 +2,7 @@ import { MinifyOptions as TerserOptions } from "terser";
 import { Configuration as WebpackConfiguration } from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import * as WebpackChain from "webpack-chain";
+import * as CompressionPlugin from "compression-webpack-plugin";
 import { QuasarHookParams } from "./conf";
 
 interface InvokeParams {
@@ -125,11 +126,21 @@ interface QuasarStaticBuildConfiguration {
   env?: { [index: string]: string };
   /**
    * Gzip the distributables.
-   * Useful when the web server with which you are serving the content does not have gzip.
-   *
+   * Could be either a boolean or compression plugin options object.
+   * In addition, you can specify which file extension you want to 
+   * gzip with extension array field in replacement of compression plugin test option.
+   * By default it's ['js','css'].
+   * @example
+   *    {
+   *      extension: ['js','css','svg'],
+   *      threshold: 0,
+   *      minRatio: 1
+   *    }
    * @default false
    */
-  gzip?: boolean;
+  gzip?:boolean | CompressionPlugin.Options<any> & {
+    extensions: string[]
+  }
   /**
    * Show analysis of build bundle with webpack-bundle-analyzer.
    * When providing an object, it represents webpack-bundle-analyzer config options.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

As my commit description mentions,: 
* I don't what the old filename was supposed to do but it seems to break something.
We should want to keep the default filename defined within Webpack-compression ```[path][base].gz``` as @youmax210139 suggested in #10161 . *
And i added type definition that match what's going in the quasar-conf-file.js
