### PR TITLE
feat(router-link): add href and target - backport from Qv2 #10636

### DIFF
--- a/docs/src/components/DocApiEntry.js
+++ b/docs/src/components/DocApiEntry.js
@@ -132,7 +132,17 @@ function getProp (h, prop, propName, level, onlyChildren) {
 
   if (prop.default !== void 0) {
     child.push(
-      getDiv(h, 3, 'Default value', JSON.stringify(prop.default))
+      getDiv(
+        h,
+        3,
+        'Default value',
+        void 0,
+        h(
+          'div',
+          { staticClass: 'api-row--indent api-row__value' },
+          h('div', { staticClass: 'api-row__example' }, '' + prop.default)
+        )
+      )
     )
   }
 

--- a/docs/src/components/HeaderMenu.vue
+++ b/docs/src/components/HeaderMenu.vue
@@ -8,12 +8,12 @@ div
           q-icon(:name="mdiClipboardText")
         q-item-section Release notes
 
-      q-item(clickable, tag="a", href="https://github.com/quasarframework/quasar/issues", target="_blank", rel="noopener")
+      q-item(clickable, href="https://github.com/quasarframework/quasar/issues", target="_blank", rel="noopener")
         q-item-section.text-purple(avatar)
           q-icon(:name="mdiBugCheck")
         q-item-section Report a bug
 
-      q-item(clickable, tag="a", href="https://github.com/quasarframework/quasar", target="_blank", rel="noopener")
+      q-item(clickable, href="https://github.com/quasarframework/quasar", target="_blank", rel="noopener")
         q-item-section(avatar)
           q-icon(:name="fabGithub")
         q-item-section Repository
@@ -23,7 +23,6 @@ div
       q-item-label(header) Newer Releases
       q-item(
         clickable
-        tag="a"
         :href="`https://v2.quasar.dev/start/upgrade-guide`"
         target="_blank"
         rel="noopener"
@@ -40,7 +39,6 @@ div
         v-for="version in ['17', '16', '15', '14', '13']"
         :key="version"
         clickable
-        tag="a"
         :href="`https://v0-${version}.quasar-framework.org/`"
         target="_blank"
         rel="noopener"
@@ -49,7 +47,7 @@ div
 
   q-btn-dropdown.text-bold(:align="align", flat, no-caps, stretch, label="Tools", auto-close)
     q-list(dense padding)
-      q-item(clickable, tag="a", href="https://awesome.quasar.dev", rel="noopener", target="_blank")
+      q-item(clickable, href="https://awesome.quasar.dev", rel="noopener", target="_blank")
         q-item-section.text-yellow-9(avatar)
           q-icon(:name="mdiFlare")
         q-item-section Awesome List
@@ -79,7 +77,7 @@ div
           q-icon(:name="mdiInvertColors")
         q-item-section Dark Mode
 
-      q-item(clickable, tag="a", href="layout-builder", target="_blank")
+      q-item(clickable, href="layout-builder", target="_blank")
         q-item-section.text-brand-primary(avatar)
           q-icon(:name="mdiViewDashboard")
         q-item-section Layout Builder
@@ -98,17 +96,17 @@ div
 
       q-item-label.q-mt-md(header) Playground
 
-      q-item(clickable, tag="a", href="https://codepen.io/rstoenescu/pen/VgQbdx", target="_blank", rel="noopener")
+      q-item(clickable, href="https://codepen.io/rstoenescu/pen/VgQbdx", target="_blank", rel="noopener")
         q-item-section.text-brown-5(avatar)
           q-icon(:name="fabCodepen")
         q-item-section Codepen
 
-      q-item(clickable, tag="a", href="https://jsfiddle.net/rstoenescu/rmaodk0f", target="_blank", rel="noopener")
+      q-item(clickable, href="https://jsfiddle.net/rstoenescu/rmaodk0f", target="_blank", rel="noopener")
         q-item-section.text-brand-primary(avatar)
           q-icon(:name="fabJsfiddle")
         q-item-section jsFiddle
 
-      q-item(clickable, tag="a", href="https://codesandbox.io/s/github/quasarframework/quasar-codesandbox/tree/legacy-v1", target="_blank", rel="noopener")
+      q-item(clickable, href="https://codesandbox.io/s/github/quasarframework/quasar-codesandbox/tree/legacy-v1", target="_blank", rel="noopener")
         q-item-section.text-black(avatar)
           q-icon(:name="fasCubes")
         q-item-section Codesandbox
@@ -116,39 +114,39 @@ div
   q-btn-dropdown.text-bold(:align="align", flat, no-caps, stretch, label="Support", auto-close)
     q-list(dense padding)
 
-      q-item(clickable, tag="a", href="https://chat.quasar.dev", rel="noopener", target="_blank")
+      q-item(clickable, href="https://chat.quasar.dev", rel="noopener", target="_blank")
         q-item-section.text-brand-primary(avatar)
           q-icon(:name="mdiChat")
         q-item-section Discord Chat
 
-      q-item(clickable, tag="a", href="https://forum.quasar.dev/", rel="noopener", target="_blank")
+      q-item(clickable, href="https://forum.quasar.dev/", rel="noopener", target="_blank")
         q-item-section.text-secondary(avatar)
           q-icon(:name="mdiForum")
         q-item-section Forum
 
-      q-item(clickable, tag="a", href="https://github.com/quasarframework", rel="noopener", target="_blank")
+      q-item(clickable, href="https://github.com/quasarframework", rel="noopener", target="_blank")
         q-item-section(avatar)
           q-icon(:name="fabGithub")
         q-item-section GitHub Repositories
 
       q-item-label.q-mt-md(header) Social
 
-      q-item(clickable, tag="a", href="https://blog.quasar.dev", rel="noopener", target="_blank")
+      q-item(clickable, href="https://blog.quasar.dev", rel="noopener", target="_blank")
         q-item-section.text-brand-primary(avatar)
           q-icon(:name="mdiPost")
         q-item-section Blog
 
-      q-item(clickable, tag="a", href="https://github.com/quasarframework/quasar/discussions/categories/announcements", target="_blank", rel="noopener")
+      q-item(clickable, href="https://github.com/quasarframework/quasar/discussions/categories/announcements", target="_blank", rel="noopener")
         q-item-section.text-purple(avatar)
           q-icon(:name="mdiBullhorn")
         q-item-section Announcements
 
-      q-item(clickable, tag="a", href="https://twitter.quasar.dev", target="_blank", rel="noopener")
+      q-item(clickable, href="https://twitter.quasar.dev", target="_blank", rel="noopener")
         q-item-section.text-blue(avatar)
           q-icon(:name="fabTwitter")
         q-item-section Twitter
 
-      q-item(clickable, tag="a", href="https://facebook.quasar.dev", target="_blank", rel="noopener")
+      q-item(clickable, href="https://facebook.quasar.dev", target="_blank", rel="noopener")
         q-item-section.text-blue-8(avatar)
           q-icon(:name="fabFacebook")
         q-item-section
@@ -157,7 +155,7 @@ div
 
       q-item-label.q-mt-md(header) Donate
 
-      q-item(clickable, tag="a", href="https://donate.quasar.dev", target="_blank", rel="noopener")
+      q-item(clickable, href="https://donate.quasar.dev", target="_blank", rel="noopener")
         q-item-section(avatar)
           q-icon(:name="mdiCharity")
         q-item-section GitHub Sponsorship

--- a/docs/src/components/_SurveyCountdown._vue
+++ b/docs/src/components/_SurveyCountdown._vue
@@ -2,7 +2,6 @@
   q-banner(v-if="!hasEnded" inline-actions).survey-countdown
     template(v-slot:action)
       q-btn(
-        type="a"
         href="https://forms.gle/AGTQqkjCEAuDA8oCA"
         target="_blank"
         :color="color"

--- a/docs/src/components/page-parts/layout/LayoutGallery.vue
+++ b/docs/src/components/page-parts/layout/LayoutGallery.vue
@@ -8,8 +8,8 @@
         .row.items-center.no-wrap.q-px-md.q-py-sm
           div {{ layout.name }}
           q-space
-          q-btn(type="a", :href="layout.demoLink", target="_blank", size="12px" flat, round, color="brand-primary", :icon="mdiOpenInNew")
-          q-btn(type="a", :href="layout.sourceLink", , target="_blank", size="12px" flat, round, color="grey-7", :icon="mdiCodeTags")
+          q-btn(:href="layout.demoLink", target="_blank", size="12px" flat, round, color="brand-primary", :icon="mdiOpenInNew")
+          q-btn(:href="layout.sourceLink", , target="_blank", size="12px" flat, round, color="grey-7", :icon="mdiCodeTags")
 
         q-separator
 

--- a/docs/src/components/page-parts/layout/LayoutGalleryPage.vue
+++ b/docs/src/components/page-parts/layout/LayoutGalleryPage.vue
@@ -7,7 +7,6 @@
       push
       color="white"
       text-color="brand-primary"
-      type="a"
       :href="sourceLink"
       target="_blank"
       rel="noopener"

--- a/docs/src/components/page-parts/meet-the-team/TeamMember.vue
+++ b/docs/src/components/page-parts/meet-the-team/TeamMember.vue
@@ -14,11 +14,11 @@
 
     q-card-actions(align="around")
       div(v-if="twitter")
-        q-btn(type="a", :href="url.twitter", target="_blank", rel="noopener", round, flat, :icon="fabTwitter")
+        q-btn(:href="url.twitter", target="_blank", rel="noopener", round, flat, :icon="fabTwitter")
       div(v-if="github")
-        q-btn(type="a", :href="url.github", target="_blank", rel="noopener", round, flat, :icon="fabGithub")
+        q-btn(:href="url.github", target="_blank", rel="noopener", round, flat, :icon="fabGithub")
       div(v-if="email")
-        q-btn(type="a", :href="url.email", target="_blank", rel="noopener", round, flat, icon="mail")
+        q-btn(:href="url.email", target="_blank", rel="noopener", round, flat, icon="mail")
 </template>
 
 <script>

--- a/docs/src/components/page-parts/sponsors-and-backers/DonatingButtons.vue
+++ b/docs/src/components/page-parts/sponsors-and-backers/DonatingButtons.vue
@@ -5,7 +5,6 @@
       color="black"
       style="height: 65px; width: 250px;"
       no-caps
-      type="a"
       href="https://donate.quasar.dev"
       target="_blank"
       rel="sponsored"

--- a/docs/src/examples/QBtn/Links.vue
+++ b/docs/src/examples/QBtn/Links.vue
@@ -3,8 +3,8 @@
     <q-btn to="/start/pick-quasar-flavour" label="To Docs index" outline color="purple" />
     <q-btn to="/start/pick-quasar-flavour" label="To Docs index in 2s" @click="linkClick" glossy color="purple" />
 
-    <q-btn type="a" href="start/pick-quasar-flavour" label="Type 'a'" push color="purple" />
-    <q-btn type="a" href="start/pick-quasar-flavour" target="_blank" label="Type 'a' - external" color="purple" />
+    <q-btn href="start/pick-quasar-flavour" label="With href" push color="purple" />
+    <q-btn href="start/pick-quasar-flavour" target="_blank" label="With href - open in new window" color="purple" />
   </div>
 </template>
 

--- a/docs/src/layouts/DocLayout.vue
+++ b/docs/src/layouts/DocLayout.vue
@@ -44,7 +44,6 @@ q-layout.doc-layout(view="lHh LpR lff", @scroll="onScroll")
       template(v-else)
         .row.justify-center.q-my-md
           q-btn.doc-layout__main-btn(
-            type="a"
             href="https://donate.quasar.dev"
             target="_blank"
             rel="noopener"

--- a/docs/src/layouts/gallery/quasar-classic-dark.vue
+++ b/docs/src/layouts/gallery/quasar-classic-dark.vue
@@ -24,7 +24,7 @@
     >
       <q-list dark>
         <q-item-label header>Essential Links</q-item-label>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="http://quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="http://quasar.dev">
           <q-item-section avatar>
             <q-icon name="school" />
           </q-item-section>
@@ -33,7 +33,7 @@
             <q-item-label caption>https://quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://github.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://github.quasar.dev">
           <q-item-section avatar>
             <q-icon name="code" />
           </q-item-section>
@@ -42,7 +42,7 @@
             <q-item-label caption>github.com/quasarframework</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="http://chat.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="http://chat.quasar.dev">
           <q-item-section avatar>
             <q-icon name="chat" />
           </q-item-section>
@@ -51,7 +51,7 @@
             <q-item-label caption>https://chat.quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://forum.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://forum.quasar.dev">
           <q-item-section avatar>
             <q-icon name="record_voice_over" />
           </q-item-section>
@@ -60,7 +60,7 @@
             <q-item-label caption>https://forum.quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://twitter.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://twitter.quasar.dev">
           <q-item-section avatar>
             <q-icon name="rss_feed" />
           </q-item-section>
@@ -69,7 +69,7 @@
             <q-item-label caption>@quasarframework</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://facebook.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://facebook.quasar.dev">
           <q-item-section avatar>
             <q-icon name="public" />
           </q-item-section>

--- a/docs/src/layouts/gallery/quasar-classic.vue
+++ b/docs/src/layouts/gallery/quasar-classic.vue
@@ -25,7 +25,7 @@
     >
       <q-list>
         <q-item-label header>Essential Links</q-item-label>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="http://quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="http://quasar.dev">
           <q-item-section avatar>
             <q-icon name="school" />
           </q-item-section>
@@ -34,7 +34,7 @@
             <q-item-label caption>https://quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://github.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://github.quasar.dev">
           <q-item-section avatar>
             <q-icon name="code" />
           </q-item-section>
@@ -43,7 +43,7 @@
             <q-item-label caption>github.com/quasarframework</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="http://chat.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="http://chat.quasar.dev">
           <q-item-section avatar>
             <q-icon name="chat" />
           </q-item-section>
@@ -52,7 +52,7 @@
             <q-item-label caption>https://chat.quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://forum.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://forum.quasar.dev">
           <q-item-section avatar>
             <q-icon name="record_voice_over" />
           </q-item-section>
@@ -61,7 +61,7 @@
             <q-item-label caption>https://forum.quasar.dev</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://twitter.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://twitter.quasar.dev">
           <q-item-section avatar>
             <q-icon name="rss_feed" />
           </q-item-section>
@@ -70,7 +70,7 @@
             <q-item-label caption>@quasarframework</q-item-label>
           </q-item-section>
         </q-item>
-        <q-item clickable tag="a" target="_blank" rel="noopener" href="https://facebook.quasar.dev">
+        <q-item clickable target="_blank" rel="noopener" href="https://facebook.quasar.dev">
           <q-item-section avatar>
             <q-icon name="public" />
           </q-item-section>

--- a/docs/src/pages/app-extensions/discover.md
+++ b/docs/src/pages/app-extensions/discover.md
@@ -3,7 +3,7 @@ title: Discover App Extensions
 desc: Look up official and community Quasar App Extensions.
 ---
 
-<q-btn push class="q-py-xs" no-caps color="brand-primary" icon-right="search" label="Look up extensions" type="a" href="https://www.npmjs.com/search?q=quasar-app-extension" target="_blank" rel="noopener" />
+<q-btn push class="q-py-xs" no-caps color="brand-primary" icon-right="search" label="Look up extensions" href="https://www.npmjs.com/search?q=quasar-app-extension" target="_blank" rel="noopener" />
 
 ## Community App Extensions
 

--- a/docs/src/pages/layout/drawer.md
+++ b/docs/src/pages/layout/drawer.md
@@ -16,7 +16,7 @@ QDrawer is the sidebar part of your QLayout.
 ## Layout Builder
 Scaffold your layout(s) by clicking on the button below.
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" type="a" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 ::: tip

--- a/docs/src/pages/layout/header-and-footer.md
+++ b/docs/src/pages/layout/header-and-footer.md
@@ -21,7 +21,7 @@ QLayout allows you to configure your views as a 3x3 matrix, containing an option
 ## Layout Builder
 Scaffold your layout(s) by clicking on the button below.
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" type="a" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 ::: tip

--- a/docs/src/pages/layout/layout.md
+++ b/docs/src/pages/layout/layout.md
@@ -32,7 +32,7 @@ You are likely going to need the following components - QLayout, QHeader, QToolb
 Keep an eye on your developer console for handy helpers on which components are being used but not declared in your quasar.conf.js file.
 :::
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" type="a" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 
@@ -67,7 +67,7 @@ For example, if you want your layout's right side / drawer to be placed on the r
 
 These settings are completely up to you to use as you'd like. You could even go wild with a setup like this: `lhh LpR ffr`. Try it out!
 
-<q-btn push color="red" icon-right="launch" label="Layout Builder" type="a" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="red" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ::: warning
 * It is important that you specify all sections of a QLayout, even if you don't use them. For example, even if you don't use footer or right side drawer, still specify them within your QLayout's `view` prop.

--- a/docs/src/pages/layout/page.md
+++ b/docs/src/pages/layout/page.md
@@ -16,7 +16,7 @@ We will be talking about encapsulating pages within a QLayout. If you haven’t 
 ## Layout Builder
 Scaffold your layout(s) by clicking on the button below.
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" type="a" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 

--- a/docs/src/pages/quasar-cli/testing-and-auditing.md
+++ b/docs/src/pages/quasar-cli/testing-and-auditing.md
@@ -15,7 +15,7 @@ Testing is not in and of itself hard. The most complicated part is setting up th
 
 Testing has its own documentation website (https://testing.quasar.dev), so head there for full info.
 
-<q-btn color="brand-primary" label="testing.quasar.dev" icon-right="launch" no-caps type="a"  href="https://testing.quasar.dev" target="_blank" />
+<q-btn color="brand-primary" label="testing.quasar.dev" icon-right="launch" no-caps href="https://testing.quasar.dev" target="_blank" />
 
 ## Installing
 

--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -51,7 +51,7 @@ openURL(
 ```
 
 ::: tip
-If you want to open the telephone dialer in a Cordova app, don't use `openURL()`. Instead you should directly use `<a href="tel:123456789">` tags or `<QBtn type="a" href="tel:123456789">`
+If you want to open the telephone dialer in a Cordova app, don't use `openURL()`. Instead you should directly use `<a href="tel:123456789">` tags or `<QBtn href="tel:123456789">`
 :::
 
 ## Copy to Clipboard <q-badge align="top" color="brand-primary" label="v1.5+" />

--- a/docs/src/pages/start/roadmap.md
+++ b/docs/src/pages/start/roadmap.md
@@ -7,7 +7,7 @@ Where will Quasar be in one year, five years or ten years? It's up to you, the d
 
 You, the community, are Quasar. We listen to your opinions and your needs. Which is why we encourage you to directly contact us on [Discord](https://chat.quasar.dev) or submit [Feature Requests](https://github.com/quasarframework/quasar/issues/new/choose). We carefully ponder on all the ideas and we decide along with the community what are the next steps to be taken.
 
-<q-btn push class="q-my-sm q-py-sm" no-caps color="brand-primary" icon-right="launch" label="https://roadmap.quasar.dev" type="a" href="https://roadmap.quasar.dev" target="_blank" rel="noopener" />
+<q-btn push class="q-my-sm q-py-sm" no-caps color="brand-primary" icon-right="launch" label="https://roadmap.quasar.dev" href="https://roadmap.quasar.dev" target="_blank" rel="noopener" />
 
 ### Important!
 

--- a/docs/src/pages/vue-components/button.md
+++ b/docs/src/pages/vue-components/button.md
@@ -71,9 +71,16 @@ Should you wish, you can also display a deterministic progress within the button
 
 <doc-example title="Custom ripple" file="QBtn/CustomRipple" />
 
-### Handling links
+### Handling navigation <q-badge align="top" color="brand-primary" label="updated for v1.17+" />
 
-The two examples below won't work with UMD version (so in Codepen/jsFiddle too) because it relies on the existence of Vue Router.
+::: warning UMD usage
+* If you will be using `to` & `replace` props, make sure that you also inject Vue Router in your project. Otherwise use the alternative `href` prop.
+* Due to the above, some of the QBtn below won't work in Codepen/jsFiddle too.
+:::
+
+::: tip
+Prefer the Vue Router props over `href` when you can, because with `href` you will trigger a window navigation instead of an in-page Vue Router navigation.
+:::
 
 <doc-example title="Links" file="QBtn/Links" no-edit />
 

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -189,7 +189,7 @@ You can couple this with a Quasar [language pack](/options/quasar-language-packs
 When using the persian calendar, the mask for QDate is forced to `YYYY/MM/DD`.
 :::
 
-<q-btn type="a" href="https://codepen.io/rstoenescu/pen/MWKpbNa" target="_blank" label="See example" icon-right="launch" color="brand-primary" />
+<q-btn href="https://codepen.io/rstoenescu/pen/MWKpbNa" target="_blank" label="See example" icon-right="launch" color="brand-primary" />
 
 ### Native form submit <q-badge align="top" color="brand-primary" label="v1.9+" />
 

--- a/ui/dev/src/pages/components/breadcrumbs.vue
+++ b/ui/dev/src/pages/components/breadcrumbs.vue
@@ -27,11 +27,19 @@
       </q-breadcrumbs>
       <br><br>
       <q-breadcrumbs active-color="secondary" class="text-orange" align="right">
-        <q-breadcrumbs-el label="Home Disabled" disable to="/" />
-        <q-breadcrumbs-el label="Home" to="/" />
-        <q-breadcrumbs-el label="Components" to="/components" />
-        <q-breadcrumbs-el label="Breadcrumbs" to="/components/breadcrumbs" />
-        <q-breadcrumbs-el label="Bogus" to="/components/breadcrumbs/bogus" />
+        <q-breadcrumbs-el label="Router; Home Disabled" disable to="/" />
+        <q-breadcrumbs-el label="Router; Home" to="/" />
+        <q-breadcrumbs-el label="Router; Components" to="/components" />
+        <q-breadcrumbs-el label="Router; Breadcrumbs" to="/components/breadcrumbs" />
+        <q-breadcrumbs-el label="Router; Bogus" to="/components/breadcrumbs/bogus" />
+      </q-breadcrumbs>
+      <br><br>
+      <q-breadcrumbs active-color="secondary" class="text-orange" align="right">
+        <q-breadcrumbs-el label="href; Home Disabled" disable href="/" />
+        <q-breadcrumbs-el label="href; Home + _blank" href="/" target="_blank" />
+        <q-breadcrumbs-el label="href; Components" href="/components" />
+        <q-breadcrumbs-el label="href; Breadcrumbs" href="/components/breadcrumbs" />
+        <q-breadcrumbs-el label="href; Bogus" href="/components/breadcrumbs/bogus" />
       </q-breadcrumbs>
       <br><br>
       <q-breadcrumbs align="center">

--- a/ui/dev/src/pages/components/button-links.vue
+++ b/ui/dev/src/pages/components/button-links.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="q-layout-padding column q-gutter-y-md">
+    <q-toggle v-model="disable" label="Disabled" />
+
+    <div class="row items-center q-gutter-md">
+      <q-btn color="primary" :disable="disable" label="Router link - no type" replace :to="{ name: $route.name, query: { s: '1' } }" />
+      <q-btn color="primary" :disable="disable" label="Router link - a" replace :to="{ name: $route.name, query: { s: '2' } }" type="a" />
+      <q-btn color="primary" :disable="disable" label="Router link - button" replace :to="{ name: $route.name, query: { s: '3' } }" type="button" />
+      <q-btn color="primary" :disable="disable" label="Router link - submit" replace :to="{ name: $route.name, query: { s: '4' } }" type="submit" />
+      <q-btn color="primary" :disable="disable" label="Router link - reset" replace :to="{ name: $route.name, query: { s: '5' } }" type="reset" />
+      <q-btn color="primary" :disable="disable" label="Router link - media type" replace :to="{ name: $route.name, query: { s: '6' } }" type="text/html" />
+      <router-link :disable="disable" replace :to="{ name: $route.name, query: { s: '7' } }">Router link</router-link>
+    </div>
+
+    <div class="row items-center q-gutter-md">
+      <q-btn color="primary" :disable="disable" label="Href - no type" target="_blank" href="https://www.google.com" />
+      <q-btn color="primary" :disable="disable" label="Href - a" target="_blank" href="https://www.google.com" type="a" />
+      <q-btn color="primary" :disable="disable" label="Href - button" target="_blank" href="https://www.google.com" type="button" />
+      <q-btn color="primary" :disable="disable" label="Href - submit" target="_blank" href="https://www.google.com" type="submit" />
+      <q-btn color="primary" :disable="disable" label="Href - reset" target="_blank" href="https://www.google.com" type="reset" />
+      <q-btn color="primary" :disable="disable" label="Href - media type" target="_blank" href="https://www.google.com" type="text/html" />
+    </div>
+
+    <div class="row items-center q-gutter-md">
+      <q-btn color="primary" :disable="disable" label="Button - no type" />
+      <q-btn color="primary" :disable="disable" label="Button - a" type="a" />
+      <q-btn color="primary" :disable="disable" label="Button - button" type="button" />
+      <q-btn color="primary" :disable="disable" label="Button - submit" type="submit" />
+      <q-btn color="primary" :disable="disable" label="Button - reset" type="reset" />
+      <q-btn color="primary" :disable="disable" label="Button - wrong type" type="wrong" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      disable: false
+    }
+  }
+}
+</script>

--- a/ui/dev/src/pages/components/button.vue
+++ b/ui/dev/src/pages/components/button.vue
@@ -74,12 +74,18 @@
         Links
         <q-toggle v-model="toDisable" label="Disabled" />
       </div>
-      <q-btn to="/" :disable="toDisable" label="To index" outline color="secondary" />
-      <q-btn type="a" href="#/gigi" label="Type 'a' - bogus href" push color="secondary" class="q-ml-md" />
-      <q-btn type="a" href="#/gigi" target="_blank" label="Type 'a' - external" color="secondary" class="q-ml-md" />
-      <q-btn to="/" :disable="toDisable" label="To index in 2s" @click="linkClick" glossy color="secondary" class="q-ml-md" />
-      <br><br>
-      <div>
+      <div class="row items-center q-gutter-sm">
+        <q-btn to="/" :disable="toDisable" label="To index" outline color="secondary" />
+        <q-btn type="a" :disable="toDisable" label="type 'a'" color="secondary">
+          <q-tooltip>Tooltip</q-tooltip>
+        </q-btn>
+        <q-btn href="#/gigi" type="image/png" :disable="toDisable" label="href + media type" push color="secondary" />
+        <q-btn type="a" href="#/gigi" :disable="toDisable" label="href" push color="secondary" />
+        <q-btn href="#/gigi" :disable="toDisable" target="_blank" label="href + _blank" push color="secondary" />
+        <q-btn href="#/gigi" disable label="href + disable" push color="secondary" />
+        <q-btn to="/" :disable="toDisable" label="To index in 2s" @click="linkClick" glossy color="secondary" />
+      </div>
+      <div class="q-mt-md">
         <q-toggle v-model="testD" label="Disable form buttons" />
         <q-toggle v-model="testR" label="Wait for ripple" />
         <form @submit.prevent="submit" @reset.prevent="reset" class="shadow-2 q-pa-md row items-center">
@@ -94,8 +100,8 @@
               <q-input type="number" v-model="testN" />
             </div>
           </div>
-          <q-btn :tag="tag" fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
-          <q-btn :tag="tag" fab color="primary" icon="android" type="submit" class="on-right" title="Submit" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
+          <q-btn fab-mini color="primary" icon="android" type="reset" class="on-right" title="Reset" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
+          <q-btn fab color="primary" icon="android" type="submit" class="on-right" title="Submit" @click="onClick" :disable="testD" :wait-for-ripple="testR" />
         </form>
       </div>
 

--- a/ui/dev/src/pages/components/list-expansion-item.vue
+++ b/ui/dev/src/pages/components/list-expansion-item.vue
@@ -221,6 +221,30 @@
             </q-card-section>
           </q-card>
         </q-expansion-item>
+
+        <q-expansion-item expand-separator href="/" icon="home" label="Href">
+          <q-card>
+            <q-card-section>
+              {{ lorem }}
+            </q-card-section>
+          </q-card>
+        </q-expansion-item>
+
+        <q-expansion-item expand-separator href="/" target="_blank" icon="home" label="Href + _blank">
+          <q-card>
+            <q-card-section>
+              {{ lorem }}
+            </q-card-section>
+          </q-card>
+        </q-expansion-item>
+
+        <q-expansion-item expand-separator disable href="/" icon="home" label="Href + disable">
+          <q-card>
+            <q-card-section>
+              {{ lorem }}
+            </q-card-section>
+          </q-card>
+        </q-expansion-item>
       </q-list>
 
       <p class="caption">

--- a/ui/dev/src/pages/components/list-item.vue
+++ b/ui/dev/src/pages/components/list-item.vue
@@ -166,6 +166,27 @@
           </q-item-section>
           <q-item-section>Customized active link</q-item-section>
         </q-item>
+
+        <q-item href="/">
+          <q-item-section avatar>
+            <q-icon name="bluetooth" />
+          </q-item-section>
+          <q-item-section>Href (/)</q-item-section>
+        </q-item>
+
+        <q-item href="/" target="_blank">
+          <q-item-section avatar>
+            <q-icon name="bluetooth" />
+          </q-item-section>
+          <q-item-section>Href + _blank (/)</q-item-section>
+        </q-item>
+
+        <q-item href="/" exact disable>
+          <q-item-section avatar>
+            <q-icon name="bluetooth" />
+          </q-item-section>
+          <q-item-section>Href + Disabled (/)</q-item-section>
+        </q-item>
       </q-list>
 
       <p class="caption">

--- a/ui/dev/src/pages/components/tabs.vue
+++ b/ui/dev/src/pages/components/tabs.vue
@@ -361,6 +361,13 @@
         <q-route-tab key="6" replace :to="{ name: 'r.3' }" label="r.3 - redirect to r.1.1" @click="routeNavChange" />
       </q-tabs>
 
+      <h4>Href</h4>
+      <q-tabs :dense="dense" class="test q-mt-sm">
+        <q-route-tab name="tabs" href="/components/tabs" label="/components/tabs" no-caps />
+        <q-route-tab name="blank+/" href="/" target="_blank" label="/ + _blank" no-caps />
+        <q-route-tab name="/+disable" disable href="/" target="_blank" label="/ + _blank" no-caps />
+      </q-tabs>
+
       <h4>Tabs model (respect model): {{ tabModel }}</h4>
       <q-tabs :dense="dense" :value="tabModel" @input="onChangeTab1" class="bg-grey-1 text-teal">
         <q-tab name="one" label="One" />

--- a/ui/src/api.extends.json
+++ b/ui/src/api.extends.json
@@ -102,7 +102,6 @@
 
     "sanitize": {
       "type": "Boolean",
-      "default": "false",
       "desc": "Force use of textContent instead of innerHTML to render text; Use it when the text might be unsafe (from user input)",
       "category": "behavior"
     },

--- a/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
+++ b/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
@@ -2,9 +2,9 @@ import Vue from 'vue'
 
 import { mergeSlot } from '../../utils/slot.js'
 import ListenersMixin from '../../mixins/listeners.js'
+import RouterLinkMixin from '../../mixins/router-link.js'
 
 import QIcon from '../icon/QIcon.js'
-import { RouterLinkMixin } from '../../mixins/router-link.js'
 
 export default Vue.extend({
   name: 'QBreadcrumbsEl',
@@ -23,14 +23,18 @@ export default Vue.extend({
     },
 
     renderData () {
-      const staticClass = 'q-breadcrumbs__el q-link ' +
-        'flex inline items-center relative-position ' +
-        (this.disable !== true ? 'q-link--focusable' : 'q-breadcrumbs__el--disabled')
-
-      return this.hasRouterLink === true
-        ? [ 'router-link', { staticClass, props: this.routerLinkProps, nativeOn: { ...this.qListeners } } ]
-        : [ 'span', { staticClass, on: { ...this.qListeners } } ]
+      return {
+        staticClass: 'q-breadcrumbs__el q-link ' +
+          'flex inline items-center relative-position ' +
+          (this.disable !== true ? 'q-link--focusable' : 'q-breadcrumbs__el--disabled'),
+        ...this.linkProps,
+        [this.hasRouterLink === true ? 'nativeOn' : 'on']: { ...this.qListeners }
+      }
     }
+  },
+
+  beforeCreate () {
+    this.fallbackTag = 'span'
   },
 
   render (h) {
@@ -43,8 +47,8 @@ export default Vue.extend({
       })
     )
 
-    this.label && child.push(this.label)
+    this.label !== void 0 && child.push(this.label)
 
-    return h(...this.renderData, mergeSlot(child, this, 'default'))
+    return h(this.linkTag, this.renderData, mergeSlot(child, this, 'default'))
   }
 })

--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -37,7 +37,7 @@ export default Vue.extend({
       return this.ripple === false
         ? false
         : {
-          keyCodes: this.isLink === true ? [ 13, 32 ] : [ 13 ],
+          keyCodes: this.hasLink === true ? [ 13, 32 ] : [ 13 ],
           ...(this.ripple === true ? {} : this.ripple)
         }
     },
@@ -147,7 +147,7 @@ export default Vue.extend({
         // vue-router now throwing error if navigating
         // to the same route that the user is currently at
         // https://github.com/vuejs/vue-router/issues/2872
-        this.$router[this.replace === true ? 'replace' : 'push'](this.currentLocation.route, void 0, noop)
+        this.$router[this.replace === true ? 'replace' : 'push'](this.linkRoute.route, void 0, noop)
       }
 
       this.$emit('click', e, go)
@@ -346,7 +346,7 @@ export default Vue.extend({
       ] : void 0)
     )
 
-    return h(this.isLink === true ? 'a' : 'button', {
+    return h(this.hasLink === true || this.type === 'a' ? 'a' : 'button', {
       staticClass: 'q-btn q-btn-item non-selectable no-outline',
       class: this.classes,
       style: this.style,

--- a/ui/src/components/expansion-item/QExpansionItem.js
+++ b/ui/src/components/expansion-item/QExpansionItem.js
@@ -7,7 +7,7 @@ import QIcon from '../icon/QIcon.js'
 import QSlideTransition from '../slide-transition/QSlideTransition.js'
 import QSeparator from '../separator/QSeparator.js'
 
-import { RouterLinkMixin } from '../../mixins/router-link.js'
+import RouterLinkMixin from '../../mixins/router-link.js'
 import ModelToggleMixin from '../../mixins/model-toggle.js'
 import DarkMixin from '../../mixins/dark.js'
 
@@ -92,7 +92,7 @@ export default Vue.extend({
     },
 
     isClickable () {
-      return this.hasRouterLink === true || this.expandIconToggle !== true
+      return this.hasLink === true || this.expandIconToggle !== true
     },
 
     expansionIcon () {
@@ -102,13 +102,13 @@ export default Vue.extend({
     },
 
     activeToggleIcon () {
-      return this.disable !== true && (this.hasRouterLink === true || this.expandIconToggle === true)
+      return this.disable !== true && (this.hasLink === true || this.expandIconToggle === true)
     }
   },
 
   methods: {
     __onHeaderClick (e) {
-      this.hasRouterLink !== true && this.toggle(e)
+      this.hasLink !== true && this.toggle(e)
       this.$emit('click', e)
     },
 
@@ -219,18 +219,20 @@ export default Vue.extend({
       }
 
       if (this.isClickable === true) {
-        const evtProp = this.hasRouterLink === true ? 'nativeOn' : 'on'
-
         data.props.clickable = true
-        data[evtProp] = {
+        data[this.hasRouterLink === true ? 'nativeOn' : 'on'] = {
           ...this.qListeners,
           click: this.__onHeaderClick
         }
 
-        this.hasRouterLink === true && Object.assign(
-          data.props,
-          this.routerLinkProps
-        )
+        if (this.hasLink === true) {
+          Object.assign(
+            data.props,
+            this.linkProps.props
+          )
+
+          data.attrs = this.linkProps.attrs
+        }
       }
 
       return h(QItem, data, child)

--- a/ui/src/components/item/QItem.js
+++ b/ui/src/components/item/QItem.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 
 import DarkMixin from '../../mixins/dark.js'
 import TagMixin from '../../mixins/tag.js'
-import { RouterLinkMixin } from '../../mixins/router-link.js'
+import RouterLinkMixin from '../../mixins/router-link.js'
 import ListenersMixin from '../../mixins/listeners.js'
 
 import { uniqueSlot } from '../../utils/slot.js'
@@ -30,8 +30,7 @@ export default Vue.extend({
   computed: {
     isActionable () {
       return this.clickable === true ||
-        this.hasRouterLink === true ||
-        this.tag === 'a' ||
+        this.hasLink === true ||
         this.tag === 'label'
     },
 
@@ -120,28 +119,24 @@ export default Vue.extend({
       staticClass: 'q-item q-item-type row no-wrap',
       class: this.classes,
       style: this.style,
+      attrs: {},
       [ this.hasRouterLink === true ? 'nativeOn' : 'on' ]: this.onEvents
     }
 
     if (this.isClickable === true) {
-      data.attrs = {
-        tabindex: this.tabindex || '0'
-      }
+      data.attrs.tabindex = this.tabindex || '0'
     }
     else if (this.isActionable === true) {
-      data.attrs = {
-        'aria-disabled': 'true'
-      }
+      data.attrs['aria-disabled'] = 'true'
     }
 
-    if (this.hasRouterLink === true) {
-      data.props = this.routerLinkProps
-
-      return h('router-link', data, this.__getContent(h))
+    if (this.hasLink === true) {
+      data.props = this.linkProps.props
+      Object.assign(data.attrs, this.linkProps.attrs)
     }
 
     return h(
-      this.tag,
+      this.linkTag,
       data,
       this.__getContent(h)
     )

--- a/ui/src/components/tabs/QRouteTab.js
+++ b/ui/src/components/tabs/QRouteTab.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 
 import QTab from './QTab.js'
-import { RouterLinkMixin } from '../../mixins/router-link.js'
+import RouterLinkMixin from '../../mixins/router-link.js'
 import { isSameRoute, isIncludedRoute } from '../../utils/router.js'
 import { stopAndPrevent, noop } from '../../utils/event.js'
 
@@ -9,10 +9,6 @@ export default Vue.extend({
   name: 'QRouteTab',
 
   mixins: [ QTab, RouterLinkMixin ],
-
-  props: {
-    to: { required: true }
-  },
 
   inject: {
     __activateRoute: {}
@@ -27,7 +23,7 @@ export default Vue.extend({
   computed: {
     routerTabLinkProps () {
       return {
-        ...this.routerLinkProps,
+        ...this.linkProps.props,
         custom: true
       }
     }
@@ -48,14 +44,14 @@ export default Vue.extend({
           // handle this by its own
           this.__checkActivation(true)
         }
-        else {
+        else if (this.hasRouterLink === true) {
           // we use programatic navigation instead of letting vue-router handle it
           // so we can check for activation when the navigation is complete
           e !== void 0 && stopAndPrevent(e)
 
           const go = (to = this.to, append = this.append, replace = this.replace) => {
             const { route } = this.$router.resolve(to, this.$route, append)
-            const checkFn = to === this.to && append === this.append && replace === this.replace
+            const checkFn = to === this.to && append === this.append
               ? this.__checkActivation
               : noop
 
@@ -89,6 +85,10 @@ export default Vue.extend({
     },
 
     __checkActivation (selected = false) {
+      if (this.hasRouterLink !== true) {
+        return
+      }
+
       const
         current = this.$route,
         { href, location, route } = this.$router.resolve(this.to, current, this.append),
@@ -136,6 +136,6 @@ export default Vue.extend({
   },
 
   render (h) {
-    return this.__renderTab(h, 'router-link')
+    return this.__renderTab(h, this.linkTag)
   }
 })

--- a/ui/src/components/tabs/QRouteTab.json
+++ b/ui/src/components/tabs/QRouteTab.json
@@ -5,13 +5,6 @@
 
   "mixins": [ "components/tabs/QTab", "mixins/router-link" ],
 
-  "props": {
-    "to": {
-      "required": true,
-      "category": "general"
-    }
-  },
-
   "events": {
     "click": {
       "desc": "Emitted when component is clicked (activated)",

--- a/ui/src/components/tabs/QTab.js
+++ b/ui/src/components/tabs/QTab.js
@@ -232,7 +232,7 @@ export default Vue.extend({
         ]
       }
 
-      if (tag === 'router-link') {
+      if (this.hasRouterLink === true) {
         return h(tag, {
           ...data,
           nativeOn: this.onEvents,
@@ -240,15 +240,22 @@ export default Vue.extend({
           scopedSlots: {
             default: ({ href, isActive, isExactActive }) => h('a', {
               class: {
-                [this.routerLinkProps.activeClass]: isActive,
-                [this.routerLinkProps.exactActiveClass]: isExactActive
+                [this.activeClass]: isActive,
+                [this.exactActiveClass]: isExactActive
               },
-              attrs: this.hasRouterLink === true ? { href } : void 0
+              attrs: {
+                ...this.linkProps.attrs,
+                href
+              }
             }, this.__getContent(h))
           }
         })
       }
 
+      if (this.hasLink === true) {
+        Object.assign(data.attrs, this.linkProps.attrs)
+        data.props = this.linkProps.props
+      }
       data.on = this.onEvents
       return h(tag, data, this.__getContent(h))
     }

--- a/ui/src/mixins/btn.json
+++ b/ui/src/mixins/btn.json
@@ -4,38 +4,53 @@
   "props": {
     "type":{
       "type": "String",
-      "desc": "Define the button HTML DOM type",
+      "desc": "1) Define the button native type attribute (submit, reset, button) or 2) render component with <a> tag so you can access events even if disable or 3) Use 'href' prop and specify 'type' as a media tag",
       "default": "button",
-      "values": [
-        "a", "submit", "button", "reset"
-      ],
       "examples": [
-        "type=\"a\" href=\"http://some-site.net\" target=\"__blank\""
+        "a", "submit", "button", "reset",
+        "image/png",
+        "href=\"https://some-site.net\" target=\"_blank\""
       ],
       "category": "general"
     },
 
     "to": {
       "type": [ "String", "Object" ],
-      "desc": "Equivalent to Vue Router <router-link> 'to' property",
+      "desc": "Equivalent to Vue Router <router-link> 'to' property; Superseeded by 'href' prop if used",
       "examples": [
         "/home/dashboard",
         ":to=\"{ name: 'my-route-name' }\""
       ],
-      "category": "router"
+      "category": "navigation"
     },
 
     "replace": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'replace' property",
-      "category": "router"
+      "desc": "Equivalent to Vue Router <router-link> 'replace' property; Superseeded by 'href' prop if used",
+      "category": "navigation"
     },
 
     "append": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'append' property",
-      "category": "router",
+      "desc": "Equivalent to Vue Router <router-link> 'append' property; Superseeded by 'href' prop if used",
+      "category": "navigation",
       "addedIn": "v1.13.0"
+    },
+
+    "href": {
+      "type": "String",
+      "desc": "Native <a> link href attribute; Has priority over the 'to' and 'replace' props",
+      "examples": [ "https://quasar.dev", "href=\"https://quasar.dev\" target=\"_blank\"" ],
+      "category": "navigation",
+      "addedIn": "v1.17"
+    },
+
+    "target": {
+      "type": "String",
+      "desc": "Native <a> link target attribute; Use it only with 'to' or 'href' props",
+      "examples": [ "_blank", "_self", "_parent", "_top" ],
+      "category": "navigation",
+      "addedIn": "v1.17"
     },
 
     "label":{

--- a/ui/src/mixins/router-link.js
+++ b/ui/src/mixins/router-link.js
@@ -29,14 +29,14 @@ export default {
 
   computed: {
     hasHrefLink () {
-      return this.disable !== true && typeof this.href === 'string' && this.href.trim().length > 0
+      return this.disable !== true && this.href !== void 0
     },
 
     hasRouterLinkProps () {
-      return this.disable !== true &&
+      return this.$router !== void 0 &&
+        this.disable !== true &&
         this.hasHrefLink !== true &&
-        this.to !== void 0 && this.to !== null && this.to !== '' &&
-        this.$router !== void 0
+        this.to !== void 0 && this.to !== null && this.to !== ''
     },
 
     linkRoute () {

--- a/ui/src/mixins/router-link.js
+++ b/ui/src/mixins/router-link.js
@@ -1,30 +1,105 @@
-export const routerLinkProps = {
+const routerLinkProps = {
+  // router-link
   to: [String, Object],
   exact: Boolean,
   append: Boolean,
   replace: Boolean,
-  activeClass: String,
-  exactActiveClass: String,
+  activeClass: {
+    type: String,
+    default: 'q-router-link--active'
+  },
+  exactActiveClass: {
+    type: String,
+    default: 'q-router-link--exact-active'
+  },
+
+  // regular <a> link
+  href: String,
+  target: String,
+
+  // state
   disable: Boolean
 }
 
-export const RouterLinkMixin = {
+// external props: type, tag
+// external: fallbackTag
+
+export default {
   props: routerLinkProps,
 
   computed: {
-    hasRouterLink () {
-      return this.disable !== true && this.to !== void 0 && this.to !== null && this.to !== ''
+    hasHrefLink () {
+      return this.disable !== true && typeof this.href === 'string' && this.href.trim().length > 0
     },
 
-    routerLinkProps () {
-      return {
-        to: this.to,
-        exact: this.exact,
-        append: this.append,
-        replace: this.replace,
-        activeClass: this.activeClass || 'q-router-link--active',
-        exactActiveClass: this.exactActiveClass || 'q-router-link--exact-active'
+    hasRouterLinkProps () {
+      return this.disable !== true &&
+        this.hasHrefLink !== true &&
+        this.to !== void 0 && this.to !== null && this.to !== '' &&
+        this.$router !== void 0
+    },
+
+    linkRoute () {
+      if (this.hasRouterLinkProps === true) {
+        // we protect from accessing this.$route without
+        // actually needing it so that we won't trigger
+        // unnecessary updates
+
+        try {
+          return this.append === true
+            ? this.$router.resolve(this.to, this.$route, true)
+            : this.$router.resolve(this.to)
+        }
+        catch (err) {}
       }
+
+      return null
+    },
+
+    hasRouterLink () {
+      return this.linkRoute !== null
+    },
+
+    hasLink () {
+      return this.hasHrefLink === true || this.hasRouterLink === true
+    },
+
+    linkTag () {
+      if (this.hasRouterLink === true) {
+        return 'router-link'
+      }
+
+      return this.type === 'a' || this.hasLink === true
+        ? 'a'
+        : (this.tag || this.fallbackTag || 'div')
+    },
+
+    linkProps () {
+      return this.hasHrefLink === true
+        ? {
+          attrs: {
+            href: this.href,
+            target: this.target
+          }
+        }
+        : (
+          this.hasRouterLink === true
+            ? {
+              props: {
+                to: this.to,
+                exact: this.exact,
+                append: this.append,
+                replace: this.replace,
+                activeClass: this.activeClass,
+                exactActiveClass: this.exactActiveClass
+              },
+              attrs: {
+                href: this.linkRoute.href,
+                target: this.target
+              }
+            }
+            : {}
+        )
     }
   }
 }

--- a/ui/src/mixins/router-link.json
+++ b/ui/src/mixins/router-link.json
@@ -2,44 +2,60 @@
   "props": {
     "to": {
       "type": [ "String", "Object" ],
-      "desc": "Equivalent to Vue Router <router-link> 'to' property",
+      "desc": "Equivalent to Vue Router <router-link> 'to' property; Superseeded by 'href' prop if used",
       "examples": [
         "/home/dashboard",
         ":to=\"{ name: 'my-route-name' }\""
       ],
-      "category": "behavior"
+      "category": "navigation"
     },
 
     "exact": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'exact' property",
-      "category": "behavior"
+      "desc": "Equivalent to Vue Router <router-link> 'exact' property; Superseeded by 'href' prop if used",
+      "category": "navigation"
     },
 
     "append": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'append' property",
-      "category": "behavior"
+      "desc": "Equivalent to Vue Router <router-link> 'append' property; Superseeded by 'href' prop if used",
+      "category": "navigation"
     },
 
     "replace": {
       "type": "Boolean",
-      "desc": "Equivalent to Vue Router <router-link> 'replace' property",
-      "category": "behavior"
+      "desc": "Equivalent to Vue Router <router-link> 'replace' property; Superseeded by 'href' prop if used",
+      "category": "navigation"
     },
 
     "active-class": {
       "type": "String",
       "desc": "Equivalent to Vue Router <router-link> 'active-class' property",
       "examples": [ "my-active-class" ],
-      "category": "behavior"
+      "category": "navigation"
     },
 
     "exact-active-class": {
       "type": "String",
       "desc": "Equivalent to Vue Router <router-link> 'active-class' property",
       "examples": [ "my-exact-active-class" ],
-      "category": "behavior"
+      "category": "navigation"
+    },
+
+    "href": {
+      "type": "String",
+      "desc": "Native <a> link href attribute; Has priority over the 'to'/'exact'/'replace' props",
+      "examples": [ "http://quasar.dev" ],
+      "category": "navigation",
+      "addedIn": "v1.17"
+    },
+
+    "target": {
+      "type": "String",
+      "desc": "Native <a> link target attribute; Use it only along with 'href' prop; Has priority over the 'to'/'exact'/'replace' props",
+      "examples": [ "_blank", "_self", "_parent", "_top" ],
+      "category": "navigation",
+      "addedIn": "v1.17"
     },
 
     "disable": {


### PR DESCRIPTION
If it is disable and type is not 'a' then it must render as button (link cannot be disabled)

If it renders as link (<a>):
- it must not have type (except if type is a MediaType)
- if it has href it does not need a role - it is link by default
- if it does not have href then if does need role=button

If it renders as button:
- the type must be one of 'button', 'submit', 'reset'
- it does not need a role