### PR TITLE
feature(header-before and header-after slots for q-table)

### DIFF
--- a/ui/dev/src/pages/components/data-table-part6-header-slots.vue
+++ b/ui/dev/src/pages/components/data-table-part6-header-slots.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="q-layout-padding q-gutter-md" style="max-width: 1400px;">
+    <q-table
+      :rows="data"
+      :columns="columns"
+      row-key="name"
+      title="header-before and header-after slots"
+      style="height: 400px"
+      :rows-per-page-options="[ 15, 20, 25, 50, 0 ]"
+    >
+      <template v-slot:header-before="{ cols }">
+        <tr class="bg-light-blue-3">
+          <td :colspan="cols.length" class="text-center q-pa-md">
+            before-header with colspan
+          </td>
+        </tr>
+      </template>
+
+      <template v-slot:header-after="{ cols }">
+        <tr class="bg-light-blue-3">
+          <td v-for="col in cols" v-bind:key="col.id" >
+          <q-input dense label="input for each column" :stack-label="true"/>
+          </td>
+        </tr>
+      </template>
+    </q-table>
+
+  </div>
+
+  <div class="q-pa-md" style="max-width: 1400px;">
+    <q-table
+      :rows="data"
+      :columns="columns"
+      row-key="name"
+      title="header-before and header-after slots with selection='multiple', sticky header, loading state and virtual-scroll"
+      style="height: 600px"
+      :rows-per-page-options="[ 15, 20, 25, 50, 0 ]"
+      class="sticky-header"
+      selection="multiple"
+      v-model:selected="selected"
+      virtual-scroll
+      :loading="loading"
+    >
+      <template v-slot:header-before="{ cols }">
+        <tr class="bg-light-blue-3">
+          <td :colspan="cols.length+1" class="text-center q-pa-md">
+            <q-toggle v-model="loading" label="Loading state" class="q-mb-md" />
+            <p>before-header with colspan (colspan needs to be cols.length+1)</p>
+          </td>
+        </tr>
+      </template>
+
+      <template v-slot:header-after="{ cols }">
+        <tr class="bg-light-blue-3">
+          <td>extra td for layout</td>
+          <td v-for="col in cols" v-bind:key="col.id" >
+            <q-input dense label="input for each column" :stack-label="true"/>
+          </td>
+        </tr>
+      </template>
+    </q-table>
+
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue'
+
+export default {
+  setup () {
+    const randomIntFromInterval = (min, max) => Math.floor(Math.random() * (max - min + 1) + min)
+
+    const data = []
+    for (let i = 0; i < 1000; i++) {
+      data.push(
+        {
+          name: 'entry' + i,
+          inp: '',
+          calories: randomIntFromInterval(120, 160),
+          fat: randomIntFromInterval(4, 7),
+          carbs: randomIntFromInterval(20, 30),
+          protein: randomIntFromInterval(4, 7),
+          sodium: randomIntFromInterval(70, 90),
+          calcium: randomIntFromInterval(10, 17) + '%',
+          iron: randomIntFromInterval(1, 3) + '%'
+        })
+    }
+
+    return {
+      columns: [
+        {
+          name: 'desc',
+          required: true,
+          label: 'Dessert (100g serving)',
+          align: 'left',
+          field: row => row.name,
+          format: val => `${ val }`,
+          sortable: true
+        },
+        { name: 'calories', align: 'center', label: 'Calories', field: 'calories', sortable: true },
+        { name: 'fat', label: 'Fat (g)', field: 'fat', sortable: true, style: 'width: 10px' },
+        { name: 'carbs', label: 'Carbs (g)', field: 'carbs' },
+        { name: 'protein', label: 'Protein (g)', field: 'protein' },
+        { name: 'sodium', label: 'Sodium (mg)', field: 'sodium' },
+        { name: 'calcium', label: 'Calcium (%)', field: 'calcium', sortable: true, sort: (a, b) => parseInt(a, 10) - parseInt(b, 10) },
+        { name: 'iron', label: 'Iron (%)', field: 'iron', sortable: true, sort: (a, b) => parseInt(a, 10) - parseInt(b, 10) }
+      ],
+      data,
+      selected: ref([]),
+      loading: ref(false)
+    }
+  },
+
+  methods: {
+    onExpanded (rows, added) {
+      console.log(added ? 'selected' : 'un-selected', rows)
+    }
+  }
+}
+</script>
+
+<style lang="sass">
+.sticky-header
+  height: 310px
+
+  .q-table__top,
+  .q-table__bottom,
+  thead
+    background-color: #ffffff
+
+  thead
+    position: sticky
+    z-index: 1
+  thead
+    top: 0
+
+  &.q-table--loading thead tr:last-child th
+    top: 0px
+</style>

--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -611,8 +611,23 @@ export default createComponent({
     function getTHead () {
       const child = getTHeadTR()
 
+      const hBeforeSlot = slots[ 'header-before' ]
+      const beforeChildren = hBeforeSlot ? hBeforeSlot(
+        getHeaderScope({ header: true })
+      ).slice() : null
+
+      const hAfterSlot = slots[ 'header-after' ]
+      const afterChildren = hAfterSlot ? hAfterSlot(
+        getHeaderScope({ header: true })
+      ).slice() : null
+
+      const headerChildren = []
+      if (beforeChildren) headerChildren.push(...beforeChildren)
+      headerChildren.push(...child)
+      if (afterChildren) headerChildren.push(...afterChildren)
+
       if (props.loading === true && slots.loading === void 0) {
-        child.push(
+        headerChildren.push(
           h('tr', { class: 'q-table__progress' }, [
             h('th', {
               class: 'relative-position',
@@ -622,7 +637,7 @@ export default createComponent({
         )
       }
 
-      return h('thead', child)
+      return h('thead', headerChildren)
     }
 
     function getTHeadTR () {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
I opened a feature request here before: https://github.com/quasarframework/quasar/discussions/12231
The problem was, that the use of selection="multiple" broke the header, when the header-slot was used. It would require a lot of work to recreate the selection-functionality.
Here is a example of the broken case. see: https://codepen.io/Error07/pen/rNYeqvr
Instead, i introduced two slots to extend on the default header without breaking the functionality.
Among the comitted files is a example, that demonstrates the slot's functionality. see: ui/dev/src/pages/components/data-table-part6-header-slots.vue

One thing to mention is, that if selection="multiple" is used, the user needs to make sure, that the added slots fit the new table-size or column-count, as that checkbox acts as a own column. I handled it by either setting :colspan="cols.length+1" or by adding a extra td to the header.  How the developer handles it, depends on his individual flavour.

Thank you for the opportunity to support such a awesome project!