### PR TITLE
Fix Dialog's ssrAPI okCancel() => onCancel() & add onDismiss() (so that components using these functions can be tested)

### DIFF
--- a/ui/src/utils/private/global-dialog.js
+++ b/ui/src/utils/private/global-dialog.js
@@ -5,7 +5,7 @@ import { createGlobalNode, removeGlobalNode } from './global-nodes.js'
 
 const ssrAPI = {
   onOk: () => ssrAPI,
-  okCancel: () => ssrAPI,
+  onCancel: () => ssrAPI,
   hide: () => ssrAPI,
   update: () => ssrAPI
 }

--- a/ui/src/utils/private/global-dialog.js
+++ b/ui/src/utils/private/global-dialog.js
@@ -6,6 +6,7 @@ import { createGlobalNode, removeGlobalNode } from './global-nodes.js'
 const ssrAPI = {
   onOk: () => ssrAPI,
   onCancel: () => ssrAPI,
+  onDismiss: () => ssrAPI,
   hide: () => ssrAPI,
   update: () => ssrAPI
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It seems to me that the `Dialog`'s `ssrAPI` contains a spelling mistake. There is no other reference to an `okCancel` callback anywhere in the rest of the framework's codebase. [It differs from the normal (non-SSR) API](https://github.com/quasarframework/quasar/blob/9107f34f9fdb548cc0cd7c10904d047df378e3f0/ui/src/utils/private/global-dialog.js#L79-L111).

With the current implementation (`okCancel`), testing otherwise valid code fails. [For example](https://jsfiddle.net/41bnyL0m/1/),

```javascript
const app = Vue.createApp({
  setup () {
    return {}
  },
  created () {
    this.$q.dialog({
      title: 'Demo',
      message: 'Working dialog'
    }).onOk(() => {
      console.log('dialog onOk')
    }).onCancel(() => {
      console.log('dialog onCancel')
    })
  }
})

app.use(Quasar)
app.mount('#q-app')
```

is valid code in the browser. Running this code through `@quasar/quasar-app-extension-testing-unit-jest'`, however, will fail. In the test, the Dialog's `ssrAPI` will be used which does not provide an `onCancel` function. The test

```javascript
import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest'
import { mount } from '@vue/test-utils'
import MyDialog from 'MyDialog.vue'
import { Dialog } from 'quasar'

installQuasarPlugin({ plugins: { Dialog } })

describe('MyDialog.vue', () => {
  it('does not explode', () => {
    const wrapper = mount(MyDialog)
  })
})
```

thus fails with an error like this

```
  ● MyDialog.vue › does not explode

    TypeError: this.$q.dialog(...).onOk(...).onCancel is not a function

      146 |     }).onOk(() => {
      147 |       console.log('dialog onOk')
    > 148 |     }).onCancel(() => {
          |        ^
      149 |       console.log('dialog onCancel')
      150 |     })
      151 |   },
```

Sidenote: the non-SSR API also provides an `onDismiss` which the ssrAPI does not provide. It would probably be helpful to add that as well, which this PR also does.