### PR TITLE
feat(ts): Improve rest and index signature types generation

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -95,43 +95,52 @@ function getTypeVal (def) {
 }
 
 function getPropDefinition ({ name, definition, docs = true, isMethodParam = false, isCompProps = false, escapeName = true }) {
-  const propName = escapeName ? toCamelCase(name) : name
+  let propName = escapeName ? toCamelCase(name) : name
 
   if (propName.startsWith('...')) {
-    return isMethodParam ? `${ propName }: any[]` : '[index: string]: any'
+    if (isMethodParam) {
+      // A rest parameter must be of an array type. e.g. '...params: any[]'
+      definition.type = 'Array'
+      // A rest parameter cannot be optional
+      definition.required = true
+    }
+    else {
+      propName = `[${ propName.replace('...', '') || 'key' }: string]`
+      // Optionality with index signature types works differently and use of '?:' is invalid and not required, so always mark it as required
+      definition.required = true
+    }
   }
-  else {
-    addToExtraInterfaces(definition)
 
-    let propType = getTypeVal(definition)
+  addToExtraInterfaces(definition)
 
-    if (isCompProps === true && name !== 'model-value' && !definition.required && propType.indexOf(' undefined') === -1) {
-      propType += ' | undefined;'
+  let propType = getTypeVal(definition)
+
+  if (isCompProps === true && name !== 'model-value' && !definition.required && propType.indexOf(' undefined') === -1) {
+    propType += ' | undefined;'
+  }
+
+  let jsDoc = ''
+
+  if (docs) {
+    jsDoc += `/**\n * ${ definition.desc }\n`
+
+    if (definition.default) {
+      jsDoc += ` * Default value: ${ definition.default }\n`
     }
 
-    let jsDoc = ''
-
-    if (docs) {
-      jsDoc += `/**\n * ${ definition.desc }\n`
-
-      if (definition.default) {
-        jsDoc += ` * Default value: ${ definition.default }\n`
-      }
-
-      for (const [ name, paramDef ] of Object.entries(definition.params || {})) {
-        jsDoc += ` * @param ${ name } ${ paramDef.desc || '' }\n`
-      }
-
-      const { returns } = definition
-      if (returns && returns.desc) {
-        jsDoc += ` * @returns ${ returns.desc }\n`
-      }
-
-      jsDoc += ' */\n'
+    for (const [ name, paramDef ] of Object.entries(definition.params || {})) {
+      jsDoc += ` * @param ${ name } ${ paramDef.desc || '' }\n`
     }
 
-    return `${ jsDoc }${ propName }${ !definition.required ? '?' : '' }: ${ propType }`
+    const { returns } = definition
+    if (returns && returns.desc) {
+      jsDoc += ` * @returns ${ returns.desc }\n`
+    }
+
+    jsDoc += ' */\n'
   }
+
+  return `${ jsDoc }${ propName }${ !definition.required ? '?' : '' }: ${ propType }`
 }
 
 function getPropDefinitions ({ definitions, docs = true, areMethodParams = false, isCompProps = false }) {

--- a/ui/src/components/btn-toggle/QBtnToggle.json
+++ b/ui/src/components/btn-toggle/QBtnToggle.json
@@ -189,6 +189,9 @@
   "slots": {
     "default": {
       "desc": "Suggestions: QTooltip, QBadge"
+    },
+    "...": {
+      "desc": "Any other dynamic slots to be used with 'slot' property of the 'options' prop"
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?** 

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

Resolves #11494, but the changes are not limited to it.

📜 Changes for `dist/types/index.d.ts`:

```diff
@@ -1795,9 +1795,12 @@
     /**
      * Slot name to use for this button content; Useful for customizing content or even add tooltips
      */
     slot?: string;
-    [index: string]: any;
+    /**
+     * Any other QBtn props (including class and style)
+     */
+    [props: string]: any;
   }[];
   /**
    * Color name for component from the Quasar Color Palette
    */
@@ -1903,8 +1906,12 @@
   /**
    * Suggestions: QTooltip, QBadge
    */
   default: () => VNode[];
+  /**
+   * Any other dynamic slots to be used with 'slot' property of the 'options' prop
+   */
+  [key: string]: () => VNode[];
 }
 
 export interface QBtnToggle extends ComponentPublicInstance<QBtnToggleProps> {}
 
@@ -6392,9 +6399,12 @@
         /**
          * If true, the option will be disabled
          */
         disable?: boolean;
-        [index: string]: any;
+        /**
+         * Any other props from QToggle, QCheckbox, or QRadio
+         */
+        [props: string]: any;
       }[]
     | undefined;
   /**
    * Used to specify the name of the controls; Useful if dealing with forms submitted directly to a URL
@@ -6457,9 +6467,12 @@
     /**
      * If true, the option will be disabled
      */
     disable?: boolean;
-    [index: string]: any;
+    /**
+     * Any other props from QToggle, QCheckbox, or QRadio
+     */
+    [props: string]: any;
   }) => VNode[];
   /**
    * Slot to define the specific label for the option at '[name]' where name is a 0-based index; Overrides the generic 'label' slot if used
    * @param scope The corresponding option entry from the 'options' prop
@@ -6476,9 +6489,12 @@
     /**
      * If true, the option will be disabled
      */
     disable?: boolean;
-    [index: string]: any;
+    /**
+     * Any other props from QToggle, QCheckbox, or QRadio
+     */
+    [props: string]: any;
   }) => VNode[];
 }
 
 export interface QOptionGroup
@@ -13388,13 +13404,29 @@
       };
   /**
    * Props for an 'OK' button
    */
-  ok?: string | { [index: string]: any } | boolean;
+  ok?:
+    | string
+    | {
+        /**
+         * See QBtn for available props
+         */
+        [props: string]: any;
+      }
+    | boolean;
   /**
    * Props for a 'CANCEL' button
    */
-  cancel?: string | { [index: string]: any } | boolean;
+  cancel?:
+    | string
+    | {
+        /**
+         * See QBtn for available props
+         */
+        [props: string]: any;
+      }
+    | boolean;
   /**
    * What button to focus, unless you also have 'prompt' or 'options'
    * Default value: ok
    */
@@ -13533,9 +13565,33 @@
   style?: LooseDictionary;
 }
 
 export interface SliderMarkerLabelObjectConfig {
-  [index: string]: any;
+  /**
+   * Marker label config
+   */
+  [key: string]: {
+    /**
+     * Index of the marker label (0-based)
+     */
+    index?: number;
+    /**
+     * Equivalent model value for the marker label
+     */
+    value?: number;
+    /**
+     * Configured label for the marker
+     */
+    label?: number | string;
+    /**
+     * Required CSS classes to be applied to the marker element
+     */
+    classes?: string;
+    /**
+     * Style definitions to be attributed to the marker label
+     */
+    style?: LooseDictionary;
+  };
 }
 ```