### PR TITLE
feat(app-vite&app-webpack): Simplify and clarify the "quasar new" command

### DIFF
--- a/app-vite/lib/cmd/new.js
+++ b/app-vite/lib/cmd/new.js
@@ -58,7 +58,7 @@ function showHelp () {
                              * ts-composition - TS composition API (default if using TS)
                              * ts-options - TS options API
                              * ts-class - [DEPRECATED] TS class style syntax
-                             * ts - Plain TS template (for boot and store files)
+                             * ts - Plain TS template (for boot, store, and ssrmiddleware files)
   `)
   process.exit(0)
 }
@@ -108,10 +108,9 @@ if (!['default', 'ts-options', 'ts-class', 'ts-composition', 'ts'].includes(form
 
 const isTypeScript = format === 'ts' || format.startsWith('ts-')
 
-// If they've supplied a TS format i.e ts-options and
-// are creating a boot file / store then set format
-// to TS as they're the same for all formats.
-if (isTypeScript && (type === 'boot' || type === 'store')) {
+// If using a TS sub-format(e.g. ts-options) and the type is a plain file (e.g. boot) then
+// set format to just TS as sub-formats(e.g. Composition API) doesn't matter for plain files.
+if (isTypeScript && (type === 'boot' || type === 'store' || type === 'ssrmiddleware')) {
   format = 'ts'
 }
 
@@ -190,7 +189,7 @@ const mapping = {
   },
   ssrmiddleware: {
     folder: 'src-ssr/middlewares',
-    ext: '.js',
+    ext: isTypeScript ? '.ts' : '.js',
     reference: 'quasar.config.js > ssr > middlewares'
   }
 }

--- a/app-vite/lib/cmd/new.js
+++ b/app-vite/lib/cmd/new.js
@@ -23,7 +23,7 @@ const argv = parseArgs(process.argv.slice(2), {
 function showHelp () {
   console.log(`
   Description
-    Quickly scaffold a page/layout/component/store module.
+    Quickly scaffold files.
 
   Usage
     $ quasar new <p|page> [-f <option>] <page_file_name>
@@ -31,10 +31,9 @@ function showHelp () {
     $ quasar new <c|component> [-f <option>] <component_file_name>
     $ quasar new <b|boot> [-f ts] <boot_name>
     $ quasar new <s|store> [-f ts] <store_module_name>
-    $ quasar new ssrmiddleware <middleware_name>
+    $ quasar new ssrmiddleware [-f ts] <middleware_name>
 
-    # Examples:
-
+  Examples
     # Create src/pages/MyNewPage.vue:
     $ quasar new p MyNewPage
 
@@ -47,18 +46,19 @@ function showHelp () {
     # Create src/layouts/shop/Checkout.vue with TypeScript options API
     $ quasar new layout -f ts-options shop/Checkout.vue
 
-    # Create a store with TypeScript support
+    # Create a store with TypeScript (-f ts is optional if tsconfig.json is present)
     $ quasar new store -f ts myStore
 
   Options
     --help, -h            Displays this message
 
     --format -f <option>  (optional) Use a supported format for the template
-                          Option can be:
+                          Possible values:
+                             * default - Default JS template
+                             * ts-composition - TS composition API (default if using TS)
                              * ts-options - TS options API
-                             * ts-composition - TS composition API
                              * ts-class - [DEPRECATED] TS class style syntax
-                             * ts - use for TS boot file and store modules only
+                             * ts - Plain TS template (for boot and store files)
   `)
   process.exit(0)
 }

--- a/app-vite/lib/cmd/new.js
+++ b/app-vite/lib/cmd/new.js
@@ -1,5 +1,13 @@
 const parseArgs = require('minimist')
 
+const path = require('path')
+const fs = require('fs')
+const fse = require('fs-extra')
+
+const { log, warn } = require('../helpers/logger')
+const appPaths = require('../app-paths')
+const storeProvider = require('../helpers/store-provider')
+
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
     h: 'help',
@@ -8,7 +16,7 @@ const argv = parseArgs(process.argv.slice(2), {
   boolean: ['h'],
   string: ['f'],
   default: {
-    f: 'default'
+    f: fs.existsSync(appPaths.resolve.app('tsconfig.json')) ? 'ts-composition' : 'default'
   }
 })
 
@@ -65,14 +73,6 @@ if (argv.help) {
   showHelp()
 }
 
-const path = require('path')
-const fs = require('fs')
-const fse = require('fs-extra')
-
-const { log, warn } = require('../helpers/logger')
-const appPaths = require('../app-paths')
-const storeProvider = require('../helpers/store-provider')
-
 console.log()
 
 if (argv._.length < 2) {
@@ -104,10 +104,6 @@ const type = typeAliasMap[rawType] || rawType
 
 if (!['default', 'ts-options', 'ts-class', 'ts-composition', 'ts'].includes(format)) {
   showError('Invalid asset format', format)
-}
-
-if (format === 'ts' && type !== 'store' && type !== 'boot') {
-  showError('Please select a TypeScript variation for *.vue files, i.e ts-class. Current', format)
 }
 
 const isTypeScript = format === 'ts' || format.startsWith('ts-')

--- a/app-webpack/lib/cmd/new.js
+++ b/app-webpack/lib/cmd/new.js
@@ -58,7 +58,7 @@ function showHelp () {
                              * ts-composition - TS composition API (default if using TS)
                              * ts-options - TS options API
                              * ts-class - [DEPRECATED] TS class style syntax
-                             * ts - Plain TS template (for boot and store files)
+                             * ts - Plain TS template (for boot, store, and ssrmiddleware files)
   `)
   process.exit(0)
 }
@@ -108,10 +108,9 @@ if (!['default', 'ts-options', 'ts-class', 'ts-composition', 'ts'].includes(form
 
 const isTypeScript = format === 'ts' || format.startsWith('ts-')
 
-// If they've supplied a TS format i.e ts-options and
-// are creating a boot file / store then set format
-// to TS as they're the same for all formats.
-if (isTypeScript && (type === 'boot' || type === 'store')) {
+// If using a TS sub-format(e.g. ts-options) and the type is a plain file (e.g. boot) then
+// set format to just TS as sub-formats(e.g. Composition API) doesn't matter for plain files.
+if (isTypeScript && (type === 'boot' || type === 'store' || type === 'ssrmiddleware')) {
   format = 'ts'
 }
 
@@ -190,7 +189,7 @@ const mapping = {
   },
   ssrmiddleware: {
     folder: 'src-ssr/middlewares',
-    ext: '.js',
+    ext: isTypeScript ? '.ts' : '.js',
     reference: 'quasar.config.js > ssr > middlewares'
   }
 }

--- a/app-webpack/lib/cmd/new.js
+++ b/app-webpack/lib/cmd/new.js
@@ -1,4 +1,3 @@
-
 const parseArgs = require('minimist')
 
 const argv = parseArgs(process.argv.slice(2), {
@@ -7,7 +6,10 @@ const argv = parseArgs(process.argv.slice(2), {
     f: 'format'
   },
   boolean: ['h'],
-  string: ['f']
+  string: ['f'],
+  default: {
+    f: 'default'
+  }
 })
 
 function showHelp () {
@@ -53,6 +55,12 @@ function showHelp () {
   process.exit(0)
 }
 
+function showError (message, param) {
+  console.log()
+  warn(`${message}: ${param}`)
+  showHelp()
+}
+
 if (argv.help) {
   showHelp()
 }
@@ -64,7 +72,8 @@ const fse = require('fs-extra')
 const { log, warn } = require('../helpers/logger')
 const appPaths = require('../app-paths')
 const storeProvider = require('../helpers/store-provider')
-const defaultFilePath = 'default'
+
+console.log()
 
 if (argv._.length < 2) {
   console.log()
@@ -73,45 +82,41 @@ if (argv._.length < 2) {
   process.exit(1)
 }
 
-let [ type, ...names ] = argv._
-let format = argv.format || defaultFilePath
+/** @type {string[]} */
+const [ rawType, ...names ] = argv._
+/** @type {{ format: 'default'|'ts'|'ts-options'|'ts-class'|'ts-composition'}} */
+let { format } = argv
 
-function showError (message, param) {
-  console.log()
-  warn(`${message}: ${param}`)
-  showHelp()
+const typeAliasMap = {
+  p: 'page',
+  l: 'layout',
+  c: 'component',
+  s: 'store',
+  b: 'boot'
 }
 
-if (!['p', 'page', 'l', 'layout', 'c', 'component', 's', 'store', 'b', 'boot', 'ssrmiddleware'].includes(type)) {
-  showError('Invalid asset type', type)
+if (![...Object.entries(typeAliasMap).flat(), 'ssrmiddleware'].includes(rawType)) {
+  showError('Invalid asset type', rawType)
 }
+
+/** @type {'page'|'layout'|'component'|'store'|'boot'|'ssrmiddleware'} */
+const type = typeAliasMap[rawType] || rawType
 
 if (!['default', 'ts-options', 'ts-class', 'ts-composition', 'ts'].includes(format)) {
   showError('Invalid asset format', format)
 }
 
-if (format === 'ts' && !['b', 'boot', 's', 'store'].includes(type)) {
+if (format === 'ts' && type !== 'store' && type !== 'boot') {
   showError('Please select a TypeScript variation for *.vue files, i.e ts-class. Current', format)
 }
 
-const isTypeScript = format === 'ts' || format.indexOf('ts-') > -1
+const isTypeScript = format === 'ts' || format.startsWith('ts-')
 
 // If they've supplied a TS format i.e ts-options and
 // are creating a boot file / store then set format
 // to TS as they're the same for all formats.
-if (isTypeScript && ['b', 'boot', 's', 'store'].includes(type)) {
+if (isTypeScript && (type === 'boot' || type === 'store')) {
   format = 'ts'
-}
-
-if (type.length === 1) {
-  const fullCmd = {
-    p: 'page',
-    l: 'layout',
-    c: 'component',
-    s: 'store',
-    b: 'boot'
-  }
-  type = fullCmd[type]
 }
 
 function createFile (asset, file) {
@@ -123,7 +128,7 @@ function createFile (asset, file) {
     return
   }
 
-  fse.mkdirp(path.dirname(file))
+  fse.ensureDir(path.dirname(file))
   let templatePath = path.join('templates/app', format)
 
   templatePath = type === 'store'
@@ -204,7 +209,7 @@ if (asset.install) {
   }
 
   if (!fs.existsSync(folder)) {
-    fse.mkdirp(folder)
+    fse.ensureDir(folder)
     fse.copy(
       appPaths.resolve.cli(`templates/store/${storeProvider.name}/${format}`),
       folder,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Refactor

**Does this PR introduce a breaking change?** <!-- Check one -->

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

Part of #8572.

If `tsconfig.json` exists, the `ts-composition` format will be used by default, so TS users won't have to type `-f ts` or `-f ts-composition` every time. Options API users will still have to use `-f ts-options` when they are creating Vue-based files. TS users can still create JS files using `-f default`.