### PR TITLE
chore(vite-plugin): Add type for transformAssetUrls

### DIFF
--- a/vite-plugin/index.d.ts
+++ b/vite-plugin/index.d.ts
@@ -32,10 +32,24 @@ export interface QuasarPluginOpts {
 
 export function quasar(opts?: QuasarPluginOpts): Plugin;
 
-export interface TransformAssetUrls {
-  base: unknown;
-  includeAbsolute: boolean;
-  tags: Record<string, string | string[]>;
+// `TransformAssetUrls` copy of https://github.com/vuejs/vue-next/blob/2c221fcd497d1541e667892ed908631df7e4a745/packages/compiler-sfc/src/compileTemplate.ts#L67
+export interface AssetURLTagConfig {
+  [name: string]: string[];
 }
 
-export const transformAssetUrls: TransformAssetUrls;
+export interface AssetURLOptions {
+  /**
+   * If base is provided, instead of transforming relative asset urls into
+   * imports, they will be directly rewritten to absolute urls.
+   */
+  base?: string | null;
+  /**
+   * If true, also processes absolute urls.
+   */
+  includeAbsolute?: boolean;
+  tags?: AssetURLTagConfig;
+}
+
+export type TransformAssetUrls = AssetURLOptions | AssetURLTagConfig | boolean;
+
+export const transformAssetUrls: AssetURLOptions;

--- a/vite-plugin/index.d.ts
+++ b/vite-plugin/index.d.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
 /// <reference types="@quasar/vite-plugin" />
 
-import type { Plugin } from 'vite'
+import type { Plugin } from "vite";
 
-interface QuasarPluginOpts {
+export interface QuasarPluginOpts {
   /**
    * Auto import - how to detect components in your vue files
    *   "kebab": q-carousel q-page
@@ -30,6 +30,12 @@ interface QuasarPluginOpts {
   // runMode?: "web-client" | "ssr-client" | "ssr-server";
 }
 
-export function quasar(
-  opts?: QuasarPluginOpts
-): Plugin;
+export function quasar(opts?: QuasarPluginOpts): Plugin;
+
+export interface TransformAssetUrls {
+  base: unknown;
+  includeAbsolute: boolean;
+  tags: Record<string, string | string[]>;
+}
+
+export const transformAssetUrls: TransformAssetUrls;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The example https://quasar.dev/start/vite-plugin#using-quasar shows that we should use `vue({ template: { transformAssetUrls } })`, but when using `vite.config.ts` we cannot access `transformAssetUrls` without getting an error.