### PR TITLE
feat(api/ts): Use narrower types for component refs (closes #11483)

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -115,7 +115,7 @@ const objectTypes = {
 
   // special type, not common
   Component: {
-    props: [ 'desc', 'required', 'category', 'examples', 'addedIn', 'internal' ],
+    props: [ 'tsType', 'desc', 'required', 'category', 'examples', 'addedIn', 'internal' ],
     required: [ 'desc' ],
     isBoolean: [ 'internal' ]
   },

--- a/ui/src/components/file/QFile.json
+++ b/ui/src/components/file/QFile.json
@@ -115,6 +115,7 @@
 
         "ref": {
           "type": "Component",
+          "tsType": "QFile",
           "desc": "Reference to the QFile component"
         }
       }
@@ -131,6 +132,7 @@
 
         "ref": {
           "type": "Component",
+          "tsType": "QFile",
           "desc": "Reference to the QFile component"
         }
       }

--- a/ui/src/components/file/QFile.json
+++ b/ui/src/components/file/QFile.json
@@ -114,9 +114,8 @@
         },
 
         "ref": {
-          "type": "Object",
-          "desc": "Reference to the QFile component",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "Reference to the QFile component"
         }
       }
     },
@@ -131,9 +130,8 @@
         },
 
         "ref": {
-          "type": "Object",
-          "desc": "Reference to the QFile component",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "Reference to the QFile component"
         }
       }
     }

--- a/ui/src/components/form/QForm.json
+++ b/ui/src/components/form/QForm.json
@@ -52,9 +52,8 @@
       "desc": "Emitted after a validation was triggered and at least one of the inner Quasar components models are NOT valid",
       "params": {
         "ref": {
-          "type": "Object",
-          "desc": "Vue reference to the first component that triggered the validation error",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "Vue reference to the first component that triggered the validation error"
         }
       }
     }

--- a/ui/src/components/scroll-area/QScrollArea.json
+++ b/ui/src/components/scroll-area/QScrollArea.json
@@ -98,10 +98,9 @@
           "desc": "An object containing scroll information",
           "definition": {
             "ref": {
-              "type": "Object",
+              "type": "Component",
               "required": true,
-              "desc": "Vue reference to the QScrollArea which triggered the event",
-              "__exemption": [ "examples" ]
+              "desc": "Vue reference to the QScrollArea which triggered the event"
             },
 
             "verticalPosition": {
@@ -163,9 +162,8 @@
     "getScrollTarget": {
       "desc": "Get the scrolling DOM element target",
       "returns": {
-        "type": "Object",
-        "desc": "DOM element upon which scrolling takes place",
-        "__exemption": [ "examples" ]
+        "type": "Element",
+        "desc": "DOM element upon which scrolling takes place"
       }
     },
 

--- a/ui/src/components/scroll-area/QScrollArea.json
+++ b/ui/src/components/scroll-area/QScrollArea.json
@@ -99,6 +99,7 @@
           "definition": {
             "ref": {
               "type": "Component",
+              "tsType": "QScrollArea",
               "required": true,
               "desc": "Vue reference to the QScrollArea which triggered the event"
             },

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -598,6 +598,7 @@
               "params": {
                 "ref": {
                   "type": "Component",
+                  "tsType": "QSelect",
                   "required": true,
                   "desc": "Vue reference to the QSelect which triggered the filtering"
                 }
@@ -638,6 +639,19 @@
           "type": "Object",
           "desc": "JS event object",
           "__exemption": [ "examples" ]
+        }
+      }
+    },
+
+    "virtual-scroll": {
+      "params": {
+        "details": {
+          "definition": {
+            "ref": {
+              "tsType": "QSelect",
+              "desc": "Vue reference to the QSelect"
+            }
+          }
         }
       }
     }

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -597,10 +597,9 @@
               "desc": "Callback to call at the end after the update has been fully processed by QSelect",
               "params": {
                 "ref": {
-                  "type": "Object",
+                  "type": "Component",
                   "required": true,
-                  "desc": "Vue reference to the QSelect which triggered the filtering",
-                  "__exemption": [ "examples" ]
+                  "desc": "Vue reference to the QSelect which triggered the filtering"
                 }
               },
               "returns": null

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -187,6 +187,7 @@
         },
         "tree": {
           "type": "Component",
+          "tsType": "QTree",
           "desc": "QTree instance"
         },
         "node": {
@@ -226,6 +227,7 @@
         },
         "tree": {
           "type": "Component",
+          "tsType": "QTree",
           "desc": "QTree instance"
         },
         "node": {
@@ -265,6 +267,7 @@
         },
         "tree": {
           "type": "Component",
+          "tsType": "QTree",
           "desc": "QTree instance"
         },
         "node": {
@@ -304,6 +307,7 @@
         },
         "tree": {
           "type": "Component",
+          "tsType": "QTree",
           "desc": "QTree instance"
         },
         "node": {

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -186,9 +186,8 @@
           "reactive": true
         },
         "tree": {
-          "type": "Object",
-          "desc": "QTree instance",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "QTree instance"
         },
         "node": {
           "type": "Object",
@@ -226,9 +225,8 @@
           "reactive": true
         },
         "tree": {
-          "type": "Object",
-          "desc": "QTree instance",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "QTree instance"
         },
         "node": {
           "type": "Object",
@@ -266,9 +264,8 @@
           "reactive": true
         },
         "tree": {
-          "type": "Object",
-          "desc": "QTree instance",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "QTree instance"
         },
         "node": {
           "type": "Object",
@@ -306,9 +303,8 @@
           "reactive": true
         },
         "tree": {
-          "type": "Object",
-          "desc": "QTree instance",
-          "__exemption": [ "examples" ]
+          "type": "Component",
+          "desc": "QTree instance"
         },
         "node": {
           "type": "Object",

--- a/ui/src/components/virtual-scroll/QVirtualScroll.json
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.json
@@ -67,6 +67,21 @@
     }
   },
 
