### PR TITLE
(fix: QLayout & QHeader): not always sticky when containerized (fix: #11397)

### DIFF
--- a/ui/dev/src/pages/layout/layout-container.vue
+++ b/ui/dev/src/pages/layout/layout-container.vue
@@ -68,7 +68,7 @@
     </q-layout>
 
     <q-layout view="Lhh lpR fff" container style="height: 500px; width: 900px" class="q-mt-xl shadow-2">
-      <q-header class="bg-black">
+      <q-header reveal class="bg-black">
         <q-toolbar>
           <q-btn flat @click="drawer3 = !drawer3" round dense icon="menu" />
           <q-toolbar-title>Header</q-toolbar-title>
@@ -76,7 +76,7 @@
         </q-toolbar>
       </q-header>
 
-      <q-footer>
+      <q-footer reveal>
         <q-toolbar>
           <q-btn flat @click="drawer3 = !drawer3" round dense icon="menu" />
           <q-toolbar-title>Footer</q-toolbar-title>

--- a/ui/dev/src/pages/layout/layout-container.vue
+++ b/ui/dev/src/pages/layout/layout-container.vue
@@ -68,7 +68,7 @@
     </q-layout>
 
     <q-layout view="Lhh lpR fff" container style="height: 500px; width: 900px" class="q-mt-xl shadow-2">
-      <q-header reveal class="bg-black">
+      <q-header class="bg-black">
         <q-toolbar>
           <q-btn flat @click="drawer3 = !drawer3" round dense icon="menu" />
           <q-toolbar-title>Header</q-toolbar-title>
@@ -76,7 +76,7 @@
         </q-toolbar>
       </q-header>
 
-      <q-footer reveal>
+      <q-footer>
         <q-toolbar>
           <q-btn flat @click="drawer3 = !drawer3" round dense icon="menu" />
           <q-toolbar-title>Footer</q-toolbar-title>

--- a/ui/src/components/footer/QFooter.js
+++ b/ui/src/components/footer/QFooter.js
@@ -46,7 +46,6 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('F') > -1
-      || $layout.isContainer.value === true
     )
 
     const containerHeight = computed(() => (

--- a/ui/src/components/footer/QFooter.js
+++ b/ui/src/components/footer/QFooter.js
@@ -46,6 +46,7 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('F') > -1
+      || ($q.platform.is.ios && $layout.isContainer.value === true)
     )
 
     const containerHeight = computed(() => (

--- a/ui/src/components/header/QHeader.js
+++ b/ui/src/components/header/QHeader.js
@@ -43,7 +43,6 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('H') > -1
-      || $layout.isContainer.value === true
     )
 
     const offset = computed(() => {

--- a/ui/src/components/header/QHeader.js
+++ b/ui/src/components/header/QHeader.js
@@ -43,6 +43,7 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('H') > -1
+      || ($q.platform.is.ios && $layout.isContainer.value === true)
     )
 
     const offset = computed(() => {


### PR DESCRIPTION
When using a containerized layout the 'H/h' and 'F/f' is not respected.
This means a containerized layout behaves different from a normal layout which I don't think is very logical. I did not see any abnormalities when testing it like this. 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
