### PR TITLE
Fix wrong "Please add back <div id="q-app"></div>" error.

### DIFF
--- a/app-webpack/lib/helpers/app-files-validations.js
+++ b/app-webpack/lib/helpers/app-files-validations.js
@@ -18,7 +18,7 @@ module.exports = function (cfg) {
     error = true
   }
 
-  if (content.indexOf('<div id="q-app') === -1) {
+  if (!/<div id=['"]q-app/.test(content)) {
     warn(`Please add back <div id="q-app"></div> to
     /src/index.template.html inside of <body>\n`)
     error = true


### PR DESCRIPTION
If a project codebase is using single-quotes instead of double-quotes in HTML, user gets a `Please add back <div id="q-app"></div> to /src/index.template.html inside of <body>` error. This PR prevents this error from happening and avoid failing `quasar build`.