### PR TITLE
feat(ts): Improve useDialogPluginComponent types

### DIFF
--- a/ui/types/composables.d.ts
+++ b/ui/types/composables.d.ts
@@ -6,15 +6,15 @@ import { Ref } from "vue";
 import { QVueGlobals } from "./globals";
 
 interface useDialogPluginComponent {
-  (): {
+  <T = any>(): {
     dialogRef: Ref<QDialog | undefined>;
     onDialogHide: () => void;
-    onDialogOK: (payload?: any) => void;
+    onDialogOK: (payload?: T) => void;
     onDialogCancel: () => void;
   };
   emits: ['ok', 'hide'];
   emitsObject: {
-    ok: () => true;
+    ok: (payload?: any) => true;
     hide: () => true;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When using `useDialogPluginComponent`, you can specify the type of the `onDialogOK` argument.

Also, if you don't specify it, `any` will be inserted, so it won't be broken.

```ts
const { dialogRef, onDialogOK } = useDialogPluginComponent<string>();
onDialogOK("foo"); // OK
onDialogOK(10); // Error
```

And since `ok` in `emitsObject` did not have an argument, I added one.
However, I couldn't think of a way to specify the type here, so it is `any`...