### PR TITLE
chore(app-vite/docs/ui): disable `x-powered-by` header

### DIFF
--- a/app-vite/templates/ssr/server.js
+++ b/app-vite/templates/ssr/server.js
@@ -22,6 +22,10 @@ import compression from 'compression'
 export function create (/* { ... } */) {
   const app = express()
 
+  // attackers can use this header to detect apps running Express
+  // and then launch specifically-targeted attacks
+  app.disable('x-powered-by')
+
   // place here any middlewares that
   // absolutely need to run before anything else
   if (process.env.PROD) {

--- a/docs/src-ssr/server.js
+++ b/docs/src-ssr/server.js
@@ -22,6 +22,10 @@ import compression from 'compression'
 export function create (/* { ... } */) {
   const app = express()
 
+  // attackers can use this header to detect apps running Express
+  // and then launch specifically-targeted attacks
+  app.disable('x-powered-by')
+
   // place here any middlewares that
   // absolutely need to run before anything else
   if (process.env.PROD) {

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-webserver.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-webserver.md
@@ -38,6 +38,10 @@ import compression from 'compression'
 export function create (/* { ... } */) {
   const app = express()
 
+  // attackers can use this header to detect apps running Express
+  // and then launch specifically-targeted attacks
+  app.disable('x-powered-by')
+
   // place here any middlewares that
   // absolutely need to run before anything else
   if (process.env.PROD) {

--- a/ui/dev/src-ssr/server.js
+++ b/ui/dev/src-ssr/server.js
@@ -22,6 +22,10 @@ import compression from 'compression'
 export function create (/* { ... } */) {
   const app = express()
 
+  // attackers can use this header to detect apps running Express
+  // and then launch specifically-targeted attacks
+  app.disable('x-powered-by')
+
   // place here any middlewares that
   // absolutely need to run before anything else
   if (process.env.PROD) {


### PR DESCRIPTION
Attackers can use this header (which is enabled by default) to detect apps running Express and then launch specifically-targeted attacks.

[At a minimum, disable X-Powered-By header](https://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header)