### PR TITLE
fix(app-vite): Ignore unmatched patterns for ESLint plugin

### DIFF
--- a/app-vite/lib/eslint.js
+++ b/app-vite/lib/eslint.js
@@ -36,6 +36,7 @@ function extractStore ({
   const eslintOptions = {
     cache,
     fix,
+    errorOnUnmatchedPattern: false,
     ...rawOptions
   }
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

When using different loaders, transformers, etc., especially for files types like Vue SFC which have a single file extension to match but have different parts inside, the app may throw errors like `[plugin:quasar:eslint] No files matching XYZ were found.`. One specific example would be Pug templates, `yarn add -D pug` makes everything load and work correctly but the full `id` for a specific resource would be like `src/pages/IndexPage.vue?vue&type=template&lang.js'`, which makes ESLint doesn't match that particular resource, thus resulting in an unmatched pattern error.
So, this PR sets ESLint's [errorOnUnmatchedPattern](https://eslint.org/docs/developer-guide/nodejs-api#parameters:~:text=options.errorOnUnmatchedPattern) option to `false` to avoid those errors. It's still overridable through `quasar.config.js > eslint > rawOptions` in case anyone needs that for whatever purpose, so we are safe on that side too.