### PR TITLE
Fix @vue/compat ATTR_FALSE_VALUE warning

### DIFF
--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -556,7 +556,7 @@ export default function (state) {
     const labelAttrs = state.getControl === void 0 && slots.control === void 0
       ? {
           ...state.splitAttrs.attributes.value,
-          'data-autofocus': props.autofocus,
+          'data-autofocus': props.autofocus === true || void 0,
           ...attributes.value
         }
       : attributes.value


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Using the Vue3 compatibility build ([@vue/compat](https://www.npmjs.com/package/@vue/compat)) surfaces this warning about Quasar code:

```
[Vue warn]: (deprecation ATTR_FALSE_VALUE) Attribute "data-autofocus" with v-bind value `false` will render data-autofocus="false" instead of removing it in Vue 3. To remove the attribute, use `null` or `undefined` instead. If the usage is intended, you can disable the compat behavior and suppress this warning with:

  configureCompat({ ATTR_FALSE_VALUE: false })

  Details: https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html 
```

Updated to use the same pattern used here: https://github.com/quasarframework/quasar/blob/9ddf1c822c6130b06990313138cbccafd5cb4d4a/ui/src/composables/private/use-field.js#L450