### PR TITLE
Docs: fix wrong `Layout Builder` link href

### DIFF
--- a/docs/src/pages/layout/layout.md
+++ b/docs/src/pages/layout/layout.md
@@ -33,7 +33,7 @@ You are likely going to need the following components - QLayout, QHeader, QToolb
 Keep an eye on your developer console for handy helpers on which components are being used but not declared in your quasar.config.js file.
 :::
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" to="/layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 
@@ -68,7 +68,7 @@ For example, if you want your layout's right side / drawer to be placed on the r
 
 These settings are completely up to you to use as you'd like. You could even go wild with a setup like this: `lhh LpR ffr`. Try it out!
 
-<q-btn push color="red" icon-right="launch" label="Layout Builder" href="layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="red" icon-right="launch" label="Layout Builder" to="/layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ::: warning
 * It is important that you specify all sections of a QLayout, even if you don't use them. For example, even if you don't use footer or right side drawer, still specify them within your QLayout's `view` prop.

--- a/docs/src/pages/layout/layout.md
+++ b/docs/src/pages/layout/layout.md
@@ -33,7 +33,7 @@ You are likely going to need the following components - QLayout, QHeader, QToolb
 Keep an eye on your developer console for handy helpers on which components are being used but not declared in your quasar.config.js file.
 :::
 
-<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" to="/layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="brand-primary" icon-right="launch" label="Layout Builder" href="/layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ## Usage
 
@@ -68,7 +68,7 @@ For example, if you want your layout's right side / drawer to be placed on the r
 
 These settings are completely up to you to use as you'd like. You could even go wild with a setup like this: `lhh LpR ffr`. Try it out!
 
-<q-btn push color="red" icon-right="launch" label="Layout Builder" to="/layout-builder" target="_blank" rel="noopener noreferrer" />
+<q-btn push color="red" icon-right="launch" label="Layout Builder" href="/layout-builder" target="_blank" rel="noopener noreferrer" />
 
 ::: warning
 * It is important that you specify all sections of a QLayout, even if you don't use them. For example, even if you don't use footer or right side drawer, still specify them within your QLayout's `view` prop.


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Issue:
- in Layout page, q-btn links to Layout Builder are wrong due to using href="layout-builder", resulting in `/layout/layout-builder`
FIx:
- Fix `href="layout-builder"` to `to="/layout-builder"` as defined in router/route.js