### PR TITLE
Removed unnecessary console statements

### DIFF
--- a/ui/dev/src/pages/components/infinite-scroll.vue
+++ b/ui/dev/src/pages/components/infinite-scroll.vue
@@ -93,7 +93,6 @@ export default {
   },
   methods: {
     loadReverse (index, done) {
-      console.log('load reverse called', index)
       setTimeout(() => {
         this.itemsReverse.splice(0, 0, {}, {}, {}, {}, {}, {}, {})
         done()
@@ -101,7 +100,6 @@ export default {
     },
 
     loadRef (index, done) {
-      console.log('load ref called', index)
       setTimeout(() => {
         this.itemsRef.push({}, {}, {}, {}, {}, {}, {})
         done()
@@ -109,7 +107,6 @@ export default {
     },
 
     loadId (index, done) {
-      console.log('load id called', index)
       setTimeout(() => {
         this.itemsId.push({}, {}, {}, {}, {}, {}, {})
         done()


### PR DESCRIPTION
Left here as part of the `QInfinteScroll` commit
[fix(QInfiniteScroll): loading slot after "done(true)" doesn't disappear](https://github.com/quasarframework/quasar/commit/ea0cb5434bdd92f9a11e9ef574464ab2d757f063)