### PR TITLE
feat(QUploader/QFile): improve kbd navigation; emit rejected; more unique key for files

### DIFF
--- a/docs/src/examples/QUploader/SlotHeader.vue
+++ b/docs/src/examples/QUploader/SlotHeader.vue
@@ -18,7 +18,7 @@
             <div class="q-uploader__title">Upload your files</div>
             <div class="q-uploader__subtitle">{{ scope.uploadSizeLabel }} / {{ scope.uploadProgressLabel }}</div>
           </div>
-          <q-btn v-if="scope.canAddFiles" type="a" icon="add_box" round dense flat>
+          <q-btn v-if="scope.canAddFiles" type="a" icon="add_box" @click="scope.pickFiles" round dense flat>
             <q-uploader-add-trigger />
             <q-tooltip>Pick Files</q-tooltip>
           </q-btn>

--- a/docs/src/pages/vue-components/file-picker.md
+++ b/docs/src/pages/vue-components/file-picker.md
@@ -44,7 +44,7 @@ As a helper, you can use `clearable` prop so user can reset model to `null` thro
 ## Usage
 
 ::: warning
-Under the covers, QFile uses a native input. Due to browser security policy, it is not allowed to programmatically fill such an input with a value. As a result, even if you set v-model from the beginning to a value, the component will show those file(s) but the input tag itself won't be filled in with that value. A user interaction (click/tap/<kbd>ENTER</kbd> key) is absolutely required in order for the native input to contain them. It's best to always have the initial value of model set to `null` or `undefined/void 0`.
+Under the covers, QFile uses a native input. Due to browser security policy, it is not allowed to programmatically fill such an input with a value. As a result, even if you set v-model from the beginning to a value, the component will show those file(s) but the input tag itself won't be filled in with that value. A user interaction (click/tap/<kbd>ENTER</kbd> key/<kbd>SPACE</kbd> key) is absolutely required in order for the native input to contain them. It's best to always have the initial value of model set to `null` or `undefined/void 0`.
 :::
 
 ### Basic

--- a/ui/dev/src/pages/form/file-picker.vue
+++ b/ui/dev/src/pages/form/file-picker.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="q-layout-padding">
     <form action="http://localhost:4444/upload" method="post" enctype="multipart/form-data" target="wind1" style="max-width: 600px;" class="q-gutter-y-md">
-      <q-file name="file1" filled v-model="fileS" label="Single" clearable />
-      <q-file name="file2" color="yellow" filled v-model="fileM" multiple label="Multiple" clearable />
+      <q-file name="file1" filled v-model="fileS" label="Single" clearable @rejected="onRejected" />
+      <q-file name="file2" color="yellow" filled v-model="fileM" multiple label="Multiple" clearable @rejected="onRejected" />
 
-      <q-file name="file3" color="accent" filled v-model="fileS" use-chips label="Single chips" clearable />
-      <q-file name="file4" color="accent" filled v-model="fileM" multiple use-chips label="Multiple chips" clearable counter max-files="3" />
+      <q-file name="file3" color="accent" filled v-model="fileS" use-chips label="Single chips" clearable @rejected="onRejected" />
+      <q-file name="file4" color="accent" filled v-model="fileM" multiple use-chips label="Multiple chips" clearable counter max-files="3" @rejected="onRejected" />
 
       <q-toggle v-model="showFileInput" label="Show copy file pickers" />
 
       <template v-if="showFileInput">
-        <q-file name="file5" color="accent" filled v-model="fileS" use-chips label="Single chips" clearable />
-        <q-file name="file6" color="accent" filled v-model="fileM" multiple use-chips label="Multiple chips" clearable counter max-files="3" />
+        <q-file name="file5" color="accent" filled v-model="fileS" use-chips label="Single chips" clearable @rejected="onRejected" />
+        <q-file name="file6" color="accent" filled v-model="fileM" multiple use-chips label="Multiple chips" clearable counter max-files="3" @rejected="onRejected" />
       </template>
 
       <q-btn label="Move first file to single" @click="testMove" />
@@ -20,7 +20,7 @@
     </form>
 
     <div class="q-mt-md">
-      <q-file name="file1" filled v-model="multiAppend" label="Mutiple & Append" clearable multiple append />
+      <q-file name="file1" filled v-model="multiAppend" label="Mutiple & Append" clearable multiple append @rejected="onRejected" />
     </div>
   </div>
 </template>
@@ -44,6 +44,10 @@ export default {
       }
 
       this.fileS = this.fileM.splice(0, 1)[0]
+    },
+
+    onRejected (files) {
+      console.log('@rejected', files)
     }
   }
 }

--- a/ui/dev/src/pages/form/uploader.vue
+++ b/ui/dev/src/pages/form/uploader.vue
@@ -151,7 +151,7 @@
                   {{ scope.uploadSizeLabel }} / {{ scope.uploadProgressLabel }}
                 </div>
               </div>
-              <q-btn v-if="scope.canAddFiles" type="a" icon="add_box" round dense flat>
+              <q-btn v-if="scope.canAddFiles" type="a" icon="add_box" @click="scope.pickFiles" round dense flat>
                 <q-uploader-add-trigger />
               </q-btn>
               <q-btn v-if="scope.canUpload" icon="cloud_upload" @click="scope.upload" round dense flat />

