### PR TITLE
fix(QItem): take active prop into account if both route and active given

### DIFF
--- a/ui/src/components/item/QItem.js
+++ b/ui/src/components/item/QItem.js
@@ -20,7 +20,10 @@ export default createComponent({
       default: 'div'
     },
 
-    active: Boolean,
+    active: {
+      type: Boolean,
+      default: null
+    },
 
     clickable: Boolean,
     dense: Boolean,
@@ -58,7 +61,7 @@ export default createComponent({
       + (props.dense === true ? ' q-item--dense' : '')
       + (isDark.value === true ? ' q-item--dark' : '')
       + (
-        hasLink.value === true && props.active === undefined
+        hasLink.value === true && props.active === null
           ? linkClass.value
           : (
               props.active === true

--- a/ui/src/components/item/QItem.js
+++ b/ui/src/components/item/QItem.js
@@ -58,7 +58,7 @@ export default createComponent({
       + (props.dense === true ? ' q-item--dense' : '')
       + (isDark.value === true ? ' q-item--dark' : '')
       + (
-        hasLink.value === true
+        hasLink.value === true && props.active === undefined
           ? linkClass.value
           : (
               props.active === true

--- a/ui/src/components/item/QItem.json
+++ b/ui/src/components/item/QItem.json
@@ -9,7 +9,8 @@
     "active": {
       "type": "Boolean",
       "desc": "Put item into 'active' state",
-      "category": "state"
+      "category": "state",
+      "default": null
     },
 
     "dark": {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
This ensures that if the `active` prop is given it will always be used, otherwise if using a route the active prop has no use and the  logic to determine if active has no way to be customized

Use case: to be able to mark the item as active in a related route (not necessarily a children route, so `exact` does not fit this use case)

```vue
<QItem :to="{name: 'some.route.list'}" :active="/^some.route/.test($route.name)"/>
```

Currently the previous code would not result in the item being active on route `some.route.edit` even though it's clearly what's wanted, this PR fixes this