### PR TITLE
feat/fix(Platform): Add detailed types for 'Platform.is' (fix: #12054)

### DIFF
--- a/ui/src/plugins/Platform.js
+++ b/ui/src/plugins/Platform.js
@@ -27,15 +27,11 @@ function getMatch (userAgent, platformMatch) {
     || /(opr)[\/]([\w.]+)/.exec(userAgent)
     || /(vivaldi)[\/]([\w.]+)/.exec(userAgent)
     || /(chrome|crios)[\/]([\w.]+)/.exec(userAgent)
-    || /(iemobile)[\/]([\w.]+)/.exec(userAgent)
     || /(version)(applewebkit)[\/]([\w.]+).*(safari)[\/]([\w.]+)/.exec(userAgent)
     || /(webkit)[\/]([\w.]+).*(version)[\/]([\w.]+).*(safari)[\/]([\w.]+)/.exec(userAgent)
     || /(firefox|fxios)[\/]([\w.]+)/.exec(userAgent)
     || /(webkit)[\/]([\w.]+)/.exec(userAgent)
     || /(opera)(?:.*version|)[\/]([\w.]+)/.exec(userAgent)
-    || /(msie) ([\w.]+)/.exec(userAgent)
-    || (userAgent.indexOf('trident') >= 0 && /(rv)(?::| )([\w.]+)/.exec(userAgent))
-    || (userAgent.indexOf('compatible') < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(userAgent))
     || []
 
   return {

--- a/ui/src/plugins/Platform.js
+++ b/ui/src/plugins/Platform.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-useless-escape */
-/* eslint-disable no-unused-expressions */
-/* eslint-disable no-mixed-operators */
 
 import { ref, reactive } from 'vue'
 import { injectProp } from '../utils/private/inject-obj-prop'
@@ -60,6 +58,8 @@ function getPlatformMatch (userAgent) {
     || /(mac)/.exec(userAgent)
     || /(linux)/.exec(userAgent)
     || /(cros)/.exec(userAgent)
+    // TODO: Remove BlackBerry detection. BlackBerry OS, BlackBerry 10, and BlackBerry PlayBook OS
+    // is officially dead as of January 4, 2022 (https://www.blackberry.com/us/en/support/devices/end-of-life)
     || /(playbook)/.exec(userAgent)
     || /(bb)/.exec(userAgent)
     || /(blackberry)/.exec(userAgent)
@@ -151,6 +151,10 @@ function getPlatform (UA) {
     delete browser[ 'windows phone' ]
   }
 
+  // TODO: The assumption about WebKit based browsers below is not completely accurate.
+  // Google released Blink(a fork of WebKit) engine on April 3, 2013, which is really different than WebKit today.
+  // Today, one might want to check for WebKit to deal with its bugs, which is used on all browsers on iOS, and Safari browser on all platforms.
+
   // Chrome, Opera 15+, Vivaldi and Safari are webkit based browsers
   if (
     browser.chrome
@@ -168,7 +172,7 @@ function getPlatform (UA) {
   }
 
   // Blackberry browsers are marked as Safari on BlackBerry
-  if (browser.safari && browser.blackberry || browser.bb) {
+  if ((browser.safari && browser.blackberry) || browser.bb) {
     matched.browser = 'blackberry'
     browser.blackberry = true
   }

--- a/ui/src/plugins/Platform.js
+++ b/ui/src/plugins/Platform.js
@@ -23,7 +23,7 @@ export let iosEmulated = false
 export let iosCorrection
 
 function getMatch (userAgent, platformMatch) {
-  const match = /(edge|edga|edgios)\/([\w.]+)/.exec(userAgent)
+  const match = /(edg|edge|edga|edgios)\/([\w.]+)/.exec(userAgent)
     || /(opr)[\/]([\w.]+)/.exec(userAgent)
     || /(vivaldi)[\/]([\w.]+)/.exec(userAgent)
     || /(chrome|crios)[\/]([\w.]+)/.exec(userAgent)
@@ -169,6 +169,13 @@ function getPlatform (UA) {
     )
   ) {
     browser.webkit = true
+  }
+
+  // TODO: (Qv3) rename the terms 'edge' to 'edge legacy'(or remove it) then 'edge chromium' to 'edge' to match with the known up-to-date terms
+  // Microsoft Edge is the new Chromium-based browser. Microsoft Edge Legacy is the old EdgeHTML-based browser (EOL: March 9, 2021).
+  if (browser.edg) {
+    matched.browser = 'edgechromium'
+    browser.edgeChromium = true
   }
 
   // Blackberry browsers are marked as Safari on BlackBerry

--- a/ui/src/plugins/Platform.json
+++ b/ui/src/plugins/Platform.json
@@ -98,6 +98,11 @@
           "required": false,
           "desc": "Whether the browser is Safari"
         },
+        "edgeChromium": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Microsoft Edge (Chromium)"
+        },
         "edge": {
           "type": "Boolean",
           "required": false,

--- a/ui/src/plugins/Platform.json
+++ b/ui/src/plugins/Platform.json
@@ -17,6 +17,167 @@
     "is": {
       "type": "Object",
       "desc": "Client browser details (property names depend on browser)",
+      "definition": {
+        "name": {
+          "type": "String",
+          "desc": "Browser name",
+          "examples": [ "chrome" ]
+        },
+        "platform": {
+          "type": "String",
+          "desc": "Platform name",
+          "examples": [ "mac" ]
+        },
+        "version": {
+          "type": "String",
+          "required": false,
+          "desc": "Detailed browser version",
+          "examples": [ "71.0.3578.98" ]
+        },
+        "versionNumber": {
+          "type": "Number",
+          "required": false,
+          "desc": "Major browser version as a number",
+          "examples": [ 71 ]
+        },
+
+        "desktop": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is desktop"
+        },
+        "mobile": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is mobile"
+        },
+        "electron": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is Electron"
+        },
+        "bex": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is BEX(Browser Extension)"
+        },
+        "capacitor": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is Capacitor"
+        },
+        "cordova": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is Cordova"
+        },
+        "nativeMobile": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the platform is a native mobile wrapper"
+        },
+        "nativeMobileWrapper": {
+          "type": "String",
+          "required": false,
+          "values": ["cordova", "capacitor"],
+          "desc": "Type of the native mobile wrapper"
+        },
+
+        "chrome": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Google Chrome"
+        },
+        "firefox": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Firefox"
+        },
+        "safari": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Safari"
+        },
+        "edge": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Microsoft Edge Legacy"
+        },
+        "opera": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Opera"
+        },
+        "vivaldi": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Vivaldi"
+        },
+
+        "win": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Windows"
+        },
+        "linux": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Linux"
+        },
+        "mac": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Mac OS"
+        },
+        "cros": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Chrome OS"
+        },
+
+        "android": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Android"
+        },
+        "ios": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is iOS"
+        },
+        "winphone": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the operating system is Windows Phone"
+        },
+
+        "iphone": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the device is an iPhone"
+        },
+        "ipad": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the device is an iPad"
+        },
+        "ipod": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the device is an iPod"
+        },
+
+        "kindle": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the device is a Kindle"
+        },
+        "silk": {
+          "type": "Boolean",
+          "required": false,
+          "desc": "Whether the browser is Amazon Silk"
+        }
+      },
       "examples": [
         "{ chrome: true, version: '71.0.3578.98', versionNumber: 71, mac: true, desktop: true, webkit: true, name: 'chrome', platform: 'mac' }"
       ]


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- Bugfix
- Feature
- Refactor

