### PR TITLE
feat(docs): call out slot caveat for custom image URLs

### DIFF
--- a/docs/src/pages/vue-components/icon.md
+++ b/docs/src/pages/vue-components/icon.md
@@ -427,6 +427,10 @@ You can also make an icon point to an image URL instead of relying on any webfon
 Remember that you can place images in your `/public` folder too and point to them. You don't always need a full URL.
 :::
 
+::: warning
+Since `<img>` tags cannot contain children, you will not be able to use the default `<slot>` in a QIcon that uses a custom image URL.  The best option in this case is to place your QIcon in a `<div>` alongside any other content intended for the default QIcon slot.
+:::
+
 This is not restricted to SVG only. You can use whatever image type you want (png, jpg, ...):
 
 ```html


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Hopefully, adding this warning in the docs will make it less likely for people like me to open duplicates of #5967.  I actually looked in the docs before opening #11917 and didn't find anything so thought it was indeed a bug.
