### PR TITLE
feat(ts&api): Generate inline function types, improve some types

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -226,69 +226,62 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
         continue
       }
 
-      if (verifyCategory && obj.category === void 0) {
-        logError(`${ banner } missing required API prop "category" for its type (${ type })`)
-        console.error(obj)
-        console.log()
-        process.exit(1)
-      }
-
       if (!def.props.includes(prop)) {
         logError(`${ banner } object has unrecognized API prop "${ prop }" for its type (${ type })`)
         console.error(obj)
         console.log()
         process.exit(1)
       }
+    }
 
-      def.required.forEach(prop => {
-        if (obj.__exemption !== void 0 && obj.__exemption.includes(prop)) {
-          return
-        }
-        if (
-          !prop.examples
-          && (obj.definition !== void 0 || obj.values !== void 0)
-        ) {
-          return
-        }
-
-        if (obj[ prop ] === void 0) {
-          logError(`${ banner } missing required API prop "${ prop }" for its type (${ type })`)
-          console.error(obj)
-          console.log()
-          process.exit(1)
-        }
-      })
-
-      if (obj.__exemption !== void 0) {
-        const { __exemption, ...p } = obj
-        api[ itemName ] = p
+    [ ...def.required, ...(verifyCategory ? [ 'category' ] : []) ].forEach(prop => {
+      if (obj.__exemption !== void 0 && obj.__exemption.includes(prop)) {
+        return
+      }
+      if (
+        !prop.examples
+        && (obj.definition !== void 0 || obj.values !== void 0)
+      ) {
+        return
       }
 
-      def.isBoolean && def.isBoolean.forEach(prop => {
-        if (obj[ prop ] && obj[ prop ] !== true && obj[ prop ] !== false) {
-          logError(`${ banner }/"${ prop }" is not a Boolean`)
-          console.error(obj)
-          console.log()
-          process.exit(1)
-        }
-      })
-      def.isObject && def.isObject.forEach(prop => {
-        if (obj[ prop ] && Object(obj[ prop ]) !== obj[ prop ]) {
-          logError(`${ banner }/"${ prop }" is not an Object`)
-          console.error(obj)
-          console.log()
-          process.exit(1)
-        }
-      })
-      def.isArray && def.isArray.forEach(prop => {
-        if (obj[ prop ] && !Array.isArray(obj[ prop ])) {
-          logError(`${ banner }/"${ prop }" is not an Array`)
-          console.error(obj)
-          console.log()
-          process.exit(1)
-        }
-      })
+      if (obj[ prop ] === void 0) {
+        logError(`${ banner } missing required API prop "${ prop }" for its type (${ type })`)
+        console.error(obj)
+        console.log()
+        process.exit(1)
+      }
+    })
+
+    if (obj.__exemption !== void 0) {
+      const { __exemption, ...p } = obj
+      api[ itemName ] = p
     }
+
+    def.isBoolean && def.isBoolean.forEach(prop => {
+      if (obj[ prop ] && obj[ prop ] !== true && obj[ prop ] !== false) {
+        logError(`${ banner }/"${ prop }" is not a Boolean`)
+        console.error(obj)
+        console.log()
+        process.exit(1)
+      }
+    })
+    def.isObject && def.isObject.forEach(prop => {
+      if (obj[ prop ] && Object(obj[ prop ]) !== obj[ prop ]) {
+        logError(`${ banner }/"${ prop }" is not an Object`)
+        console.error(obj)
+        console.log()
+        process.exit(1)
+      }
+    })
+    def.isArray && def.isArray.forEach(prop => {
+      if (obj[ prop ] && !Array.isArray(obj[ prop ])) {
+        logError(`${ banner }/"${ prop }" is not an Array`)
+        console.error(obj)
+        console.log()
+        process.exit(1)
+      }
+    })
   }
 
   if (obj.returns) {

--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -222,6 +222,7 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
 
   if (obj.internal !== true) {
     for (const prop in obj) {
+      // These props are always valid and doesn't need to be specified in 'props' of 'objectTypes' entries
       if ([ 'type', '__exemption' ].includes(prop)) {
         continue
       }
@@ -238,10 +239,8 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
       if (obj.__exemption !== void 0 && obj.__exemption.includes(prop)) {
         return
       }
-      if (
-        !prop.examples
-        && (obj.definition !== void 0 || obj.values !== void 0)
-      ) {
+      // 'examples' property is not required if 'definition' or 'values' properties are specified
+      if (prop === 'examples' && (obj.definition !== void 0 || obj.values !== void 0)) {
         return
       }
 
@@ -253,6 +252,7 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
       }
     })
 
+    // Since we processed '__exemption', we can strip it
     if (obj.__exemption !== void 0) {
       const { __exemption, ...p } = obj
       api[ itemName ] = p

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -51,9 +51,7 @@ function convertTypeVal (type, def, required) {
     return def.tsType
   }
 
-  const t = type.trim()
-
-  if (def.values && t === 'String') {
+  if (def.values && type === 'String') {
     const narrowedValues = def.values.filter(v =>
       !dontNarrowValues.includes(v)
       && typeof v === 'string'
@@ -64,31 +62,31 @@ function convertTypeVal (type, def, required) {
     }
   }
 
-  if (typeMap.has(t)) {
-    return typeMap.get(t)
+  if (typeMap.has(type)) {
+    return typeMap.get(type)
   }
 
-  if (fallbackComplexTypeMap.has(t)) {
+  if (fallbackComplexTypeMap.has(type)) {
     if (def.definition) {
       const propDefinitions = getPropDefinitions({ definitions: def.definition, required })
       const lines = []
       propDefinitions.forEach(propDef => writeLines(lines, propDef, 2))
 
       if (lines.length > 0) {
-        return `{ ${ lines.join('') } }${ t === 'Array' ? '[]' : '' }`
+        return `{ ${ lines.join('') } }${ type === 'Array' ? '[]' : '' }`
       }
     }
 
-    return fallbackComplexTypeMap.get(t)
+    return fallbackComplexTypeMap.get(type)
   }
 
-  if (t === 'Function') {
+  if (type === 'Function') {
     // FIXME: paramsRequired should be false for Notify plugin's return type
     // Function type notations must be parenthesized when used in a union type
     return '(' + getFunctionDefinition({ definition: def, paramsRequired: true }) + ')'
   }
 
-  return t
+  return type
 }
 
 function getTypeVal (def, required) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -82,6 +82,12 @@ function convertTypeVal (type, def, required) {
     return fallbackComplexTypeMap.get(t)
   }
 
+  if (t === 'Function') {
+    // FIXME: paramsRequired should be false for Notify plugin's return type
+    // Function type notations must be parenthesized when used in a union type
+    return '(' + getFunctionDefinition({ definition: def, paramsRequired: true }) + ')'
+  }
+
   return t
 }
 

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -81,7 +81,12 @@ function convertTypeVal (type, def, required) {
   }
 
   if (type === 'Function') {
-    // FIXME: paramsRequired should be false for Notify plugin's return type
+    // FIXME: Find a better way to handle this, figure out if there are other cases as well
+    // Set paramsRequired to false for the function returned from Notify.create(...)
+    if (def.desc === 'Calling this function with no parameters hides the notification; When called with one Object parameter (the original notification must NOT be grouped), it updates the notification (specified properties are shallow merged with previous ones; note that group and position cannot be changed while updating and so they are ignored)') {
+      return '(' + getFunctionDefinition({ definition: def, paramsRequired: false }) + ')'
+    }
+
     // Function type notations must be parenthesized when used in a union type
     return '(' + getFunctionDefinition({ definition: def, paramsRequired: true }) + ')'
   }

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -70,8 +70,11 @@ function convertTypeVal (type, def, required) {
     if (def.definition) {
       const propDefinitions = getPropDefinitions({ propDefs: def.definition, required, docs: true })
       const lines = []
-      propDefinitions.forEach(p => lines.push(...p.split('\n')))
-      return propDefinitions && propDefinitions.length > 0 ? `{\n        ${ lines.join('\n        ') } }${ t === 'Array' ? '[]' : '' }` : fallbackComplexTypeMap.get(t)
+      propDefinitions.forEach(propDef => writeLines(lines, propDef, 2))
+
+      if (lines.length > 0) {
+        return `{ ${ lines.join('') } }${ t === 'Array' ? '[]' : '' }`
+      }
     }
 
     return fallbackComplexTypeMap.get(t)

--- a/ui/src/components/date/QDate.json
+++ b/ui/src/components/date/QDate.json
@@ -61,6 +61,17 @@
     "events": {
       "type": [ "Array", "Function" ],
       "desc": "A list of events to highlight on the calendar; If using a function, it receives the date as a String and must return a Boolean (matches or not); If using a function then for best performance, reference it from your scope and do not define it inline",
+      "params": {
+        "date": {
+          "type": "String",
+          "desc": "The current date being processed.",
+          "examples": [ "2018/11/05", "2021/10/25" ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, the current date will be highlighted"
+      },
       "examples": [
         ":events=\"['2018/11/05', '2018/11/06', '2018/11/09', '2018/11/23']\"",
         ":events=\"date => date[9] % 3 === 0\""
@@ -71,6 +82,18 @@
     "event-color": {
       "type": [ "String", "Function" ],
       "desc": "Color name (from the Quasar Color Palette); If using a function, it receives the date as a String and must return a String (color for the received date); If using a function then for best performance, reference it from your scope and do not define it inline",
+      "params": {
+        "date": {
+          "type": "String",
+          "desc": "The current date being processed.",
+          "examples": [ "2018/11/05", "2021/10/25" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "Color for the current date.",
+        "examples": [ "teal", "orange" ]
+      },
       "examples": [
         "teal-10",
         ":event-color=\"(date) => date[9] % 2 === 0 ? 'teal' : 'orange'\""
@@ -81,6 +104,17 @@
     "options": {
       "type": [ "Array", "Function" ],
       "desc": "Optionally configure the days that are selectable; If using a function, it receives the date as a String and must return a Boolean (is date acceptable or not); If using a function then for best performance, reference it from your scope and do not define it inline; Incompatible with 'range' prop",
+      "params": {
+        "date": {
+          "type": "String",
+          "desc": "The current date being processed.",
+          "examples": [ "2018/11/05", "2021/10/25" ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, the current date will be made available for selection"
+      },
       "examples": [
         ":options=\"['2018/11/05', '2018/11/12', '2018/11/19', '2018/11/26' ]\"",
         ":options=\"date => date[9] % 3 === 0\"",

--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -120,8 +120,12 @@
         },
         "disable": {
           "type": [ "Boolean", "Function" ],
-          "desc": "Is button disabled? If specifying a function, return a Boolean value.",
-          "examples": [ "() => this.userIsActive()" ]
+          "desc": "Is button disabled?",
+          "returns": {
+            "type": "Boolean",
+            "desc": "If true, the button will be disabled"
+          },
+          "examples": [ "!user.active", "() => !checkIfUserIsActive()" ]
         },
         "type": {
           "type": "String",

--- a/ui/src/components/footer/QFooter.json
+++ b/ui/src/components/footer/QFooter.json
@@ -32,7 +32,7 @@
     },
 
     "height-hint": {
-      "type": [ "Number", "String " ],
+      "type": [ "Number", "String" ],
       "desc": "When using SSR, you can optionally hint of the height (in pixels) of the QFooter",
       "default": 50,
       "examples": [ "150" ],

--- a/ui/src/components/header/QHeader.json
+++ b/ui/src/components/header/QHeader.json
@@ -42,7 +42,7 @@
     },
 
     "height-hint": {
-      "type": [ "Number", "String " ],
+      "type": [ "Number", "String" ],
       "desc": "When using SSR, you can optionally hint of the height (in pixels) of the QHeader",
       "default": 50,
       "examples": [ "150" ],

--- a/ui/src/components/scroll-area/QScrollArea.json
+++ b/ui/src/components/scroll-area/QScrollArea.json
@@ -95,13 +95,14 @@
       "params": {
         "info": {
           "type": "Object",
-          "__exemption": [ "examples" ],
+          "desc": "An object containing scroll information",
           "definition": {
             "ref": {
               "type": "Object",
               "desc": "Vue reference to the QScrollArea which triggered the event",
               "__exemption": [ "examples" ]
             },
+
             "verticalPosition": {
               "type": "Number",
               "desc": "Vertical scroll position (in px)",
@@ -215,6 +216,7 @@
       "desc": "Get current scroll position",
       "returns": {
         "type": "Object",
+        "desc": "An object containing scroll position information",
         "definition": {
           "top": {
             "type": "Number",
@@ -235,6 +237,7 @@
       "desc": "Get current scroll position in percentage (0.0 <= x <= 1.0)",
       "returns": {
         "type": "Object",
+        "desc": "An object containing scroll position information in percentage",
         "definition": {
           "top": {
             "type": "Number",

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -47,6 +47,22 @@
       "type": [ "Function", "String" ],
       "desc": "Property of option which holds the 'value'; If using a function then for best performance, reference it from your scope and do not define it inline",
       "default": "value",
+      "params": {
+        "option": {
+          "type": [ "String", "Object" ],
+          "desc": "The current option being processed",
+          "examples": [
+            "'BMW'",
+            "'Samsung Phone'",
+            "{ label: 'BMW', value: 'car', cannotSelect: true }"
+          ]
+        }
+      },
+      "returns": {
+        "type": "Any",
+        "desc": "Value of the current option",
+        "examples": [ "'car'", "34" ]
+      },
       "examples": [
         "option-value=\"modelNumber\"",
         ":option-value=\"(item) => item === null ? null : item.modelNumber\""
@@ -58,6 +74,22 @@
       "type": [ "Function", "String" ],
       "desc": "Property of option which holds the 'label'; If using a function then for best performance, reference it from your scope and do not define it inline",
       "default": "label",
+      "params": {
+        "option": {
+          "type": [ "String", "Object" ],
+          "desc": "The current option being processed",
+          "examples": [
+            "'BMW'",
+            "'Samsung Phone'",
+            "{ label: 'BMW', value: 'car', cannotSelect: true }"
+          ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "Label of the current option",
+        "examples": [ "'BMW'", "'Samsung Phone'" ]
+      },
       "examples": [
         "option-label=\"itemName\"",
         ":option-label=\"(item) => item === null ? 'Null value' : item.itemName\""
@@ -69,6 +101,21 @@
       "type": [ "Function", "String" ],
       "desc": "Property of option which tells it's disabled; The value of the property must be a Boolean; If using a function then for best performance, reference it from your scope and do not define it inline",
       "default": "disable",
+      "params": {
+        "option": {
+          "type": [ "String", "Object" ],
+          "desc": "The current option being processed",
+          "examples": [
+            "'BMW'",
+            "'Samsung Phone'",
+            "{ label: 'BMW', value: 'car', cannotSelect: true }"
+          ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, the current option will be disabled"
+      },
       "examples": [
         "option-disable=\"cannotSelect\"",
         ":option-disable=\"(item) => item === null ? true : item.cannotSelect\""

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -17,6 +17,18 @@
       "type": [ "String", "Function" ],
       "desc": "Property of each row that defines the unique key of each row (the result must be a primitive, not Object, Array, etc); The value of property must be string or a function taking a row and returning the desired (nested) key in the row; If supplying a function then for best performance, reference it from your scope and do not define it inline",
       "default": "id",
+      "params": {
+        "row": {
+          "type": "Object",
+          "desc": "The current row being processed",
+          "examples": [ "{ name: 'Lorem Ipsum', price: 19 }" ]
+        }
+      },
+      "returns": {
+        "type": "Any",
+        "desc": "Current row's key",
+        "examples": [ "'34f39dda-6206-4071-a9df-4393aabe49ac'", "34" ]
+      },
       "examples": [ "row-key=\"name\"", ":row-key=\"row => row.name\"" ],
       "category": "general"
     },
@@ -146,7 +158,19 @@
           "type": [ "String", "Function" ],
           "desc": "Row Object property to determine value for this column or function which maps to the required property",
           "required": true,
-          "examples": [ "name", "row => row.some.nested.prop" ]
+          "params": {
+            "row": {
+              "type": "Object",
+              "desc": "The current row being processed",
+              "examples": [ "{ name: 'Lorem Ipsum', prices: { active: 19, old: 25, list: 29 } }" ]
+            }
+          },
+          "returns": {
+            "type": "Any",
+            "desc": "Value for this column",
+            "examples": [ "19" ]
+          },
+          "examples": [ "name", "row => row.prices.active" ]
         },
         "required": {
           "type": "Boolean",
@@ -228,17 +252,39 @@
         "style": {
           "type": [ "String", "Function" ],
           "desc": "Style to apply on normal cells of the column",
+          "params": {
+            "row": {
+              "type": "Object",
+              "desc": "The current row being processed",
+              "examples": [ "{ name: 'Frozen Yogurt', calories: 159 }" ]
+            }
+          },
+          "returns": {
+            "type": "String",
+            "__exemption": [ "examples" ]
+          },
           "examples": [
-            "width: 500px",
-            "row => (row.calories % 2 === 0 ? 'width:10px' : 'font-size:2em')"
+            "'width: 500px'",
+            "row => (row.calories % 2 === 0 ? 'width: 10px' : 'font-size: 2em; font-weight: bold')"
           ]
         },
         "classes": {
           "type": [ "String", "Function" ],
           "desc": "Classes to add on normal cells of the column",
+          "params": {
+            "row": {
+              "type": "Object",
+              "desc": "The current row being processed",
+              "examples": [ "{ name: 'Frozen Yogurt', calories: 159 }" ]
+            }
+          },
+          "returns": {
+            "type": "String",
+            "__exemption": [ "examples" ]
+          },
           "examples": [
-            "my-special-class",
-            "row => (row.calories % 2 === 0 ? 'bg-green' : 'bg-yellow')"
+            "'my-special-class bg-primary'",
+            "row => (row.calories % 2 === 0 ? 'bg-green text-white' : 'bg-yellow')"
           ]
         },
         "headerStyle": {

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -261,7 +261,7 @@
           },
           "returns": {
             "type": "String",
-            "__exemption": [ "examples" ]
+            "__exemption": [ "desc", "examples" ]
           },
           "examples": [
             "'width: 500px'",
@@ -280,7 +280,7 @@
           },
           "returns": {
             "type": "String",
-            "__exemption": [ "examples" ]
+            "__exemption": [ "desc", "examples" ]
           },
           "examples": [
             "'my-special-class bg-primary'",

--- a/ui/src/components/tabs/QRouteTab.json
+++ b/ui/src/components/tabs/QRouteTab.json
@@ -24,29 +24,7 @@
         "navigateFn": {
           "type": "Function",
           "desc": "When you need to control the time at which the tab should trigger the route navigation then set 'evt.navigate' to false and call this function; Useful if you have async work to be done before the actual route navigation",
-          "params": {
-            "to": {
-              "type": [ "String", "Object" ],
-              "desc": "Equivalent to Vue Router <router-link> 'to' property",
-              "examples": [
-                "/home/dashboard",
-                "{ name: 'my-route-name' }"
-              ],
-              "default": "Tab's 'to' property"
-            },
-
-            "append": {
-              "type": "Boolean",
-              "desc": "Equivalent to Vue Router <router-link> 'append' property",
-              "default": "Tab's 'append' property"
-            },
-
-            "replace": {
-              "type": "Boolean",
-              "desc": "Equivalent to Vue Router <router-link> 'replace' property",
-              "default": "Tab's 'replace' property"
-            }
-          },
+          "params": null,
           "returns": null
         }
       }

--- a/ui/src/components/uploader/xhr-uploader-plugin.json
+++ b/ui/src/components/uploader/xhr-uploader-plugin.json
@@ -22,6 +22,18 @@
       "type": [ "String", "Function" ],
       "desc": "URL or path to the server which handles the upload. Takes String or factory function, which returns String. Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline",
       "examples": [ "https://example.com/path", "files => `https://example.com?count=${files.length}`" ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "URL or path to the server which handles the upload",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -54,6 +66,18 @@
         "backgroundFile",
         ":field-name=\"(file) => 'background' + file.name\""
       ],
+      "params": {
+        "files": {
+          "type": "File",
+          "desc": "The current file being processed",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "Field name for the current file upload",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -79,6 +103,18 @@
         "() => [{name: 'X-Custom-Timestamp', value: Date.now()}]",
         "files => [{name: 'X-Custom-Count', value: files.length}]"
       ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "An array consists of objects with header definitions",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -104,6 +140,18 @@
         "() => [{name: 'my-field', value: 'my-value'}]",
         "files => [{name: 'my-field', value: 'my-value' + files.length}]"
       ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "An array consists of objects with additional fields definitions (used by Form to be uploaded)",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -111,6 +159,18 @@
       "type": [ "Boolean", "Function" ],
       "desc": "Sets withCredentials to true on the XHR that manages the upload; Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline",
       "examples": [ "with-credentials", ":with-credentials=\"files => ...\"" ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, withCredentials will be set to true on the XHR that manages the upload",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -118,6 +178,18 @@
       "type": [ "Boolean", "Function" ],
       "desc": "Send raw files without wrapping into a Form(); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline",
       "examples": [ "send-raw", ":send-raw=\"files => ...\"" ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, raw files will get sent without wrapping into a Form()",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 
@@ -125,6 +197,18 @@
       "type": [ "Boolean", "Function" ],
       "desc": "Upload files in batch (in one XHR request); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline",
       "examples": [ "files => files.length > 10" ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "Boolean",
+        "desc": "If true, files will be uploaded in a batch (in one XHR request)",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     }
   },

--- a/ui/src/components/uploader/xhr-uploader-plugin.json
+++ b/ui/src/components/uploader/xhr-uploader-plugin.json
@@ -11,7 +11,7 @@
         }
       },
       "returns": {
-        "type": [ "Object", "Promise" ],
+        "type": [ "Object", "Promise<any>" ],
         "desc": "Optional configuration for the upload process; You can override QUploader props in this Object (url, method, headers, formFields, fieldName, withCredentials, sendRaw); Props of these Object can also be Functions with the form of (file[s]) => value",
         "__exemption": [ "examples" ]
       },
@@ -31,6 +31,18 @@
       "desc": "HTTP method to use for upload; Takes String or factory function which returns a String; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline",
       "values": [ "POST", "PUT" ],
       "examples": [ "POST", ":method=\"files => files.length > 10 ? 'POST' : 'PUT'\"" ],
+      "params": {
+        "files": {
+          "type": "Array",
+          "desc": "Uploaded files",
+          "__exemption": [ "examples" ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "HTTP method to use for upload",
+        "__exemption": [ "examples" ]
+      },
       "category": "upload"
     },
 

--- a/ui/src/utils/private/global-dialog.json
+++ b/ui/src/utils/private/global-dialog.json
@@ -35,8 +35,16 @@
                 "type": "Function",
                 "desc": "Tell what to do",
                 "required": true,
-                "params": null,
-                "returns": null
+                "params": {
+                  "payload": {
+                    "type": "Any",
+                    "desc": "The payload if called onDialogOK with the parameter or emitted one with the 'ok' event",
+                    "required": false,
+                    "examples": [ "'Quasar Framework'", "[ 1, 2, 6, 3 ]", "{ book: { id: 1, name: 'Lorem Ipsum' }, user: { name: 'Lorem J. Ipsum', role: 'admin' } }" ]
+                  }
+                },
+                "returns": null,
+                "examples": [ "() => console.log('OK!')", "(payload) => Notify.create({ type: 'positive', message: `Successfully saved '${payload.book.name}' book!` })" ]
               }
             },
             "returns": {

--- a/ui/src/utils/private/web-storage.json
+++ b/ui/src/utils/private/web-storage.json
@@ -118,6 +118,14 @@
           "type": [ "Date", "RegExp", "Number", "Boolean", "Function", "Object", "Array", "String", "null" ],
           "desc": "Entry value",
           "required": true,
+          "params": {
+            "...params": {
+              "type": "Any"
+            }
+          },
+          "returns": {
+            "type": "Any"
+          },
           "examples": [ "john12" ]
         }
       }

--- a/ui/src/utils/private/web-storage.json
+++ b/ui/src/utils/private/web-storage.json
@@ -120,11 +120,13 @@
           "required": true,
           "params": {
             "...params": {
-              "type": "Any"
+              "type": "Any",
+              "__exemption": [ "desc", "examples" ]
             }
           },
           "returns": {
-            "type": "Any"
+            "type": "Any",
+            "__exemption": [ "desc", "examples" ]
           },
           "examples": [ "john12" ]
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Code style update
- Refactor

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch

**Other information:**
Please see commit messages and descriptions for more info.

Notable changes:
 - Updated JSON API definitions of lots of `Function` typed properties
 - We are now generating TS definitions for function typed function parameters(_e.g. callbacks_) and functions in union types(_e.g. props which accepts a value or a function that returns that value_).
 - Return types of some methods had all properties as optional, but they should have been required, they are fixed:
   - `QScrollArea.getScroll`
   - `QScrollArea.getScrollPosition`
   - `QScrollArea.getScrollPercentage`
 - The parameter of `DialogChainObject.update` was optional before, which was wrong, it's now required.

`dist/types/index.d.ts` diff: 
```diff
@@ -408,7 +408,7 @@ export interface LocalStorage {
       | RegExp
       | number
       | boolean
-      | Function
+      | ((...params: any[]) => any)
       | LooseDictionary
       | any[]
       | string
@@ -549,7 +549,7 @@ export interface Notify {
           /**
            * Function to call when notification gets dismissed
            */
-          onDismiss?: Function;
+          onDismiss?: () => void;
           /**
            * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
            */
@@ -564,7 +564,85 @@ export interface Notify {
           ignoreDefaults?: boolean;
         }
       | string
-  ) => Function;
+  ) => (props: {
+    /**
+     * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
+     */
+    type: string;
+    /**
+     * Color name for component from the Quasar Color Palette
+     */
+    color: string;
+    /**
+     * Color name for component from the Quasar Color Palette
+     */
+    textColor: string;
+    /**
+     * The content of your message
+     */
+    message: string;
+    /**
+     * The content of your optional caption
+     */
+    caption: string;
+    /**
+     * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
+     */
+    html: boolean;
+    /**
+     * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix
+     */
+    icon: string;
+    /**
+     * URL to an avatar/image; Suggestion: use statics folder
+     */
+    avatar: string;
+    /**
+     * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
+     */
+    spinner: boolean | Component;
+    /**
+     * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
+     */
+    progress: boolean;
+    /**
+     * Class definitions to be attributed to the progress bar
+     */
+    progressClass: any[] | string | LooseDictionary;
+    /**
+     * Add CSS class(es) to the notification for easier customization
+     */
+    classes: string;
+    /**
+     * Key-value for attributes to be set on the notification
+     */
+    attrs: LooseDictionary;
+    /**
+     * Amount of time to display (in milliseconds)
+     * Default value: 5000
+     */
+    timeout: number;
+    /**
+     * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
+     */
+    actions: any[];
+    /**
+     * Function to call when notification gets dismissed
+     */
+    onDismiss: () => void;
+    /**
+     * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
+     */
+    closeBtn: boolean | string;
+    /**
+     * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
+     */
+    multiLine: boolean;
+    /**
+     * Ignore the default configuration (set by setDefaults()) for this instance only
+     */
+    ignoreDefaults: boolean;
+  }) => void;
   /**
    * Merge options into the default ones
    * @param opts Notification options
@@ -669,7 +747,7 @@ export interface Notify {
     /**
      * Function to call when notification gets dismissed
      */
-    onDismiss?: Function;
+    onDismiss?: () => void;
     /**
      * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
      */
@@ -786,7 +864,7 @@ export interface Notify {
       /**
        * Function to call when notification gets dismissed
        */
-      onDismiss?: Function;
+      onDismiss?: () => void;
       /**
        * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
        */
@@ -1015,7 +1093,7 @@ export interface SessionStorage {
       | RegExp
       | number
       | boolean
-      | Function
+      | ((...params: any[]) => any)
       | LooseDictionary
       | any[]
       | string
@@ -1974,7 +2052,7 @@ export interface QBtnProps {
    * @param evt JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false
    * @param navigateFn When you need to control the time at which the button should trigger the route navigation then set 'evt.navigate' to false and call this function; Useful if you have async work to be done before the actual route navigation
    */
-  onClick?: (evt: LooseDictionary, navigateFn: Function) => void;
+  onClick?: (evt: LooseDictionary, navigateFn: () => void) => void;
 }
 
 export interface QBtnSlots {
@@ -2267,7 +2345,7 @@ export interface QCarouselSlots {
     /**
      * Default trigger when clicked/tapped on
      */
-    onClick: Function;
+    onClick: (evt: LooseDictionary) => void;
   }) => VNode[];
 }
 
@@ -2893,15 +2971,15 @@ export interface QDateProps {
   /**
    * A list of events to highlight on the calendar; If using a function, it receives the date as a String and must return a Boolean (matches or not); If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  events?: any[] | Function | undefined;
+  events?: any[] | ((date: string) => boolean) | undefined;
   /**
    * Color name (from the Quasar Color Palette); If using a function, it receives the date as a String and must return a String (color for the received date); If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  eventColor?: string | Function | undefined;
+  eventColor?: string | ((date: string) => string) | undefined;
   /**
    * Optionally configure the days that are selectable; If using a function, it receives the date as a String and must return a Boolean (is date acceptable or not); If using a function then for best performance, reference it from your scope and do not define it inline; Incompatible with 'range' prop
    */
-  options?: any[] | Function | undefined;
+  options?: any[] | ((date: string) => boolean) | undefined;
   /**
    * Lock user from navigating below a specific year+month (in YYYY/MM format); This prop is not used to correct the model; You might want to also use 'default-year-month' prop
    */
@@ -3523,7 +3601,7 @@ export interface QEditorProps {
         /**
          * Either this or "cmd" is required. Function for when button gets clicked/tapped.
          */
-        handler?: Function;
+        handler?: () => void;
         /**
          * Either this or "handler" is required. This must be a valid execCommand method according to the designMode API.
          */
@@ -3533,9 +3611,9 @@ export interface QEditorProps {
          */
         param?: string;
         /**
-         * Is button disabled? If specifying a function, return a Boolean value.
+         * Is button disabled?
          */
-        disable?: boolean | Function;
+        disable?: boolean | (() => boolean);
         /**
          * Pass the value "no-state" if the button should not have an "active" state
          */
@@ -4356,7 +4434,7 @@ export interface QFieldSlots {
     /**
      * Function that emits an @input event in the context of the field
      */
-    emitValue: Function;
+    emitValue: (value: any) => void;
   }) => VNode[];
   /**
    * undefined
@@ -4417,7 +4495,7 @@ export interface QFileProps {
   /**
    * Custom filter for added files; Only files that pass this filter will be added to the queue and uploaded; For best performance, reference it from your scope and do not define it inline
    */
-  filter?: Function | undefined;
+  filter?: ((files: FileList | any[]) => any[]) | undefined;
   /**
    * Model of the component; Must be FileList or Array if using 'multiple' prop; Either use this property (along with a listener for 'update:modelValue' event) OR use v-model directive
    */
@@ -4577,7 +4655,22 @@ export interface QFileProps {
   /**
    * Label for the counter; The 'counter' prop is necessary to enable this one
    */
-  counterLabel?: Function | undefined;
+  counterLabel?:
+    | ((props: {
+        /**
+         * The total size of files in human readable format
+         */
+        totalSize: string;
+        /**
+         * Number of picked files
+         */
+        filesNumber: number;
+        /**
+         * Maximum number of files (same as 'max-files' prop, if specified); When 'max-files' is not specified, this has 'void 0' as value
+         */
+        maxFiles: number | string;
+      }) => string)
+    | undefined;
   /**
    * Tabindex HTML attribute value
    */
@@ -5098,7 +5191,7 @@ export interface QInfiniteScrollProps {
    * @param index The index parameter can be used to make some sort of pagination on the content you load. It takes numeric values starting with 1 and incrementing with each call
    * @param done Function to call when you made all necessary updates. DO NOT forget to call it otherwise your loading message will continue to be displayed
    */
-  onLoad?: (index: number, done: Function) => void;
+  onLoad?: (index: number, done: (stop: boolean) => void) => void;
 }
 
 export interface QInfiniteScrollSlots {
@@ -6380,7 +6473,7 @@ export interface QPageProps {
    * Override default CSS style applied to the component (sets minHeight); Function(offset: Number) => CSS props/value: Object; For best performance, reference it from your scope and do not define it inline
    * Default value: (see source code)
    */
-  styleFn?: Function | undefined;
+  styleFn?: ((offset: number, height: number) => LooseDictionary) | undefined;
 }
 
 export interface QPageSlots {
@@ -6480,7 +6573,7 @@ export interface QPaginationProps {
   /**
    * Generate link for page buttons; For best performance, reference it from your scope and do not define it inline
    */
-  toFn?: Function | undefined;
+  toFn?: ((page: number) => LooseDictionary | string) | undefined;
   /**
    * Show boundary button links
    */
@@ -6645,7 +6738,7 @@ export interface QPopupEditProps {
   /**
    * Validates model then triggers 'save' and closes Popup; Returns a Boolean ('true' means valid, 'false' means abort); Syntax: validate(value); For best performance, reference it from your scope and do not define it inline
    */
-  validate?: Function | undefined;
+  validate?: ((value: any) => boolean) | undefined;
   /**
    * Put component in disabled mode
    */
@@ -6779,19 +6872,19 @@ export interface QPopupEditSlots {
     /**
      * Function that checks if the value is valid
      */
-    validate: Function;
+    validate: (value: any) => boolean;
     /**
      * Function that sets the value and closes the popup
      */
-    set: Function;
+    set: () => void;
     /**
      * Function that cancels the editing and reverts the value to the initialValue
      */
-    cancel: Function;
+    cancel: () => void;
     /**
      * There are some custom scenarios for which Quasar cannot automatically reposition the component without significant performance drawbacks so the optimal solution is for you to call this method when you need it
      */
-    updatePosition: Function;
+    updatePosition: () => void;
   }) => VNode[];
 }
 
@@ -6924,7 +7017,7 @@ export interface QPullToRefreshProps {
    * Called whenever a refresh is triggered; at this time, your function should load more data
    * @param done Call the done() function when your data has been refreshed
    */
-  onRefresh?: (done: Function) => void;
+  onRefresh?: (done: () => void) => void;
 }
 
 export interface QPullToRefreshSlots {
@@ -7405,35 +7498,35 @@ export interface QScrollArea extends ComponentPublicInstance<QScrollAreaProps> {
     /**
      * Vertical scroll position (in px)
      */
-    verticalPosition?: number;
+    verticalPosition: number;
     /**
      * Vertical scroll percentage (0.0 <= x <= 1.0)
      */
-    verticalPercentage?: number;
+    verticalPercentage: number;
     /**
      * Vertical scroll size (in px)
      */
-    verticalSize?: number;
+    verticalSize: number;
     /**
      * Height of the container (in px)
      */
-    verticalContainerSize?: number;
+    verticalContainerSize: number;
     /**
      * Horizontal scroll position (in px)
      */
-    horizontalPosition?: number;
+    horizontalPosition: number;
     /**
      * Horizontal scroll percentage (0.0 <= x <= 1.0)
      */
-    horizontalPercentage?: number;
+    horizontalPercentage: number;
     /**
      * Horizontal scroll size (in px)
      */
-    horizontalSize?: number;
+    horizontalSize: number;
     /**
      * Width of the container (in px)
      */
-    horizontalContainerSize?: number;
+    horizontalContainerSize: number;
   };
   /**
    * Get current scroll position
@@ -7442,11 +7535,11 @@ export interface QScrollArea extends ComponentPublicInstance<QScrollAreaProps> {
     /**
      * Scroll offset from top (vertical)
      */
-    top?: number;
+    top: number;
     /**
      * Scroll offset from left (horizontal)
      */
-    left?: number;
+    left: number;
   };
   /**
    * Get current scroll position in percentage (0.0 <= x <= 1.0)
@@ -7455,11 +7548,11 @@ export interface QScrollArea extends ComponentPublicInstance<QScrollAreaProps> {
     /**
      * Scroll percentage (0.0 <= x <= 1.0) offset from top (vertical)
      */
-    top?: number;
+    top: number;
     /**
      * Scroll percentage (0.0 <= x <= 1.0) offset from left (horizontal)
      */
-    left?: number;
+    left: number;
   };
   /**
    * Set scroll position to an offset; If a duration (in milliseconds) is specified then the scroll is animated
@@ -7778,17 +7871,26 @@ export interface QSelectProps {
    * Property of option which holds the 'value'; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: value
    */
-  optionValue?: Function | string | undefined;
+  optionValue?:
+    | ((option: string | LooseDictionary) => any)
+    | string
+    | undefined;
   /**
    * Property of option which holds the 'label'; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: label
    */
-  optionLabel?: Function | string | undefined;
+  optionLabel?:
+    | ((option: string | LooseDictionary) => string)
+    | string
+    | undefined;
   /**
    * Property of option which tells it's disabled; The value of the property must be a Boolean; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: disable
    */
-  optionDisable?: Function | string | undefined;
+  optionDisable?:
+    | ((option: string | LooseDictionary) => boolean)
+    | string
+    | undefined;
   /**
    * Hides selection; Use the underlying input tag to hold the label (instead of showing it to the right of the input) of the selected option; Only works for non 'multiple' Selects
    */
@@ -8021,14 +8123,24 @@ export interface QSelectProps {
    * @param inputValue What the user typed
    * @param doneFn Adds (optional) value to the model; Do not forget to call it after you validate the newly created value; Call it with no parameters if nothing should be added
    */
-  onNewValue?: (inputValue: string, doneFn: Function) => void;
+  onNewValue?: (
+    inputValue: string,
+    doneFn: (item: any, mode: "add" | "add-unique" | "toggle") => void
+  ) => void;
   /**
    * Emitted when user wants to filter a value
    * @param inputValue What the user typed
    * @param doneFn Supply a function which makes the necessary updates
    * @param abortFn Call this function if something went wrong
    */
-  onFilter?: (inputValue: string, doneFn: Function, abortFn: Function) => void;
+  onFilter?: (
+    inputValue: string,
+    doneFn: (
+      callbackFn: () => void,
+      afterFn: (ref: LooseDictionary) => void
+    ) => void,
+    abortFn: () => void
+  ) => void;
   /**
    * Emitted when a filtering was aborted; Probably a new one was requested?
    */
@@ -8128,11 +8240,11 @@ export interface QSelectSlots {
     /**
      * Remove selected option located at specific index
      */
-    removeAtIndex: Function;
+    removeAtIndex: (index: number) => void;
     /**
      * Add/remove option from model
      */
-    toggleOption: Function;
+    toggleOption: (opt: any) => void;
     /**
      * Tabindex HTML attribute value associated with respective option
      */
@@ -8162,11 +8274,11 @@ export interface QSelectSlots {
     /**
      * Add/remove option from model
      */
-    toggleOption: Function;
+    toggleOption: (opt: any) => void;
     /**
      * Sets option from menu as 'focused'
      */
-    setOptionIndex: Function;
+    setOptionIndex: (index: number) => void;
     /**
      * Computed properties passed down to QItem
      */
@@ -8440,7 +8552,7 @@ export interface QSlideItemProps {
     /**
      * When called, it resets the component to its initial non-slided state
      */
-    reset: Function;
+    reset: () => void;
   }) => void;
   /**
    * Emitted when user finished sliding the item to the right
@@ -8450,7 +8562,7 @@ export interface QSlideItemProps {
     /**
      * When called, it resets the component to its initial non-slided state
      */
-    reset: Function;
+    reset: () => void;
   }) => void;
   /**
    * Emitted when user finished sliding the item up
@@ -8460,7 +8572,7 @@ export interface QSlideItemProps {
     /**
      * When called, it resets the component to its initial non-slided state
      */
-    reset: Function;
+    reset: () => void;
   }) => void;
   /**
    * Emitted when user finished sliding the item down
@@ -8470,7 +8582,7 @@ export interface QSlideItemProps {
     /**
      * When called, it resets the component to its initial non-slided state
      */
-    reset: Function;
+    reset: () => void;
   }) => void;
   /**
    * Emitted while user is sliding the item to one of the available sides
@@ -8502,7 +8614,7 @@ export interface QSlideItemProps {
     /**
      * When called, it resets the component to its initial non-slided state
      */
-    reset: Function;
+    reset: () => void;
   }) => void;
 }
 
@@ -9524,7 +9636,7 @@ export interface QTableProps {
    * Property of each row that defines the unique key of each row (the result must be a primitive, not Object, Array, etc); The value of property must be string or a function taking a row and returning the desired (nested) key in the row; If supplying a function then for best performance, reference it from your scope and do not define it inline
    * Default value: id
    */
-  rowKey?: string | Function | undefined;
+  rowKey?: string | (() => void) | undefined;
   /**
    * Display data using QVirtualScroll (for non-grid mode only)
    */
@@ -9612,7 +9724,7 @@ export interface QTableProps {
         /**
          * Row Object property to determine value for this column or function which maps to the required property
          */
-        field: string | Function;
+        field: string | (() => void);
         /**
          * If we use visible-columns, this col will always be visible
          */
@@ -9629,7 +9741,12 @@ export interface QTableProps {
         /**
          * Compare function if you have some custom data or want a specific way to compare two rows
          */
-        sort?: Function;
+        sort?: (
+          a: any,
+          b: any,
+          rowA: LooseDictionary,
+          rowB: LooseDictionary
+        ) => number;
         /**
          * Set column sort order: 'ad' (ascending-descending) or 'da' (descending-ascending); Overrides the 'column-sort-order' prop
          * Default value: ad
@@ -9638,15 +9755,15 @@ export interface QTableProps {
         /**
          * Function you can apply to format your data
          */
-        format?: Function;
+        format?: (val: any, row: LooseDictionary) => any;
         /**
          * Style to apply on normal cells of the column
          */
-        style?: string | Function;
+        style?: string | (() => void);
         /**
          * Classes to add on normal cells of the column
          */
-        classes?: string | Function;
+        classes?: string | (() => void);
         /**
          * Style to apply on header cells of the column
          */
@@ -9738,7 +9855,7 @@ export interface QTableProps {
   /**
    * Text to display when user selected at least one row; For best performance, reference it from your scope and do not define it inline
    */
-  selectedRowsLabel?: Function | undefined;
+  selectedRowsLabel?: ((numberOfRows: number) => string) | undefined;
   /**
    * Text to override default rows per page label at bottom of table
    */
@@ -9746,7 +9863,13 @@ export interface QTableProps {
   /**
    * Text to override default pagination label at bottom of table (unless 'pagination' scoped slot is used); For best performance, reference it from your scope and do not define it inline
    */
-  paginationLabel?: Function | undefined;
+  paginationLabel?:
+    | ((
+        firstRowIndex: number,
+        endRowIndex: number,
+        totalRowsNumber: number
+      ) => string)
+    | undefined;
   /**
    * CSS style to apply to native HTML <table> element's wrapper (which is a DIV)
    */
@@ -9791,7 +9914,14 @@ export interface QTableProps {
    * The actual filtering mechanism; For best performance, reference it from your scope and do not define it inline
    * Default value: (see source code)
    */
-  filterMethod?: Function | undefined;
+  filterMethod?:
+    | ((
+        rows: any[],
+        terms: string | LooseDictionary,
+        cols: any[],
+        getCellValue: (col: LooseDictionary, row: LooseDictionary) => any
+      ) => any[])
+    | undefined;
   /**
    * Pagination object; You can also use the 'v-model:pagination' for synching; When not synching it simply initializes the pagination on first render
    */
@@ -9843,7 +9973,9 @@ export interface QTableProps {
    * The actual sort mechanism. Function (rows, sortBy, descending) => sorted rows; For best performance, reference it from your scope and do not define it inline
    * Default value: (see source code)
    */
-  sortMethod?: Function | undefined;
+  sortMethod?:
+    | ((rows: any[], sortBy: string, descending: boolean) => any[])
+    | undefined;
   /**
    * Emitted when user clicks/taps on a row; Is not emitted when using body/row/item scoped slots
    * @param evt JS event object
@@ -9906,11 +10038,16 @@ export interface QTableProps {
     /**
      * Filter method (the 'filter-method' prop)
      */
-    filter: Function;
+    filter: (
+      rows: any[],
+      terms: string | LooseDictionary,
+      cols: any[],
+      getCellValue: (col: LooseDictionary, row: LooseDictionary) => any
+    ) => any[];
     /**
      * Optional function to get a cell value
      */
-    getCellValue: Function;
+    getCellValue: (col: LooseDictionary, row: LooseDictionary) => any;
   }) => void;
   /**
    * Emitted when user selects/unselects row(s)
@@ -10027,7 +10164,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row/item selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10082,7 +10219,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10149,7 +10286,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10212,7 +10349,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10251,7 +10388,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10302,7 +10439,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10345,7 +10482,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10400,7 +10537,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10439,7 +10576,7 @@ export interface QTableSlots {
     /**
      * Trigger a table sort
      */
-    sort: Function;
+    sort: (col: string | LooseDictionary) => void;
     /**
      * (Only if using selection) Is row selected? Can directly be assigned new Boolean value which changes selection state
      */
@@ -10523,19 +10660,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10543,7 +10680,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to define how table bottom looks like
@@ -10586,19 +10723,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10606,7 +10743,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to override default pagination label and buttons
@@ -10649,19 +10786,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10669,7 +10806,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to define how left part of the table top looks like
@@ -10712,19 +10849,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10732,7 +10869,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to define how right part of the table top looks like
@@ -10775,19 +10912,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10795,7 +10932,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to define how top table section looks like when user has selected at least one row
@@ -10838,19 +10975,19 @@ export interface QTableSlots {
     /**
      * Navigates to first page
      */
-    firstPage: Function;
+    firstPage: () => void;
     /**
      * Navigates to previous page, if available
      */
-    prevPage: Function;
+    prevPage: () => void;
     /**
      * Navigates to next page, if available
      */
-    nextPage: Function;
+    nextPage: () => void;
     /**
      * Navigates to last page
      */
-    lastPage: Function;
+    lastPage: () => void;
     /**
      * Is table in fullscreen mode?
      */
@@ -10858,7 +10995,7 @@ export interface QTableSlots {
     /**
      * Toggles fullscreen mode
      */
-    toggleFullscreen: Function;
+    toggleFullscreen: () => void;
   }) => VNode[];
   /**
    * Slot to define how the bottom will look like when is nothing to display
@@ -10918,7 +11055,12 @@ export interface QTable extends ComponentPublicInstance<QTableProps> {
     /**
      * Filtering method (the 'filter-method' prop)
      */
-    filter?: Function;
+    filter?: (
+      rows: any[],
+      terms: string | LooseDictionary,
+      cols: any[],
+      getCellValue: (col: LooseDictionary, row: LooseDictionary) => any
+    ) => any[];
   }) => void;
   /**
    * Unless using an external pagination Object (through 'v-model:pagination' prop), you can use this method and force the internal pagination to change
@@ -11141,7 +11283,14 @@ export interface QRouteTabProps {
    * @param evt JS event object; If you want to cancel navigation set synchronously 'evt.navigate' to false
    * @param navigateFn When you need to control the time at which the tab should trigger the route navigation then set 'evt.navigate' to false and call this function; Useful if you have async work to be done before the actual route navigation
    */
-  onClick?: (evt: LooseDictionary, navigateFn: Function) => void;
+  onClick?: (
+    evt: LooseDictionary,
+    navigateFn: (
+      to: string | LooseDictionary,
+      append: boolean,
+      replace: boolean
+    ) => void
+  ) => void;
 }
 
 export interface QRouteTabSlots {
@@ -11397,7 +11546,7 @@ export interface QTimeProps {
   /**
    * Optionally configure what time is the user allowed to set; Overridden by 'hour-options', 'minute-options' and 'second-options' if those are set; For best performance, reference it from your scope and do not define it inline
    */
-  options?: Function | undefined;
+  options?: ((hr: number, min: number, sec: number) => void) | undefined;
   /**
    * Optionally configure what hours is the user allowed to set; Overrides 'options' prop if that is also set
    */
@@ -11943,7 +12092,9 @@ export interface QTreeProps {
    * The function to use to filter the tree nodes; For best performance, reference it from your scope and do not define it inline
    * Default value: (see source code)
    */
-  filterMethod?: Function | undefined;
+  filterMethod?:
+    | ((node: LooseDictionary, filter: string) => boolean)
+    | undefined;
   /**
    * Toggle animation duration (in milliseconds)
    * Default value: 300
@@ -11978,11 +12129,11 @@ export interface QTreeProps {
     /**
      * The callback to be carried out when the loading is successful
      */
-    done: Function;
+    done: (children: any[]) => void;
     /**
      * The callback to be carried out should the loading fails
      */
-    fail: Function;
+    fail: () => void;
   }) => void;
   /**
    * Emitted when nodes are ticked/unticked via the checkbox; Used by Vue on 'v-model:ticked' to update its value
@@ -12198,21 +12349,21 @@ export interface QUploaderProps {
   /**
    * Function which should return an Object or a Promise resolving with an Object; For best performance, reference it from your scope and do not define it inline
    */
-  factory?: Function | undefined;
+  factory?: ((files: any[]) => LooseDictionary | Promise<any>) | undefined;
   /**
    * URL or path to the server which handles the upload. Takes String or factory function, which returns String. Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  url?: string | Function | undefined;
+  url?: string | (() => void) | undefined;
   /**
    * HTTP method to use for upload; Takes String or factory function which returns a String; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: POST
    */
-  method?: "POST" | "PUT" | Function | undefined;
+  method?: "POST" | "PUT" | ((files: any[]) => string) | undefined;
   /**
    * Field name for each file upload; This goes into the following header: 'Content-Disposition: form-data; name="__HERE__"; filename="somefile.png"; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: (file) => file.name
    */
-  fieldName?: string | Function | undefined;
+  fieldName?: string | (() => void) | undefined;
   /**
    * Array or a factory function which returns an array; Array consists of objects with header definitions; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    */
@@ -12227,7 +12378,7 @@ export interface QUploaderProps {
          */
         value: string;
       }[]
-    | Function
+    | (() => void)
     | undefined;
   /**
    * Array or a factory function which returns an array; Array consists of objects with additional fields definitions (used by Form to be uploaded); Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
@@ -12243,20 +12394,20 @@ export interface QUploaderProps {
          */
         value: string;
       }[]
-    | Function
+    | (() => void)
     | undefined;
   /**
    * Sets withCredentials to true on the XHR that manages the upload; Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  withCredentials?: boolean | Function | undefined;
+  withCredentials?: boolean | (() => void) | undefined;
   /**
    * Send raw files without wrapping into a Form(); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  sendRaw?: boolean | Function | undefined;
+  sendRaw?: boolean | (() => void) | undefined;
   /**
    * Upload files in batch (in one XHR request); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    */
-  batch?: boolean | Function | undefined;
+  batch?: boolean | (() => void) | undefined;
   /**
    * Allow multiple file uploads
    */
@@ -12284,7 +12435,7 @@ export interface QUploaderProps {
   /**
    * Custom filter for added files; Only files that pass this filter will be added to the queue and uploaded; For best performance, reference it from your scope and do not define it inline
    */
-  filter?: Function | undefined;
+  filter?: ((files: FileList | any[]) => any[]) | undefined;
   /**
    * Label for the uploader
    */
@@ -12534,7 +12685,7 @@ export interface QVirtualScrollProps {
   /**
    * Function to return the scope for the items to be displayed; Should return an array for items starting from 'from' index for size length; For best performance, reference it from your scope and do not define it inline
    */
-  itemsFn?: Function | undefined;
+  itemsFn?: ((from: number, size: number) => any[]) | undefined;
   /**
    * CSS selector or DOM element to be used as a custom scroll container instead of the auto detected one
    */
@@ -12626,19 +12777,19 @@ export interface DialogChainObject {
    * @param callbackFn Tell what to do
    * @returns Chained Object
    */
-  onOk: (callbackFn: Function) => DialogChainObject;
+  onOk: (callbackFn: (payload: any) => void) => DialogChainObject;
   /**
    * Receives a Function as param to tell what to do when Cancel is pressed / dialog is dismissed
    * @param callbackFn Tell what to do
    * @returns Chained Object
    */
-  onCancel: (callbackFn: Function) => DialogChainObject;
+  onCancel: (callbackFn: () => void) => DialogChainObject;
   /**
    * Receives a Function param to tell what to do when the dialog is closed
    * @param callbackFn Tell what to do
    * @returns Chained Object
    */
-  onDismiss: (callbackFn: Function) => DialogChainObject;
+  onDismiss: (callbackFn: () => void) => DialogChainObject;
   /**
    * Hides the dialog when called
    * @returns Chained Object
@@ -12649,7 +12800,7 @@ export interface DialogChainObject {
    * @param opts Props (except 'component') which will overwrite the initial create() params; If create() was invoked with a custom dialog component then this param should contain the new componentProps
    * @returns Chained Object
    */
-  update: (opts?: LooseDictionary) => DialogChainObject;
+  update: (opts: LooseDictionary) => DialogChainObject;
 }
 
 import { CookiesGetMethodType } from "./api";
@@ -12695,7 +12846,7 @@ export interface QDialogOptions {
     /**
      * Is typed content valid?
      */
-    isValid?: Function;
+    isValid?: (val: string) => boolean;
     /**
      * Attributes to pass to prompt control
      */
@@ -12765,7 +12916,7 @@ export interface QDialogOptions {
     /**
      * Is the model valid?
      */
-    isValid?: Function;
+    isValid?: (model: string | any[]) => boolean;
   };
   /**
    * Display a Quasar spinner (if value is true, then the defaults are used); Useful for conveying the idea that something is happening behind the covers; Tip: use along with persistent, ok: false and update() method
@@ -12785,21 +12936,11 @@ export interface QDialogOptions {
   /**
    * Props for an 'OK' button
    */
-  ok?:
-    | string
-    | {
-        [index: string]: any;
-      }
-    | boolean;
+  ok?: string | { [index: string]: any } | boolean;
   /**
    * Props for a 'CANCEL' button
    */
-  cancel?:
-    | string
-    | {
-        [index: string]: any;
-      }
-    | boolean;
+  cancel?: string | { [index: string]: any } | boolean;
   /**
    * What button to focus, unless you also have 'prompt' or 'options'
    * Default value: ok
@@ -13073,7 +13214,7 @@ declare module "./globals" {
             /**
              * Function to call when notification gets dismissed
              */
-            onDismiss?: Function;
+            onDismiss?: () => void;
             /**
              * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
              */
@@ -13088,7 +13229,85 @@ declare module "./globals" {
             ignoreDefaults?: boolean;
           }
         | string
-    ) => Function;
+    ) => (props: {
+      /**
+       * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
+       */
+      type: string;
+      /**
+       * Color name for component from the Quasar Color Palette
+       */
+      color: string;
+      /**
+       * Color name for component from the Quasar Color Palette
+       */
+      textColor: string;
+      /**
+       * The content of your message
+       */
+      message: string;
+      /**
+       * The content of your optional caption
+       */
+      caption: string;
+      /**
+       * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
+       */
+      html: boolean;
+      /**
+       * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix
+       */
+      icon: string;
+      /**
+       * URL to an avatar/image; Suggestion: use statics folder
+       */
+      avatar: string;
+      /**
+       * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
+       */
+      spinner: boolean | Component;
+      /**
+       * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
+       */
+      progress: boolean;
+      /**
+       * Class definitions to be attributed to the progress bar
+       */
+      progressClass: any[] | string | LooseDictionary;
+      /**
+       * Add CSS class(es) to the notification for easier customization
+       */
+      classes: string;
+      /**
+       * Key-value for attributes to be set on the notification
+       */
+      attrs: LooseDictionary;
+      /**
+       * Amount of time to display (in milliseconds)
+       * Default value: 5000
+       */
+      timeout: number;
+      /**
+       * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
+       */
+      actions: any[];
+      /**
+       * Function to call when notification gets dismissed
+       */
+      onDismiss: () => void;
+      /**
+       * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
+       */
+      closeBtn: boolean | string;
+      /**
+       * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
+       */
+      multiLine: boolean;
+      /**
+       * Ignore the default configuration (set by setDefaults()) for this instance only
+       */
+      ignoreDefaults: boolean;
+    }) => void;
     platform: Platform;
     screen: Screen;
     sessionStorage: SessionStorage;

```