### PR TITLE
sass variables for files with only @use statements

### DIFF
--- a/vite-plugin/src/scss-transform.js
+++ b/vite-plugin/src/scss-transform.js
@@ -23,7 +23,11 @@ export function createScssTransform (fileExtension, sassVariables) {
       return prefix + content
     }
 
-    const newLineIndex = content.indexOf('\n', useIndex) + 1
-    return content.substring(0, newLineIndex) + prefix + content.substring(newLineIndex)
+    const newLineIndex = content.indexOf('\n', useIndex);
+    if (newLineIndex === -1) {
+      return content + '\n' + prefix
+    } else {
+      return content.substring(0, newLineIndex + 1) + prefix + content.substring(newLineIndex + 1)
+    }
   }
 }

--- a/vite-plugin/src/scss-transform.js
+++ b/vite-plugin/src/scss-transform.js
@@ -23,11 +23,13 @@ export function createScssTransform (fileExtension, sassVariables) {
       return prefix + content
     }
 
-    const newLineIndex = content.indexOf('\n', useIndex);
-    if (newLineIndex === -1) {
-      return content + '\n' + prefix
-    } else {
-      return content.substring(0, newLineIndex + 1) + prefix + content.substring(newLineIndex + 1)
+    const newLineIndex = content.indexOf('\n', useIndex)
+    
+    if (newLineIndex !== -1) {
+      const index = newLineIndex + 1
+      return content.substring(0, index) + prefix + content.substring(index)
     }
+
+    return content + '\n' + prefix
   }
 }


### PR DESCRIPTION
scss-transform will fail currently for files like this:
```scss
@use 'A';
@use 'B'; // no new line here
```
gives
```
[vite] Internal server error: @use rules must be written before any other rules.
```

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] No
