### PR TITLE
fix(app-vite&app-webpack): Avoid Vue "enumaration" warning when using router inside Pinia (fix: #12936)

### DIFF
--- a/app-vite/templates/entry/app.js
+++ b/app-vite/templates/entry/app.js
@@ -20,6 +20,9 @@ import <%= metaConf.needsAppMountHook === true ? 'AppComponent' : 'RootComponent
 
 <% if (store) { %>
 import createStore from 'app/<%= sourceFiles.store %>'
+  <% if (metaConf.storePackage === 'pinia') { %>
+  import { markRaw } from 'vue'
+  <% } %>
 <% } %>
 import createRouter from 'app/<%= sourceFiles.router %>'
 
@@ -116,7 +119,9 @@ export default async function (createAppFn, quasarUserOptions<%= ctx.mode.ssr ? 
     <% if (metaConf.storePackage === 'vuex') { %>
       store.$router = router
     <% } else if (metaConf.storePackage === 'pinia') { %>
-      store.use(() => ({ router }))
+      store.use(({ store }) => {
+        store.router = markRaw(router)
+      })
     <% } %>
   <% } %>
 

--- a/app-webpack/templates/entry/app.js
+++ b/app-webpack/templates/entry/app.js
@@ -38,6 +38,10 @@ import createRouter from 'app/<%= sourceFiles.router %>'
   <% } %>
 <% } %>
 
+<% if (__storePackage === 'pinia') { %>
+  import { markRaw } from 'vue'
+<% } %>
+
 <% if (__needsAppMountHook === true) { %>
 import { defineComponent, h, onMounted<%= ctx.mode.ssr && ssr.manualPostHydrationTrigger !== true ? ', getCurrentInstance' : '' %> } from 'vue'
 const RootComponent = defineComponent({
@@ -114,9 +118,11 @@ export default async function (createAppFn, quasarUserOptions<%= ctx.mode.ssr ? 
     // make router instance available in store
     <% if (__storePackage === 'vuex') { %>
       store.$router = router
-    <% } else if (__storePackage === 'pinia') { %>
-      store.use(() => ({ router }))
-    <% } %>
+      <% } else if (__storePackage === 'pinia') { %>
+        store.use(({ store }) => {
+          store.router = markRaw(router)
+        })
+      <% } %>
   <% } %>
 
   // Expose the app, the router and the store.

--- a/app-webpack/templates/entry/app.js
+++ b/app-webpack/templates/entry/app.js
@@ -19,6 +19,9 @@ import <%= __needsAppMountHook === true ? 'AppComponent' : 'RootComponent' %> fr
 
 <% if (store) { %>
 import createStore from 'app/<%= sourceFiles.store %>'
+  <% if (__storePackage === 'pinia') { %>
+  import { markRaw } from 'vue'
+  <% } %>
 <% } %>
 import createRouter from 'app/<%= sourceFiles.router %>'
 
@@ -36,10 +39,6 @@ import createRouter from 'app/<%= sourceFiles.router %>'
     import { SplashScreen } from '@capacitor/splash-screen'
     <% } %>
   <% } %>
-<% } %>
-
-<% if (__storePackage === 'pinia') { %>
-  import { markRaw } from 'vue'
 <% } %>
 
 <% if (__needsAppMountHook === true) { %>

--- a/app-webpack/templates/entry/app.js
+++ b/app-webpack/templates/entry/app.js
@@ -117,11 +117,11 @@ export default async function (createAppFn, quasarUserOptions<%= ctx.mode.ssr ? 
     // make router instance available in store
     <% if (__storePackage === 'vuex') { %>
       store.$router = router
-      <% } else if (__storePackage === 'pinia') { %>
-        store.use(({ store }) => {
-          store.router = markRaw(router)
-        })
-      <% } %>
+    <% } else if (__storePackage === 'pinia') { %>
+      store.use(({ store }) => {
+        store.router = markRaw(router)
+      })
+    <% } %>
   <% } %>
 
   // Expose the app, the router and the store.


### PR DESCRIPTION
**What kind of change does this PR introduce?** 

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
This PR fixes the Vue warning:
> Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid the performance overhead.