### PR TITLE
fix(QStepper): prevent dot line to create scrollable panels - firefox #11997, #8533

### DIFF
--- a/ui/src/components/stepper/QStep.js
+++ b/ui/src/components/stepper/QStep.js
@@ -67,7 +67,7 @@ export default Vue.extend({
     onEvents () {
       return this.isActive !== true ||
         this.stepper.vertical !== true ||
-        (this.$q.platform.is.ios !== true && this.$q.platform.is.safari !== true && this.$q.platform.is.ie !== true)
+        (this.$q.platform.is.ios !== true && this.$q.platform.is.chrome === true)
         ? { ...this.qListeners }
         : { ...this.qListeners, scroll: this.__keepScroll }
     }


### PR DESCRIPTION
Firefox does not respect contain in this case

#11997, #8533
