### PR TITLE
feat(ui): Change applicable prop types to readonly (fix: #13119)

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -46,64 +46,64 @@ const nativeTypes = [ 'Component', 'Error', 'Element', 'File', 'FileList', 'Even
 
 const objectTypes = {
   Boolean: {
-    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'default', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isArray: [ 'examples' ]
   },
 
   String: {
-    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'transformAssetUrls', 'internal' ],
+    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'transformAssetUrls', 'internal' ],
     required: [ 'desc', 'examples' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'transformAssetUrls', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'transformAssetUrls', 'internal' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Number: {
-    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'examples' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Object: {
-    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'definition', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'examples' ],
     recursive: [ 'definition' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isObject: [ 'definition' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Array: {
-    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'definition', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'examples' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isObject: [ 'definition' ],
     isArray: [ 'examples', 'values' ]
   },
 
   Promise: {
-    props: [ 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'default', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'examples' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isObject: [ 'definition' ],
     isArray: [ 'examples' ]
   },
 
   Function: {
-    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'link', 'default', 'params', 'returns', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'default', 'params', 'returns', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'params', 'returns' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isObject: [ 'params', 'returns' ],
     canBeNull: [ 'params', 'returns' ],
     isArray: [ 'examples' ]
   },
 
   MultipleTypes: {
-    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'link', 'values', 'default', 'definition', 'params', 'returns', 'examples', 'category', 'addedIn', 'internal' ],
+    props: [ 'tsInjectionPoint', 'tsType', 'autoDefineTsType', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'definition', 'params', 'returns', 'examples', 'category', 'addedIn', 'internal' ],
     required: [ 'desc', 'examples' ],
-    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'internal' ],
+    isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'internal' ],
     isObject: [ 'definition', 'params', 'returns' ],
     isArray: [ 'examples', 'values' ]
   },
@@ -342,6 +342,11 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory, verif
       console.log()
       process.exit(1)
     }
+  }
+
+  // If it must be synced, then it is syncable too (v-model:xyz)
+  if (obj.sync === true) {
+    obj.syncable = true
   }
 
   if (obj.returns) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -77,7 +77,9 @@ function convertTypeVal (type, def) {
       }
     }
 
-    return fallbackComplexTypeMap.get(type)
+    const prefix = type === 'Array' && def.syncable !== true ? 'readonly ' : ''
+
+    return prefix + fallbackComplexTypeMap.get(type)
   }
 
   if (type === 'Function') {

--- a/ui/src/api.extends.json
+++ b/ui/src/api.extends.json
@@ -105,6 +105,7 @@
     "model-value": {
       "desc": "Model of the component; Either use this property (along with a listener for 'update:model-value' event) OR use v-model directive",
       "required": true,
+      "syncable": true,
       "category": "model"
     },
 

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -676,6 +676,7 @@
           "examples": [ 100, 200 ]
         }
       },
