### PR TITLE
fix(ui): QInfiniteScroll poll.cancel is undefined when debounce prop equal to 0

### DIFF
--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -120,7 +120,7 @@ export default createComponent({
         isWorking.value = false
         isFetching.value = false
         localScrollTarget.removeEventListener('scroll', poll, passive)
-        if(poll !== void 0 && poll.cancel) {
+        if (poll !== void 0 && poll.cancel !== void 0) {
           poll.cancel()
         }
       }

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -120,7 +120,9 @@ export default createComponent({
         isWorking.value = false
         isFetching.value = false
         localScrollTarget.removeEventListener('scroll', poll, passive)
-        poll !== void 0 && poll.cancel()
+        if(poll !== void 0 && poll.cancel) {
+          poll.cancel()
+        }
       }
     }
 


### PR DESCRIPTION

**What kind of change does this PR introduce?** 

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**Other information:**
When debounce prop equal to 0 and immediatePoll function assigned.
https://github.com/quasarframework/quasar/blob/712ccc84239e1673e90aa8db3b86ebc4d12c8160/ui/src/components/infinite-scroll/QInfiniteScroll.js#L155
`poll.cancel() ` is `undefined` in this case
https://github.com/quasarframework/quasar/blob/712ccc84239e1673e90aa8db3b86ebc4d12c8160/ui/src/components/infinite-scroll/QInfiniteScroll.js#L123
