### PR TITLE
fix(docs): Release names too wide

### DIFF
--- a/docs/src/components/page-parts/releases/PackageReleases.vue
+++ b/docs/src/components/page-parts/releases/PackageReleases.vue
@@ -8,8 +8,8 @@ div
     template(#before)
       q-scroll-area
         q-tabs.text-grey-7(vertical v-model="selectedVersion"  active-color="brand-primary" active-bg-color="blue-1" indicator-color="brand-primary")
-          q-tab(v-for="releaseInfo in filteredReleases" :key="releaseInfo.label" :name="releaseInfo.label")
-            .q-tab__label {{ releaseInfo.version }}
+          q-tab(v-for="releaseInfo in filteredReleases" :key="releaseInfo.label" :name="releaseInfo.label" :title="releaseInfo.label")
+            .q-tab__label {{ releaseInfo.version.split(' ')[0] }}
             small.text-grey-7 {{ releaseInfo.date }}
     template(#after)
       q-tab-panels.releases-container(v-model="selectedVersion" animated transition-prev="slide-down" transition-next="slide-up")


### PR DESCRIPTION
On the [Release notes](https://quasar.dev/start/release-notes) page, the `QTab` is too wide when the release name is too long, example is `quasar-v1.17.0 aka "Backport features and fixes from v2"`

![Screenshot 2022-01-08 at 15 12 48](https://user-images.githubusercontent.com/62475782/148647460-d4195407-9a02-46b5-b585-7285957d5da5.png)
![Screenshot 2022-01-08 at 15 12 58](https://user-images.githubusercontent.com/62475782/148647465-bde0424e-6ab3-4cd9-836f-453a6ba32fee.png)

Shoul be backported to `v1` docs as well.