+      "syncable": true,
       "examples": [
         ":pagination=\"myInitialPagination\"",
         "v-model:pagination=\"myPagination\""
@@ -706,6 +707,7 @@
       "type": "Array",
       "desc": "Keeps the user selection array",
       "default": "[]",
+      "syncable": true,
       "examples": [
         "v-model:selected=\"selection\""
       ],
@@ -716,6 +718,7 @@
       "type": "Array",
       "desc": "Keeps the array with expanded rows keys",
       "default": "[]",
+      "syncable": true,
       "examples": [
         "v-model:expanded=\"expanded\""
       ],

--- a/ui/types/api/quploader.d.ts
+++ b/ui/types/api/quploader.d.ts
@@ -14,15 +14,15 @@ type ValueOrFunction<ValueType, Param = never> =
   | ValueType;
 
 export type QUploaderFactoryObject = {
-  url?: ValueOrFunction<string, File[]>;
-  method?: ValueOrFunction<LiteralUnion<"POST" | "PUT">, File[]>;
-  headers?: ValueOrFunction<QUploaderHeaderItem[], File[]>;
-  formFields?: ValueOrFunction<QUploaderFormFieldsItem[], File[]>;
+  url?: ValueOrFunction<string, readonly File[]>;
+  method?: ValueOrFunction<LiteralUnion<"POST" | "PUT">, readonly File[]>;
+  headers?: ValueOrFunction<QUploaderHeaderItem[], readonly File[]>;
+  formFields?: ValueOrFunction<QUploaderFormFieldsItem[], readonly File[]>;
   fieldName?: ValueOrFunction<string, File>;
-  withCredentials?: ValueOrFunction<boolean, File[]>;
-  sendRaw?: ValueOrFunction<boolean, File[]>;
+  withCredentials?: ValueOrFunction<boolean, readonly File[]>;
+  sendRaw?: ValueOrFunction<boolean, readonly File[]>;
 };
 
 export type QUploaderFactoryFn = (
-  files: File[]
+  files: readonly File[]
 ) => QUploaderFactoryObject | Promise<QUploaderFactoryObject>;

--- a/ui/types/utils/dom.d.ts
+++ b/ui/types/utils/dom.d.ts
@@ -11,6 +11,6 @@ export namespace dom {
   function height(el: Element): number;
   function width(el: Element): number;
   function css(el: Element, css: VueStyleObjectProp): void;
-  function cssBatch(elements: Element[], css: VueStyleObjectProp): void;
+  function cssBatch(elements: readonly Element[], css: VueStyleObjectProp): void;
   function ready<F extends (...args: any[]) => any>(fn: F): ReturnType<F>;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

Closes #13119 

📜 Changes for `dist/types/index.d.ts`

```diff
@@ -412,11 +412,11 @@
       | Date
       | RegExp
       | number
       | boolean
-      | ((...params: any[]) => any)
+      | ((...params: readonly any[]) => any)
       | any
-      | any[]
+      | readonly any[]
       | string
       | null
   ) => void;
   /**
@@ -799,11 +799,11 @@
       | Date
       | RegExp
       | number
       | boolean
-      | ((...params: any[]) => any)
+      | ((...params: readonly any[]) => any)
       | any
-      | any[]
+      | readonly any[]
       | string
       | null
   ) => void;
   /**
@@ -1383,9 +1383,9 @@
     | undefined;
   /**
    * An array of two numbers to offset the menu horizontally and vertically in pixels
    */
-  menuOffset?: any[] | undefined;
+  menuOffset?: readonly any[] | undefined;
   /**
    * Emitted when showing/hidden state changes; Is also used by v-model
    * @param value New state (showing/hidden)
    */
@@ -1917,13 +1917,13 @@
   keepAlive?: boolean | undefined;
   /**
    * Equivalent to using Vue's native include prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveInclude?: string | any[] | RegExp | undefined;
+  keepAliveInclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native exclude prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveExclude?: string | any[] | RegExp | undefined;
+  keepAliveExclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native max prop for <keep-alive>
    */
   keepAliveMax?: number | undefined;
@@ -2135,9 +2135,9 @@
   /**
    * An array of two numbers to offset the component horizontally and vertically (in pixels)
    * Default value: [18, 18]
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
 }
 
 export interface QCarouselControlSlots {
   /**
@@ -2201,9 +2201,9 @@
   avatar?: string | undefined;
   /**
    * Array of strings that are the message body. Strings are not sanitized (see details in docs)
    */
-  text?: any[] | undefined;
+  text?: readonly any[] | undefined;
   /**
    * Creation timestamp
    */
   stamp?: string | undefined;
@@ -2568,9 +2568,9 @@
   /**
    * Use a custom palette of colors for the palette tab
    * Default value: (hard-coded palette)
    */
-  palette?: any[] | undefined;
+  palette?: readonly any[] | undefined;
   /**
    * Removes border-radius so borders are squared
    */
   square?: boolean | undefined;
@@ -2643,21 +2643,21 @@
     | {
         /**
          * List of full day names (DDDD), starting with Sunday
          */
-        days?: any[];
+        days?: readonly any[];
         /**
          * List of short day names (DDD), starting with Sunday
          */
-        daysShort?: any[];
+        daysShort?: readonly any[];
         /**
          * List of full month names (MMMM), starting with January
          */
-        months?: any[];
+        months?: readonly any[];
         /**
          * List of short month names (MMM), starting with January
          */
-        monthsShort?: any[];
+        monthsShort?: readonly any[];
       }
     | undefined;
   /**
    * Specify calendar type
@@ -2725,9 +2725,9 @@
    * A list of events to highlight on the calendar; If using a function, it receives the date as a String and must return a Boolean (matches or not); If using a function then for best performance, reference it from your scope and do not define it inline
    * @param date The current date being processed.
    * @returns If true, the current date will be highlighted
    */
-  events?: any[] | ((date: string) => boolean) | undefined;
+  events?: readonly any[] | ((date: string) => boolean) | undefined;
   /**
    * Color name (from the Quasar Color Palette); If using a function, it receives the date as a String and must return a String (color for the received date); If using a function then for best performance, reference it from your scope and do not define it inline
    * @param date The current date being processed.
    * @returns Color for the current date.
@@ -2737,9 +2737,9 @@
    * Optionally configure the days that are selectable; If using a function, it receives the date as a String and must return a Boolean (is date acceptable or not); If using a function then for best performance, reference it from your scope and do not define it inline; Incompatible with 'range' prop
    * @param date The current date being processed.
    * @returns If true, the current date will be made available for selection
    */
-  options?: any[] | ((date: string) => boolean) | undefined;
+  options?: readonly any[] | ((date: string) => boolean) | undefined;
   /**
    * Lock user from navigating below a specific year+month (in YYYY/MM format); This prop is not used to correct the model; You might want to also use 'default-year-month' prop
    */
   navigationMinYearMonth?: string | undefined;
@@ -2782,9 +2782,9 @@
    * @param reason Reason of the user interaction (what was picked)
    * @param details Object of properties on the new model
    */
   "onUpdate:modelValue"?: (
-    value: string | any[] | any | null,
+    value: string | readonly any[] | any | null,
     reason:
       | "add-day"
       | "remove-day"
       | "add-range"
@@ -3400,9 +3400,9 @@
   /**
    * An array of arrays of Objects/Strings that you use to define the construction of the elements and commands available in the toolbar
    * Default value: left,center,right,justify,bold,italic,underline,strike,undo,redo
    */
-  toolbar?: any[] | undefined;
+  toolbar?: readonly any[] | undefined;
   /**
    * Font color (from the Quasar Palette) of buttons and text in the toolbar
    */
   toolbarColor?: string | undefined;
@@ -4304,9 +4304,9 @@
    * Custom filter for added files; Only files that pass this filter will be added to the queue and uploaded; For best performance, reference it from your scope and do not define it inline
    * @param files Candidate files to be added to queue
    * @returns Filtered files to be added to queue
    */
-  filter?: ((files: FileList | any[]) => any[]) | undefined;
+  filter?: ((files: FileList | readonly any[]) => readonly any[]) | undefined;
   /**
    * Model of the component; Must be FileList or Array if using 'multiple' prop; Either use this property (along with a listener for 'update:modelValue' event) OR use v-model directive
    */
   modelValue: File | FileList | any[] | null | undefined;
@@ -4578,9 +4578,9 @@
   selected: (scope: {
     /**
      * Array of File objects
      */
-    files: FileList | any[];
+    files: FileList | readonly any[];
     /**
      * Reference to the QFile component
      */
     ref: QFile;
@@ -4596,9 +4596,9 @@
   /**
    * Add files programmatically
    * @param files Array of files (instances of File)
    */
-  addFiles: (files: FileList | any[]) => void;
+  addFiles: (files: FileList | readonly any[]) => void;
   /**
    * Reset validation status
    */
   resetValidation: () => void;
@@ -4744,9 +4744,9 @@
   /**
    * Get array of children vue components that support validation
    * @returns Vue components that support Quasar validation API
    */
-  getValidationComponents: () => any[];
+  getValidationComponents: () => readonly any[];
 }
 
 export interface QFormChildMixinProps {}
 
@@ -5446,9 +5446,9 @@
   margin?: string | undefined;
   /**
    * [Intersection API threshold prop] Threshold(s) at which to trigger, specified as a ratio, or list of ratios, of (visible area / total area) of the observed element
    */
-  threshold?: any[] | number | undefined;
+  threshold?: readonly any[] | number | undefined;
   /**
    * One of Quasar's embedded transitions
    */
   transition?: string | undefined;
@@ -6023,9 +6023,9 @@
     | undefined;
   /**
    * An array of two numbers to offset the menu horizontally and vertically in pixels
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
   /**
    * CSS selector or DOM element to be used as a custom scroll container instead of the auto detected one
    */
   scrollTarget?: Element | string | undefined;
@@ -6302,9 +6302,9 @@
   /**
    * An array of two numbers to offset the component horizontally and vertically in pixels
    * Default value: 18,18
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
   /**
    * By default the component shrinks to content's size; By using this prop you make the component fully expand horizontally or vertically, based on 'position' prop
    */
   expand?: boolean | undefined;
@@ -6351,9 +6351,9 @@
     | undefined;
   /**
    * An array of two numbers to offset the component horizontally and vertically in pixels
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
   /**
    * By default the component shrinks to content's size; By using this prop you make the component fully expand horizontally or vertically, based on 'position' prop
    */
   expand?: boolean | undefined;
@@ -6705,9 +6705,9 @@
     | undefined;
   /**
    * An array of two numbers to offset the menu horizontally and vertically in pixels
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
   /**
    * Allows for the target position to be set by the mouse position, when the target of the menu is either clicked or touched
    */
   touchPosition?: boolean | undefined;
@@ -7325,29 +7325,29 @@
   max?: number | string | undefined;
   /**
    * Icon name following Quasar convention; make sure you have the icon library installed unless you are using 'img:' prefix; If an array is provided each rating value will use the corresponding icon in the array (0 based)
    */
-  icon?: string | any[] | undefined;
+  icon?: string | readonly any[] | undefined;
   /**
    * Icon name following Quasar convention to be used when selected (optional); make sure you have the icon library installed unless you are using 'img:' prefix; If an array is provided each rating value will use the corresponding icon in the array (0 based)
    */
-  iconSelected?: string | any[] | undefined;
+  iconSelected?: string | readonly any[] | undefined;
   /**
    * Icon name following Quasar convention to be used when selected (optional); make sure you have the icon library installed unless you are using 'img:' prefix; If an array is provided each rating value will use the corresponding icon in the array (0 based)
    */
-  iconHalf?: string | any[] | undefined;
+  iconHalf?: string | readonly any[] | undefined;
   /**
    * Color name for component from the Quasar Color Palette; v1.5.0+: If an array is provided each rating value will use the corresponding color in the array (0 based)
    */
-  color?: string | any[] | undefined;
+  color?: string | readonly any[] | undefined;
   /**
    * Color name from the Quasar Palette for selected icons
    */
-  colorSelected?: string | any[] | undefined;
+  colorSelected?: string | readonly any[] | undefined;
   /**
    * Color name from the Quasar Palette for half selected icons
    */
-  colorHalf?: string | any[] | undefined;
+  colorHalf?: string | readonly any[] | undefined;
   /**
    * Does not lower opacity for unselected icons
    */
   noDimming?: boolean | undefined;
@@ -7912,9 +7912,9 @@
   /**
    * Available options that the user can select from. For best performance freeze the list of options.
    * Default value: []
    */
-  options?: any[] | undefined;
+  options?: readonly any[] | undefined;
   /**
    * Property of option which holds the 'value'; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: value
    * @param option The current option being processed
@@ -8017,9 +8017,9 @@
     | undefined;
   /**
    * An array of two numbers to offset the options list horizontally and vertically in pixels (only in menu mode)
    */
-  menuOffset?: any[] | undefined;
+  menuOffset?: readonly any[] | undefined;
   /**
    * Class definitions to be attributed to the popup content
    */
   popupContentClass?: string | undefined;
@@ -9356,9 +9356,9 @@
   /**
    * An array of two values representing the minimum and maximum split size of the two panels; When 'px' unit is set then you can use Infinity as the second value to make it unbound on the other side
    * Default value: For '%' unit: [10, 90]; For 'px' unit: [50, Infinity]
    */
-  limits?: any[] | undefined;
+  limits?: readonly any[] | undefined;
   /**
    * Put component in disabled mode
    */
   disable?: boolean | undefined;
@@ -9498,13 +9498,13 @@
   keepAlive?: boolean | undefined;
   /**
    * Equivalent to using Vue's native include prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveInclude?: string | any[] | RegExp | undefined;
+  keepAliveInclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native exclude prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveExclude?: string | any[] | RegExp | undefined;
+  keepAliveExclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native max prop for <keep-alive>
    */
   keepAliveMax?: number | undefined;
@@ -9699,13 +9699,13 @@
   keepAlive?: boolean | undefined;
   /**
    * Equivalent to using Vue's native include prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveInclude?: string | any[] | RegExp | undefined;
+  keepAliveInclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native exclude prop for <keep-alive>; Values must be valid Vue component names
    */
-  keepAliveExclude?: string | any[] | RegExp | undefined;
+  keepAliveExclude?: string | readonly any[] | RegExp | undefined;
   /**
    * Equivalent to using Vue's native max prop for <keep-alive>
    */
   keepAliveMax?: number | undefined;
@@ -9796,9 +9796,9 @@
   noRouteFullscreenExit?: boolean | undefined;
   /**
    * Rows of data to display
    */
-  rows?: any[] | undefined;
+  rows?: readonly any[] | undefined;
   /**
    * Property of each row that defines the unique key of each row (the result must be a primitive, not Object, Array, etc); The value of property must be string or a function taking a row and returning the desired (nested) key in the row; If supplying a function then for best performance, reference it from your scope and do not define it inline
    * Default value: id
    * @param row The current row being processed
@@ -9955,9 +9955,9 @@
     | undefined;
   /**
    * Array of Strings defining column names ('name' property of each column from 'columns' prop definitions); Columns marked as 'required' are not affected by this property
    */
-  visibleColumns?: any[] | undefined;
+  visibleColumns?: readonly any[] | undefined;
   /**
    * Put Table into 'loading' state; Notify the user something is happening behind the scenes
    */
   loading?: boolean | undefined;
@@ -10105,13 +10105,13 @@
    * @returns Filtered rows
    */
   filterMethod?:
     | ((
-        rows: any[],
+        rows: readonly any[],
         terms: string | any,
-        cols: any[],
+        cols: readonly any[],
         getCellValue: (col: any, row: any) => any
-      ) => any[])
+      ) => readonly any[])
     | undefined;
   /**
    * Pagination object; You can also use the 'v-model:pagination' for synching; When not synching it simply initializes the pagination on first render
    */
@@ -10142,9 +10142,9 @@
   /**
    * Options for user to pick (Numbers); Number 0 means 'Show all rows in one page'
    * Default value: [ 3, 5, 7, 10, 15, 20, 25, 50, 0 ]
    */
-  rowsPerPageOptions?: any[] | undefined;
+  rowsPerPageOptions?: readonly any[] | undefined;
   /**
    * Selection type
    * Default value: none
    */
@@ -10167,9 +10167,13 @@
    * @param descending Is sorting in descending order?
    * @returns Sorted rows
    */
   sortMethod?:
-    | ((rows: any[], sortBy: string, descending: boolean) => any[])
+    | ((
+        rows: readonly any[],
+        sortBy: string,
+        descending: boolean
+      ) => readonly any[])
     | undefined;
   /**
    * Emitted when user clicks/taps on a row; Is not emitted when using body/row/item scoped slots
    * @param evt JS event object
@@ -10225,13 +10229,13 @@
      * @param getCellValue Optional function to get a cell value
      * @returns Filtered rows
      */
     filter: (
-      rows: any[],
+      rows: readonly any[],
       terms: string | any,
-      cols?: any[],
+      cols?: readonly any[],
       getCellValue?: (col: any, row: any) => any
-    ) => any[];
+    ) => readonly any[];
     /**
      * Function to get a cell value
      * @param col Column name from column definitions
      * @param row The row object
@@ -10246,13 +10250,13 @@
   onSelection?: (details: {
     /**
      * Array of row objects that were selected/unselected
      */
-    rows: any[];
+    rows: readonly any[];
     /**
      * Array of the keys of rows that were selected/unselected
      */
-    keys: any[];
+    keys: readonly any[];
     /**
      * Were the rows added to selection (true) or removed from selection (false)
      */
     added: boolean;
@@ -10290,14 +10294,14 @@
   /**
    * Used by Vue on 'v-model:selected' prop for updating its value
    * @param newSelected The updated selected array
    */
-  "onUpdate:selected"?: (newSelected: any[]) => void;
+  "onUpdate:selected"?: (newSelected: readonly any[]) => void;
   /**
    * Used by Vue on 'v-model:expanded' prop for updating its value
    * @param newExpanded The updated expanded array
    */
-  "onUpdate:expanded"?: (newExpanded: any[]) => void;
+  "onUpdate:expanded"?: (newExpanded: readonly any[]) => void;
   /**
    * Emitted when the virtual scroll occurs, if using virtual scroll
    * @param details Object of properties on the new scroll position
    */
@@ -11254,13 +11258,13 @@
      * @param getCellValue Optional function to get a cell value
      * @returns Filtered rows
      */
     filter?: (
-      rows: any[],
+      rows: readonly any[],
       terms: string | any,
-      cols?: any[],
+      cols?: readonly any[],
       getCellValue?: (col?: any, row?: any) => any
-    ) => any[];
+    ) => readonly any[];
   }) => void;
   /**
    * Unless using an external pagination Object (through 'v-model:pagination' prop), you can use this method and force the internal pagination to change
    * @param pagination Pagination object
@@ -11322,9 +11326,9 @@
   /**
    * Sets the expanded rows keys array; Especially useful if not using an external 'expanded' state otherwise just emits 'update:expanded' with the value
    * @param expanded Array containing keys of the expanded rows
    */
-  setExpanded: (expanded: any[]) => void;
+  setExpanded: (expanded: readonly any[]) => void;
   /**
    * Trigger a table sort
    * @param col Column name or column definition object
    */
@@ -11676,21 +11680,21 @@
     | {
         /**
          * List of full day names (DDDD), starting with Sunday
          */
-        days?: any[];
+        days?: readonly any[];
         /**
          * List of short day names (DDD), starting with Sunday
          */
-        daysShort?: any[];
+        daysShort?: readonly any[];
         /**
          * List of full month names (MMMM), starting with January
          */
-        months?: any[];
+        months?: readonly any[];
         /**
          * List of short month names (MMM), starting with January
          */
-        monthsShort?: any[];
+        monthsShort?: readonly any[];
       }
     | undefined;
   /**
    * Specify calendar type
@@ -11754,17 +11758,17 @@
     | undefined;
   /**
    * Optionally configure what hours is the user allowed to set; Overrides 'options' prop if that is also set
    */
-  hourOptions?: any[] | undefined;
+  hourOptions?: readonly any[] | undefined;
   /**
    * Optionally configure what minutes is the user allowed to set; Overrides 'options' prop if that is also set
    */
-  minuteOptions?: any[] | undefined;
+  minuteOptions?: readonly any[] | undefined;
   /**
    * Optionally configure what seconds is the user allowed to set; Overrides 'options' prop if that is also set
    */
-  secondOptions?: any[] | undefined;
+  secondOptions?: readonly any[] | undefined;
   /**
    * Allow the time to be set with seconds
    */
   withSeconds?: boolean | undefined;
@@ -12138,9 +12142,9 @@
   /**
    * An array of two numbers to offset the Tooltip horizontally and vertically in pixels
    * Default value: [14, 14]
    */
-  offset?: any[] | undefined;
+  offset?: readonly any[] | undefined;
   /**
    * CSS selector or DOM element to be used as a custom scroll container instead of the auto detected one
    */
   scrollTarget?: Element | string | undefined;
@@ -12325,9 +12329,9 @@
   /**
    * Triggered when nodes are expanded or collapsed; Used by Vue on 'v-model:update' to update its value
    * @param expanded The expanded node keys
    */
-  "onUpdate:expanded"?: (expanded: any[]) => void;
+  "onUpdate:expanded"?: (expanded: readonly any[]) => void;
   /**
    * Emitted when the lazy loading of nodes is finished
    * @param details Lazy loading details
    */
@@ -12343,9 +12347,9 @@
     /**
      * The callback to be carried out when the loading is successful
      * @param children Array of nodes
      */
-    done: (children?: any[]) => void;
+    done: (children?: readonly any[]) => void;
     /**
      * The callback to be carried out should the loading fails
      */
     fail: () => void;
@@ -12353,9 +12357,9 @@
   /**
    * Emitted when nodes are ticked/unticked via the checkbox; Used by Vue on 'v-model:ticked' to update its value
    * @param target The ticked node keys
    */
-  "onUpdate:ticked"?: (target: any[]) => void;
+  "onUpdate:ticked"?: (target: readonly any[]) => void;
   /**
    * Emitted when selected node changes; Used by Vue on 'v-model:selected' to update its value
    * @param target The selected node key
    */
@@ -12519,14 +12523,14 @@
   /**
    * Get array of nodes that are ticked
    * @returns Ticked node objects
    */
-  getTickedNodes: () => any[];
+  getTickedNodes: () => readonly any[];
   /**
    * Get array of nodes that are expanded
    * @returns Expanded node objects
    */
-  getExpandedNodes: () => any[];
+  getExpandedNodes: () => readonly any[];
   /**
    * Determine if a node is expanded
    * @param key The key of a node
    * @returns Is specified node expanded?
@@ -12556,9 +12560,9 @@
    * Method to set a node's checkbox programmatically
    * @param keys The keys of nodes to tick/untick
    * @param state Set to 'true' to tick the checkbox of nodes, otherwise 'false' unticks them
    */
-  setTicked: (keys: any[], state: boolean) => void;
+  setTicked: (keys: readonly any[], state: boolean) => void;
 }
 
 export interface QUploaderProps {
   /**
@@ -12571,16 +12575,16 @@
    * URL or path to the server which handles the upload. Takes String or factory function, which returns String. Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * @param files Uploaded files
    * @returns URL or path to the server which handles the upload
    */
-  url?: string | ((files: any[]) => string) | undefined;
+  url?: string | ((files: readonly any[]) => string) | undefined;
   /**
    * HTTP method to use for upload; Takes String or factory function which returns a String; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: POST
    * @param files Uploaded files
    * @returns HTTP method to use for upload
    */
-  method?: "POST" | "PUT" | ((files: any[]) => string) | undefined;
+  method?: "POST" | "PUT" | ((files: readonly any[]) => string) | undefined;
   /**
    * Field name for each file upload; This goes into the following header: 'Content-Disposition: form-data; name="__HERE__"; filename="somefile.png"; If using a function then for best performance, reference it from your scope and do not define it inline
    * Default value: (file) => file.name
    * @param files The current file being processed
@@ -12602,9 +12606,9 @@
          * Header value
          */
         value: string;
       }[]
-    | ((files: any[]) => string)
+    | ((files: readonly any[]) => string)
     | undefined;
   /**
    * Array or a factory function which returns an array; Array consists of objects with additional fields definitions (used by Form to be uploaded); Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * @param files Uploaded files
@@ -12620,28 +12624,28 @@
          * Field value
          */
         value: string;
       }[]
-    | ((files: any[]) => string)
+    | ((files: readonly any[]) => string)
     | undefined;
   /**
    * Sets withCredentials to true on the XHR that manages the upload; Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * @param files Uploaded files
    * @returns If true, withCredentials will be set to true on the XHR that manages the upload
    */
-  withCredentials?: boolean | ((files: any[]) => boolean) | undefined;
+  withCredentials?: boolean | ((files: readonly any[]) => boolean) | undefined;
   /**
    * Send raw files without wrapping into a Form(); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * @param files Uploaded files
    * @returns If true, raw files will get sent without wrapping into a Form()
    */
-  sendRaw?: boolean | ((files: any[]) => boolean) | undefined;
+  sendRaw?: boolean | ((files: readonly any[]) => boolean) | undefined;
   /**
    * Upload files in batch (in one XHR request); Takes boolean or factory function for Boolean; Function is called right before upload; If using a function then for best performance, reference it from your scope and do not define it inline
    * @param files Uploaded files
    * @returns If true, files will be uploaded in a batch (in one XHR request)
    */
-  batch?: boolean | ((files: any[]) => boolean) | undefined;
+  batch?: boolean | ((files: readonly any[]) => boolean) | undefined;
   /**
    * Allow multiple file uploads
    */
   multiple?: boolean | undefined;
@@ -12669,9 +12673,9 @@
    * Custom filter for added files; Only files that pass this filter will be added to the queue and uploaded; For best performance, reference it from your scope and do not define it inline
    * @param files Candidate files to be added to queue
    * @returns Filtered files to be added to queue
    */
-  filter?: ((files: FileList | any[]) => any[]) | undefined;
+  filter?: ((files: FileList | readonly any[]) => readonly any[]) | undefined;
   /**
    * Label for the uploader
    */
   label?: string | undefined;
@@ -12726,9 +12730,9 @@
   onUploaded?: (info: {
     /**
      * Uploaded files
      */
-    files: any[];
+    files: readonly any[];
     /**
      * XMLHttpRequest that has been used to upload this batch of files
      */
     xhr: any;
@@ -12740,9 +12744,9 @@
   onFailed?: (info: {
     /**
      * Files which encountered error
      */
-    files: any[];
+    files: readonly any[];
     /**
      * XMLHttpRequest that has been used to upload this batch of files
      */
     xhr: any;
@@ -12754,9 +12758,9 @@
   onUploading?: (info: {
     /**
      * Files which are now uploading
      */
-    files: any[];
+    files: readonly any[];
     /**
      * XMLHttpRequest used for uploading
      */
     xhr: any;
@@ -12765,9 +12769,9 @@
    * Emitted when factory function is supplied with a Promise which is rejected
    * @param err Error object which is the Promise rejection reason
    * @param files Files which were to get uploaded
    */
-  onFactoryFailed?: (err: Error, files: any[]) => void;
+  onFactoryFailed?: (err: Error, files: readonly any[]) => void;
   /**
    * Emitted after files are picked and some do not pass the validation props (accept, max-file-size, max-total-size, filter, etc)
    * @param rejectedEntries Array of { failedPropValidation: string, file: File } Objects for files that do not pass the validation
    */
@@ -12775,14 +12779,14 @@
   /**
    * Emitted when files are added into the list
    * @param files Array of files that were added
    */
-  onAdded?: (files: any[]) => void;
+  onAdded?: (files: readonly any[]) => void;
   /**
    * Emitted when files are removed from the list
    * @param files Array of files that were removed
    */
-  onRemoved?: (files: any[]) => void;
+  onRemoved?: (files: readonly any[]) => void;
   /**
    * Started working
    */
   onStart?: () => void;
@@ -12814,9 +12818,9 @@
   /**
    * Add files programmatically
    * @param files Array of files (instances of File)
    */
-  addFiles: (files: FileList | any[]) => void;
+  addFiles: (files: FileList | readonly any[]) => void;
   /**
    * Start uploading (same as clicking the upload button)
    */
   upload: () => void;
@@ -12940,9 +12944,9 @@
   /**
    * Available list items that will be passed to the scoped slot; For best performance freeze the list of items; Required if 'itemsFn' is not supplied
    * Default value: []
    */
-  items?: any[] | undefined;
+  items?: readonly any[] | undefined;
   /**
    * Number of available items in the list; Required and used only if 'itemsFn' is provided
    * Default value: void 0
    */
@@ -12952,9 +12956,9 @@
    * @param from Index of the first item (0 based)
    * @param size Number of items to return
    * @returns List of scope for items to be displayed
    */
-  itemsFn?: ((from: number, size: number) => any[]) | undefined;
+  itemsFn?: ((from: number, size: number) => readonly any[]) | undefined;
   /**
    * CSS selector or DOM element to be used as a custom scroll container instead of the auto detected one
    */
   scrollTarget?: Element | string | undefined;
@@ -13174,24 +13178,24 @@
   options?: {
     /**
      * The value of the selection (String if it's of type radio or Array otherwise)
      */
-    model: string | any[];
+    model: string | readonly any[];
     /**
      * The type of selection
      * Default value: radio
      */
     type?: "radio" | "checkbox" | "toggle";
     /**
      * The list of options to interact with; Equivalent to options prop of the QOptionsGroup component
      */
-    items?: any[];
+    items?: readonly any[];
     /**
      * Is the model valid?
      * @param model The current model (String if it's of type radio or Array otherwise)
      * @returns The selection passed validation or not
      */
-    isValid?: (model: string | any[]) => boolean;
+    isValid?: (model: string | readonly any[]) => boolean;
   };
   /**
    * Display a Quasar spinner (if value is true, then the defaults are used); Useful for conveying the idea that something is happening behind the covers; Tip: use along with persistent, ok: false and update() method
    */
```