### PR TITLE
fix(ui): QSelect does not emit 'virtual-scroll'

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -12,7 +12,7 @@ import QMenu from '../menu/QMenu.js'
 import QDialog from '../dialog/QDialog.js'
 
 import useField, { useFieldState, useFieldProps, useFieldEmits, fieldValueIsFilled } from '../../composables/private/use-field.js'
-import { useVirtualScroll, useVirtualScrollProps } from '../virtual-scroll/use-virtual-scroll.js'
+import { useVirtualScroll, useVirtualScrollProps, useVirtualScrollEmits } from '../virtual-scroll/use-virtual-scroll.js'
 import { useFormProps, useFormInputNameAttr } from '../../composables/private/use-form.js'
 import useKeyComposition from '../../composables/private/use-key-composition.js'
 
@@ -127,6 +127,7 @@ export default createComponent({
 
   emits: [
     ...useFieldEmits,
+    ...useVirtualScrollEmits,
     'add', 'remove', 'input-value',
     'keyup', 'keypress', 'keydown',
     'filter-abort'

--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -13,7 +13,7 @@ import QBtn from '../btn/QBtn.js'
 import getTableMiddle from './get-table-middle.js'
 
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
-import { commonVirtPropsList } from '../virtual-scroll/use-virtual-scroll.js'
+import { commonVirtPropsList, useVirtualScrollEmits } from '../virtual-scroll/use-virtual-scroll.js'
 import useFullscreen, { useFullscreenProps, useFullscreenEmits } from '../../composables/private/use-fullscreen.js'
 
 import { useTableSort, useTableSortProps } from './table-sort.js'
@@ -115,7 +115,8 @@ export default createComponent({
   },
 
   emits: [
-    'request', 'virtual-scroll',
+    'request',
+    ...useVirtualScrollEmits,
     ...useFullscreenEmits,
     ...useTableRowExpandEmits,
     ...useTableRowSelectionEmits

--- a/ui/src/components/virtual-scroll/use-virtual-scroll.js
+++ b/ui/src/components/virtual-scroll/use-virtual-scroll.js
@@ -4,6 +4,8 @@ import debounce from '../../utils/debounce.js'
 import { noop } from '../../utils/event.js'
 import { rtlHasScrollBug } from '../../utils/private/rtl.js'
 
+export const useVirtualScrollEmits = [ 'virtual-scroll' ]
+
 const aggBucketSize = 1000
 
 const scrollToEdges = [


### PR DESCRIPTION
This is an alternative solution to #11475
This PR follows the current direction used by other composables (ie: useFieldEmits, etc)
