### PR TITLE
Add warning about lazy loading of Node packages

### DIFF
--- a/docs/src/pages/quasar-cli/lazy-loading.md
+++ b/docs/src/pages/quasar-cli/lazy-loading.md
@@ -79,6 +79,34 @@ import('./categories.json')
   })
 ```
 
+::: warning
+Quasar includes installed Node packages in the app bundle by default, even if your code imports them dynamically.
+
+For example, if you have installed the ````node-vibrant```` package that extracts the dominant colors from images, you could import it dynamically like this:
+
+````js
+import('node-vibrant')
+  .then(vibrant => {
+    // use vibrant
+  })
+````
+
+To make Quasar put ````node-vibrant```` in its own bundle you'd also have to enter it in ````quasar.conf.js````:
+
+````js
+// quasar.conf.js
+return {
+  vendor: {
+    remove: ['node-vibrant']
+  }
+}
+````
+
+For more details, see the [vendors section](https://quasar.dev/quasar-cli/quasar-conf-js#property-vendor)
+of ````quasar.conf.js````.
+
+:::
+
 One advantage of using dynamic imports as opposed to regular imports is that the import path can be determined at runtime:
 
 ```js


### PR DESCRIPTION
To make lazy loading of installed Node packages work as expected, you need to also add them to quasar.conf.js. Unless you've read all the docs, you may not realize this. Add a warning and examples about this.


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
