### PR TITLE
Added QIcon support for Loading plugin

### DIFF
--- a/ui/src/plugins/Loading.js
+++ b/ui/src/plugins/Loading.js
@@ -21,7 +21,7 @@ const originalDefaults = {
   spinnerSize: 80,
   spinnerColor: '',
   iconName: undefined,
-  iconSize: 'lg',
+  iconSize: 80,
   iconColor: '',
   messageColor: '',
   backgroundColor: '',

--- a/ui/src/plugins/Loading.js
+++ b/ui/src/plugins/Loading.js
@@ -1,6 +1,7 @@
 import { h, createApp, Transition, onMounted } from 'vue'
 
 import QSpinner from '../components/spinner/QSpinner.js'
+import QIcon from '../components/icon/QIcon.js'
 
 import defineReactivePlugin from '../utils/private/define-reactive-plugin.js'
 import { createGlobalNode, removeGlobalNode } from '../utils/private/global-nodes.js'
@@ -19,6 +20,9 @@ const originalDefaults = {
   html: false,
   spinnerSize: 80,
   spinnerColor: '',
+  iconName: undefined,
+  iconSize: 'lg',
+  iconColor: '',
   messageColor: '',
   backgroundColor: '',
   boxClass: '',
@@ -80,11 +84,17 @@ const Plugin = defineReactivePlugin({
             }
 
             const content = [
-              h(props.spinner, {
-                class: 'q-loading__spinner',
-                color: props.spinnerColor,
-                size: props.spinnerSize
-              })
+              props.iconName
+              ? h(QIcon, {
+                  name: props.iconName,
+                  color: props.iconColor,
+                  size: props.iconSize
+                })
+              : h(props.spinner, {
+                  class: 'q-loading__spinner',
+                  color: props.spinnerColor,
+                  size: props.spinnerSize
+                })
             ]
 
             props.message && content.push(

--- a/ui/src/plugins/Loading.json
+++ b/ui/src/plugins/Loading.json
@@ -36,6 +36,20 @@
         "extends": "color",
         "desc": "Color name for spinner from the Quasar Color Palette"
       },
+      "iconName": {
+        "type": "String",
+        "desc": "Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix",
+        "examples": [ "map", "ion-add" ]
+      },
+      "iconSize": {
+        "type": "Number",
+        "desc": "Icon size (in pixels)",
+        "examples": [ 60 ]
+      },
+      "iconColor": {
+        "extends": "color",
+        "desc": "Color name for icon from the Quasar Color Palette"
+      },
       "messageColor": {
         "extends": "color",
         "desc": "Color name for text from the Quasar Color Palette"
@@ -101,6 +115,20 @@
               "extends": "color",
               "desc": "Color name for spinner from the Quasar Color Palette"
             },
+            "iconName": {
+              "type": "Number",
+              "desc": "Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix",
+              "examples": [ "map", "ion-add" ]
+            },
+            "iconSize": {
+              "type": "Number",
+              "desc": "Icon size (in pixels)",
+              "examples": [ 60 ]
+            },
+            "iconColor": {
+              "extends": "color",
+              "desc": "Color name for icon from the Quasar Color Palette"
+            },
             "messageColor": {
               "extends": "color",
               "desc": "Color name for text from the Quasar Color Palette"
@@ -157,6 +185,20 @@
             "spinnerColor": {
               "extends": "color",
               "desc": "Color name for spinner from the Quasar Color Palette"
+            },
+            "iconName": {
+              "type": "Number",
+              "desc": "Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix",
+              "examples": [ "map", "ion-add" ]
+            },
+            "iconSize": {
+              "type": "Number",
+              "desc": "Icon size (in pixels)",
+              "examples": [ 60 ]
+            },
+            "iconColor": {
+              "extends": "color",
+              "desc": "Color name for icon from the Quasar Color Palette"
             },
             "messageColor": {
               "extends": "color",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
I added support for using `QIcon` components in the `Loading` plugin. It's a small change that still uses the default flow of a spinner as the component if an icon is not provided. I came across a use case where having an icon instead of a spinner was more beneficial.