### PR TITLE
fix(ui): select clearable is not working (on a dialog) (#11297)

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -75,7 +75,7 @@ export default createComponent({
 
     const onEvents = computed(() => {
       const evt = {
-        ...state.splitAttrs.listeners.value,
+        ...state.listeners.value,
         onInput,
         onPaste,
         // Safari < 10.2 & UIWebView doesn't fire compositionend when

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -1182,7 +1182,7 @@ export default createComponent({
           itemAligned: false,
           filled: true,
           stackLabel: inputValue.value.length > 0,
-          ...state.splitAttrs.listeners.value,
+          ...state.listeners.value,
           onFocus: onDialogFieldFocus,
           onBlur: onDialogFieldBlur
         }, {

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -8,6 +8,7 @@ import QSpinner from '../../components/spinner/QSpinner.js'
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
 import useValidate, { useValidateProps } from './use-validate.js'
 import useSplitAttrs from './use-split-attrs.js'
+import useListeners from './use-listeners.js'
 
 import { hSlot } from '../../utils/private/render.js'
 import uid from '../../utils/uid.js'
@@ -75,7 +76,7 @@ export const useFieldProps = {
 export const useFieldEmits = [ 'update:modelValue', 'clear', 'focus', 'blur', 'popup-show', 'popup-hide' ]
 
 export function useFieldState () {
-  const { props, attrs, proxy } = getCurrentInstance()
+  const { props, attrs, proxy, vnode } = getCurrentInstance()
 
   const isDark = useDark(props, proxy.$q)
 
@@ -91,6 +92,7 @@ export function useFieldState () {
     hasPopupOpen: false,
 
     splitAttrs: useSplitAttrs(attrs),
+    listeners: useListeners(vnode.props),
     targetUid: ref(getTargetUid(props.for)),
 
     rootRef: ref(null),

--- a/ui/src/composables/private/use-listeners.js
+++ b/ui/src/composables/private/use-listeners.js
@@ -1,0 +1,25 @@
+import { ref, onBeforeUpdate } from 'vue'
+
+const listenerRE = /^on[A-Z]/
+
+export default function (vnodeProps) {
+  const listeners = ref({})
+
+  function update () {
+    const items = {}
+
+    Object.keys(vnodeProps).forEach(key => {
+      if (listenerRE.test(key) === true) {
+        items[ key ] = vnodeProps[ key ]
+      }
+    })
+
+    listeners.value = items
+  }
+
+  onBeforeUpdate(update)
+
+  update()
+
+  return listeners
+}


### PR DESCRIPTION
The "state.splitAttrs.listeners.value" does not contain the listeners (like it used too. Did Vue make some undocumented changes?) as expected. I added a composable, "use-listeners.js" (quasar had something similar at start of v2). Anyway, it all works now - in a dialog/menu, or stand-alone desktop web page. I create a "dev/select-mobile" for testing this functionality. You can test before the merge to verify (it's already in dev) 
