### PR TITLE
Fix getPackageJson problem for pnpm

### DIFF
--- a/app-vite/lib/helpers/get-package-json.js
+++ b/app-vite/lib/helpers/get-package-json.js
@@ -8,7 +8,7 @@ module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     return require(
       require.resolve(`${pkgName}/package.json`, {
-        paths: [ folder ]
+        paths: [ folder ].concat(module.paths)
       })
     )
   }

--- a/app-vite/lib/helpers/get-package-major-version.js
+++ b/app-vite/lib/helpers/get-package-major-version.js
@@ -16,7 +16,7 @@ module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     const pkg = require(
       require.resolve(`${pkgName}/package.json`, {
-        paths: [ folder ]
+        paths: [ folder ].concat(module.paths)
       })
     )
 

--- a/app-vite/lib/helpers/get-package-path.js
+++ b/app-vite/lib/helpers/get-package-path.js
@@ -3,7 +3,7 @@ const appPaths = require('../app-paths')
 module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     return require.resolve(pkgName, {
-      paths: [ folder ]
+      paths: [ folder ].concat(module.paths)
     })
   }
   catch (e) {}

--- a/app-vite/lib/helpers/get-package.js
+++ b/app-vite/lib/helpers/get-package.js
@@ -4,7 +4,7 @@ module.exports = function (pkgName) {
   try {
     return require(
       require.resolve(pkgName, {
-        paths: [ appPaths.appDir ]
+        paths: [ appPaths.appDir ].concat(module.paths)
       })
     )
   }

--- a/app-webpack/lib/helpers/get-package-json.js
+++ b/app-webpack/lib/helpers/get-package-json.js
@@ -8,7 +8,7 @@ module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     return require(
       require.resolve(`${pkgName}/package.json`, {
-        paths: [ folder ]
+        paths: [ folder ].concat(module.paths)
       })
     )
   }

--- a/app-webpack/lib/helpers/get-package-major-version.js
+++ b/app-webpack/lib/helpers/get-package-major-version.js
@@ -16,7 +16,7 @@ module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     const pkg = require(
       require.resolve(`${pkgName}/package.json`, {
-        paths: [ folder ]
+        paths: [ folder ].concat(module.paths)
       })
     )
 

--- a/app-webpack/lib/helpers/get-package-path.js
+++ b/app-webpack/lib/helpers/get-package-path.js
@@ -3,7 +3,7 @@ const appPaths = require('../app-paths')
 module.exports = function (pkgName, folder = appPaths.appDir) {
   try {
     return require.resolve(pkgName, {
-      paths: [ folder ]
+      paths: [ folder ].concat(module.paths)
     })
   }
   catch (e) {}

--- a/app-webpack/lib/helpers/get-package.js
+++ b/app-webpack/lib/helpers/get-package.js
@@ -4,7 +4,7 @@ module.exports = function (pkgName) {
   try {
     return require(
       require.resolve(pkgName, {
-        paths: [ appPaths.appDir ]
+        paths: [ appPaths.appDir ].concat(module.paths)
       })
     )
   }

--- a/cli/lib/get-package-json.js
+++ b/cli/lib/get-package-json.js
@@ -3,7 +3,7 @@ module.exports = function (root) {
     try {
       return require(
         require.resolve(`${pkgName}/package.json`, {
-          paths: [ root ]
+          paths: [ root ].concat(module.paths)
         })
       )
     }


### PR DESCRIPTION
When using ```pnpm```, the *Quasar CLI* with using function ```getPackageJson()``` fails to resolve ```vite``` package (to get version number from its ```package.json``` file) because of how ```pnpm``` structures the ```node_modules```.

The problem is in file ```app-vite/lib/helpers/banner-global.js```. The ```getPackageJson()``` function could not resolve the ```vite``` package and returned ```undefined```...

This fix makes the resolver to look first in the specified directory and then in default paths instead of just in the specified directory. Then it works also with ```pnpm``` out of the box.

The error:
```
> quasar dev

 .d88888b.
d88P" "Y88b
888     888
888     888 888  888  8888b.  .d8888b   8888b.  888d888
888     888 888  888     "88b 88K          "88b 888P"
888 Y8b 888 888  888 .d888888 "Y8888b. .d888888 888
Y88b.Y8b88P Y88b 888 888  888      X88 888  888 888
 "Y888888"   "Y88888 "Y888888  88888P' "Y888888 888
       Y8b


 App • ⚠️  ️️Setting port to closest one available: 9001

/app/node_modules/.pnpm/@quasar+app-vite@1.0.0-beta.14_aonw7kxj5rrzambm5jgx5za7q4/node_modules/@quasar/app-vite/lib/helpers/banner-global.js:6
const viteVersion = getPackageJson('vite').version
                                          ^

TypeError: Cannot read properties of undefined (reading 'version')
    at Object.<anonymous> (/app/node_modules/.pnpm/@quasar+app-vite@1.0.0-beta.14_aonw7kxj5rrzambm5jgx5za7q4/node_modules/@quasar/app-vite/lib/helpers/banner-global.js:6:43)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/app/node_modules/.pnpm/@quasar+app-vite@1.0.0-beta.14_aonw7kxj5rrzambm5jgx5za7q4/node_modules/@quasar/app-vite/lib/helpers/print-dev-banner.js:5:64)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
```

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
