### PR TITLE
fix(electron-builder): path consistency

### DIFF
--- a/app-vite/lib/modes/electron/electron-builder.js
+++ b/app-vite/lib/modes/electron/electron-builder.js
@@ -63,7 +63,7 @@ class ElectronBuilder extends AppBuilder {
       this.quasarConf.electron.extendPackageJson(pkg)
     }
 
-    this.writeFile('Unpackaged/package.json', JSON.stringify(pkg))
+    this.writeFile('UnPackaged/package.json', JSON.stringify(pkg))
   }
 
   async #copyElectronFiles () {
@@ -74,12 +74,12 @@ class ElectronBuilder extends AppBuilder {
       'yarn.lock',
     ].map(filename => ({
       from: filename,
-      to: './Unpackaged'
+      to: './UnPackaged'
     }))
 
     patterns.push({
       from: appPaths.resolve.electron('icons'),
-      to: './Unpackaged/icons'
+      to: './UnPackaged/icons'
     })
 
     this.copyFiles(patterns)


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

This PR fix an issue with case of somes hardcoded path`Unpackaged` -> `UnPackaged`, with case-sensitive FS this issue break Electron build:

```
 App •  WAIT  • Bundling app with electron-packager...
Packaging app for platform linux x64 using electron v18.2.3

 App • ⚠️   electron-packager could not build

Error: Application manifest was not found. Make sure "/home/william/......./dist/electron/UnPackaged/package.json" exists and does not get ignored by your ignore option

node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
