### PR TITLE
fix(QStepper): prevent dot line to create scrollable panels - firefox #11997, #8533

### DIFF
--- a/ui/src/components/stepper/QStep.js
+++ b/ui/src/components/stepper/QStep.js
@@ -70,7 +70,7 @@ export default createComponent({
     const isActive = computed(() => $stepper.value.modelValue === props.name)
 
     const scrollEvent = computed(() => (
-      ($q.platform.is.ios !== true && $q.platform.is.safari !== true)
+      ($q.platform.is.ios !== true && $q.platform.is.chrome === true)
         || isActive.value !== true
         || $stepper.value.vertical !== true
         ? {}


### PR DESCRIPTION
Firefox does not respect contain in this case

#11997, #8533