### PR TITLE
fix: Adding an extra props "unSelectable" to QTree (fix #7701)

### DIFF
--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -46,6 +46,10 @@ export default createComponent({
     controlColor: String,
     textColor: String,
     selectedColor: String,
+    unSelectable: {
+      type: Boolean,
+      default: true
+    },
 
     icon: String,
 
@@ -615,7 +619,11 @@ export default createComponent({
 
       if (hasSelection.value) {
         if (meta.selectable) {
-          emit('update:selected', meta.key !== props.selected ? meta.key : null)
+          if (props.unSelectable) {
+            emit('update:selected', meta.key !== props.selected ? meta.key : null)
+          } else if (meta.key !== props.selected) {
+            emit('update:selected', meta.key || null)
+          }
         }
       }
       else {

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -46,10 +46,6 @@ export default createComponent({
     controlColor: String,
     textColor: String,
     selectedColor: String,
-    unSelectable: {
-      type: Boolean,
-      default: true
-    },
 
     icon: String,
 
@@ -61,6 +57,8 @@ export default createComponent({
     ticked: Array, // v-model:ticked
     expanded: Array, // v-model:expanded
     selected: {}, // v-model:selected
+
+    noSelectionUnset: Boolean,
 
     defaultExpandAll: Boolean,
     accordion: Boolean,
@@ -619,10 +617,9 @@ export default createComponent({
 
       if (hasSelection.value) {
         if (meta.selectable) {
-          if (props.unSelectable) {
-            emit('update:selected', meta.key !== props.selected ? meta.key : null)
-          } else if (meta.key !== props.selected) {
-            emit('update:selected', meta.key || null)
+          const val = meta.key !== props.selected ? meta.key : null
+          if (props.noSelectionUnset !== true || val !== null) {
+            emit('update:selected', val)
           }
         }
       }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

Hi.
Example
1.https://codepen.io/superseo/pen/XWeyBpz
2.https://codepen.io/superseo/pen/oNGQMQO?editors=101

Taken from the manual https://quasar.dev/vue-components/tree

The second click on the selected element always resets the selection. That is, click on the element for the first time - the corresponding Tab Panel opens, click again on the same element - it closes.
But it is necessary that the second click on the same element does not cause deselection.

Adding an extra props "unSelectable" is probably enough. By default (true) - old behavior. If false, then the second click does not deselect. For those cases when such behavior is necessary, without breaking the old logic.

https://codepen.io/superseo/pen/xxXQJLz?editors=101

added a new parameter, for example on PR fix: Adding an extra props "unSelectable" to QTree (fix #7701) #12012
just use <q-tree ... :un-selectable="false" />
The error from the description occurs because of a check on this line
https://github.com/pdanpdan/quasar/blob/8a5a2d799bc4af2dc185ca0ec1614b7dd66737aa/ui/src/components/tree/QTree.js#L607

Same request but for v1
#3551

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [*] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [*] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [*] It's submitted to the `dev` branch (or `v[X]` branch)
- [*] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
