### PR TITLE
Added missing 'new-value' to emits for QSelect

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -129,7 +129,7 @@ export default createComponent({
     ...useFieldEmits,
     'add', 'remove', 'input-value',
     'keyup', 'keypress', 'keydown',
-    'filter-abort'
+    'filter-abort', 'new-value'
   ],
 
   setup (props, { slots, emit }) {


### PR DESCRIPTION
Added missing 'new-value' to emits for QSelect to avoid vue warn:
Component emitted event "new-value" but it is neither declared in the emits option nor as an "onNew-value" prop.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
it is kind of bug, but it generates only warning, so not sure what is real impact of it.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.
