### PR TITLE
(fix: #13154) v-ripple unhandled error

### DIFF
--- a/ui/src/directives/Ripple.js
+++ b/ui/src/directives/Ripple.js
@@ -62,7 +62,7 @@ function showRipple (evt, el, ctx, forceCenter) {
 }
 
 function updateModifiers (ctx, { modifiers, value, arg, instance }) {
-  const cfg = Object.assign({}, instance.$q.config.ripple, modifiers, value)
+  const cfg = Object.assign({}, instance?.$q?.config?.ripple, modifiers, value)
   ctx.modifiers = {
     early: cfg.early === true,
     stop: cfg.stop === true,


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

With the `v-ripple` directive issue. From comments, there are 3 immediate work around:

1. Downgrade to `vue 3.2.31`
2. Keep `vue ^3.2.33`, that is now the [recommended](https://github.com/cailloumajor/factory-frontend/pull/51). Since [latest update on vue](https://github.com/quasarframework/quasar/issues/13154#issuecomment-1113273509), the developer need to explicit `defineExpose({ $q })` on `<script setup>` on components using `v-ripple`.
3. Stop using `v-ripple` on your components 😢.

But I like to propose to another temporary solution:

* Add Optional chaining to `Ripple.js:65 => const cfg = Object.assign({}, instance?.$q?.config?.ripple, modifiers, value)`.

There is still the issue with `vue ^3.2.33` not injecting `$q` and losing `quasar.config`, that need another workaround than `defineExpose`, but when this issue go fix, the optional chaining will be still valid.