### PR TITLE
Update Heroku SPA deployment

### DIFF
--- a/docs/src/pages/quasar-cli/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli/developing-spa/deploying.md
@@ -148,16 +148,20 @@ module.exports = function (ctx) {
 ```
 ## Deploying with Heroku
 
+### Preparing for static hosting
+
 Unfortunately, Heroku does not support static sites out of the box. But don't worry, we just need to add an HTTP server to our project so Heroku can serve our Quasar application.
 
 In this example, we will use [Express](https://expressjs.com/) to create a minimal server which Heroku can use.
 
 First, we need to install the required dependencies to our project:
+
 ```bash
 $ yarn add express serve-static connect-history-api-fallback
 ```
 
 Now that we have installed the required dependencies, we can add our server. Create a file called `server.js` in the root directory of your project.
+
 ```js
 const
   express = require('express'),
@@ -172,7 +176,7 @@ app.use(serveStatic(__dirname + '/dist/spa'))
 app.listen(port)
 ```
 
-Heroku assumes a set of npm scripts to be available, so we have to alter our `package.json` and add the following under the `script` section:
+Heroku also assumes a set of npm scripts to be available, so we have to alter our `package.json` and add the following under the `script` section:
 
 ```js
 "build": "quasar build",
@@ -180,9 +184,35 @@ Heroku assumes a set of npm scripts to be available, so we have to alter our `pa
 "heroku-postbuild": "yarn build"
 ```
 
-::: tip
-You may also need to edit the engines to use a more restrictive semver lock. For example, use `12.x` instead of the open-ended `>= 12.22.1`.
+::: warning
+You must include the nodejs buildpack for it to automatically install your yarn dependencies.
+
+Otherwise, update the `"heroku-postbuild"` to include yarn install: `"yarn && yarn build"`
 :::
+
+You may also need to edit your engines to use a non-open-ended version lock, for example if your engines look something like `>= 12.22.1`:
+
+```js
+"engines": {
+  "node": ">= 12.22.1",
+  "npm": ">= 6.13.4",
+  "yarn": ">= 1.21.1"
+}
+```
+
+Instead use `12.x` or `^12.22.1`:
+
+```js
+"engines": {
+  "node": "12.x",
+  "npm": "6.x",
+  "yarn": "1.x"
+}
+```
+
+Next, you can either deploy manually using Heroku Git, or automatically using Github deployment.
+
+### Manual deployment using Heroku Git
 
 Now it is time to create an app on Heroku by running:
 
@@ -206,6 +236,28 @@ For existing Git repositories, simply add the heroku remote:
 ```bash
 $ heroku git:remote -a <heroku app name>
 ```
+
+### Automatic deployment using Github
+
+From the [Heroku Dashboard](https://dashboard.heroku.com/apps), create a new app.
+
+::: tip
+The app name will be used for Heroku only, and does not need to match what you used in Quasar.
+
+This will be used as the subdomain of herokuapps, if you do not setup a custom domain.
+:::
+
+For "Deployment Method", select Github. You will need to connect Heroku to your Github account, and if you want to deploy from an organization owned repo, you must request access for that organization as well.
+
+Once you've connected to Github, from the dropdown select which user/organization the repo belongs to, then search for the repo name and connect it.
+
+Before making your first deployment, you'll want to go to the Settings tab, and under Buildpacks add the official `heroku/nodejs` option from the menu.
+
+Once you've added the nodejs buildpack, go back to the Deploy tab.
+
+You may choose to enable automatic deployments, and optionally wait for CI (your tests) to pass before deploying a new version.
+
+You can also deploy manually by selecting a branch, and clicking Deploy Branch.
 
 ## Deploying with Surge
 

--- a/docs/src/pages/quasar-cli/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli/developing-spa/deploying.md
@@ -177,8 +177,12 @@ Heroku assumes a set of npm scripts to be available, so we have to alter our `pa
 ```js
 "build": "quasar build",
 "start": "node server.js",
-"heroku-postbuild": "yarn && yarn build"
+"heroku-postbuild": "yarn build"
 ```
+
+::: tip
+You may also need to edit the engines to use a more restrictive semver lock. For example, use `12.x` instead of the open-ended `>= 12.22.1`.
+:::
 
 Now it is time to create an app on Heroku by running:
 

--- a/docs/src/pages/quasar-cli/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli/developing-spa/deploying.md
@@ -186,8 +186,6 @@ Heroku also assumes a set of npm scripts to be available, so we have to alter ou
 
 ::: warning
 You must include the nodejs buildpack for it to automatically install your yarn dependencies.
-
-Otherwise, update the `"heroku-postbuild"` to include yarn install: `"yarn && yarn build"`
 :::
 
 You may also need to edit your engines to use a non-open-ended version lock, for example if your engines look something like `>= 12.22.1`:


### PR DESCRIPTION
Heroku will bark about open ended version locks for your engines, and including `yarn install` in the post-build will overwrite how it normally installs packages, causing it to fail to find the quasar command during the build step.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I could also add a section for deploying using the Dashboard and Github auto deploy, if that's desirable.