### PR TITLE
feat(QBreadcrumbs): improvement for breadcrumb elements

### DIFF
--- a/ui/src/components/breadcrumbs/QBreadcrumbs.js
+++ b/ui/src/components/breadcrumbs/QBreadcrumbs.js
@@ -4,6 +4,8 @@ import AlignMixin from '../../mixins/align.js'
 import { slot } from '../../utils/slot.js'
 import ListenersMixin from '../../mixins/listeners.js'
 
+const disabledValues = [ true, '' ]
+
 export default Vue.extend({
   name: 'QBreadcrumbs',
 
@@ -34,13 +36,13 @@ export default Vue.extend({
     },
 
     sepClass () {
-      if (this.separatorColor) {
-        return `text-${this.separatorColor}`
-      }
+      return this.separatorColor
+        ? ` text-${this.separatorColor}`
+        : ''
     },
 
     activeClass () {
-      return `text-${this.activeColor}`
+      return ` text-${this.activeColor}`
     }
   },
 
@@ -60,18 +62,20 @@ export default Vue.extend({
     nodes.forEach(comp => {
       if (comp.tag !== void 0 && comp.tag.endsWith('-QBreadcrumbsEl')) {
         const middle = els < len
+        const disabled = disabledValues.includes(comp.componentOptions.propsData.disable)
+        const cls = middle === true
+          ? (disabled !== true ? this.activeClass : '')
+          : ' q-breadcrumbs--last'
+
         els++
 
         child.push(h('div', {
-          staticClass: 'flex items-center',
-          class: middle ? this.activeClass : 'q-breadcrumbs--last'
+          staticClass: 'flex items-center' + cls
         }, [ comp ]))
 
-        if (middle) {
-          child.push(h('div', {
-            staticClass: 'q-breadcrumbs__separator', class: this.sepClass
-          }, separator()))
-        }
+        middle === true && child.push(h('div', {
+          staticClass: 'q-breadcrumbs__separator' + this.sepClass
+        }, separator()))
       }
       else {
         child.push(comp)

--- a/ui/src/components/breadcrumbs/QBreadcrumbs.sass
+++ b/ui/src/components/breadcrumbs/QBreadcrumbs.sass
@@ -9,8 +9,5 @@
     &--with-label
       margin-right: 8px
 
-  &--last a
-    pointer-events: none
-
 [dir=rtl] .q-breadcrumbs__separator .q-icon
   transform: scaleX(-1) #{"/* rtl:ignore */"}

--- a/ui/src/components/breadcrumbs/QBreadcrumbs.styl
+++ b/ui/src/components/breadcrumbs/QBreadcrumbs.styl
@@ -9,8 +9,5 @@
     &--with-label
       margin-right: 8px
 
-  &--last a
-    pointer-events: none
-
 [dir=rtl] .q-breadcrumbs__separator .q-icon
   transform: scaleX(-1) /* rtl:ignore */

--- a/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
+++ b/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
@@ -16,23 +16,35 @@ export default Vue.extend({
     icon: String
   },
 
+  computed: {
+    iconClass () {
+      return 'q-breadcrumbs__el-icon' +
+        (this.label !== void 0 ? ' q-breadcrumbs__el-icon--with-label' : '')
+    },
+
+    renderData () {
+      const staticClass = 'q-breadcrumbs__el q-link ' +
+        'flex inline items-center relative-position ' +
+        (this.disable !== true ? 'q-link--focusable' : 'q-breadcrumbs__el--disabled')
+
+      return this.hasRouterLink === true
+        ? [ 'router-link', { staticClass, props: this.routerLinkProps, nativeOn: { ...this.qListeners } } ]
+        : [ 'span', { staticClass, on: { ...this.qListeners } } ]
+    }
+  },
+
   render (h) {
     const child = []
 
     this.icon !== void 0 && child.push(
       h(QIcon, {
-        staticClass: 'q-breadcrumbs__el-icon',
-        class: this.label !== void 0 ? 'q-breadcrumbs__el-icon--with-label' : null,
+        staticClass: this.iconClass,
         props: { name: this.icon }
       })
     )
 
     this.label && child.push(this.label)
 
-    return h(this.hasRouterLink === true ? 'router-link' : 'span', {
-      staticClass: 'q-breadcrumbs__el q-link flex inline items-center relative-position',
-      props: this.hasRouterLink === true ? this.routerLinkProps : null,
-      [this.hasRouterLink === true ? 'nativeOn' : 'on']: { ...this.qListeners }
-    }, mergeSlot(child, this, 'default'))
+    return h(...this.renderData, mergeSlot(child, this, 'default'))
   }
 })

--- a/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
+++ b/ui/src/components/breadcrumbs/QBreadcrumbsEl.js
@@ -38,7 +38,7 @@ export default Vue.extend({
 
     this.icon !== void 0 && child.push(
       h(QIcon, {
-        staticClass: this.iconClass,
+        class: this.iconClass,
         props: { name: this.icon }
       })
     )

--- a/ui/src/css/core/helpers.sass
+++ b/ui/src/css/core/helpers.sass
@@ -47,6 +47,9 @@
   outline: 0
   text-decoration: none
 
+  &--focusable:focus-visible
+    text-decoration: underline dashed currentColor 1px
+
 body.electron
   .q-electron-drag
     -webkit-user-select: none

--- a/ui/src/css/core/helpers.styl
+++ b/ui/src/css/core/helpers.styl
@@ -47,6 +47,9 @@
   outline: 0
   text-decoration: none
 
+  &--focusable:focus-visible
+    text-decoration: underline dashed currentColor 1px
+
 body.electron
   .q-electron-drag
     -webkit-user-select: none


### PR DESCRIPTION
- add marker classes on breadcrumb el parent for when it's disabled/inactive or last
- don't apply activeClass on disabled breadcrumb els
- really disable last breadcrumb el (instead of using pointer-events)
- add visual indicator for active el when kbd navigating