### PR TITLE
fix: Use correct template path on issue workflow

### DIFF
--- a/.github/workflows/process-created-issue.yml
+++ b/.github/workflows/process-created-issue.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: stefanbuck/github-issue-parser@v2
         id: issue-parser
         with:
-          template-path: .github/ISSUE_TEMPLATE/${{ env.TEMPLATE_TYPE }}-report--${{ env.TEMPLATE_VERSION }}.yml
+          template-path: .github/ISSUE_TEMPLATE/${{ env.TEMPLATE_TYPE }}-report--quasar-${{ env.TEMPLATE_VERSION }}.yml
 
       - uses: actions/github-script@v5
         env:


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- Triaging Improvements

**Does this PR introduce a breaking change?** <!-- Check one -->

- No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

-  It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

https://github.com/quasarframework/quasar/actions/runs/1682167018
> Error: ENOENT: no such file or directory, open '.github/ISSUE_TEMPLATE/bug-report--v2.yml'