### PR TITLE
fix(ui): QSelect missing classes that show up as "[object Object]"

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -1173,7 +1173,7 @@ export default createComponent({
     function getDialog () {
       const content = [
         h(QField, {
-          class: `col-auto ${ state.fieldClass }`,
+          class: `col-auto ${ state.fieldClass.value }`,
           ...innerFieldProps.value,
           for: state.targetUid.value,
           dark: isOptionsDark.value,

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -194,7 +194,7 @@ export default function (state) {
 
   const classes = computed(() =>
     `q-field row no-wrap items-start q-field--${ styleType.value }`
-    + (state.fieldClass.value !== void 0 ? ` ${ state.fieldClass.value }` : '')
+    + (state.fieldClass?.value !== void 0 ? ` ${ state.fieldClass.value }` : '')
     + (props.rounded === true ? ' q-field--rounded' : '')
     + (props.square === true ? ' q-field--square' : '')
     + (floatingLabel.value === true ? ' q-field--float' : '')

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -194,7 +194,7 @@ export default function (state) {
 
   const classes = computed(() =>
     `q-field row no-wrap items-start q-field--${ styleType.value }`
-    + (state.fieldClass !== void 0 ? ` ${ state.fieldClass.value }` : '')
+    + (state.fieldClass.value !== void 0 ? ` ${ state.fieldClass.value }` : '')
     + (props.rounded === true ? ' q-field--rounded' : '')
     + (props.square === true ? ' q-field--square' : '')
     + (floatingLabel.value === true ? ' q-field--float' : '')

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -194,7 +194,7 @@ export default function (state) {
 
   const classes = computed(() =>
     `q-field row no-wrap items-start q-field--${ styleType.value }`
-    + (state.fieldClass?.value !== void 0 ? ` ${ state.fieldClass.value }` : '')
+    + (state.fieldClass !== void 0 ? ` ${ state.fieldClass.value }` : '')
     + (props.rounded === true ? ' q-field--rounded' : '')
     + (props.square === true ? ' q-field--square' : '')
     + (floatingLabel.value === true ? ' q-field--float' : '')


### PR DESCRIPTION
QSelect is missing many classes that come from `computed`:

**missing:**

```js
      fieldClass: computed(() =>
        `q-select q-field--auto-height q-select--with${ props.useInput !== true ? 'out' : '' }-input`
        + ` q-select--with${ props.useChips !== true ? 'out' : '' }-chips`
        + ` q-select--${ props.multiple === true ? 'multiple' : 'single' }`
      ),
```