### PR TITLE
feat(ts): Add lots of new types, drop LooseDictionary type (fix: #11309)

### DIFF
--- a/app/tsconfig-preset.json
+++ b/app/tsconfig-preset.json
@@ -8,6 +8,8 @@
     // Needed to address https://github.com/quasarframework/app-extension-typescript/issues/36
     "noEmit": true,
     "resolveJsonModule": true,
+    // Avoid cross-os errors due to inconsistent file casing
+    "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,
     "target": "es6",

--- a/app/types/configuration/electron-conf.d.ts
+++ b/app/types/configuration/electron-conf.d.ts
@@ -3,7 +3,7 @@ import * as ElectronBuilder from "electron-builder";
 import * as ElectronPackager from "electron-packager";
 import { Configuration as WebpackConfiguration } from "webpack";
 import * as WebpackChain from "webpack-chain";
-import { LiteralUnion } from "../ts-helpers";
+import { LiteralUnion } from "quasar";
 
 export type QuasarElectronBundlersInternal = "builder" | "packager";
 

--- a/app/types/ts-helpers.ts
+++ b/app/types/ts-helpers.ts
@@ -1,5 +1,0 @@
-// Needed to prevent TS to collapse `'value1' | 'value2' | string` to `string`, which breaks first parameter autocomplete
-// See: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-832522611
-export type LiteralUnion<T extends U, U = string> =
-  | T
-  | (U & Record<never, never>);

--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -419,3 +419,26 @@ export default {
   }
 }
 ```
+
+If you're using TypeScript, you'd need to register the new component types to allow Volar to autocomplete props and slots for you.
+
+```ts
+import {
+  GlobalComponentConstructor,
+  QUploaderProps,
+  QUploaderSlots,
+} from 'quasar';
+
+interface MyUploaderProps extends QUploaderProps {
+  // .. add custom props
+  freeze: boolean;
+  // .. add custom events
+  onFreeze: boolean;
+}
+
+declare module '@vue/runtime-core' {
+  interface GlobalComponents {
+    MyUploader: GlobalComponentConstructor<MyUploaderProps, QUploaderSlots>;
+  }
+}
+```

--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -422,7 +422,7 @@ export default {
 
 If you're using TypeScript, you'd need to register the new component types to allow Volar to autocomplete props and slots for you.
 
-```ts
+```js
 import {
   GlobalComponentConstructor,
   QUploaderProps,

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -36,7 +36,7 @@ const typeMap = new Map([
 
 const fallbackComplexTypeMap = new Map([
   [ 'Array', 'any[]' ],
-  [ 'Object', 'LooseDictionary' ]
+  [ 'Object', 'any' ]
 ])
 
 const dontNarrowValues = [
@@ -287,7 +287,7 @@ function writeIndexDTS (apis) {
   writeLine(contents, '/// <reference types="@quasar/app" />')
   // ----
   writeLine(contents, 'import { App, Component, ComponentPublicInstance, VNode } from \'vue\'')
-  writeLine(contents, 'import { LooseDictionary, ComponentConstructor, GlobalComponentConstructor } from \'./ts-helpers\'')
+  writeLine(contents, 'import { ComponentConstructor, GlobalComponentConstructor } from \'./ts-helpers\'')
   writeLine(contents)
   writeLine(quasarTypeContents, 'export as namespace quasar')
   // We expose `ts-helpers` because they are needed by `@quasar/app` augmentations

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -6,6 +6,7 @@
   "props": {
     "nodes": {
       "type": "Array",
+      "tsType": "QTreeNode",
       "desc": "The array of nodes that designates the tree structure",
       "required": true,
       "examples": [ "[ {...}, {...} ]" ],

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -436,6 +436,8 @@ export function getRenderer (getPlugin) {
     abort: state.abort
   }
 
+  // TODO: the result of this computed, especially the dynamic part, isn't currently typed
+  // This result in an error with Volar when accessing the state (eg. files array)
   const slotScope = computed(() => {
     const acc = {
       canAddFiles: canAddFiles.value,

--- a/ui/src/components/uploader/xhr-uploader-plugin.json
+++ b/ui/src/components/uploader/xhr-uploader-plugin.json
@@ -2,6 +2,7 @@
   "props": {
     "factory": {
       "type": "Function",
+      "tsType": "QUploaderFactoryFn",
       "desc": "Function which should return an Object or a Promise resolving with an Object; For best performance, reference it from your scope and do not define it inline",
       "params": {
         "files": {
@@ -112,7 +113,7 @@
       },
       "returns": {
         "type": "String",
-        "desc": "An array consists of objects with header definitions",
+        "desc": "An array consisting of objects with header definitions",
         "__exemption": [ "examples" ]
       },
       "category": "upload"

--- a/ui/src/composables/private/use-file.json
+++ b/ui/src/composables/private/use-file.json
@@ -72,6 +72,7 @@
       "params": {
         "rejectedEntries": {
           "type": "Array",
+          "tsType": "QRejectedEntry",
           "desc": "Array of { failedPropValidation: string, file: File } Objects for files that do not pass the validation",
           "__exemption": ["examples"]
         }

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -1,4 +1,5 @@
 export * from "./api/cookies";
+export * from "./api/qfile";
 export * from "./api/web-storage";
 export * from "./api/validation";
 export * from "./api/slider";

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -2,6 +2,7 @@ export * from "./api/cookies";
 export * from "./api/qfile";
 export * from "./api/qselect";
 export * from "./api/qtable";
+export * from "./api/quploader";
 export * from "./api/touchswipe";
 export * from "./api/web-storage";
 export * from "./api/validation";

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -1,6 +1,7 @@
 export * from "./api/cookies";
 export * from "./api/qfile";
 export * from "./api/qselect";
+export * from "./api/qtable";
 export * from "./api/web-storage";
 export * from "./api/validation";
 export * from "./api/slider";

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -1,5 +1,6 @@
 export * from "./api/cookies";
 export * from "./api/qfile";
+export * from "./api/qselect";
 export * from "./api/web-storage";
 export * from "./api/validation";
 export * from "./api/slider";

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -2,6 +2,7 @@ export * from "./api/cookies";
 export * from "./api/qfile";
 export * from "./api/qselect";
 export * from "./api/qtable";
+export * from "./api/touchswipe";
 export * from "./api/web-storage";
 export * from "./api/validation";
 export * from "./api/slider";

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -2,6 +2,7 @@ export * from "./api/cookies";
 export * from "./api/qfile";
 export * from "./api/qselect";
 export * from "./api/qtable";
+export * from "./api/qtree";
 export * from "./api/quploader";
 export * from "./api/touchswipe";
 export * from "./api/web-storage";

--- a/ui/types/api/qfile.d.ts
+++ b/ui/types/api/qfile.d.ts
@@ -1,0 +1,8 @@
+export interface QRejectedEntry {
+  failedPropValidation:
+    | "accept"
+    | "max-file-size"
+    | "max-total-size"
+    | "filter";
+  file: File;
+}

--- a/ui/types/api/qselect.d.ts
+++ b/ui/types/api/qselect.d.ts
@@ -1,0 +1,4 @@
+export type QSelectOption<T = string> = {
+  label: string;
+  value: T;
+};

--- a/ui/types/api/qtable.d.ts
+++ b/ui/types/api/qtable.d.ts
@@ -1,0 +1,12 @@
+// Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
+// The import will work correctly at runtime
+import { QTable } from "quasar";
+
+export type QTableColumn<
+  Row extends Record<string, any> = any,
+  K = Row extends Record<string, any> ? keyof Row : string,
+  Field = K | ((row: Row) => any)
+> = Omit<NonNullable<QTable["columns"]>[0], "field" | "format"> & {
+  field: Field;
+  format?: (val: any, row: Row) => string;
+};

--- a/ui/types/api/qtree.d.ts
+++ b/ui/types/api/qtree.d.ts
@@ -1,0 +1,31 @@
+// We can't set QTreeNode as default assignment for the generics param,
+// we use unknown and use conditional types to set it
+export interface QTreeNode<Node = unknown> {
+  label?: string;
+  icon?: string;
+  iconColor?: string;
+  img?: string;
+  avatar?: string;
+  children?: (Node extends unknown ? QTreeNode : Node)[];
+  disabled?: boolean;
+  expandable?: boolean;
+  selectable?: boolean;
+  handler?: (node: Node extends unknown ? QTreeNode : Node) => void;
+  tickable?: boolean;
+  noTick?: boolean;
+  tickStrategy?: "leaf" | "leaf-filtered" | "string" | "none";
+  lazy?: boolean;
+  header?: string;
+  body?: string;
+  [index: string]: any;
+}
+
+export interface QTreeLazyLoadParams<
+  Node extends QTreeNode = QTreeNode,
+  UpdatedNodes extends QTreeNode = Node
+> {
+  node: Node;
+  key: string;
+  done: (nodes: UpdatedNodes[]) => void;
+  fail: () => void;
+}

--- a/ui/types/api/quploader.d.ts
+++ b/ui/types/api/quploader.d.ts
@@ -1,0 +1,28 @@
+import { LiteralUnion } from "../ts-helpers";
+
+export interface QUploaderHeaderItem {
+  name: string;
+  value: string;
+}
+export interface QUploaderFormFieldsItem {
+  name: string;
+  value: string;
+}
+
+type ValueOrFunction<ValueType, Param = never> =
+  | ((arg: Param) => ValueType)
+  | ValueType;
+
+export type QUploaderFactoryObject = {
+  url?: ValueOrFunction<string, File[]>;
+  method?: ValueOrFunction<LiteralUnion<"POST" | "PUT">, File[]>;
+  headers?: ValueOrFunction<QUploaderHeaderItem[], File[]>;
+  formFields?: ValueOrFunction<QUploaderFormFieldsItem[], File[]>;
+  fieldName?: ValueOrFunction<string, File>;
+  withCredentials?: ValueOrFunction<boolean, File[]>;
+  sendRaw?: ValueOrFunction<boolean, File[]>;
+};
+
+export type QUploaderFactoryFn = (
+  files: File[]
+) => QUploaderFactoryObject | Promise<QUploaderFactoryObject>;

--- a/ui/types/api/touchswipe.d.ts
+++ b/ui/types/api/touchswipe.d.ts
@@ -1,0 +1,11 @@
+export interface TouchSwipeParams {
+  evt: TouchEvent | MouseEvent;
+  touch: boolean;
+  mouse: boolean;
+  direction: "up" | "down" | "left" | "right";
+  duration: number;
+  distance: {
+    x: number;
+    y: number;
+  };
+}

--- a/ui/types/ts-helpers.d.ts
+++ b/ui/types/ts-helpers.d.ts
@@ -6,6 +6,12 @@ export type StringDictionary<T extends string> = Required<
   { [index in T]: string }
 >;
 
+// Needed to prevent TS to collapse `'value1' | 'value2' | string` to `string`, which breaks first parameter autocomplete
+// See: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-832522611
+export type LiteralUnion<T extends U, U = string> =
+  | T
+  | (U & Record<never, never>);
+
 // See: https://stackoverflow.com/a/49936686/7931540
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>

--- a/ui/types/ts-helpers.d.ts
+++ b/ui/types/ts-helpers.d.ts
@@ -1,7 +1,5 @@
 import { ComponentOptions, ComponentPublicInstance, ComputedOptions, MethodOptions, VNodeProps, AllowedComponentProps, ComponentCustomProps } from 'vue';
 
-export type LooseDictionary = { [index in string]: any };
-
 export type StringDictionary<T extends string> = Required<
   { [index in T]: string }
 >;

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -1,3 +1,6 @@
+// Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
+// The import will work correctly at runtime
+import { QUploader, QUploaderProps } from "quasar";
 import {
   ComponentOptionsMixin,
   ComponentPropsOptions,
@@ -135,4 +138,4 @@ export function createUploaderComponent<
   Emits extends EmitsOptions = []
 >(
   options: CreateUploaderComponentOptions<Props, Emits>
-): DefineComponent<Props, {}, {}, {}, {}, {}, {}, EmitsOptions>;
+): QUploader & DefineComponent<Props & QUploaderProps, {}, {}, {}, {}, {}, {}, Emits>;

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -1,6 +1,6 @@
 // Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
 // The import will work correctly at runtime
-import { QUploader, QUploaderProps } from "quasar";
+import { QUploader } from "quasar";
 import {
   ComponentOptionsMixin,
   ComponentPropsOptions,
@@ -138,4 +138,4 @@ export function createUploaderComponent<
   Emits extends EmitsOptions = []
 >(
   options: CreateUploaderComponentOptions<Props, Emits>
-): QUploader & DefineComponent<Props & QUploaderProps, {}, {}, {}, {}, {}, {}, Emits>;
+): QUploader & DefineComponent<Props, {}, {}, {}, {}, {}, {}, Emits>;


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->
Some types has been loosen up since they're creating problems with Volar template checking, while others has been made more precise and stricter. All those made stricter are also exported as interfaces, so users can use them in their code directly, avoiding and with better type-safety problems.

Being a type-only breaking change it doesn't need a major, but it would be better to release these into a minor patch.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
