### PR TITLE
fix(QField/QSelect): improve attrs on controls #12383

### DIFF
--- a/ui/dev/src/pages/form/field-attrs.vue
+++ b/ui/dev/src/pages/form/field-attrs.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="q-layout-padding">
+    <div class="q-gutter-y-md" style="max-width: 300px">
+      <div>
+        Search in console for $$('[data-test-attr]') and $$('[aria-owns]')
+      </div>
+
+      <q-field for="test1" label="QField - no slot" stack-label data-test-attr="test" />
+
+      <q-field for="test2" label="QField - slot" stack-label data-test-attr="test">
+        <template #control>
+          <div>Control slot</div>
+        </template>
+      </q-field>
+
+      <q-input for="test3" label="QInput" v-model="text" data-test-attr="test" />
+
+      <q-select for="test4" label="QSelect - menu" v-model="sel" :options="options" behavior="menu" data-test-attr="test" />
+
+      <q-select for="test5" label="QSelect - dialog" v-model="sel" :options="options" behavior="dialog" data-test-attr="test" />
+
+      <q-select for="test6" label="QSelect - use input - menu" v-model="sel" :options="options" use-input behavior="menu" data-test-attr="test" />
+
+      <q-select for="test7" label="QSelect - use input - dialog" v-model="sel" :options="options" use-input behavior="dialog" data-test-attr="test" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      text: '',
+      sel: null,
+      options: [ 'Opt 1', 'Opt 2' ]
+    }
+  }
+}
+</script>

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -975,6 +975,8 @@ export default createComponent({
     }
 
     function getInput (fromDialog, isTarget) {
+      const attrs = isTarget === true ? { ...comboboxAttrs.value, ...state.splitAttrs.attributes.value } : void 0
+
       const data = {
         ref: isTarget === true ? targetRef : void 0,
         key: 'i_t',
@@ -983,8 +985,7 @@ export default createComponent({
         value: inputValue.value !== void 0 ? inputValue.value : '',
         // required for Android in order to show ENTER key when in form
         type: 'search',
-        ...comboboxAttrs.value,
-        ...state.splitAttrs.attributes.value,
+        ...attrs,
         id: isTarget === true ? state.targetUid.value : void 0,
         maxlength: props.maxlength,
         autocomplete: props.autocomplete,
@@ -1464,13 +1465,16 @@ export default createComponent({
         }
         // there can be only one (when dialog is opened the control in dialog should be target)
         else if (state.editable.value === true) {
+          const attrs = isTarget === true ? comboboxAttrs.value : void 0
+
           child.push(
-            h('div', {
+            h('input', {
               ref: isTarget === true ? targetRef : void 0,
               key: 'd_t',
               class: 'q-select__focus-target',
               id: isTarget === true ? state.targetUid.value : void 0,
-              ...comboboxAttrs.value,
+              readonly: true,
+              ...attrs,
               onKeydown: onTargetKeydown,
               onKeyup: onTargetKeyup,
               onKeypress: onTargetKeypress
@@ -1500,9 +1504,11 @@ export default createComponent({
           )
         }
 
+        const attrs = props.useInput === true || isTarget !== true ? void 0 : state.splitAttrs.attributes.value
+
         return h('div', {
           class: 'q-field__native row items-center',
-          ...state.splitAttrs.attributes.value
+          ...attrs
         }, child)
       },
 

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -552,6 +552,14 @@ export default function (state) {
   })
 
   return function renderField () {
+    const labelAttrs = state.getControl === void 0 && slots.control === void 0
+      ? {
+          ...state.splitAttrs.attributes.value,
+          'data-autofocus': props.autofocus,
+          ...attributes.value
+        }
+      : attributes.value
+
     return h('label', {
       ref: state.rootRef,
       class: [
@@ -559,7 +567,7 @@ export default function (state) {
         attrs.class
       ],
       style: attrs.style,
-      ...attributes.value
+      ...labelAttrs
     }, [
       slots.before !== void 0
         ? h('div', {


### PR DESCRIPTION
#12383

- QField: apply on external label if control slot is not present and if not QInput/QSelect
- QSelect: apply on active element (target)
