### PR TITLE
fix(QField/QSelect): improve attrs on controls #12383

### DIFF
--- a/ui/dev/src/pages/form/field-attrs.vue
+++ b/ui/dev/src/pages/form/field-attrs.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="q-layout-padding">
+    <div class="q-gutter-y-md" style="max-width: 300px">
+      <div>
+        Search in console for $$('[data-test-attr]') and $$('[aria-owns]')
+      </div>
+
+      <q-field for="test1" label="QField - no slot" stack-label data-test-attr="test" />
+
+      <q-field for="test2" label="QField - slot" stack-label data-test-attr="test">
+        <template #control>
+          <div>Control slot</div>
+        </template>
+      </q-field>
+
+      <q-input for="test3" label="QInput" v-model="text" data-test-attr="test" />
+
+      <q-select for="test4" label="QSelect - menu" v-model="sel" :options="options" behavior="menu" data-test-attr="test" />
+
+      <q-select for="test5" label="QSelect - dialog" v-model="sel" :options="options" behavior="dialog" data-test-attr="test" />
+
+      <q-select for="test6" label="QSelect - use input - menu" v-model="sel" :options="options" use-input behavior="menu" data-test-attr="test" />
+
+      <q-select for="test7" label="QSelect - use input - dialog" v-model="sel" :options="options" use-input behavior="dialog" data-test-attr="test" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      text: '',
+      sel: null,
+      options: ['Opt 1', 'Opt 2']
+    }
+  }
+}
+</script>

--- a/ui/src/components/field/QField.js
+++ b/ui/src/components/field/QField.js
@@ -539,10 +539,18 @@ export default Vue.extend({
     this.__onPreRender !== void 0 && this.__onPreRender()
     this.__onPostRender !== void 0 && this.$nextTick(this.__onPostRender)
 
+    const attrs = this.__getControl === void 0 && this.$scopedSlots.control === void 0
+      ? {
+        ...this.qAttrs,
+        'data-autofocus': this.autofocus,
+        ...this.attrs
+      }
+      : this.attrs
+
     return h('label', {
       staticClass: 'q-field q-validation-component row no-wrap items-start',
       class: this.classes,
-      attrs: this.attrs
+      attrs
     }, [
       this.$scopedSlots.before !== void 0 ? h('div', {
         staticClass: 'q-field__before q-field__marginal row no-wrap items-center',

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -948,6 +948,8 @@ export default Vue.extend({
       }
       // there can be only one (when dialog is opened the control in dialog should be target)
       else if (this.editable === true) {
+        const attrs = isTarget === true ? this.comboboxAttrs : void 0
+
         child.push(
           h('div', {
             ref: isTarget === true ? 'target' : void 0,
@@ -956,7 +958,7 @@ export default Vue.extend({
             attrs: {
               id: isTarget === true ? this.targetUid : void 0,
               tabindex: this.tabindex,
-              ...this.comboboxAttrs
+              ...attrs
             },
             on: cache(this, 'f-tget', {
               keydown: this.__onTargetKeydown,
@@ -995,7 +997,9 @@ export default Vue.extend({
         )
       }
 
-      return h('div', { staticClass: 'q-field__native row items-center', attrs: this.qAttrs }, child)
+      const attrs = this.useInput === true || isTarget !== true ? void 0 : this.qAttrs
+
+      return h('div', { staticClass: 'q-field__native row items-center', attrs }, child)
     },
 
     __getOptions (h) {
@@ -1057,6 +1061,8 @@ export default Vue.extend({
     },
 
     __getInput (h, fromDialog, isTarget) {
+      const attrs = isTarget === true ? { ...this.comboboxAttrs, ...this.qAttrs } : void 0
+
       const options = {
         ref: isTarget === true ? 'target' : void 0,
         key: 'i_t',
@@ -1067,15 +1073,14 @@ export default Vue.extend({
         attrs: {
           // required for Android in order to show ENTER key when in form
           type: 'search',
-          ...this.qAttrs,
+          ...attrs,
           id: isTarget === true ? this.targetUid : void 0,
           maxlength: this.maxlength, // this is converted to prop by QField
           tabindex: this.tabindex,
           autocomplete: this.autocomplete,
           'data-autofocus': fromDialog === true ? false : this.autofocus,
           disabled: this.disable === true,
-          readonly: this.readonly === true,
-          ...this.comboboxAttrs
+          readonly: this.readonly === true
         },
         on: this.inputControlEvents
       }


### PR DESCRIPTION
#12383

- QField: apply on external label if control slot is not present and if not QInput/QSelect
- QSelect: apply on active element (target)