### PR TITLE
fix(ui/QNotify): Use the correct type for actions

### DIFF
--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -357,7 +357,7 @@
 
             "actions": {
               "type": "Array",
-              "tsType": "QNotifyActions",
+              "tsType": "QNotifyAction",
               "desc": "Notification actions (buttons); Unless 'noDismiss' is true, clicking/tapping on the button will close the notification; Also check 'closeBtn' convenience prop",
               "definition": {
                 "handler": {

--- a/ui/types/api/qnotify.d.ts
+++ b/ui/types/api/qnotify.d.ts
@@ -7,4 +7,3 @@ export type QNotifyUpdateOptions = Omit<QNotifyCreateOptions, 'group' | 'positio
 export type QNotifyOptions = Omit<QNotifyCreateOptions, 'ignoreDefaults'>;
 
 export type QNotifyAction = Omit<QBtnProps, 'onClick'> & ButtonHTMLAttributes & { noDismiss?: boolean; handler?: () => void };
-export type QNotifyActions = QNotifyAction[];


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
See https://github.com/quasarframework/quasar/pull/12962#issuecomment-1084684904

```diff
@@ -13260,9 +13264,9 @@
 import { WebStorageGetItemMethodType } from "./api";
 import { WebStorageGetIndexMethodType } from "./api";
 import { WebStorageGetKeyMethodType } from "./api";
 import { WebStorageGetAllKeysMethodType } from "./api";
-import { QNotifyActions } from "./api";
+import { QNotifyAction } from "./api";
 export interface QNotifyCreateOptions {
   /**
    * Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')
    */
@@ -13378,9 +13382,9 @@
   timeout?: number;
   /**
    * Notification actions (buttons); Unless 'noDismiss' is true, clicking/tapping on the button will close the notification; Also check 'closeBtn' convenience prop
    */
-  actions?: QNotifyActions[];
+  actions?: QNotifyAction[];
   /**
    * Function to call when notification gets dismissed
    */
   onDismiss?: () => void;
```