### PR TITLE
feat(dialog) allow disable buttons

### DIFF
--- a/ui/dev/src/pages/global/dialog-plugin.vue
+++ b/ui/dev/src/pages/global/dialog-plugin.vue
@@ -26,6 +26,7 @@
         <q-btn label="Prompt (validation)" flat color="primary" @click="promptValidation" />
         <q-btn label="Radio (validation)" flat color="primary" @click="radioValidation" />
         <q-btn label="Checkbox (validation)" flat color="primary" @click="checkboxValidation" />
+        <q-btn label="Disable button" flat color="primary" @click="disabledButtons" />
         <q-btn-dropdown color="accent" label="Open from dropdown" unelevated>
           <q-list flat>
             <q-item @click="alert" clickable v-close-popup>
@@ -330,6 +331,30 @@ export default {
         },
         cancel: true,
         persistent: true,
+        dark: this.dark
+      }).onOk(data => {
+        console.log('>>>> OK, received', data)
+      }).onCancel(() => {
+        console.log('>>>> Cancel')
+      }).onDismiss(() => {
+        this.dialogHandler = void 0
+      })
+    },
+
+    disabledButtons () {
+      this.dialogHandler = this.$q.dialog({
+        title: 'Disabled buttons',
+        message: 'buttons should be disabled',
+        ok: {
+          label: 'resend',
+          unelevated: true,
+          disable: true
+        },
+        cancel: {
+          label: 'remove',
+          flat: true,
+          disable: true
+        },
         dark: this.dark
       }).onOk(data => {
         console.log('>>>> OK, received', data)

--- a/ui/src/components/dialog-plugin/DialogPlugin.js
+++ b/ui/src/components/dialog-plugin/DialogPlugin.js
@@ -144,8 +144,8 @@ export default createComponent({
       color: vmColor.value,
       label: okLabel.value,
       ripple: false,
-      ...(Object(props.ok) === props.ok ? props.ok : { flat: true }),
       disable: okDisabled.value,
+      ...(Object(props.ok) === props.ok ? props.ok : { flat: true }),
       'data-autofocus': (props.focus === 'ok' && hasForm.value !== true) || void 0,
       onClick: onOk
     }))


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**
According to the documentation the ok/cancel buttons can have all props of a QBtn, it's true except for the `disable` prop.

**Example:**
```js
  this.$q.dialog({
    title: 'Alert',
    message: 'Some message',
    ok: {
      label: 'resend',
      unelevated: true,
      disable: true // <-- overwritten
    },
  })
```

This PR allow to use disable prop on ok/cancel buttons
