### PR TITLE
feat(ts/Cookies): Improve Cookies plugin types (fix: #8642)

### DIFF
--- a/ui/src/plugins/Cookies.json
+++ b/ui/src/plugins/Cookies.json
@@ -73,8 +73,8 @@
             },
             "sameSite": {
               "type": "String",
-              "desc": "SameSite cookie option (not supported by IE11)",
-              "examples": [ "Strict", "Lax" ]
+              "desc": "SameSite cookie option",
+              "values": [ "Lax", "Strict", "None" ]
             },
             "httpOnly": {
               "type": "Boolean",

--- a/ui/types/api/cookies.d.ts
+++ b/ui/types/api/cookies.d.ts
@@ -1,1 +1,1 @@
-export type CookiesGetMethodType = <T = string>(name: string) => T | null;
+export type CookiesGetMethodType = <T = string | null>(name: string) => T;

--- a/ui/types/api/cookies.d.ts
+++ b/ui/types/api/cookies.d.ts
@@ -1,1 +1,1 @@
-export type CookiesGetMethodType = <T = string>(name: string) => T;
+export type CookiesGetMethodType = <T = string>(name: string) => T | null;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- Feature

**Does this PR introduce a breaking change?**

- Yesn't (in terms of types)

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch
- When resolving a specific issue, it's referenced in the PR's title

**Other information:**

```ts
// Let's assume this cookie will always exist because we know we always set it when starting the app or whatever
const nonNullCookie = Cookies.get('a_cookie_that_definitely_exists')
nullCookie.split('') // This will now throw an error because it could also be null

// After the changes, it should be defined like this to explicitly state that it will always be a string
const nonNullCookie = Cookies.get<string>('a_cookie_that_definitely_exists')
nullCookie.split('') // Now it's safe
```

```ts
if (Cookies.has('a_cookie_that_may_or_may_not_exist')) {
  // Now we are sure it exists because we checked with .has(...)
  const nonNullCookie = Cookies.get('a_cookie_that_may_or_may_not_exist')

  nullCookie.split('') // This will still throw an error because TS still thinks it can be null according to types
  // It still needs passing the generic parameter explicitly like Cookies.get<string>
}
```

On the other hand, currently, since it doesn't warn you about null values at all, you could face runtime errors, which is way worse. We are already shipping way more "breaking" types for other stuff as well. But that's a pretty natural thing for TS. But, I wanted to mention the possible cases anyways, they might be added as a small note to the release notes, or at least a mention to make the developers read this PR's description.

Resolves #8642