### PR TITLE
feat(app-vite&app-webpack): Improve package manager detection

### DIFF
--- a/app-vite/lib/helpers/node-packager.js
+++ b/app-vite/lib/helpers/node-packager.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const { normalize, join, sep } = require('path')
 
 const appPaths = require('../app-paths')
 const spawn = require('cross-spawn').sync
@@ -9,8 +10,22 @@ class PackageManager {
   name = 'unknown'
   lockFile = 'unknown'
 
+  /**
+   * Recursively checks for presence of the lock file by traversing
+   * the directory tree up to the root
+   */
   isUsed () {
-    return fs.existsSync(appPaths.resolve.app(this.lockFile))
+    let directory = process.cwd()
+
+    while (directory.length && directory[directory.length - 1] !== sep) {
+      if (fs.existsSync(join(directory, this.lockFile))) {
+        return true
+      }
+
+      directory = normalize(join(directory, '..'))
+    }
+
+    return false
   }
 
   isInstalled () {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Source of the idea: https://github.com/quasarframework/quasar/issues/12784#issuecomment-1080544150

It now checks for the lock file recursively. So, it eliminates some "edge" cases with yarn/npm workspaces where the lock file does not exist on a specific workspace folder(_e.g. /packages/client_) but exists on the workspace root(_e.g. /_). It can also be seen as a fix, depending on where you look at it.