### PR TITLE
fix(vite-plugin): Sourcemaps off due to auto imports

### DIFF
--- a/vite-plugin/src/js-transform.js
+++ b/vite-plugin/src/js-transform.js
@@ -1,6 +1,6 @@
 import importTransformation from 'quasar/dist/transforms/import-transformation.js'
 
-export const importQuasarRegex = /import\s*\{([\w,\s]+)\}\s*from\s*['"]{1}quasar['"]{1}/
+export const importQuasarRegex = /import\s*\{([\w,\s]+)\}\s*from\s*['"]{1}quasar['"]{1};?/
 export const jsTransformRegex = /\.[j|t]s$/
 
 export function jsTransform (code) {

--- a/vite-plugin/src/js-transform.js
+++ b/vite-plugin/src/js-transform.js
@@ -23,7 +23,7 @@ export function jsTransform (code) {
           ? data[1].trim()
           : importName
 
-        return `import ${importAs} from '${importTransformation(importName)}'\n`
+        return `import ${importAs} from '${importTransformation(importName)}';`
       })
       .join('')
   )

--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -35,7 +35,7 @@ export function vueTransform (content, autoImportComponentCase) {
             : importName
 
           importMap[importName] = importAs
-          return `import ${importAs} from '${importTransformation(importName)}'\n`
+          return `import ${importAs} from '${importTransformation(importName)}';`
         })
         .join('')
     )

--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -90,7 +90,7 @@ export function vueTransform (content, autoImportComponentCase) {
 
   const codePrefix = importList
     .map(name => `import ${name} from '${importTransformation(name)}'`)
-    .join(`\n`)
+    .join(`;`)
 
-  return codePrefix + '\n' + code
+  return codePrefix + ';' + code
 }


### PR DESCRIPTION


<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The problem I have been running into has to do with the new lines being added by quasar for each of its auto imported components or utility files. Each import is  causing the source map to be off by an additional line. I only noticed this issue
using script setup in vue along with the auto import from the quasar plugin. 

I first reported this issue  [here](https://github.com/vitejs/vite/issues/6114) and after I got tired of being unable to debug anything by the chrome debugger due to sourcemaps being off as much as 20 lines in some bigger files I looked into the issue a bit more. 

A  minimal reproduction repo as explained on the vitejs issue can be found [here](https://github.com/kalvenschraut/vite-sourcemaps-repro). 

My solution to the issue is to simply use semicolons and do the inserts either on the first line of the file or the same line as the quasar import. This may make the compiled code a bit harder to read, but that is what the sourcemaps are for. After looking over the compiled vite code to debug this issue,  I noticed the vite vue plugin seems to insert code on the same line and not add new lines also.  To be able to keep the ability to add new lines still would involve digging into why the changes to the file are not being accounted for by vite when its generating the sourcemaps which I think is not worth the time/effort to do.

I also added a check for an optional semicolon to the importQuasarRegex otherwise any semi colon written by the user after their import would be leftover after the replace. With new lines being added means the semicolon leftover would be on the next line and with my semicolon change it resulted in two semicolons back to back.

I have been testing this change in my code base and the sourcemaps are pointing to the right location again.