### PR TITLE
[V1] Qinput.js new Option preventFocusScroll to control side effects

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -36,6 +36,8 @@ export default Vue.extend({
     debounce: [String, Number],
 
     autogrow: Boolean, // makes a textarea
+    
+    preventFocusScroll: Boolean,
 
     inputClass: [Array, String, Object],
     inputStyle: [Array, String, Object]
@@ -172,7 +174,7 @@ export default Vue.extend({
           // IE can have null document.activeElement
           (el === null || el.id !== this.targetUid)
         ) {
-          this.$refs.input.focus()
+           this.$refs.input.focus({ preventScroll: this.preventFocusScroll })
         }
       })
     },


### PR DESCRIPTION
Support the { preventScroll: true } of the element.focus  to limit 
side-effects  - scrolled position break and transition break .

https://html.spec.whatwg.org/#focus-management-apis  (EDITED : changed to thr right anchor)

Browser Matrix with Out-of-the-Box vs using the attribute

The 2 effects with focus / autofocus (not only on keep-alived elements)

Effect A:  vue-router, savedPosition is not respected

Effect B: Transition breaks immediatly (distortion during sliding ..)


------------------   Chrome Android: "Has" effect A (opens the Keyboard) + effect B
with the preventFocusScroll option:
-> no (side effect) on effect A (opens the Keyboard nicely)
-> effect B solved by preventFocusScroll 

------------------   Chrome Windows: Has effect B
with the preventFocusScroll option:
-> solved by preventFocusScroll 

------------------   Firefox windows:  has effect A + B
with the preventFocusScroll option:
Both effects are solved with  preventFocusScroll 

------------------  iOS safari: has only effect B
-> Ignores ?  the preventFocusScroll by Design / no change of behaviour

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
