### PR TITLE
Missing config

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -53,6 +53,8 @@ You can now edit files without violating the standard es-lint rules!
 
 ## Prettier ES-Lint rules
 
+VS Code can use the Prettier extension to automatically format your code on save. 
+
 ### Install VS Code Extensions for Prettier
 
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
@@ -65,15 +67,16 @@ To edit the settings use the command `Open Settings JSON` in the Command Palette
 
 ```js
 {
-    "editor.formatOnPaste": true,
-    "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
 
-    "editor.codeActionsOnSave": {
-        "source.fixAll": true
-    },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
 
-    "vetur.format.defaultFormatter.html": "prettyhtml",
-    "vetur.format.defaultFormatter.js": "prettier-eslint"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "vetur.format.defaultFormatter.html": "prettyhtml",
+  "vetur.format.defaultFormatter.js": "prettier-eslint",
 }
 ```
 
@@ -115,6 +118,17 @@ To edit the settings use the command `Open Settings JSON` in the Command Palette
 
 ```js
 {
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
+
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "vetur.format.defaultFormatter.html": "prettyhtml",
+  "vetur.format.defaultFormatter.js": "prettier-eslint",
+
   "attrsSorter.order": [
     "is",
     "v-for",


### PR DESCRIPTION
Hi, maybe this changed?  I needed this new config lines for this to work again.

`"editor.defaultFormatter": "esbenp.prettier-vscode",`


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
