### PR TITLE
fix(QIcon): Add check for lowercase 'm' for valid start of svg path

### DIFF
--- a/ui/dev/src/pages/components/icon.vue
+++ b/ui/dev/src/pages/components/icon.vue
@@ -19,6 +19,20 @@
       </q-icon>
 
       <q-icon name="android" size="5rem" />
+
+    </div>
+      <!-- This is the raw SVG -->
+      <q-icon color="secondary" size="5rem">
+        <svg height="21" viewBox="0 0 21 21" width="21" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="translate(3 4)"><path d="m3.5 10.5-1-.0345601c-1.10193561-.0037085-2-.93261826-2-2.03456011v-5.9654399c0-1.1045695.8954305-2 2-2l10-.00245977c1.1045695 0 2 .8954305 2 2v6.00245977c0 1.1045695-.8954305 2.00000001-2 2.00000001-.0014957 0-.3348291.01234-1 .0370199"/><path d="m7.5 12.5-3-3h6z" transform="matrix(1 0 0 -1 0 22)"/></g></svg>
+      </q-icon>
+
+      <!-- This one is broken, because it starts with lower-case 'm' to work. Adding 'M0 0z' to start, causes a dot
+      <q-icon :name="suiAirplay" size="5rem" color="primary" /> -->
+
+      <!-- This one has special hand-added handling to make it work -->
+      <q-icon :name="suiAirplay2" size="5rem" color="accent" />
+    <div>
+
     </div>
 
     <q-option-group
@@ -90,6 +104,12 @@ import { tiFullscreen } from '@quasar/extras/themify'
 import { laAtomSolid } from '@quasar/extras/line-awesome'
 import { biBugFill } from '@quasar/extras/bootstrap-icons'
 
+// currently does not work with QIcon because it only look for capital 'M'
+const suiAirplay = 'm3.5 10.5-1-.0345601c-1.10193561-.0037085-2-.93261826-2-2.03456011v-5.9654399c0-1.1045695.8954305-2 2-2l10-.00245977c1.1045695 0 2 .8954305 2 2v6.00245977c0 1.1045695-.8954305 2.00000001-2 2.00000001-.0014957 0-.3348291.01234-1 .0370199@@fill:none;fill-rule:evenodd;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;@@translate(3 4)&&m7.5 12.5-3-3h6z@@fill:none;fill-rule:evenodd;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;@@matrix(1 0 0 -1 3 26)|0 0 21 21'
+
+// This only works if you add the '@@fill:none;stroke:none;&&' at the start, but this breaks other icon sets
+const suiAirplay2 = 'M0 0z@@fill:none;stroke:none;&&m3.5 10.5-1-.0345601c-1.10193561-.0037085-2-.93261826-2-2.03456011v-5.9654399c0-1.1045695.8954305-2 2-2l10-.00245977c1.1045695 0 2 .8954305 2 2v6.00245977c0 1.1045695-.8954305 2.00000001-2 2.00000001-.0014957 0-.3348291.01234-1 .0370199@@fill:none;fill-rule:evenodd;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;@@translate(3 4)&&M0 0zm7.5 12.5-3-3h6z@@fill:none;fill-rule:evenodd;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;@@matrix(1 0 0 -1 3 26)|0 0 21 21'
+
 const TOP_ICON = 'add_box'
 
 function parseSet (setName, set) {
@@ -150,6 +170,8 @@ export default {
       tiFullscreen,
       laAtomSolid,
       biBugFill,
+      suiAirplay,
+      suiAirplay2,
 
       iconOptions: [
         { value: '', label: 'Empty name' },

--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -29,7 +29,7 @@ const matMap = {
 
 const libRE = new RegExp('^(' + Object.keys(libMap).join('|') + ')')
 const matRE = new RegExp('^(' + Object.keys(matMap).join('|') + ')')
-const mRE = /^M|m/
+const mRE = /^[M|m]/
 const imgRE = /^img:/
 const svgUseRE = /^svguse:/
 const ionRE = /^ion-/

--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -29,11 +29,11 @@ const matMap = {
 
 const libRE = new RegExp('^(' + Object.keys(libMap).join('|') + ')')
 const matRE = new RegExp('^(' + Object.keys(matMap).join('|') + ')')
-const mRE = /^[M|m]/
+const mRE = /^[Mm]/
 const imgRE = /^img:/
 const svgUseRE = /^svguse:/
 const ionRE = /^ion-/
-const faLaRE = /^[l|f]a[s|r|l|b|d|k]? /
+const faLaRE = /^[lf]a[srlbdk]? /
 
 export default createComponent({
   name: 'QIcon',

--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -29,7 +29,7 @@ const matMap = {
 
 const libRE = new RegExp('^(' + Object.keys(libMap).join('|') + ')')
 const matRE = new RegExp('^(' + Object.keys(matMap).join('|') + ')')
-const mRE = /^M/
+const mRE = /^M|m/
 const imgRE = /^img:/
 const svgUseRE = /^svguse:/
 const ionRE = /^ion-/


### PR DESCRIPTION
Some icon sets work perfectly well with lowercase 'm' and when adding `M0 0z` causes a black dot in upper-left of the icon. In this case, the regex needs to be `/^M|m/`
