### PR TITLE
chore(ui): add prefix for text-overflow

### DIFF
--- a/ui/src/css/core/visibility.sass
+++ b/ui/src/css/core/visibility.sass
@@ -13,6 +13,8 @@
 
 .ellipsis
   text-overflow: ellipsis
+  -ms-text-overflow: ellipsis
+  -o-text-overflow: ellipsis
   white-space: nowrap
   overflow: hidden
 


### PR DESCRIPTION
Default browserslist configuration doesn't prefix `text-overflow`