### PR TITLE
build(types): Improve type generation build script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ $ yarn dev [theme] # or: npm run dev [theme]
 $ yarn build      # or: npm run build
 # build only js dist files
 $ yarn build js   # or: npm run build js
+# build only type related files
+$ yarn build js types  # or: npm run build js types
 # build only css dist files
 $ yarn build css  # or: npm run build css
 
@@ -99,6 +101,8 @@ $ yarn lint # or: npm run lint
 - **`icon-set`**: Quasar icon sets
 
 - **`dist`**: contains built files for distribution (only after a build). Note this directory is only updated when a release happens; they do not reflect the latest changes in development branches.
+
+- **`types`**: contains Typescript related files. Used by `build/script.types.js` along with JSON API files to produce final Typescript type declarations.
 
 - **`dev`**: app with Quasar sources linked directly used for testing purposes. Each feature/component has its own `*.vue` file. Adding a new file automatically creates a route for it and adds it to the "homepage" list (based on the file name).
 

--- a/ui/build/script.build.javascript.js
+++ b/ui/build/script.build.javascript.js
@@ -298,7 +298,20 @@ function buildEntry (config) {
     })
 }
 
-module.exports = function () {
+module.exports = async function (subtype) {
+  if (subtype === 'types') {
+    const data = await require('./build.api').generate()
+
+    require('./build.vetur').generate(data)
+    require('./build.web-types').generate(data)
+
+    // 'types' depends on 'lang-index'
+    await require('./build.lang-index').generate()
+    require('./build.types').generate(data)
+
+    return
+  }
+
   require('./build.lang-index').generate()
     .then(() => require('./build.svg-icon-sets').generate())
     .then(() => require('./build.api').generate())

--- a/ui/build/script.build.js
+++ b/ui/build/script.build.js
@@ -1,6 +1,7 @@
 process.env.NODE_ENV = 'production'
 
 const type = process.argv[ 2 ]
+const subtype = process.argv[ 3 ]
 const { createFolder } = require('./build.utils')
 const { green } = require('chalk')
 
@@ -30,7 +31,7 @@ if (!type || type === 'js') {
   createFolder('dist/types')
   createFolder('dist/ssr-directives')
 
-  require('./script.build.javascript')()
+  require('./script.build.javascript')(subtype)
 }
 
 if (!type || type === 'css') {

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,6 +67,8 @@
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.3.3",
     "babel-preset-es2015-rollup": "^3.0.0",
+    "cli-highlight": "^2.1.11",
+    "diff": "^5.0.0",
     "eslint": "^7.4.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-friendly-formatter": "^4.0.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Build-related changes

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch

**Other information:**

When working with only the `build.types.js` file or JSON API files, it's extremely annoying to wait, even with a JS-only build. So, I added another parameter to the build script that allows building only the type-related files. This change reduced the build time from ~20s to ~3s on my machine.

Also, I added a diff-checking logic to output the diff of specific files. I used that for the `dist/types/index.d.ts` file on the types-only build. When working with types, it's extremely useful to see the impact on the generated types when updating JSON API files or `build.types.js`. 

**Before:**
![image](https://user-images.githubusercontent.com/6266078/140888418-48a37b73-c3e0-49a3-81e2-0f1be77dd2d7.png)

**After(with no changes):**
![image](https://user-images.githubusercontent.com/6266078/140886466-4419b7e2-1734-4ff5-b014-138cae029675.png)

**After(with changes):**
![image](https://user-images.githubusercontent.com/6266078/140886568-072a52c6-9fa3-448a-bf8b-95de213c0f14.png)