### PR TITLE
Added q-table body slot cols object definition

### DIFF
--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -788,7 +788,17 @@
         "cols": {
           "type": "Object",
           "desc": "Column definitions",
-          "__exemption": [ "examples" ]
+          "__exemption": [ "examples" ],
+          "definition": {
+            "name": {
+              "type": "String",
+              "desc": "Column name"
+            },
+            "value": {
+              "type": "String",
+              "desc": "Column value for the given row"
+            }
+          }
         },
         "colsMap": {
           "type": "Object",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When using `q-table` and overriding the `body` slot, the `props.cols` should be defined as having a `name` and `value` property since all columns should have this basic common information.

Use case:
```js
    <template #body="props">
      <q-tr :props="props">
        <q-td
          v-for="col in props.cols"
          :key="col.name"
          :props="props">
            <span>{{ col.value }}</span>
        </q-td>
      </q-tr>
    </template>
```