### PR TITLE
fix(QBadge): doesn't render slot if has label

### DIFF
--- a/ui/src/components/badge/QBadge.js
+++ b/ui/src/components/badge/QBadge.js
@@ -55,6 +55,6 @@ export default createComponent({
       style: style.value,
       role: 'alert',
       'aria-label': props.label
-    }, hMergeSlot(slots.default,  props.label !== void 0 ? [props.label] : [])))
+    }, hMergeSlot(slots.default, props.label !== void 0 ? [props.label] : [])))
   }
 })

--- a/ui/src/components/badge/QBadge.js
+++ b/ui/src/components/badge/QBadge.js
@@ -55,6 +55,6 @@ export default createComponent({
       style: style.value,
       role: 'alert',
       'aria-label': props.label
-    }, hMergeSlot(slots.default, props.label !== void 0 ? [props.label] : [])))
+    }, hMergeSlot(slots.default, props.label !== void 0 ? [ props.label ] : [])))
   }
 })

--- a/ui/src/components/badge/QBadge.js
+++ b/ui/src/components/badge/QBadge.js
@@ -1,7 +1,7 @@
 import { h, computed } from 'vue'
 
 import { createComponent } from '../../utils/private/create.js'
-import { hSlot } from '../../utils/private/render.js'
+import { hMergeSlot } from '../../utils/private/render.js'
 
 const alignValues = [ 'top', 'middle', 'bottom' ]
 
@@ -55,6 +55,6 @@ export default createComponent({
       style: style.value,
       role: 'alert',
       'aria-label': props.label
-    }, props.label !== void 0 ? props.label : hSlot(slots.default))
+    }, hMergeSlot(slots.default,  props.label !== void 0 ? [props.label] : [])))
   }
 })


### PR DESCRIPTION

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**
This issue is particularly problematic when using tooltips and menus, which need to be in the slot when rendering

## Doesn't work
```vue
<QBadge label="Foo"><QMenu>Doesn't show</QMenu></QBadge>
```

## Works

```vue
<QBadge>Foo<QMenu>Shows</QMenu></QBadge>
```