### PR TITLE
fix(app-vite): dev server URL with custom host

### DIFF
--- a/app-vite/lib/helpers/print-dev-banner.js
+++ b/app-vite/lib/helpers/print-dev-banner.js
@@ -28,7 +28,7 @@ function getBanner (quasarConf) {
   if (ctx.mode.bex !== true) {
     const urlList = quasarConf.devServer.host === '0.0.0.0'
       ? getIPList().map(ip => green(quasarConf.metaConf.getUrl(ip))).join(`\n                           `)
-      : green(quasarConf.build.APP_URL)
+      : green(quasarConf.metaConf.APP_URL)
 
     banner.push(` ${greenBanner} App URL................ ${urlList}`)
   }


### PR DESCRIPTION
If a custom host is provided as:
```js
{
  devServer: {
    host: 'myhost.local'
  }
}
```
the dev server banner shows the App URL as:
`App URL................ undefined`
instead of:
`App URL................ http://myhost.local/`

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app

**Other information:**
Small fix only, probably a "typo" in the original code. Also it only affects the dev server banner, so it doesn't really matter if the project uses Cordova, Electron etc.