### PR TITLE
fix(docs): fix breakpoint terminology

### DIFF
--- a/docs/src/pages/style/breakpoints.md
+++ b/docs/src/pages/style/breakpoints.md
@@ -13,7 +13,7 @@ Quasar uses the following CSS breakpoints:
 | Small | `sm` | Up to 1023px |
 | Medium | `md` | Up to 1439px |
 | Large | `lg` | Up to 1919px |
-| Extra Large | `xl` | Bigger than 1920px |
+| Extra Large | `xl` | 1920px and up |
 
 To learn how to use them, please visit the [Visibility](/style/visibility) page.
 

--- a/docs/src/pages/style/visibility.md
+++ b/docs/src/pages/style/visibility.md
@@ -31,7 +31,7 @@ First of all, let's define what the breakpoints are:
 | Small | sm | Up to 1023px |
 | Medium | md | Up to 1439px |
 | Large | lg | Up to 1919px |
-| Extra Large | xl | Bigger than 1920px |
+| Extra Large | xl | 1920px and up |
 
 Now on to the window width related CSS classes.
 


### PR DESCRIPTION
The new way is the inverse of xs. The old way implied a missing pixel.
