### PR TITLE
fix(QBtnDropdown): Added missing 'loading' slot #12857

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.js
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.js
@@ -4,6 +4,7 @@ import QIcon from '../icon/QIcon.js'
 import QBtn from '../btn/QBtn.js'
 import QBtnGroup from '../btn-group/QBtnGroup.js'
 import QMenu from '../menu/QMenu.js'
+import QSpinner from '../spinner/QSpinner.js'
 
 import { useBtnProps } from '../btn/use-btn.js'
 
@@ -173,7 +174,10 @@ export default createComponent({
           round: false,
           ...attributes.value,
           onClick
-        }, () => hSlot(slots.label, []).concat(Arrow))
+        }, {
+          default: () => hSlot(slots.label, []).concat(Arrow),
+          loading: () => slots.loading !== void 0 ? slots.loading() : [ h(QSpinner) ],
+        })
       }
 
       return h(QBtnGroup, {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

QBtnDropdown has no loading slot [#12857](https://github.com/quasarframework/quasar/issues/12857)

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
