### PR TITLE
vite-plugin - support SCSS imports

### DIFF
--- a/vite-plugin/src/get-config.js
+++ b/vite-plugin/src/get-config.js
@@ -29,16 +29,17 @@ export default ({ runMode, sassVariables }) => {
     })
   }
 
-  if (sassVariables) {    
-    const sassImportArr = [`@import 'quasar/src/css/variables.sass'`, '']
+  if (sassVariables) {
+    const sassImportCode = [ `@import 'quasar/src/css/variables.sass'`, '' ]
+
     if (typeof sassVariables === 'string') {
-      sassImportArr.unshift(`@import '${ normalizePath(sassVariables) }'`)
+      sassImportCode.unshift(`@import '${ normalizePath(sassVariables) }'`)
     }
 
     viteCfg.css = {
       preprocessorOptions: {
-        sass: { additionalData: sassImportArr.join('\n') },
-        scss: { additionalData: sassImportArr.join(';\n') }
+        sass: { additionalData: sassImportCode.join('\n') },
+        scss: { additionalData: sassImportCode.join(';\n') }
       }
     }
   }

--- a/vite-plugin/src/get-config.js
+++ b/vite-plugin/src/get-config.js
@@ -29,16 +29,16 @@ export default ({ runMode, sassVariables }) => {
     })
   }
 
-  if (sassVariables) {
-    const sassImportCode = (
-      (typeof sassVariables === 'string' ? `@import '${ normalizePath(sassVariables) }'\n` : '')
-      + `@import 'quasar/src/css/variables.sass'\n`
-    )
+  if (sassVariables) {    
+    const sassImportArr = [`@import 'quasar/src/css/variables.sass'`, '']
+    if (typeof sassVariables === 'string') {
+      sassImportArr.unshift(`@import '${ normalizePath(sassVariables) }'`)
+    }
 
     viteCfg.css = {
       preprocessorOptions: {
-        sass: { additionalData: sassImportCode },
-        scss: { additionalData: sassImportCode }
+        sass: { additionalData: sassImportArr.join('\n') },
+        scss: { additionalData: sassImportArr.join(';\n') }
       }
     }
   }


### PR DESCRIPTION
Currently, vite-plugin throws an error when using a .scss import anywhere in the end user's codebase. This PR adds/fixes .scss support in vite-plugin.

There were a couple of ways to implement this, and I didn't want to add an almost identical `const scssImportCode =` line with the only difference being added semicolons, so I chose what I believe is an elegant solution using array join with an empty final element.

You can reproduce the error by placing any .scss import in main.js:
```
import 'src/css/app.scss';
```

With this config:
```
quasar({
  sassVariables: 'src/css/variables.sass'
})
```

Results in this error:
```
[plugin:vite:css] expected ";".
  ╷
1 │ @import 'src/css/variables.sass'
  │                                 ^
  ╵
  src/css/app.scss 1:33  root stylesheet
/cms/frontend/browser/src/css/app.scss:1:33
```

--

with `sassVariables: true`, this error:
```
[plugin:vite:css] expected ";".
  ╷
2 │ a.link {
  │  ^
  ╵
  src/css/app.scss 2:2  root stylesheet
/cms/frontend/browser/src/css/app.scss:2:2
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.