### PR TITLE
fix(app): Indicator that server is running even if browser not opening

### DIFF
--- a/app-webpack/lib/dev-server-regular.js
+++ b/app-webpack/lib/dev-server-regular.js
@@ -2,6 +2,7 @@ const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')
 
 const openBrowser = require('./helpers/open-browser')
+const { log } = require('./helpers/logger')
 
 let openedBrowser = false
 
@@ -33,8 +34,12 @@ module.exports = class DevServer {
         if (openedBrowser === false) {
           openedBrowser = true
 
-          if (cfg.__devServer.open && ['spa', 'pwa'].includes(cfg.ctx.modeName)) {
-            openBrowser({ url: cfg.build.APP_URL, opts: cfg.__devServer.openOptions })
+          if (['spa', 'pwa'].includes(cfg.ctx.modeName)) {
+            const url = cfg.build.APP_URL
+
+            cfg.__devServer.open
+              ? openBrowser({ url, opts: cfg.__devServer.openOptions })
+              : log('Running at ' + url + '\n')
           }
         }
       })

--- a/app-webpack/lib/dev-server-ssr.js
+++ b/app-webpack/lib/dev-server-ssr.js
@@ -16,6 +16,7 @@ const getPackage = require('./helpers/get-package')
 const { renderToString } = getPackage('@vue/server-renderer')
 const openBrowser = require('./helpers/open-browser')
 const ouchInstance = require('./helpers/cli-error-handling').getOuchInstance()
+const { log } = require('./helpers/logger')
 
 const banner = '[Quasar Dev Webserver]'
 const compiledMiddlewareFile = appPaths.resolve.app('.quasar/ssr/compiled-middlewares.js')
@@ -83,9 +84,10 @@ module.exports = class DevServer {
         if (openedBrowser === false) {
           openedBrowser = true
 
-          if (cfg.__devServer.open) {
-            openBrowser({ url: cfg.build.APP_URL, opts: cfg.__devServer.openOptions })
-          }
+          const url = cfg.build.APP_URL
+          cfg.__devServer.open
+            ? openBrowser({ url, opts: cfg.__devServer.openOptions })
+            : log('Running at ' + url + '\n')
         }
       }
     }


### PR DESCRIPTION
> It would be nice to have an indicator when the dev environment is up and the 'open browser' setting is set to false.

https://github.com/quasarframework/quasar/issues/13013#issuecomment-1100763792