### PR TITLE
fix(create-quasar/ts-vite): Remove invalid tsconfig references

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.json
@@ -15,6 +15,5 @@
     "experimentalDecorators": true,
     "useDefineForClassFields": true<% } %>
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.node.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.node.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "composite": true,
-    "module": "esnext",
-    "moduleResolution": "node"
-  }
-}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Aims to solve the resolving problem that IDEs are having. It's reported in #12849 and many times in Discord. The `references` property was being used wrongly. Normally, `path` needs to point out to a directory, but in this case, it was pointing to a file. It has no use anyway, so I removed it completely.