### PR TITLE
fix(QFab): activeIcon prop name should be retrieved as camel instead of kebab #12932

### DIFF
--- a/ui/src/components/fab/QFab.js
+++ b/ui/src/components/fab/QFab.js
@@ -83,7 +83,7 @@ export default createComponent({
       const classes = `q-fab__${ kebab } absolute-full`
 
       return slotFn === void 0
-        ? h(QIcon, { class: classes, name: props[ kebab ] || $q.iconSet.fab[ camel ] })
+        ? h(QIcon, { class: classes, name: props[ camel ] || $q.iconSet.fab[ camel ] })
         : h('div', { class: classes }, slotFn(slotScope.value))
     }
 


### PR DESCRIPTION
#12932
