### PR TITLE
feat(ui/QNotify): Create types for Notify options (fix: #12961)

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -166,7 +166,14 @@ function isClassStyleType (type) {
   return hits === 3
 }
 
-function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
+const serializableTypes = [ 'Boolean', 'Number', 'String', 'Array', 'Object' ]
+function isSerializable (value) {
+  const types = Array.isArray(value.type) ? value.type : [ value.type ]
+
+  return types.every(type => serializableTypes.includes(type))
+}
+
+function parseObject ({ banner, api, itemName, masterType, verifyCategory, verifySerializable }) {
   let obj = api[ itemName ]
 
   if (obj.extends !== void 0 && extendApi[ masterType ] !== void 0) {
@@ -328,6 +335,13 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
         process.exit(1)
       }
     }
+
+    if (verifySerializable && isSerializable(obj) === false) {
+      logError(`${ banner } object's type is non-serializable but props in "quasarConfOptions" can only consist of ${ serializableTypes.join('/') }:`)
+      console.error(obj)
+      console.log()
+      process.exit(1)
+    }
   }
 
   if (obj.returns) {
@@ -347,7 +361,8 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory }) {
         banner: `${ banner }/"${ prop }"/"${ item }"`,
         api: api[ itemName ][ prop ],
         itemName: item,
-        masterType: 'props'
+        masterType: 'props',
+        verifySerializable
       })
     }
   })
@@ -429,7 +444,8 @@ function parseAPI (file, apiType) {
         banner: `${ banner } "${ type }"`,
         api,
         itemName: type,
-        masterType: type
+        masterType: type,
+        verifySerializable: type === 'quasarConfOptions'
       })
       continue
     }

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -89,6 +89,11 @@ function convertTypeVal (type, def) {
 }
 
 function getTypeVal (def) {
+  // Special check to avoid huge changes
+  if (def.tsType === 'QNotifyCreateOptions') {
+    return 'QNotifyCreateOptions | string'
+  }
+
   return Array.isArray(def.type)
     ? def.tsType || def.type.map(type => convertTypeVal(type, def)).join(' | ')
     : convertTypeVal(def.type, def)

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -376,9 +376,29 @@
             "actions": {
               "type": "Array",
               "tsType": "QNotifyActions",
-              "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
+              "desc": "Notification actions (buttons); Unless 'noDismiss' is true, clicking/tapping on the button will close the notification; Also check 'closeBtn' convenience prop",
+              "definition": {
+                "handler": {
+                  "type": "Function",
+                  "desc": "Function to be executed when the button is clicked/tapped",
+                  "params": null,
+                  "returns": null,
+                  "examples": [
+                    "() => console.log('button clicked')"
+                  ]
+                },
+                "noDismiss": {
+                  "type": "Boolean",
+                  "desc": "Do not dismiss the notification when the button is clicked/tapped"
+                },
+                "...": {
+                  "type": "Any",
+                  "desc": "Any other QBtn prop expect 'onClick'(use 'handler' instead)",
+                  "examples": [ "label: 'Learn more'", "color: 'primary'" ]
+                }
+              },
               "examples": [
-                "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: (Function) } ]"
+                "[ { label: 'Show', handler: () => {}, 'aria-label': 'Button label' }, { icon: 'map', handler: () => {}, color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: () => {} } ]"
               ]
             },
 

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -375,7 +375,7 @@
                 },
                 "...": {
                   "type": "Any",
-                  "desc": "Any other QBtn prop expect 'onClick'(use 'handler' instead)",
+                  "desc": "Any other QBtn prop expect 'onClick' (use 'handler' instead)",
                   "examples": [ "label: 'Learn more'", "color: 'primary'" ]
                 }
               },

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -64,7 +64,7 @@
       },
 
       "spinner": {
-        "type": [ "Boolean", "Component" ],
+        "type": "Boolean",
         "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
         "examples": [ true, "QSpinnerBars" ]
       },
@@ -167,24 +167,6 @@
         "desc": "Amount of time to display (in milliseconds)",
         "default": 5000,
         "examples": [ 2500 ]
-      },
-
-      "actions": {
-        "type": "Array",
-        "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
-        "examples": [
-          "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: (Function) } ]"
-        ]
-      },
-
-      "onDismiss": {
-        "type": "Function",
-        "desc": "Function to call when notification gets dismissed",
-        "params": null,
-        "returns": null,
-        "examples": [
-          "() => { console.log('Dismissed') }"
-        ]
       },
 
       "closeBtn": {

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -36,7 +36,7 @@
 
       "html": {
         "type": "Boolean",
-        "desc": "Render the message as HTML; This can lead to XSS attacks so make sure that you sanitize the message first"
+        "desc": "Render the message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
       },
 
       "icon": {
@@ -64,8 +64,9 @@
       },
 
       "spinner": {
-        "type": "Boolean",
-        "desc": "Useful for notifications that are updated; Displays the default Quasar spinner instead of an avatar or icon"
+        "type": [ "Boolean", "Component" ],
+        "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
+        "examples": [ true, "QSpinnerBars" ]
       },
 
       "spinnerColor": {
@@ -86,8 +87,7 @@
           "top-left", "top-right",
           "bottom-left", "bottom-right",
           "top", "bottom", "left", "right", "center"
-        ],
-        "examples": [ "top-right" ]
+        ]
       },
 
       "group": {
@@ -112,21 +112,24 @@
         "values": [
           "top-left", "top-right",
           "bottom-left", "bottom-right"
-        ],
-        "examples": [ "bottom-right" ]
+        ]
       },
       "badgeStyle": {
-        "type": "String",
+        "type": [ "String", "Array", "Object" ],
+        "tsType": "VueStyleProp",
         "desc": "Style definitions to be attributed to the badge",
         "examples": [
-          "background-color: #ff0000"
+          "background-color: #ff0000",
+          "{ backgroundColor: '#ff0000' }"
         ]
       },
       "badgeClass": {
-        "type": "String",
+        "type": [ "String", "Array", "Object" ],
+        "tsType": "VueClassProp",
         "desc": "Class definitions to be attributed to the badge",
         "examples": [
-          "my-special-class"
+          "my-special-class",
+          "{ 'my-special-class': <condition> }"
         ]
       },
 
