### PR TITLE
fix(Meta): add a space before concatening html tag attributes to ssr context

### DIFF
--- a/ui/src/plugins/Meta.js
+++ b/ui/src/plugins/Meta.js
@@ -190,7 +190,11 @@ function injectServerMeta (ssrContext) {
     : ''
 
   const ctx = ssrContext._meta
-
+  
+  if(Object.keys(data.htmlAttr).length > 0) {
+    ctx.htmlAttrs += ' '
+  }
+  
   ctx.htmlAttrs += Object.keys(data.htmlAttr)
     .filter(htmlFilter)
     .map(getAttr(data.htmlAttr))

--- a/ui/src/plugins/Meta.js
+++ b/ui/src/plugins/Meta.js
@@ -194,21 +194,22 @@ function injectServerMeta (ssrContext) {
   const htmlAttr = Object.keys(data.htmlAttr).filter(htmlFilter)
 
   if (htmlAttr.length > 0) {
-    if(ctx.htmlAttrs.length > 0) {
-      ctx.htmlAttrs += ' '
-    }
-
-    ctx.htmlAttrs += htmlAttr
-      .map(getAttr(data.htmlAttr))
-      .join(' ')
+    ctx.htmlAttrs += (
+      (ctx.htmlAttrs.length > 0 ? ' ' : '')
+      + htmlAttr.map(getAttr(data.htmlAttr)).join(' ')
+    )
   }
 
   ctx.headTags += getHead(data)
 
-  ctx.bodyAttrs += Object.keys(data.bodyAttr)
-    .filter(bodyFilter)
-    .map(getAttr(data.bodyAttr))
-    .join(' ')
+  const bodyAttr = Object.keys(data.bodyAttr).filter(bodyFilter)
+
+  if (bodyAttr.length > 0) {
+    ctx.bodyAttrs += (
+      (ctx.bodyAttrs.length > 0 ? ' ' : '')
+      + bodyAttr.map(getAttr(data.bodyAttr)).join(' ')
+    )
+  }
 
   ctx.bodyTags += Object.keys(data.noscript)
     .map(name => `<noscript data-qmeta="${ name }">${ data.noscript[ name ] }</noscript>`)

--- a/ui/src/plugins/Meta.js
+++ b/ui/src/plugins/Meta.js
@@ -194,12 +194,14 @@ function injectServerMeta (ssrContext) {
   const htmlAttr = Object.keys(data.htmlAttr).filter(htmlFilter)
 
   if (htmlAttr.length > 0) {
-    ctx.htmlAttrs += ' '
-  }
+    if(ctx.htmlAttrs.length > 0) {
+      ctx.htmlAttrs += ' '
+    }
 
-  ctx.htmlAttrs += htmlAttr
-    .map(getAttr(data.htmlAttr))
-    .join(' ')
+    ctx.htmlAttrs += htmlAttr
+      .map(getAttr(data.htmlAttr))
+      .join(' ')
+  }
 
   ctx.headTags += getHead(data)
 

--- a/ui/src/plugins/Meta.js
+++ b/ui/src/plugins/Meta.js
@@ -190,13 +190,14 @@ function injectServerMeta (ssrContext) {
     : ''
 
   const ctx = ssrContext._meta
-  
-  if(Object.keys(data.htmlAttr).length > 0) {
+
+  const htmlAttr = Object.keys(data.htmlAttr).filter(htmlFilter)
+
+  if (htmlAttr.length > 0) {
     ctx.htmlAttrs += ' '
   }
-  
-  ctx.htmlAttrs += Object.keys(data.htmlAttr)
-    .filter(htmlFilter)
+
+  ctx.htmlAttrs += htmlAttr
     .map(getAttr(data.htmlAttr))
     .join(' ')
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`ctx.htmlAttrs` already contains attributes from Quasar lang plugin.

Without this PR when adding html tag attributes with Meta Plugin, the html output is: 
```javascript
<html lang=en-US dir=ltrxmlns:cc=http://creativecommons.org/ns#>
```

With this PR the output is:
```javascript
<html lang=en-US dir=ltr xmlns:cc=http://creativecommons.org/ns#>
```