--- a/ui/dev/src/pages/form/uploader.vue
+++ b/ui/dev/src/pages/form/uploader.vue
@@ -31,6 +31,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <q-uploader
@@ -44,6 +45,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <q-uploader
@@ -76,6 +78,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <q-uploader
@@ -91,6 +94,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <q-uploader
@@ -107,6 +111,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <q-uploader
@@ -122,6 +127,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
 
         <div>
@@ -137,6 +143,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         >
           <template v-slot:header="scope">
             <div class="row no-wrap items-center q-pa-sm q-gutter-xs">
@@ -173,6 +180,7 @@
           @finish="onFinish"
           @uploaded="onUpload"
           @failed="onFail"
+          @rejected="onRejected"
         />
       </div>
     </div>

--- a/ui/src/components/file/QFile.js
+++ b/ui/src/components/file/QFile.js
@@ -9,6 +9,7 @@ import FileMixin, { FileValueMixin } from '../../mixins/file.js'
 import { isSSR } from '../../plugins/Platform'
 import { humanStorageSize } from '../../utils/format.js'
 import cache from '../../utils/cache.js'
+import { prevent } from '../../utils/event.js'
 
 export default Vue.extend({
   name: 'QFile',
@@ -115,9 +116,16 @@ export default Vue.extend({
       this.$emit('input', this.multiple === true ? files : files[0])
     },
 
+    __onKeydown (e) {
+      // prevent form submit if ENTER is pressed
+      e.keyCode === 13 && prevent(e)
+    },
+
     __onKeyup (e) {
-      // only on ENTER
-      e.keyCode === 13 && this.pickFiles(e)
+      // only on ENTER and SPACE to match native input field
+      if (e.keyCode === 13 || e.keyCode === 32) {
+        this.pickFiles(e)
+      }
     },
 
     __getFileInput () {
@@ -159,6 +167,7 @@ export default Vue.extend({
       if (this.editable === true) {
         data.on = cache(this, 'native', {
           dragover: this.__onDragOver,
+          keydown: this.__onKeydown,
           keyup: this.__onKeyup
         })
       }

--- a/ui/src/components/file/QFile.js
+++ b/ui/src/components/file/QFile.js
@@ -183,8 +183,7 @@ export default Vue.extend({
       return [
         h('input', {
           class: [ this.inputClass, 'q-file__filler' ],
-          style: this.inputStyle,
-          tabindex: -1
+          style: this.inputStyle
         })
       ]
     },

--- a/ui/src/components/file/QFile.sass
+++ b/ui/src/components/file/QFile.sass
@@ -2,7 +2,6 @@
 
   .q-field__native
     word-break: break-all
-    overflow: hidden
 
   .q-field__input
     opacity: 0 !important
@@ -11,8 +10,10 @@
       cursor: pointer
 
   &__filler
-    opacity: 0
-    pointer-events: none
+    visibility: hidden
+    width: 100%
+    border: none
+    padding: 0
 
   &__dnd
     outline: 1px dashed currentColor

--- a/ui/src/components/file/QFile.styl
+++ b/ui/src/components/file/QFile.styl
@@ -2,7 +2,6 @@
 
   .q-field__native
     word-break: break-all
-    overflow: hidden
 
   .q-field__input
     opacity: 0 !important
@@ -11,8 +10,10 @@
       cursor: pointer
 
   &__filler
-    opacity: 0
-    pointer-events: none
+    visibility: hidden
+    width: 100%
+    border: none
+    padding: 0
 
   &__dnd
     outline: 1px dashed currentColor

--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -287,7 +287,7 @@ export default Vue.extend({
             flat: true,
             dense: true
           },
-          on: icon === 'add' ? null : { click: fn }
+          on: { click: icon === 'add' ? this.pickFiles : fn }
         }, icon === 'add' ? this.__getInputControl(h) : null)
       }
     },
@@ -307,6 +307,7 @@ export default Vue.extend({
           },
           on: cache(this, 'input', {
             mousedown: stop, // need to stop refocus from QBtn
+            click: this.pickFiles,
             change: this.__addFiles
           })
         })

--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -166,7 +166,7 @@ export default Vue.extend({
         removed.size += f.size
         removed.files.push(f)
 
-        f._img !== void 0 && window.URL.revokeObjectURL(f._img.src)
+        f.__img !== void 0 && window.URL.revokeObjectURL(f.__img.src)
 
         return false
       })
@@ -182,7 +182,7 @@ export default Vue.extend({
       if (this.disable) { return }
 
       if (file.__status === 'uploaded') {
-        this.uploadedFiles = this.uploadedFiles.filter(f => f.name !== file.name)
+        this.uploadedFiles = this.uploadedFiles.filter(f => f.__key !== file.__key)
       }
       else if (file.__status === 'uploading') {
         file.__abort()
@@ -192,21 +192,21 @@ export default Vue.extend({
       }
 
       this.files = this.files.filter(f => {
-        if (f.name !== file.name) {
+        if (f.__key !== file.__key) {
           return true
         }
 
-        f._img !== void 0 && window.URL.revokeObjectURL(f._img.src)
+        f.__img !== void 0 && window.URL.revokeObjectURL(f.__img.src)
 
         return false
       })
-      this.queuedFiles = this.queuedFiles.filter(f => f.name !== file.name)
+      this.queuedFiles = this.queuedFiles.filter(f => f.__key !== file.__key)
       this.$emit('removed', [ file ])
     },
 
     __revokeImgURLs () {
       this.files.forEach(f => {
-        f._img !== void 0 && window.URL.revokeObjectURL(f._img.src)
+        f.__img !== void 0 && window.URL.revokeObjectURL(f.__img.src)
       })
     },
 
@@ -348,7 +348,7 @@ export default Vue.extend({
       }
 
       return this.files.map(file => h('div', {
-        key: file.name,
+        key: file.__key,
         staticClass: 'q-uploader__file relative-position',
         class: {
           'q-uploader__file--img': this.noThumbnails !== true && file.__img !== void 0,

--- a/ui/src/components/uploader/QUploaderBase.js
+++ b/ui/src/components/uploader/QUploaderBase.js
@@ -247,21 +247,16 @@ export default Vue.extend({
     },
 
     __addFiles (e, fileList) {
-      const processedFiles = this.__processFiles(e, fileList, this.files, true)
+      const localFiles = this.__processFiles(e, fileList, this.files, true)
 
-      if (processedFiles === void 0) { return }
-
-      const files = processedFiles
-        .filter(file => this.files.findIndex(f => file.name === f.name) === -1)
-
-      if (files === void 0) { return }
+      if (localFiles === void 0) { return }
 
       const fileInput = this.__getFileInput()
       if (fileInput !== void 0) {
         fileInput.value = ''
       }
 
-      files.forEach(file => {
+      localFiles.forEach(file => {
         this.__updateFile(file, 'idle')
         this.uploadSize += file.size
 
@@ -272,9 +267,9 @@ export default Vue.extend({
         }
       })
 
-      this.files = this.files.concat(files)
-      this.queuedFiles = this.queuedFiles.concat(files)
-      this.$emit('added', files)
+      this.files = this.files.concat(localFiles)
+      this.queuedFiles = this.queuedFiles.concat(localFiles)
+      this.$emit('added', localFiles)
       this.autoUpload === true && this.upload()
     },
 

--- a/ui/src/mixins/file.js
+++ b/ui/src/mixins/file.js
@@ -1,4 +1,4 @@
-import { stopAndPrevent } from '../utils/event.js'
+import { stop, stopAndPrevent } from '../utils/event.js'
 import cache from '../utils/cache.js'
 
 function filterFiles (files, rejectedFiles, failedPropValidation, filterFn) {
@@ -58,10 +58,20 @@ export default {
   },
 
   methods: {
-    pickFiles (e) {
-      if (this.editable) {
-        const input = this.__getFileInput()
-        input && input.click(e)
+    pickFiles (ev) {
+      if (this.editable === true) {
+        if (ev !== Object(ev)) {
+          ev = { target: null }
+        }
+
+        if (ev.target !== null && ev.target.matches('input[type="file"]') === true) {
+          // stop propagation if it's not a real pointer event
+          ev.clientX === 0 && ev.clientY === 0 && stop(ev)
+        }
+        else {
+          const input = this.__getFileInput()
+          input && input !== ev.target && input.click(ev)
+        }
       }
     },
 

--- a/ui/src/mixins/file.js
+++ b/ui/src/mixins/file.js
@@ -120,10 +120,14 @@ export default {
         files = [ files[0] ]
       }
 
+      files.forEach(file => {
+        file.__key = file.webkitRelativePath + file.lastModified + file.name + file.size
+      })
+
       // Avoid duplicate files
-      const filenameMap = currentFileList.map(entry => entry.name)
+      const filenameMap = currentFileList.map(entry => entry.__key)
       files = filterFiles(files, rejectedFiles, 'duplicate', file => {
-        return filenameMap.includes(file.name) === false
+        return filenameMap.includes(file.__key) === false
       })
 
       if (files.length === 0) { return done() }

--- a/ui/src/mixins/file.js
+++ b/ui/src/mixins/file.js
@@ -120,6 +120,14 @@ export default {
         files = [ files[0] ]
       }
 
+      // Avoid duplicate files
+      const filenameMap = currentFileList.map(entry => entry.name)
+      files = filterFiles(files, rejectedFiles, 'duplicate', file => {
+        return filenameMap.includes(file.name) === false
+      })
+
+      if (files.length === 0) { return done() }
+
       if (this.maxTotalSize !== void 0) {
         let size = append === true
           ? currentFileList.reduce((total, file) => total + file.size, 0)


### PR DESCRIPTION
- feat(QUploader): allow kdb interaction to pick files (ENTER/SPACE) #8381
- fix(QUploader): emit "rejected" event when also adding duplicate files #7298 (backport from Qv2)
- fix(QFile): prevent filler to get kbd focus and make it match field width
- feat(QUploader): use a more unique key for identifying files (duplicates) #11666