### PR TITLE
small adjustments in flex addons part

### DIFF
--- a/docs/src/pages/layout/grid/introduction-to-flexbox.md
+++ b/docs/src/pages/layout/grid/introduction-to-flexbox.md
@@ -243,7 +243,7 @@ Note that there will be a noticeable bump in CSS footprint when enabling it. So 
 .content-<bp>-(start|end|center|between|around)
 .self-<bp>-(start|end|center|baseline|stretch)
 .flex-<bp>-center
-.gutter-<bp>(|-x|-y)-(xs|sm|md|lg|xl)
+.q-gutter-<bp>(|-x|-y)-(xs|sm|md|lg|xl)
 .(col|offset)-<bp>-(|0..12)
 ```
 


### PR DESCRIPTION
I don't see `.gutter-<bp>(|-x|-y)-(xs|sm|md|lg|xl)` only `.q-gutter-<bp>(|-x|-y)-(xs|sm|md|lg|xl)`
`.(row|column|flex)-<bp>(|-inline)`  - in the generated css for row/column there is no "-inline", I only see ".inline"
`.q-my-<bp>-form`  -  it's not clear what user should do to have such functionality

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
