### PR TITLE
Hide QNotifications from devtools

### DIFF
--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -64,6 +64,8 @@ function logError (error, config) {
 function getComponent ($q) {
   return defineComponent({
     name: 'QNotifications',
+    
+    // hide App from Vue devtools
     devtools: { hide: true },
 
     setup () {

--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -64,6 +64,7 @@ function logError (error, config) {
 function getComponent ($q) {
   return defineComponent({
     name: 'QNotifications',
+    devtools: { hide: true },
 
     setup () {
       const notificationsList = {}


### PR DESCRIPTION
Sometimes QNotification vue instance "intercepts" and become selected instance in devtools, but we need nothing to inspect there.
The same issue was in vue-toastification:  https://github.com/Maronato/vue-toastification/issues/271

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

