### PR TITLE
fix(api/DialogPlugin): Allow string type as component param to custom component

### DIFF
--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -307,7 +307,7 @@
             },
 
             "component": {
-              "type": ["Component","String"],
+              "type": [ "Component", "String" ],
               "desc": "Use custom dialog component; use along with 'componentProps' prop where possible"
             },
 

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -308,7 +308,8 @@
 
             "component": {
               "type": [ "Component", "String" ],
-              "desc": "Use custom dialog component; use along with 'componentProps' prop where possible"
+              "desc": "Use custom dialog component; use along with 'componentProps' prop where possible",
+              "examples": [ "CustomComponent", "'custom-component'" ]
             },
 
             "componentProps": {

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -307,7 +307,7 @@
             },
 
             "component": {
-              "type": "Component",
+              "type": ["Component","String"],
               "desc": "Use custom dialog component; use along with 'componentProps' prop where possible"
             },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
