### PR TITLE
fix(QFab): activeIcon prop name should be retrieved as camel instead of kebab #12932

### DIFF
--- a/ui/src/components/fab/QFab.js
+++ b/ui/src/components/fab/QFab.js
@@ -101,7 +101,7 @@ export default Vue.extend({
       const staticClass = `q-fab__${kebab} absolute-full`
 
       return slotFn === void 0
-        ? h(QIcon, { staticClass, props: { name: this[kebab] || this.$q.iconSet.fab[camel] } })
+        ? h(QIcon, { staticClass, props: { name: this[camel] || this.$q.iconSet.fab[camel] } })
         : h('div', { staticClass }, slotFn(this.slotScope))
     }
   },


### PR DESCRIPTION
#12932
