### PR TITLE
feat/fix(ts/api): Allow top-level type definition for slot scopes (fix: #11090, #11500)

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -390,12 +390,15 @@ function writeIndexDTS (apis) {
           name = name.includes(replacement) ? `[key: \`${ name }\`]` : name.includes('-') ? `'${ name }'` : name
 
           const params = definition.scope ? {
-            scope: {
-              type: 'Object',
-              required: true,
-              // Make all properties required
-              definition: transformObject(definition.scope, makeRequired)
-            }
+            // If '...self' is defined, use that as the scope
+            scope: definition.scope[ '...self' ]
+              ? { ...definition.scope[ '...self' ], required: true }
+              : {
+                  type: 'Object',
+                  required: true,
+                  // Make all properties required
+                  definition: transformObject(definition.scope, makeRequired)
+                }
           } : undefined
 
           const slot = getPropDefinition({

--- a/ui/src/components/option-group/QOptionGroup.js
+++ b/ui/src/components/option-group/QOptionGroup.js
@@ -95,7 +95,9 @@ export default createComponent({
       class: classes.value,
       ...attrs.value
     }, props.options.map((opt, i) => {
-      // TODO: (Qv3) Make the 'opt' a separate property instead of the whole scope for consistency and flexibility (e.g. { opt } instead of opt)
+      // TODO: (Qv3) Make the 'opt' a separate property instead of
+      // the whole scope for consistency and flexibility
+      // (e.g. { opt } instead of opt)
       const child = slots[ 'label-' + i ] !== void 0
         ? () => slots[ 'label-' + i ](opt)
         : (

--- a/ui/src/components/option-group/QOptionGroup.js
+++ b/ui/src/components/option-group/QOptionGroup.js
@@ -95,6 +95,7 @@ export default createComponent({
       class: classes.value,
       ...attrs.value
     }, props.options.map((opt, i) => {
+      // TODO: (Qv3) Make the 'opt' a separate property instead of the whole scope for consistency and flexibility (e.g. { opt } instead of opt)
       const child = slots[ 'label-' + i ] !== void 0
         ? () => slots[ 'label-' + i ](opt)
         : (

--- a/ui/src/components/option-group/QOptionGroup.json
+++ b/ui/src/components/option-group/QOptionGroup.json
@@ -102,6 +102,29 @@
         "...self": {
           "type": "Object",
           "desc": "The corresponding option entry from the 'options' prop",
+          "definition": {
+            "label": {
+              "type": "String",
+              "desc": "Label to display along the component",
+              "required": true,
+              "examples": [ "Option 1", "Option 2", "Option 3" ]
+            },
+            "value": {
+              "type": "Any",
+              "desc": "Value of the option that will be used by the component model",
+              "required": true,
+              "examples": [ "op1", "op2", "op3" ]
+            },
+            "disable": {
+              "type": "Boolean",
+              "desc": "If true, the option will be disabled"
+            },
+            "...props": {
+              "type": "Any",
+              "desc": "Any other props from QToggle, QCheckbox, or QRadio",
+              "examples": [ "val=\"car\"", ":true-value=\"trueValue\"", "checked-icon=\"visibility\"" ]
+            }
+          },
           "__exemption": [ "examples" ]
         }
       },
@@ -114,6 +137,29 @@
         "...self": {
           "type": "Object",
           "desc": "The corresponding option entry from the 'options' prop",
+          "definition": {
+            "label": {
+              "type": "String",
+              "desc": "Label to display along the component",
+              "required": true,
+              "examples": [ "Option 1", "Option 2", "Option 3" ]
+            },
+            "value": {
+              "type": "Any",
+              "desc": "Value of the option that will be used by the component model",
+              "required": true,
+              "examples": [ "op1", "op2", "op3" ]
+            },
+            "disable": {
+              "type": "Boolean",
+              "desc": "If true, the option will be disabled"
+            },
+            "...props": {
+              "type": "Any",
+              "desc": "Any other props from QToggle, QCheckbox, or QRadio",
+              "examples": [ "val=\"car\"", ":true-value=\"trueValue\"", "checked-icon=\"visibility\"" ]
+            }
+          },
           "__exemption": [ "examples" ]
         }
       },

--- a/ui/src/components/option-group/QOptionGroup.json
+++ b/ui/src/components/option-group/QOptionGroup.json
@@ -99,7 +99,7 @@
     "label": {
       "desc": "Generic slot for all labels",
       "scope": {
-        "opt": {
+        "...self": {
           "type": "Object",
           "desc": "The corresponding option entry from the 'options' prop",
           "__exemption": [ "examples" ]
@@ -111,7 +111,7 @@
     "label-[name]": {
       "desc": "Slot to define the specific label for the option at '[name]' where name is a 0-based index; Overrides the generic 'label' slot if used",
       "scope": {
-        "...opt": {
+        "...self": {
           "type": "Object",
           "desc": "The corresponding option entry from the 'options' prop",
           "__exemption": [ "examples" ]

--- a/ui/src/components/uploader/QUploader.json
+++ b/ui/src/components/uploader/QUploader.json
@@ -67,12 +67,24 @@
   "slots": {
     "header": {
       "desc": "Slot for custom header; Scope is the QUploader instance itself",
-      "__exemption": ["scope"]
+      "scope": {
+        "...self": {
+          "type": "Component",
+          "tsType": "QUploader",
+          "desc": "QUploader instance"
+        }
+      }
     },
 
     "list": {
       "desc": "Slot for custom list; Scope is the QUploader instance itself",
-      "__exemption": ["scope"]
+      "scope": {
+        "...self": {
+          "type": "Component",
+          "tsType": "QUploader",
+          "desc": "QUploader instance"
+        }
+      }
     }
   },
 

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -446,7 +446,8 @@ export function getRenderer (getPlugin) {
         ? state[ key ].value
         : state[ key ]
     })
-    // TODO: (Qv3) Put the QUploader instance under `ref` property for consistency and flexibility
+    // TODO: (Qv3) Put the QUploader instance under `ref`
+    // property for consistency and flexibility
     // return { ref: { ...acc, ...publicMethods } }
     return { ...acc, ...publicMethods }
   })

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -446,6 +446,8 @@ export function getRenderer (getPlugin) {
         ? state[ key ].value
         : state[ key ]
     })
+    // TODO: (Qv3) Put the QUploader instance under `ref` property for consistency and flexibility
+    // return { ref: { ...acc, ...publicMethods } }
     return { ...acc, ...publicMethods }
   })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #11090
Fixes #11500

`dist/types/index.d.ts` diff:
```diff
@@ -6404,21 +6404,44 @@
 
 export interface QOptionGroupSlots {
   /**
    * Generic slot for all labels
-   * @param scope
+   * @param scope The corresponding option entry from the 'options' prop
    */
   label: (scope: {
     /**
-     * The corresponding option entry from the 'options' prop
+     * Label to display along the component
      */
-    opt: LooseDictionary;
+    label: string;
+    /**
+     * Value of the option that will be used by the component model
+     */
+    value: any;
+    /**
+     * If true, the option will be disabled
+     */
+    disable?: boolean;
+    [index: string]: any;
   }) => VNode[];
   /**
    * Slot to define the specific label for the option at '[name]' where name is a 0-based index; Overrides the generic 'label' slot if used
-   * @param scope
+   * @param scope The corresponding option entry from the 'options' prop
    */
-  [key: `label-${string}`]: (scope: { [index: string]: any }) => VNode[];
+  [key: `label-${string}`]: (scope: {
+    /**
+     * Label to display along the component
+     */
+    label: string;
+    /**
+     * Value of the option that will be used by the component model
+     */
+    value: any;
+    /**
+     * If true, the option will be disabled
+     */
+    disable?: boolean;
+    [index: string]: any;
+  }) => VNode[];
 }
 
 export interface QOptionGroup
   extends ComponentPublicInstance<QOptionGroupProps> {}
@@ -12690,14 +12713,16 @@
 
 export interface QUploaderSlots {
   /**
    * Slot for custom header; Scope is the QUploader instance itself
+   * @param scope QUploader instance
    */
-  header: () => VNode[];
+  header: (scope: QUploader) => VNode[];
   /**
    * Slot for custom list; Scope is the QUploader instance itself
+   * @param scope QUploader instance
    */
-  list: () => VNode[];
+  list: (scope: QUploader) => VNode[];
 }
 ```