### PR TITLE
fix: Add Quasar docs URL as valid to GH Actions

### DIFF
--- a/.github/workflows/process-created-issue.yml
+++ b/.github/workflows/process-created-issue.yml
@@ -123,6 +123,10 @@ jobs:
                       labelsToAdd.push('bug/1-hard-to-reproduce');
                       break;
                     }
+                  case 'quasar.dev':
+                    if (/^\/.+$/.test(reproURL.pathname)) {
+                      break;
+                    }
                   default:
                     throw new Error();
                 }


### PR DESCRIPTION
As an extension of the work on [https://github.com/quasarframework/quasar/pull/12620](https://github.com/quasarframework/quasar/pull/12620), I've noticed that there is a significant amount of issues created with links from Quasar offical docs page.

This PR is meant to allow those kinds of links as valid, e.g. not report missing/invalid link comment by GH bot.
If you think it's unnecessary, I'll close it.