+  "events": {
+    "virtual-scroll": {
+      "params": {
+        "details": {
+          "definition": {
+            "ref": {
+              "tsType": "QVirtualScroll",
+              "desc": "Vue reference to the QVirtualScroll"
+            }
+          }
+        }
+      }
+    }
+  },
+
   "slots" : {
     "before": {
       "desc": "Template slot for the elements that should be rendered before the list; Suggestion: thead before a table"

--- a/ui/src/components/virtual-scroll/use-virtual-scroll.json
+++ b/ui/src/components/virtual-scroll/use-virtual-scroll.json
@@ -95,12 +95,9 @@
               "values": [ "increase", "decrease" ]
             },
             "ref": {
-              "type": "Object",
+              "type": "Component",
               "required": true,
-              "desc": "Vue reference to the QVirtualList which triggered the event",
-              "__exemption": [
-                "examples"
-              ]
+              "desc": "Vue reference to the component which triggered the event"
             }
           }
         }

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -306,9 +306,8 @@
             },
 
             "component": {
-              "type": "Any",
-              "desc": "Use custom dialog component; use along with 'componentProps' prop where possible",
-              "__exemption": [ "examples" ]
+              "type": "Component",
+              "desc": "Use custom dialog component; use along with 'componentProps' prop where possible"
             },
 
             "componentProps": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch
- The related issue is referenced in the PR's title

**Other information:**
Closes #11483.

 📜 Changes for `dist/types/index.d.ts`
```diff
@@ -4774,9 +4774,9 @@
     file: File;
     /**
      * Reference to the QFile component
      */
-    ref: LooseDictionary;
+    ref: QFile;
   }) => VNode[];
   /**
    * Override default selection slot; Suggestion: QChip
    * @param scope
@@ -4788,9 +4788,9 @@
     files: FileList | any[];
     /**
      * Reference to the QFile component
      */
-    ref: LooseDictionary;
+    ref: QFile;
   }) => VNode[];
 }
 
 export interface QFile extends ComponentPublicInstance<QFileProps> {
@@ -4910,9 +4910,9 @@
   /**
    * Emitted after a validation was triggered and at least one of the inner Quasar components models are NOT valid
    * @param ref Vue reference to the first component that triggered the validation error
    */
-  onValidationError?: (ref: LooseDictionary) => void;
+  onValidationError?: (ref: Component) => void;
 }
 
 export interface QFormSlots {
   /**
@@ -7492,9 +7492,9 @@
   onScroll?: (info: {
     /**
      * Vue reference to the QScrollArea which triggered the event
      */
-    ref: LooseDictionary;
+    ref: QScrollArea;
     /**
      * Vertical scroll position (in px)
      */
     verticalPosition: number;
@@ -7540,9 +7540,9 @@
   /**
    * Get the scrolling DOM element target
    * @returns DOM element upon which scrolling takes place
    */
-  getScrollTarget: () => LooseDictionary;
+  getScrollTarget: () => Element;
   /**
    * Get the current scroll information
    * @returns Scroll information
    */
@@ -8130,11 +8130,11 @@
      * Direction of change
      */
     direction: "increase" | "decrease";
     /**
-     * Vue reference to the QVirtualList which triggered the event
+     * Vue reference to the QSelect
      */
-    ref: LooseDictionary;
+    ref: QSelect;
   }) => void;
   /**
    * When using the 'clearable' property, this event is emitted when the clear icon is clicked
    * @param value The previous value before clearing it
@@ -8194,12 +8194,9 @@
    * @param abortFn Call this function if something went wrong
    */
   onFilter?: (
     inputValue: string,
-    doneFn: (
-      callbackFn: () => void,
-      afterFn?: (ref: LooseDictionary) => void
-    ) => void,
+    doneFn: (callbackFn: () => void, afterFn?: (ref: QSelect) => void) => void,
     abortFn: () => void
   ) => void;
   /**
    * Emitted when a filtering was aborted; Probably a new one was requested?
@@ -12285,9 +12282,9 @@
     ticked: boolean;
     /**
      * QTree instance
      */
-    tree: LooseDictionary;
+    tree: QTree;
     /**
      * Node object
      */
     node: LooseDictionary;
@@ -12319,9 +12316,9 @@
     ticked: boolean;
     /**
      * QTree instance
      */
-    tree: LooseDictionary;
+    tree: QTree;
     /**
      * Node object
      */
     node: LooseDictionary;
@@ -12353,9 +12350,9 @@
     ticked: boolean;
     /**
      * QTree instance
      */
-    tree: LooseDictionary;
+    tree: QTree;
     /**
      * Node object
      */
     node: LooseDictionary;
@@ -12387,9 +12384,9 @@
     ticked: boolean;
     /**
      * QTree instance
      */
-    tree: LooseDictionary;
+    tree: QTree;
     /**
      * Node object
      */
     node: LooseDictionary;
@@ -12848,11 +12845,11 @@
      * Direction of change
      */
     direction: "increase" | "decrease";
     /**
-     * Vue reference to the QVirtualList which triggered the event
+     * Vue reference to the QVirtualScroll
      */
-    ref: LooseDictionary;
+    ref: QVirtualScroll;
   }) => void;
 }
 
 export interface QVirtualScrollSlots {
@@ -13143,9 +13140,9 @@
   transitionHide?: string;
   /**
    * Use custom dialog component; use along with 'componentProps' prop where possible
    */
-  component?: any;
+  component?: Component;
   /**
    * User defined props which will be forwarded to underlying custom component if 'component' prop is used
    */
   componentProps?: LooseDictionary;
   ```