### PR TITLE
migrate to sass 1.48 fix: #9362,#10427,#11683

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -92,7 +92,7 @@
     "postcss-rtlcss": "3.5.1",
     "pretty-error": "4.0.0",
     "register-service-worker": "1.7.2",
-    "sass": "1.32.12",
+    "sass": "1.48.0",
     "sass-loader": "12.4.0",
     "semver": "7.3.5",
     "table": "6.7.5",

--- a/docs/src/pages/start/vite-plugin.md
+++ b/docs/src/pages/start/vite-plugin.md
@@ -38,20 +38,20 @@ Navigate to your Vite project folder and install the necessary packages.
 
 ::: tip
 * Notice that `@quasar/extras` is optional.
-* Also, add `sass@1.32.0` (notice the pinned version) only if you want to use the Quasar Sass/SCSS variables.
+* Also, add `sass@1.48` (notice the pinned version) only if you want to use the Quasar Sass/SCSS variables.
 :::
 
 ``` bash
 $ yarn add quasar @quasar/extras
-$ yarn add -D @quasar/vite-plugin sass@1.32.0
+$ yarn add -D @quasar/vite-plugin sass@1.48
 
 # or
 $ npm install quasar @quasar/extras
-$ npm install -D @quasar/vite-plugin sass@1.32.0
+$ npm install -D @quasar/vite-plugin sass@1.48
 
 # or
 $ pnpm add quasar @quasar/extras
-$ pnpm add quasar -D @quasar/vite-plugin sass@1.32.0
+$ pnpm add quasar -D @quasar/vite-plugin sass@1.48
 ```
 
 ## Using Quasar

--- a/ui/src/css/core/flex.sass
+++ b/ui/src/css/core/flex.sass
@@ -1,3 +1,5 @@
+@use "sass:math"
+
 @import '../helpers/string.sass'
 
 @mixin fg($name, $size)
@@ -30,13 +32,13 @@
       .row
         #{str-fe('> .col<name>-<i>', $name, $noProcNotZero, $ic)}
           height: auto
-          width: toFixed(percentage($i / $flex-cols), 10000)
+          width: toFixed(percentage(calc($i / $flex-cols)), 10000)
         @if $i != 0 or $name != ''
           #{str-fe('> .offset<name>-<i>', $name, $noProcNotZero, $ic)}
-            margin-left: toFixed(percentage($i / $flex-cols), 10000)
+            margin-left: toFixed(percentage(calc($i / $flex-cols)), 10000)
       .column
         #{str-fe('> .col<name>-<i>', $name, $noProcNotZero, $ic)}
-          height: toFixed(percentage($i / $flex-cols), 10000)
+          height: toFixed(percentage(calc($i / $flex-cols)), 10000)
           width: auto
       @if $size == 0 and $i == $flex-cols
         .row > .col-all

--- a/ui/src/css/flex-addon.sass
+++ b/ui/src/css/flex-addon.sass
@@ -1,3 +1,5 @@
+@use "sass:math"
+
 @import './helpers/string.sass'
 @import './helpers/math.sass'
 
@@ -194,7 +196,7 @@
 
         @for $i from 0 through $flex-cols
           $ic: quote('' + $i)
-          $internal-size: toFixed(percentage($i / $flex-cols), 10000)
+          $internal-size: toFixed(percentage(calc($i / $flex-cols)), 10000)
 
           #{str-fr('.row<name>', $name)}
             #{str-fe('> .col<name>-<i>', $name2c, $noProcNotZero2, $ic)}

--- a/ui/src/css/helpers/math.sass
+++ b/ui/src/css/helpers/math.sass
@@ -7,7 +7,7 @@ $PI: 3.14159265359
       $value: $value * $number
   @else if $exp < 0
     @for $i from 1 through -$exp
-      $value: $value / $number
+      $value: calc($value / $number)
   @return $value
 
 @function fact($number)
@@ -21,22 +21,22 @@ $PI: 3.14159265359
 // toFixed(0.12345, 100) -> 0.12
 // toFixed(0.12345, 1000) -> 0.123
 @function toFixed($number, $power)
-  @return round($number * $power) / $power
+  @return calc(round($number * $power) / $power)
 
 @function sin($angle)
   $sin: 0
   // angle -> radians
-  $rad: $angle / 180 * $PI
+  $rad: calc($angle / 180) * $PI
   // interval determines precision
   @for $i from 0 through 25
-    $sin: $sin + pow(-1, $i) * pow($rad, (2 * $i + 1)) / fact(2 * $i + 1)
+    $sin: $sin + calc(pow(-1, $i) * pow($rad, (2 * $i + 1)) / fact(2 * $i + 1))
   @return $sin
 
 @function cos($angle)
   $cos: 0
   // angle -> radians
-  $rad: $angle / 180 * $PI
+  $rad: calc($angle / 180) * $PI
   // interval determines precision
   @for $i from 0 through 25
-    $cos: $cos + pow(-1, $i) * pow($rad, 2 * $i) / fact(2 * $i)
+    $cos: $cos + calc(pow(-1, $i) * pow($rad, 2 * $i) / fact(2 * $i))
   @return $cos


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Math divisions are now wrapped in native css `calc()`, which does not require implementing `@use`.

This resolves "Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0."

Another PR #11877 attempted to solve this, but missed `flex-addon.sass`, and used the non-desired `@use 'sass:math'` method.

fix #9362, fix #10427, fix #11683