### PR TITLE
fix(api/QRating): Provide correct examples for model-value

### DIFF
--- a/ui/src/components/rating/QRating.json
+++ b/ui/src/components/rating/QRating.json
@@ -9,7 +9,7 @@
     "model-value": {
       "extends": "model-value",
       "type": "Number",
-      "examples": [ ":value=\"2\"" ]
+      "examples": [ "v-model=\"rating\"", ":model-value=\"rating\"", ":model-value=\"2\"" ]
     },
 
     "max": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- JSON API related changes

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch

**Other information:**
It was `:value` for Vue 2, the last change to that line was 2 years ago, so it probably got forgotten.