**Does this PR introduce a breaking change?** <!-- Check one -->

- No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

Resolves #12054.

Summary of changes:

- As we no longer support IE, I removed all checks related to IE and IE Mobile.
- I added a check for the new Chromium-based Edge. It will live under `edgeChromium` property to not clash with the old Edge which lives under just `edge`. I left some notes to replace the terms in Qv3.
- I left some notes on BlackBerry detection about its death. I am pretty sure it can't really be used as it is completely officially dead, and I doubt the browser support is good enough, but still couldn't decide on removing it now as that may be a breaking change. @rstoenescu please let me know if it's a big deal, if not we can remove them now.
- I left some notes about WebKit detection as some assumptions might be outdated. (_[this commit](https://github.com/quasarframework/quasar/commit/30f53aeedce5ac0dede32bb229895b215c903cfe#diff-0cf26301fb3fd5b5fff11c71aabddb18b6ba28766eee299dd29a6418b5b52203R71) is more than 6 years old_) @rstoenescu can you confirm?

_Note for reviewers: Please see commit messages and descriptions for more context._

 📜 Changes for `dist/types/index.d.ts`:
```diff
@@ -883,9 +883,134 @@
   userAgent: string;
   /**
    * Client browser details (property names depend on browser)
    */
-  is: any;
+  is: {
+    /**
+     * Browser name
+     */
+    name: string;
+    /**
+     * Platform name
+     */
+    platform: string;
+    /**
+     * Detailed browser version
+     */
+    version?: string;
+    /**
+     * Major browser version as a number
+     */
+    versionNumber?: number;
+    /**
+     * Whether the platform is desktop
+     */
+    desktop?: boolean;
+    /**
+     * Whether the platform is mobile
+     */
+    mobile?: boolean;
+    /**
+     * Whether the platform is Electron
+     */
+    electron?: boolean;
+    /**
+     * Whether the platform is BEX(Browser Extension)
+     */
+    bex?: boolean;
+    /**
+     * Whether the platform is Capacitor
+     */
+    capacitor?: boolean;
+    /**
+     * Whether the platform is Cordova
+     */
+    cordova?: boolean;
+    /**
+     * Whether the platform is a native mobile wrapper
+     */
+    nativeMobile?: boolean;
+    /**
+     * Type of the native mobile wrapper
+     */
+    nativeMobileWrapper?: "cordova" | "capacitor";
+    /**
+     * Whether the browser is Google Chrome
+     */
+    chrome?: boolean;
+    /**
+     * Whether the browser is Firefox
+     */
+    firefox?: boolean;
+    /**
+     * Whether the browser is Safari
+     */
+    safari?: boolean;
+    /**
+     * Whether the browser is Microsoft Edge (Chromium)
+     */
+    edgeChromium?: boolean;
+    /**
+     * Whether the browser is Microsoft Edge Legacy
+     */
+    edge?: boolean;
+    /**
+     * Whether the browser is Opera
+     */
+    opera?: boolean;
+    /**
+     * Whether the browser is Vivaldi
+     */
+    vivaldi?: boolean;
+    /**
+     * Whether the operating system is Windows
+     */
+    win?: boolean;
+    /**
+     * Whether the operating system is Linux
+     */
+    linux?: boolean;
+    /**
+     * Whether the operating system is Mac OS
+     */
+    mac?: boolean;
+    /**
+     * Whether the operating system is Chrome OS
+     */
+    cros?: boolean;
+    /**
+     * Whether the operating system is Android
+     */
+    android?: boolean;
+    /**
+     * Whether the operating system is iOS
+     */
+    ios?: boolean;
+    /**
+     * Whether the operating system is Windows Phone
+     */
+    winphone?: boolean;
+    /**
+     * Whether the device is an iPhone
+     */
+    iphone?: boolean;
+    /**
+     * Whether the device is an iPad
+     */
+    ipad?: boolean;
+    /**
+     * Whether the device is an iPod
+     */
+    ipod?: boolean;
+    /**
+     * Whether the device is a Kindle
+     */
+    kindle?: boolean;
+    /**
+     * Whether the browser is Amazon Silk
+     */
+    silk?: boolean;
+  };
   /**
    * Client browser detectable properties
    */
   has: {
```