### PR TITLE
fix: typing for redirect function provided by prefetch

### DIFF
--- a/app-vite/types/prefetch.d.ts
+++ b/app-vite/types/prefetch.d.ts
@@ -5,7 +5,7 @@ import { HasStoreParam } from "./store";
 interface PreFetchOptions<TState> extends HasSsrParam, HasStoreParam<TState> {
   currentRoute: RouteLocationNormalizedLoaded;
   previousRoute: RouteLocationNormalizedLoaded;
-  redirect: (url: RouteLocationRaw) => void;
+  redirect: (url: RouteLocationRaw, statusCode?: number) => void;
   urlPath: string;
   publicPath: string;
 }

--- a/app-webpack/types/prefetch.d.ts
+++ b/app-webpack/types/prefetch.d.ts
@@ -5,7 +5,7 @@ import { HasStoreParam } from "./store";
 interface PreFetchOptions<TState> extends HasSsrParam, HasStoreParam<TState> {
   currentRoute: RouteLocationNormalizedLoaded;
   previousRoute: RouteLocationNormalizedLoaded;
-  redirect: (url: RouteLocationRaw) => void;
+  redirect: (url: RouteLocationRaw, statusCode?: number) => void;
   urlPath: string;
   publicPath: string;
 }

--- a/docs/src/pages/quasar-cli-vite/prefetch-feature.md
+++ b/docs/src/pages/quasar-cli-vite/prefetch-feature.md
@@ -172,6 +172,13 @@ preFetch ({ store, redirect }) {
 }
 ```
 
+
+By default, redirect occurs with a status response code of 302, but we can pass this status code as the second optional parameter when calling the function, like this:
+
+```js
+redirect({ path: '/moved-permanently' }, 301)
+```
+
 If `redirect(false)` is called (supported only on client-side!), it aborts the current route navigation. Note that if you use it like this in `src/App.vue` it will halt the app bootup, which is undesirable.
 
 The `redirect()` method requires a Vue Router location Object.

--- a/docs/src/pages/quasar-cli-webpack/prefetch-feature.md
+++ b/docs/src/pages/quasar-cli-webpack/prefetch-feature.md
@@ -170,6 +170,12 @@ preFetch ({ store, redirect }) {
 }
 ```
 
+By default, redirect occurs with a status response code of 302, but we can pass this status code as the second optional parameter when calling the function, like this:
+
+```js
+redirect({ path: '/moved-permanently' }, 301)
+```
+
 If `redirect(false)` is called (supported only on client-side!), it aborts the current route navigation. Note that if you use it like this in `src/App.vue` it will halt the app bootup, which is undesirable.
 
 The `redirect()` method requires a Vue Router location Object.


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The redirect function provided by prefetch takes an optional second parameter "statusCode" (#8109), but its typing is invalid.
![image](https://user-images.githubusercontent.com/81758500/169620924-c34e3282-e59e-4fd9-878e-04978ef3d1a7.png)
I tried to fix it and expand the documentation.