### PR TITLE
fix(useBtn): add the missing 'tag' prop

### DIFF
--- a/ui/src/components/btn/use-btn.js
+++ b/ui/src/components/btn/use-btn.js
@@ -33,6 +33,8 @@ export const useBtnProps = {
     default: 'button'
   },
 
+  tag: String,
+
   label: [ Number, String ],
   icon: String,
   iconRight: String,


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The `tag` prop should be in `useBtnProps` but it was not. This causes `<q-btn tag="div" />` to not work and still render with `button` tag. Adding the `tag` prop fixed this issue.