@@ -135,10 +138,12 @@
         "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is 0)"
       },
       "progressClass": {
-        "type": "String",
+        "type": [ "String", "Array", "Object" ],
+        "tsType": "VueClassProp",
         "desc": "Class definitions to be attributed to the progress bar",
         "examples": [
-          "my-special-class"
+          "my-special-class",
+          "{ 'my-special-class': <condition> }"
         ]
       },
 
@@ -164,9 +169,27 @@
         "examples": [ 2500 ]
       },
 
+      "actions": {
+        "type": "Array",
+        "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
+        "examples": [
+          "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: (Function) } ]"
+        ]
+      },
+
+      "onDismiss": {
+        "type": "Function",
+        "desc": "Function to call when notification gets dismissed",
+        "params": null,
+        "returns": null,
+        "examples": [
+          "() => { console.log('Dismissed') }"
+        ]
+      },
+
       "closeBtn": {
         "type": [ "Boolean", "String" ],
-        "desc": "Convenient way to add a dismiss button with a specific label, without using the 'actions' convoluted prop",
+        "desc": "Convenient way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label according to the current Quasar language",
         "examples": [ "Close me" ]
       },
 
@@ -184,6 +207,8 @@
       "params": {
         "opts": {
           "type": [ "Object", "String" ],
+          "tsType": "QNotifyCreateOptions",
+          "autoDefineTsType": true,
           "required": true,
           "desc": "Notification options",
           "definition": {
@@ -215,7 +240,7 @@
 
             "html": {
               "type": "Boolean",
-              "desc": "Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
+              "desc": "Render the message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
             },
 
             "icon": {
@@ -234,7 +259,7 @@
 
             "avatar": {
               "type": "String",
-              "desc": "URL to an avatar/image; Suggestion: public folder",
+              "desc": "URL to an avatar/image; Suggestion: use public folder",
               "examples": [
                 "(public folder) img/something.png",
                 "(relative path format) require('./my_img.jpg')",
@@ -368,7 +393,7 @@
 
             "closeBtn": {
               "type": [ "Boolean", "String" ],
-              "desc": "Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language",
+              "desc": "Convenient way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label according to the current Quasar language",
               "examples": [ "Close me" ]
             },
 
@@ -390,150 +415,10 @@
         "params": {
           "props": {
             "type": "Object",
+            "tsType": "QNotifyUpdateOptions",
             "required": false,
-            "desc": "Notification properties that will be shallow merged to previous ones in order to update the non-grouped notification",
-            "definition": {
-              "type": {
-                "type": "String",
-                "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')",
-                "examples": [ "negative", "custom-type" ]
-              },
-
-              "color": {
-                "extends": "color"
-              },
-
-              "textColor": {
-                "extends": "color"
-              },
-
-              "message": {
-                "type": "String",
-                "desc": "The content of your message",
-                "examples": [ "John Doe pinged you" ]
-              },
-
-              "caption": {
-                "type": "String",
-                "desc": "The content of your optional caption",
-                "examples": [ "5 minutes ago" ]
-              },
-
-              "html": {
-                "type": "Boolean",
-                "desc": "Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
-              },
-
-              "icon": {
-                "extends": "icon"
-              },
-
-              "iconColor": {
-                "extends": "color",
-                "addedIn": "v2.5.5"
-              },
-
-              "iconSize": {
-                "extends": "size",
-                "addedIn": "v2.5.5"
-              },
-
-              "avatar": {
-                "type": "String",
-                "desc": "URL to an avatar/image; Suggestion: use public folder",
-                "examples": [
-                  "(public folder) img/something.png",
-                  "(relative path format) require('./my_img.jpg')",
-                  "(URL) https://some-site.net/some-img.gif"
-                ]
-              },
-
-              "spinner": {
-                "type": [ "Boolean", "Component" ],
-                "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
-                "__exemption": [ "examples" ]
-              },
-
-              "spinnerColor": {
-                "extends": "color",
-                "addedIn": "v2.5.5"
-              },
-
-              "spinnerSize": {
-                "extends": "size",
-                "addedIn": "v2.5.5"
-              },
-
-              "progress": {
-                "type": "Boolean",
-                "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is 0)"
-              },
-              "progressClass": {
-                "type": [ "String", "Array", "Object" ],
-                "tsType": "VueClassProp",
-                "desc": "Class definitions to be attributed to the progress bar",
-                "examples": [
-                  "my-special-class",
-                  "{ 'my-special-class': <condition> }"
-                ]
-              },
-
-              "classes": {
-                "type": "String",
-                "desc": "Add CSS class(es) to the notification for easier customization",
-                "examples": [
-                  "my-notif-class"
-                ]
-              },
-
-              "attrs": {
-                "type": "Object",
-                "desc": "Key-value for attributes to be set on the notification",
-                "examples": [ "{ role: 'alertdialog' }" ],
-                "__exemption": [ "definition" ]
-              },
-
-              "timeout": {
-                "type": "Number",
-                "desc": "Amount of time to display (in milliseconds)",
-                "default": 5000,
-                "examples": [ 2500 ]
-              },
-
-              "actions": {
-                "type": "Array",
-                "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
-                "examples": [
-                  "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: (Function) } ]"
-                ]
-              },
-
-              "onDismiss": {
-                "type": "Function",
-                "desc": "Function to call when notification gets dismissed",
-                "params": null,
-                "returns": null,
-                "examples": [
-                  "() => { console.log('Dismissed') }"
-                ]
-              },
-
-              "closeBtn": {
-                "type": [ "Boolean", "String" ],
-                "desc": "Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language",
-                "examples": [ "Close me" ]
-              },
-
-              "multiLine": {
-                "type": "Boolean",
-                "desc": "Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default"
-              },
-
-              "ignoreDefaults": {
-                "type": "Boolean",
-                "desc": "Ignore the default configuration (set by setDefaults()) for this instance only"
-              }
-            }
+            "desc": "Notification properties that will be shallow merged to previous ones in order to update the non-grouped notification; (See 'opts' param of 'create()' for object properties, except 'group' and 'position')",
+            "__exemption": [ "definition", "examples" ]
           }
         },
         "returns": null
@@ -545,193 +430,10 @@
       "params": {
         "opts": {
           "type": "Object",
+          "tsType": "QNotifyOptions",
           "required": true,
-          "desc": "Notification options",
-          "definition": {
-            "type": {
-              "type": "String",
-              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')",
-              "examples": [ "negative", "custom-type" ]
-            },
-
-            "color": {
-              "extends": "color"
-            },
-
-            "textColor": {
-              "extends": "color"
-            },
-
-            "message": {
-              "type": "String",
-              "desc": "The content of your message",
-              "examples": [ "John Doe pinged you" ]
-            },
-
-            "caption": {
-              "type": "String",
-              "desc": "The content of your optional caption",
-              "examples": [ "5 minutes ago" ]
-            },
-
-            "html": {
-              "type": "Boolean",
-              "desc": "Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
-            },
-
-            "icon": {
-              "extends": "icon"
-            },
-
-            "iconColor": {
-              "extends": "color",
-              "addedIn": "v2.5.5"
-            },
-
-            "iconSize": {
-              "extends": "size",
-              "addedIn": "v2.5.5"
-            },
-
-            "avatar": {
-              "type": "String",
-              "desc": "URL to an avatar/image; Suggestion: use public folder",
-              "examples": [
-                "(public folder) img/something.png",
-                "(relative path format) require('./my_img.jpg')",
-                "(URL) https://some-site.net/some-img.gif"
-              ]
-            },
-
-            "spinner": {
-              "type": [ "Boolean", "Component" ],
-              "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
-              "__exemption": [ "examples" ]
-            },
-
-            "spinnerColor": {
-              "extends": "color",
-              "addedIn": "v2.5.5"
-            },
-
-            "spinnerSize": {
-              "extends": "size",
-              "addedIn": "v2.5.5"
-            },
-
-            "position": {
-              "type": "String",
-              "desc": "Window side/corner to stick to",
-              "default": "bottom",
-              "values": [
-                "top-left", "top-right",
-                "bottom-left", "bottom-right",
-                "top", "bottom", "left", "right", "center"
-              ],
-              "examples": [ "top-right" ]
-            },
-
-            "badgeColor": {
-              "extends": "color",
-              "desc": "Color name for the badge from the Quasar Color Palette"
-            },
-            "badgeTextColor": {
-              "extends": "color",
-              "desc": "Color name for the badge text from the Quasar Color Palette"
-            },
-            "badgePosition": {
-              "type": "String",
-              "desc": "Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left",
-              "default": "(top-left/top-right)",
-              "values": [
-                "top-left", "top-right",
-                "bottom-left", "bottom-right"
-              ],
-              "examples": [ "bottom-right" ]
-            },
-            "badgeStyle": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueStyleProp",
-              "desc": "Style definitions to be attributed to the badge",
-              "examples": [
-                "background-color: #ff0000",
-                "{ backgroundColor: '#ff0000' }"
-              ]
-            },
-            "badgeClass": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueClassProp",
-              "desc": "Class definitions to be attributed to the badge",
-              "examples": [
-                "my-special-class",
-                "{ 'my-special-class': <condition> }"
-              ]
-            },
-
-            "progress": {
-              "type": "Boolean",
-              "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is 0)"
-            },
-            "progressClass": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueClassProp",
-              "desc": "Class definitions to be attributed to the progress bar",
-              "examples": [
-                "my-special-class",
-                "{ 'my-special-class': <condition> }"
-              ]
-            },
-
-            "classes": {
-              "type": "String",
-              "desc": "Add CSS class(es) to the notification for easier customization",
-              "examples": [
-                "my-notif-class"
-              ]
-            },
-
-            "attrs": {
-              "type": "Object",
-              "desc": "Key-value for attributes to be set on the notification",
-              "examples": [ "{ role: 'alertdialog' }" ]
-            },
-
-            "timeout": {
-              "type": "Number",
-              "desc": "Amount of time to display (in milliseconds)",
-              "default": 5000,
-              "examples": [ 2500 ]
-            },
-
-            "actions": {
-              "type": "Array",
-              "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
-              "examples": [
-                "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' } ]"
-              ]
-            },
-
-            "onDismiss": {
-              "type": "Function",
-              "desc": "Function to call when notification gets dismissed",
-              "params": null,
-              "returns": null,
-              "examples": [
-                "() => { console.log('Dismissed') }"
-              ]
-            },
-
-            "closeBtn": {
-              "type": [ "Boolean", "String" ],
-              "desc": "Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language",
-              "examples": [ "Close me" ]
-            },
-
-            "multiLine": {
-              "type": "Boolean",
-              "desc": "Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default"
-            }
-          }
+          "desc": "Notification options (See 'opts' param of 'create()' for object properties)",
+          "__exemption": [ "definition", "examples" ]
         }
       }
     },
@@ -748,193 +450,10 @@
 
         "typeOpts": {
           "type": "Object",
+          "tsType": "QNotifyOptions",
           "required": true,
-          "desc": "Notification options",
-          "definition": {
-            "type": {
-              "type": "String",
-              "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')",
-              "examples": [ "negative", "custom-type" ]
-            },
-
-            "color": {
-              "extends": "color"
-            },
-
-            "textColor": {
-              "extends": "color"
-            },
-
-            "message": {
-              "type": "String",
-              "desc": "The content of your message",
-              "examples": [ "John Doe pinged you" ]
-            },
-
-            "caption": {
-              "type": "String",
-              "desc": "The content of your optional caption",
-              "examples": [ "5 minutes ago" ]
-            },
-
-            "html": {
-              "type": "Boolean",
-              "desc": "Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first"
-            },
-
-            "icon": {
-              "extends": "icon"
-            },
-
-            "iconColor": {
-              "extends": "color",
-              "addedIn": "v2.5.5"
-            },
-
-            "iconSize": {
-              "extends": "size",
-              "addedIn": "v2.5.5"
-            },
-
-            "avatar": {
-              "type": "String",
-              "desc": "URL to an avatar/image; Suggestion: use public folder",
-              "examples": [
-                "(public folder) img/something.png",
-                "(relative path format) require('./my_img.jpg')",
-                "(URL) https://some-site.net/some-img.gif"
-              ]
-            },
-
-            "spinner": {
-              "type": [ "Boolean", "Component" ],
-              "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
-              "__exemption": [ "examples" ]
-            },
-
-            "spinnerColor": {
-              "extends": "color",
-              "addedIn": "v2.5.5"
-            },
-
-            "spinnerSize": {
-              "extends": "size",
-              "addedIn": "v2.5.5"
-            },
-
-            "position": {
-              "type": "String",
-              "desc": "Window side/corner to stick to",
-              "default": "bottom",
-              "values": [
-                "top-left", "top-right",
-                "bottom-left", "bottom-right",
-                "top", "bottom", "left", "right", "center"
-              ],
-              "examples": [ "top-right" ]
-            },
-
-            "badgeColor": {
-              "extends": "color",
-              "desc": "Color name for the badge from the Quasar Color Palette"
-            },
-            "badgeTextColor": {
-              "extends": "color",
-              "desc": "Color name for the badge text from the Quasar Color Palette"
-            },
-            "badgePosition": {
-              "type": "String",
-              "desc": "Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left",
-              "default": "(top-left/top-right)",
-              "values": [
-                "top-left", "top-right",
-                "bottom-left", "bottom-right"
-              ],
-              "examples": [ "bottom-right" ]
-            },
-            "badgeStyle": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueStyleProp",
-              "desc": "Style definitions to be attributed to the badge",
-              "examples": [
-                "background-color: #ff0000",
-                "{ backgroundColor: '#ff0000' }"
-              ]
-            },
-            "badgeClass": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueClassProp",
-              "desc": "Class definitions to be attributed to the badge",
-              "examples": [
-                "my-special-class",
-                "{ 'my-special-class': <condition> }"
-              ]
-            },
-
-            "progress": {
-              "type": "Boolean",
-              "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is 0)"
-            },
-            "progressClass": {
-              "type": [ "String", "Array", "Object" ],
-              "tsType": "VueClassProp",
-              "desc": "Class definitions to be attributed to the progress bar",
-              "examples": [
-                "my-special-class",
-                "{ 'my-special-class': <condition> }"
-              ]
-            },
-
-            "classes": {
-              "type": "String",
-              "desc": "Add CSS class(es) to the notification for easier customization",
-              "examples": [
-                "my-notif-class"
-              ]
-            },
-
-            "attrs": {
-              "type": "Object",
-              "desc": "Key-value for attributes to be set on the notification",
-              "examples": [ "{ role: 'alertdialog' }" ]
-            },
-
-            "timeout": {
-              "type": "Number",
-              "desc": "Amount of time to display (in milliseconds)",
-              "default": 5000,
-              "examples": [ 2500 ]
-            },
-
-            "actions": {
-              "type": "Array",
-              "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
-              "examples": [
-                "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' } ]"
-              ]
-            },
-
-            "onDismiss": {
-              "type": "Function",
-              "desc": "Function to call when notification gets dismissed",
-              "params": null,
-              "returns": null,
-              "examples": [
-                "() => { console.log('Dismissed') }"
-              ]
-            },
-
-            "closeBtn": {
-              "type": [ "Boolean", "String" ],
-              "desc": "Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language",
-              "examples": [ "Close me" ]
-            },
-
-            "multiLine": {
-              "type": "Boolean",
-              "desc": "Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default"
-            }
-          }
+          "desc": "Notification options (See 'opts' param of 'create()' for object properties)",
+          "__exemption": [ "definition", "examples" ]
         }
       }
     }

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -375,6 +375,7 @@
 
             "actions": {
               "type": "Array",
+              "tsType": "QNotifyActions",
               "desc": "Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop",
               "examples": [
                 "[ { label: 'Show', handler: (Function), attrs: { 'aria-label': 'Button label' } }, { icon: 'map', handler: (Function), color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: (Function) } ]"

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -366,7 +366,7 @@
                   "params": null,
                   "returns": null,
                   "examples": [
-                    "() => console.log('button clicked')"
+                    "() => { console.log('button clicked') }"
                   ]
                 },
                 "noDismiss": {

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -5,6 +5,7 @@ export * from "./api/qselect";
 export * from "./api/qtable";
 export * from "./api/qtree";
 export * from "./api/quploader";
+export * from "./api/qnotify";
 export * from "./api/touchswipe";
 export * from "./api/web-storage";
 export * from "./api/validation";

--- a/ui/types/api/qnotify.d.ts
+++ b/ui/types/api/qnotify.d.ts
@@ -1,6 +1,10 @@
 // Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
 // The import will work correctly at runtime
-import { QNotifyCreateOptions } from "quasar";
+import { QNotifyCreateOptions, QBtnProps } from "quasar";
+import { ButtonHTMLAttributes } from "vue";
 
 export type QNotifyUpdateOptions = Omit<QNotifyCreateOptions, 'group' | 'position'>;
 export type QNotifyOptions = Omit<QNotifyCreateOptions, 'ignoreDefaults'>;
+
+export type QNotifyAction = Omit<QBtnProps, 'onClick'> & ButtonHTMLAttributes & { noDismiss?: boolean; handler?: () => void };
+export type QNotifyActions = QNotifyAction[];

--- a/ui/types/api/qnotify.d.ts
+++ b/ui/types/api/qnotify.d.ts
@@ -1,0 +1,6 @@
+// Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
+// The import will work correctly at runtime
+import { QNotifyCreateOptions } from "quasar";
+
+export type QNotifyUpdateOptions = Omit<QNotifyCreateOptions, 'group' | 'position'>;
+export type QNotifyOptions = Omit<QNotifyCreateOptions, 'ignoreDefaults'>;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Documentation

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

Closes #12961.

New types:
```ts
// See the diff of `dist/types/index.d.ts` for more info
import { QNotifyCreateOptions } from "quasar";

export type QNotifyUpdateOptions = Omit<QNotifyCreateOptions, 'group' | 'position'>;
export type QNotifyOptions = Omit<QNotifyCreateOptions, 'ignoreDefaults'>;
```

 📜 Changes for dist/types/index.d.ts
```diff
@@ -443,508 +443,21 @@
    * @param opts Notification options
    * @returns Calling this function with no parameters hides the notification; When called with one Object parameter (the original notification must NOT be grouped), it updates the notification (specified properties are shallow merged with previous ones; note that group and position cannot be changed while updating and so they are ignored)
    */
   create: (
-    opts:
-      | {
-          /**
-           * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-           */
-          type?: string;
-          /**
-           * Color name for component from the Quasar Color Palette
-           */
-          color?: string;
-          /**
-           * Color name for component from the Quasar Color Palette
-           */
-          textColor?: string;
-          /**
-           * The content of your message
-           */
-          message?: string;
-          /**
-           * The content of your optional caption
-           */
-          caption?: string;
-          /**
-           * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-           */
-          html?: boolean;
-          /**
-           * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-           */
-          icon?: string;
-          /**
-           * Color name for component from the Quasar Color Palette
-           */
-          iconColor?: string;
-          /**
-           * Size in CSS units, including unit name
-           */
-          iconSize?: string;
-          /**
-           * URL to an avatar/image; Suggestion: public folder
-           */
-          avatar?: string;
-          /**
-           * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-           */
-          spinner?: boolean | Component;
-          /**
-           * Color name for component from the Quasar Color Palette
-           */
-          spinnerColor?: string;
-          /**
-           * Size in CSS units, including unit name
-           */
-          spinnerSize?: string;
-          /**
-           * Window side/corner to stick to
-           * Default value: bottom
-           */
-          position?:
-            | "top-left"
-            | "top-right"
-            | "bottom-left"
-            | "bottom-right"
-            | "top"
-            | "bottom"
-            | "left"
-            | "right"
-            | "center";
-          /**
-           * Override the auto generated group with custom one; Grouped notifications cannot be updated; String or number value inform this is part of a specific group, regardless of its options; When a new notification is triggered with same group name, it replaces the old one and shows a badge with how many times the notification was triggered
-           * Default value: (message + caption + multiline + actions labels + position)
-           */
-          group?: boolean | string | number;
-          /**
-           * Color name for the badge from the Quasar Color Palette
-           */
-          badgeColor?: string;
-          /**
-           * Color name for the badge text from the Quasar Color Palette
-           */
-          badgeTextColor?: string;
-          /**
-           * Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left
-           * Default value: (top-left/top-right)
-           */
-          badgePosition?:
-            | "top-left"
-            | "top-right"
-            | "bottom-left"
-            | "bottom-right";
-          /**
-           * Style definitions to be attributed to the badge
-           */
-          badgeStyle?: VueStyleProp;
-          /**
-           * Class definitions to be attributed to the badge
-           */
-          badgeClass?: VueClassProp;
-          /**
-           * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-           */
-          progress?: boolean;
-          /**
-           * Class definitions to be attributed to the progress bar
-           */
-          progressClass?: VueClassProp;
-          /**
-           * Add CSS class(es) to the notification for easier customization
-           */
-          classes?: string;
-          /**
-           * Key-value for attributes to be set on the notification
-           */
-          attrs?: any;
-          /**
-           * Amount of time to display (in milliseconds)
-           * Default value: 5000
-           */
-          timeout?: number;
-          /**
-           * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-           */
-          actions?: any[];
-          /**
-           * Function to call when notification gets dismissed
-           */
-          onDismiss?: () => void;
-          /**
-           * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-           */
-          closeBtn?: boolean | string;
-          /**
-           * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-           */
-          multiLine?: boolean;
-          /**
-           * Ignore the default configuration (set by setDefaults()) for this instance only
-           */
-          ignoreDefaults?: boolean;
-        }
-      | string
-  ) => (props?: {
-    /**
-     * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-     */
-    type?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    color?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    textColor?: string;
-    /**
-     * The content of your message
-     */
-    message?: string;
-    /**
-     * The content of your optional caption
-     */
-    caption?: string;
-    /**
-     * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-     */
-    html?: boolean;
-    /**
-     * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-     */
-    icon?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    iconColor?: string;
-    /**
-     * Size in CSS units, including unit name
-     */
-    iconSize?: string;
-    /**
-     * URL to an avatar/image; Suggestion: use public folder
-     */
-    avatar?: string;
-    /**
-     * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-     */
-    spinner?: boolean | Component;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    spinnerColor?: string;
-    /**
-     * Size in CSS units, including unit name
-     */
-    spinnerSize?: string;
-    /**
-     * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-     */
-    progress?: boolean;
-    /**
-     * Class definitions to be attributed to the progress bar
-     */
-    progressClass?: VueClassProp;
-    /**
-     * Add CSS class(es) to the notification for easier customization
-     */
-    classes?: string;
-    /**
-     * Key-value for attributes to be set on the notification
-     */
-    attrs?: any;
-    /**
-     * Amount of time to display (in milliseconds)
-     * Default value: 5000
-     */
-    timeout?: number;
-    /**
-     * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-     */
-    actions?: any[];
-    /**
-     * Function to call when notification gets dismissed
-     */
-    onDismiss?: () => void;
-    /**
-     * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-     */
-    closeBtn?: boolean | string;
-    /**
-     * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-     */
-    multiLine?: boolean;
-    /**
-     * Ignore the default configuration (set by setDefaults()) for this instance only
-     */
-    ignoreDefaults?: boolean;
-  }) => void;
+    opts: QNotifyCreateOptions | string
+  ) => (props?: QNotifyUpdateOptions) => void;
   /**
    * Merge options into the default ones
-   * @param opts Notification options
+   * @param opts Notification options (See 'opts' param of 'create()' for object properties)
    */
-  setDefaults: (opts: {
-    /**
-     * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-     */
-    type?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    color?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    textColor?: string;
-    /**
-     * The content of your message
-     */
-    message?: string;
-    /**
-     * The content of your optional caption
-     */
-    caption?: string;
-    /**
-     * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-     */
-    html?: boolean;
-    /**
-     * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-     */
-    icon?: string;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    iconColor?: string;
-    /**
-     * Size in CSS units, including unit name
-     */
-    iconSize?: string;
-    /**
-     * URL to an avatar/image; Suggestion: use public folder
-     */
-    avatar?: string;
-    /**
-     * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-     */
-    spinner?: boolean | Component;
-    /**
-     * Color name for component from the Quasar Color Palette
-     */
-    spinnerColor?: string;
-    /**
-     * Size in CSS units, including unit name
-     */
-    spinnerSize?: string;
-    /**
-     * Window side/corner to stick to
-     * Default value: bottom
-     */
-    position?:
-      | "top-left"
-      | "top-right"
-      | "bottom-left"
-      | "bottom-right"
-      | "top"
-      | "bottom"
-      | "left"
-      | "right"
-      | "center";
-    /**
-     * Color name for the badge from the Quasar Color Palette
-     */
-    badgeColor?: string;
-    /**
-     * Color name for the badge text from the Quasar Color Palette
-     */
-    badgeTextColor?: string;
-    /**
-     * Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left
-     * Default value: (top-left/top-right)
-     */
-    badgePosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    /**
-     * Style definitions to be attributed to the badge
-     */
-    badgeStyle?: VueStyleProp;
-    /**
-     * Class definitions to be attributed to the badge
-     */
-    badgeClass?: VueClassProp;
-    /**
-     * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-     */
-    progress?: boolean;
-    /**
-     * Class definitions to be attributed to the progress bar
-     */
-    progressClass?: VueClassProp;
-    /**
-     * Add CSS class(es) to the notification for easier customization
-     */
-    classes?: string;
-    /**
-     * Key-value for attributes to be set on the notification
-     */
-    attrs?: any;
-    /**
-     * Amount of time to display (in milliseconds)
-     * Default value: 5000
-     */
-    timeout?: number;
-    /**
-     * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-     */
-    actions?: any[];
-    /**
-     * Function to call when notification gets dismissed
-     */
-    onDismiss?: () => void;
-    /**
-     * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-     */
-    closeBtn?: boolean | string;
-    /**
-     * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-     */
-    multiLine?: boolean;
-  }) => void;
+  setDefaults: (opts: QNotifyOptions) => void;
   /**
    * Register a new type of notification (or override an existing one)
    * @param typeName Name of the type (to be used as 'type' prop later on)
-   * @param typeOpts Notification options
+   * @param typeOpts Notification options (See 'opts' param of 'create()' for object properties)
    */
-  registerType: (
-    typeName: string,
-    typeOpts: {
-      /**
-       * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-       */
-      type?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      color?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      textColor?: string;
-      /**
-       * The content of your message
-       */
-      message?: string;
-      /**
-       * The content of your optional caption
-       */
-      caption?: string;
-      /**
-       * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-       */
-      html?: boolean;
-      /**
-       * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-       */
-      icon?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      iconColor?: string;
-      /**
-       * Size in CSS units, including unit name
-       */
-      iconSize?: string;
-      /**
-       * URL to an avatar/image; Suggestion: use public folder
-       */
-      avatar?: string;
-      /**
-       * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-       */
-      spinner?: boolean | Component;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      spinnerColor?: string;
-      /**
-       * Size in CSS units, including unit name
-       */
-      spinnerSize?: string;
-      /**
-       * Window side/corner to stick to
-       * Default value: bottom
-       */
-      position?:
-        | "top-left"
-        | "top-right"
-        | "bottom-left"
-        | "bottom-right"
-        | "top"
-        | "bottom"
-        | "left"
-        | "right"
-        | "center";
-      /**
-       * Color name for the badge from the Quasar Color Palette
-       */
-      badgeColor?: string;
-      /**
-       * Color name for the badge text from the Quasar Color Palette
-       */
-      badgeTextColor?: string;
-      /**
-       * Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left
-       * Default value: (top-left/top-right)
-       */
-      badgePosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
-      /**
-       * Style definitions to be attributed to the badge
-       */
-      badgeStyle?: VueStyleProp;
-      /**
-       * Class definitions to be attributed to the badge
-       */
-      badgeClass?: VueClassProp;
-      /**
-       * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-       */
-      progress?: boolean;
-      /**
-       * Class definitions to be attributed to the progress bar
-       */
-      progressClass?: VueClassProp;
-      /**
-       * Add CSS class(es) to the notification for easier customization
-       */
-      classes?: string;
-      /**
-       * Key-value for attributes to be set on the notification
-       */
-      attrs?: any;
-      /**
-       * Amount of time to display (in milliseconds)
-       * Default value: 5000
-       */
-      timeout?: number;
-      /**
-       * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-       */
-      actions?: any[];
-      /**
-       * Function to call when notification gets dismissed
-       */
-      onDismiss?: () => void;
-      /**
-       * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-       */
-      closeBtn?: boolean | string;
-      /**
-       * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-       */
-      multiLine?: boolean;
-    }
-  ) => void;
+  registerType: (typeName: string, typeOpts: QNotifyOptions) => void;
 }
 
 export interface Platform {
   /**
@@ -13747,8 +13260,146 @@
 import { WebStorageGetItemMethodType } from "./api";
 import { WebStorageGetIndexMethodType } from "./api";
 import { WebStorageGetKeyMethodType } from "./api";
 import { WebStorageGetAllKeysMethodType } from "./api";
+export interface QNotifyCreateOptions {
+  /**
+   * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
+   */
+  type?: string;
+  /**
+   * Color name for component from the Quasar Color Palette
+   */
+  color?: string;
+  /**
+   * Color name for component from the Quasar Color Palette
+   */
+  textColor?: string;
+  /**
+   * The content of your message
+   */
+  message?: string;
+  /**
+   * The content of your optional caption
+   */
+  caption?: string;
+  /**
+   * Render the message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
+   */
+  html?: boolean;
+  /**
+   * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
+   */
+  icon?: string;
+  /**
+   * Color name for component from the Quasar Color Palette
+   */
+  iconColor?: string;
+  /**
+   * Size in CSS units, including unit name
+   */
+  iconSize?: string;
+  /**
+   * URL to an avatar/image; Suggestion: use public folder
+   */
+  avatar?: string;
+  /**
+   * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
+   */
+  spinner?: boolean | Component;
+  /**
+   * Color name for component from the Quasar Color Palette
+   */
+  spinnerColor?: string;
+  /**
+   * Size in CSS units, including unit name
+   */
+  spinnerSize?: string;
+  /**
+   * Window side/corner to stick to
+   * Default value: bottom
+   */
+  position?:
+    | "top-left"
+    | "top-right"
+    | "bottom-left"
+    | "bottom-right"
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "center";
+  /**
+   * Override the auto generated group with custom one; Grouped notifications cannot be updated; String or number value inform this is part of a specific group, regardless of its options; When a new notification is triggered with same group name, it replaces the old one and shows a badge with how many times the notification was triggered
+   * Default value: (message + caption + multiline + actions labels + position)
+   */
+  group?: boolean | string | number;
+  /**
+   * Color name for the badge from the Quasar Color Palette
+   */
+  badgeColor?: string;
+  /**
+   * Color name for the badge text from the Quasar Color Palette
+   */
+  badgeTextColor?: string;
+  /**
+   * Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left
+   * Default value: (top-left/top-right)
+   */
+  badgePosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+  /**
+   * Style definitions to be attributed to the badge
+   */
+  badgeStyle?: VueStyleProp;
+  /**
+   * Class definitions to be attributed to the badge
+   */
+  badgeClass?: VueClassProp;
+  /**
+   * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
+   */
+  progress?: boolean;
+  /**
+   * Class definitions to be attributed to the progress bar
+   */
+  progressClass?: VueClassProp;
+  /**
+   * Add CSS class(es) to the notification for easier customization
+   */
+  classes?: string;
+  /**
+   * Key-value for attributes to be set on the notification
+   */
+  attrs?: any;
+  /**
+   * Amount of time to display (in milliseconds)
+   * Default value: 5000
+   */
+  timeout?: number;
+  /**
+   * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
+   */
+  actions?: any[];
+  /**
+   * Function to call when notification gets dismissed
+   */
+  onDismiss?: () => void;
+  /**
+   * Convenient way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label according to the current Quasar language
+   */
+  closeBtn?: boolean | string;
+  /**
+   * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
+   */
+  multiLine?: boolean;
+  /**
+   * Ignore the default configuration (set by setDefaults()) for this instance only
+   */
+  ignoreDefaults?: boolean;
+}
+
+import { QNotifyUpdateOptions } from "./api";
+import { QNotifyOptions } from "./api";
 import { VueStyleObjectProp } from "./api";
 import { ValidationRule } from "./api";
 import { QRejectedEntry } from "./api";
 import { SliderMarkerLabels } from "./api";
@@ -13850,244 +13501,10 @@
      * @param opts Notification options
      * @returns Calling this function with no parameters hides the notification; When called with one Object parameter (the original notification must NOT be grouped), it updates the notification (specified properties are shallow merged with previous ones; note that group and position cannot be changed while updating and so they are ignored)
      */
     notify: (
-      opts:
-        | {
-            /**
-             * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-             */
-            type?: string;
-            /**
-             * Color name for component from the Quasar Color Palette
-             */
-            color?: string;
-            /**
-             * Color name for component from the Quasar Color Palette
-             */
-            textColor?: string;
-            /**
-             * The content of your message
-             */
-            message?: string;
-            /**
-             * The content of your optional caption
-             */
-            caption?: string;
-            /**
-             * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-             */
-            html?: boolean;
-            /**
-             * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-             */
-            icon?: string;
-            /**
-             * Color name for component from the Quasar Color Palette
-             */
-            iconColor?: string;
-            /**
-             * Size in CSS units, including unit name
-             */
-            iconSize?: string;
-            /**
-             * URL to an avatar/image; Suggestion: public folder
-             */
-            avatar?: string;
-            /**
-             * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-             */
-            spinner?: boolean | Component;
-            /**
-             * Color name for component from the Quasar Color Palette
-             */
-            spinnerColor?: string;
-            /**
-             * Size in CSS units, including unit name
-             */
-            spinnerSize?: string;
-            /**
-             * Window side/corner to stick to
-             * Default value: bottom
-             */
-            position?:
-              | "top-left"
-              | "top-right"
-              | "bottom-left"
-              | "bottom-right"
-              | "top"
-              | "bottom"
-              | "left"
-              | "right"
-              | "center";
-            /**
-             * Override the auto generated group with custom one; Grouped notifications cannot be updated; String or number value inform this is part of a specific group, regardless of its options; When a new notification is triggered with same group name, it replaces the old one and shows a badge with how many times the notification was triggered
-             * Default value: (message + caption + multiline + actions labels + position)
-             */
-            group?: boolean | string | number;
-            /**
-             * Color name for the badge from the Quasar Color Palette
-             */
-            badgeColor?: string;
-            /**
-             * Color name for the badge text from the Quasar Color Palette
-             */
-            badgeTextColor?: string;
-            /**
-             * Notification corner to stick badge to; If notification is on the left side then default is top-right otherwise it is top-left
-             * Default value: (top-left/top-right)
-             */
-            badgePosition?:
-              | "top-left"
-              | "top-right"
-              | "bottom-left"
-              | "bottom-right";
-            /**
-             * Style definitions to be attributed to the badge
-             */
-            badgeStyle?: VueStyleProp;
-            /**
-             * Class definitions to be attributed to the badge
-             */
-            badgeClass?: VueClassProp;
-            /**
-             * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-             */
-            progress?: boolean;
-            /**
-             * Class definitions to be attributed to the progress bar
-             */
-            progressClass?: VueClassProp;
-            /**
-             * Add CSS class(es) to the notification for easier customization
-             */
-            classes?: string;
-            /**
-             * Key-value for attributes to be set on the notification
-             */
-            attrs?: any;
-            /**
-             * Amount of time to display (in milliseconds)
-             * Default value: 5000
-             */
-            timeout?: number;
-            /**
-             * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-             */
-            actions?: any[];
-            /**
-             * Function to call when notification gets dismissed
-             */
-            onDismiss?: () => void;
-            /**
-             * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-             */
-            closeBtn?: boolean | string;
-            /**
-             * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-             */
-            multiLine?: boolean;
-            /**
-             * Ignore the default configuration (set by setDefaults()) for this instance only
-             */
-            ignoreDefaults?: boolean;
-          }
-        | string
-    ) => (props?: {
-      /**
-       * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
-       */
-      type?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      color?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      textColor?: string;
-      /**
-       * The content of your message
-       */
-      message?: string;
-      /**
-       * The content of your optional caption
-       */
-      caption?: string;
-      /**
-       * Render message as HTML; This can lead to XSS attacks, so make sure that you sanitize the message first
-       */
-      html?: boolean;
-      /**
-       * Icon name following Quasar convention; Make sure you have the icon library installed unless you are using 'img:' prefix; If 'none' (String) is used as value then no icon is rendered (but screen real estate will still be used for it)
-       */
-      icon?: string;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      iconColor?: string;
-      /**
-       * Size in CSS units, including unit name
-       */
-      iconSize?: string;
-      /**
-       * URL to an avatar/image; Suggestion: use public folder
-       */
-      avatar?: string;
-      /**
-       * Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown
-       */
-      spinner?: boolean | Component;
-      /**
-       * Color name for component from the Quasar Color Palette
-       */
-      spinnerColor?: string;
-      /**
-       * Size in CSS units, including unit name
-       */
-      spinnerSize?: string;
-      /**
-       * Show progress bar to detail when notification will disappear automatically (unless timeout is 0)
-       */
-      progress?: boolean;
-      /**
-       * Class definitions to be attributed to the progress bar
-       */
-      progressClass?: VueClassProp;
-      /**
-       * Add CSS class(es) to the notification for easier customization
-       */
-      classes?: string;
-      /**
-       * Key-value for attributes to be set on the notification
-       */
-      attrs?: any;
-      /**
-       * Amount of time to display (in milliseconds)
-       * Default value: 5000
-       */
-      timeout?: number;
-      /**
-       * Notification actions (buttons); If a 'handler' is specified or not, clicking/tapping on the button will also close the notification; Also check 'closeBtn' convenience prop
-       */
-      actions?: any[];
-      /**
-       * Function to call when notification gets dismissed
-       */
-      onDismiss?: () => void;
-      /**
-       * Convenience way to add a dismiss button with a specific label, without using the 'actions' prop; If set to true, it uses a label accordding to the current Quasar language
-       */
-      closeBtn?: boolean | string;
-      /**
-       * Put notification into multi-line mode; If this prop isn't used and more than one 'action' is specified then notification goes into multi-line mode by default
-       */
-      multiLine?: boolean;
-      /**
-       * Ignore the default configuration (set by setDefaults()) for this instance only
-       */
-      ignoreDefaults?: boolean;
-    }) => void;
+      opts: QNotifyCreateOptions | string
+    ) => (props?: QNotifyUpdateOptions) => void;
     platform: Platform;
     screen: Screen;
     sessionStorage: SessionStorage;
   }
```