### PR TITLE
fix(docs): explain how to escape strings in date format #12611

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -74,6 +74,8 @@ Available format tokens:
 | AM/PM | <ul><li>**A**: AM, PM</li><li>**a**: am, pm</li><li>**aa**: a.m, p.m</li></ul> |
 | Unix Timestamp | <ul><li>**X**: 1360013296</li><li>**x** (ms): 1360013296123</li></ul> |
 
+If you want to insert strings (including `[` and `]` characters) into your mask, make sure you escape them by surrounding them with `[` and `]`, otherwise the characters might be interpreted as format tokens.
+
 ## Manipulate dates
 
 ### Create

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -102,7 +102,7 @@ When using the persian calendar, the mask for QDate is forced to `YYYY/MM/DD`.
 
 <doc-example title="Simple mask" file="QDate/MaskSimple" overflow />
 
-If you want to insert strings into your mask, make sure you escape them by surrounding them with `[` and `]`, otherwise the characters might be interpreted as format tokens.
+If you want to insert strings (including `[` and `]` characters) into your mask, make sure you escape them by surrounding them with `[` and `]`, otherwise the characters might be interpreted as format tokens.
 
 <doc-example title="Mask with escaped characters" file="QDate/MaskEscape" overflow />
 

--- a/docs/src/pages/vue-components/time.md
+++ b/docs/src/pages/vue-components/time.md
@@ -58,7 +58,7 @@ When using the persian calendar, the mask for QTime is forced to `HH:mm` or `HH:
 
 <doc-example title="Simple mask" file="QTime/MaskSimple" overflow />
 
-If you want to insert strings into your mask, make sure you escape them by surrounding them with `[` and `]`, otherwise the characters might be interpreted as format tokens.
+If you want to insert strings (including `[` and `]` characters) into your mask, make sure you escape them by surrounding them with `[` and `]`, otherwise the characters might be interpreted as format tokens.
 
 <doc-example title="Mask with escaped characters" file="QTime/MaskEscape" overflow />
 


### PR DESCRIPTION
#12611
