### PR TITLE
fix(docs): issues with searchbox on mobile

### DIFF
--- a/docs/src/layouts/DocLayout.vue
+++ b/docs/src/layouts/DocLayout.vue
@@ -83,6 +83,7 @@ q-layout.doc-layout(view="lHh LpR lff", @scroll="onScroll")
           @focus="onSearchFocus"
           @blur="onSearchBlur"
           placeholder="Search Quasar v2..."
+          type="search"
         )
           template(v-slot:prepend)
             q-icon(name="search")

--- a/docs/src/layouts/doc-layout/use-search.js
+++ b/docs/src/layouts/doc-layout/use-search.js
@@ -201,9 +201,7 @@ export default function useSearch (scope, $q, $route) {
       scope.leftDrawerState.value = true
     }
 
-    if ($q.platform.is.desktop === true) {
-      window.addEventListener('keypress', focusOnSearch)
-    }
+    window.addEventListener('keypress', focusOnSearch)
 
     if (searchQuery) {
       // Here we put search string from query into the input and open the search popup.
@@ -215,7 +213,7 @@ export default function useSearch (scope, $q, $route) {
     }
   })
 
-  $q.platform.is.desktop === true && onBeforeUnmount(() => {
+  onBeforeUnmount(() => {
     window.removeEventListener('keypress', focusOnSearch)
   })
 

--- a/docs/src/layouts/doc-layout/use-search.js
+++ b/docs/src/layouts/doc-layout/use-search.js
@@ -137,15 +137,17 @@ export default function useSearch (scope, $q, $route) {
     searchInputRef.value.focus()
   }
 
-  const onSearchKeydown = $q.platform.is.desktop === true
-    ? evt => {
-      switch (evt.keyCode) {
-        case 27: // escape
+  function onSearchKeydown (evt) {
+    switch (evt.keyCode) {
+      case 27: // escape
+        if ($q.platform.is.desktop === true) {
           evt.preventDefault()
           resetSearch()
-          break
-        case 38: // up
-        case 40: // down
+        }
+        break
+      case 38: // up
+      case 40: // down
+        if ($q.platform.is.desktop === true) {
           evt.preventDefault()
           if (searchResults.value !== null && searchResults.value.ids !== void 0) {
             if (searchActiveId.value === null) {
@@ -165,17 +167,17 @@ export default function useSearch (scope, $q, $route) {
               target.scrollIntoView({ block: 'center' })
             }
           }
-          break
-        case 13: // enter
-          evt.preventDefault()
-          evt.stopPropagation()
-          if (searchResults.value !== null && searchActiveId.value !== null) {
-            document.getElementById(searchActiveId.value).click(evt)
-          }
-          break
-      }
+        }
+        break
+      case 13: // enter
+        evt.preventDefault()
+        evt.stopPropagation()
+        if (searchResults.value !== null && searchActiveId.value !== null) {
+          document.getElementById(searchActiveId.value).click(evt)
+        }
+        break
     }
-    : () => {}
+  }
 
   function onResultSuccess (response) {
     searchResults.value = parseResults(response.hits)

--- a/docs/src/layouts/doc-layout/use-search.js
+++ b/docs/src/layouts/doc-layout/use-search.js
@@ -140,32 +140,28 @@ export default function useSearch (scope, $q, $route) {
   function onSearchKeydown (evt) {
     switch (evt.keyCode) {
       case 27: // escape
-        if ($q.platform.is.desktop === true) {
-          evt.preventDefault()
-          resetSearch()
-        }
+        evt.preventDefault()
+        resetSearch()
         break
       case 38: // up
       case 40: // down
-        if ($q.platform.is.desktop === true) {
-          evt.preventDefault()
-          if (searchResults.value !== null && searchResults.value.ids !== void 0) {
-            if (searchActiveId.value === null) {
-              searchActiveId.value = searchResults.value.ids[ 0 ]
-            }
-            else {
-              const ids = searchResults.value.ids
-              const index = ids.indexOf(searchActiveId.value)
-              searchActiveId.value = ids[ (ids.length + index + (evt.keyCode === 38 ? -1 : 1)) % ids.length ]
-            }
+        evt.preventDefault()
+        if (searchResults.value !== null && searchResults.value.ids !== void 0) {
+          if (searchActiveId.value === null) {
+            searchActiveId.value = searchResults.value.ids[ 0 ]
+          }
+          else {
+            const ids = searchResults.value.ids
+            const index = ids.indexOf(searchActiveId.value)
+            searchActiveId.value = ids[ (ids.length + index + (evt.keyCode === 38 ? -1 : 1)) % ids.length ]
+          }
 
-            const target = document.getElementById(searchActiveId.value)
-            if (target.scrollIntoViewIfNeeded) {
-              target.scrollIntoViewIfNeeded()
-            }
-            else {
-              target.scrollIntoView({ block: 'center' })
-            }
+          const target = document.getElementById(searchActiveId.value)
+          if (target.scrollIntoViewIfNeeded) {
+            target.scrollIntoViewIfNeeded()
+          }
+          else {
+            target.scrollIntoView({ block: 'center' })
           }
         }
         break


### PR DESCRIPTION
Basically, if you tap the "Enter" key on a mobile keyboard, after typing your search, the page gets reloaded. Right now, you can search, then tap off of the drawer to close it. This PR fixes this as well as using `type="search"` so you get proper keyboard supports on mobile.