### PR TITLE
Fix: Check for empty identifier to prevent broken import statement with app-vite (fix #13123)

### DIFF
--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -28,7 +28,16 @@ export function vueTransform (content, autoImportComponentCase) {
       importQuasarRegex,
       (_, match) => match.split(',')
         .map(identifier => {
-          const data = identifier.split(' as ')
+          const id = identifier.trim()
+
+          // might be an empty entry like below
+          // (notice useQuasar is followed by a comma)
+          // import { QTable, useQuasar, } from 'quasar'
+          if (id === '') {
+            return ''
+          }
+
+          const data = id.split(' as ')
           const importName = data[0].trim()
           const importAs = data[1] !== void 0
             ? data[1].trim()


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

Fixes issue https://github.com/quasarframework/quasar/issues/13123
When using `@quasar/app-vite`, a trailing comma breaks import statement from 'quasar'