### PR TITLE
fix(app-vite&app-webpack): Correctly resolve store provider on Node v18 (fix: #13567)

### DIFF
--- a/app-vite/lib/helpers/store-provider.js
+++ b/app-vite/lib/helpers/store-provider.js
@@ -1,15 +1,15 @@
-const getPackage = require('./get-package')
+const getPackagePath = require('./get-package-path')
 const nodePackager = require('./node-packager')
 
 function getStoreProvider () {
   /** @type {'pinia' | 'vuex'} */
-  const name = getPackage('vuex') !== void 0 ? 'vuex' : 'pinia'
+  const name = getPackagePath('vuex') !== void 0 ? 'vuex' : 'pinia'
 
   return {
     name,
     pathKey: name === 'pinia' ? 'stores' : 'store',
 
-    isInstalled: getPackage(name) !== void 0,
+    isInstalled: getPackagePath(name) !== void 0,
     install () {
       nodePackager.installPackage(name)
     }

--- a/app-vite/lib/helpers/store-provider.js
+++ b/app-vite/lib/helpers/store-provider.js
@@ -1,15 +1,15 @@
-const getPackageJson = require('./get-package-json')
+const getPackage = require('./get-package')
 const nodePackager = require('./node-packager')
 
 function getStoreProvider () {
   /** @type {'pinia' | 'vuex'} */
-  const name = getPackageJson('vuex') !== void 0 ? 'vuex' : 'pinia'
+  const name = getPackage('vuex') !== void 0 ? 'vuex' : 'pinia'
 
   return {
     name,
     pathKey: name === 'pinia' ? 'stores' : 'store',
 
-    isInstalled: getPackageJson(name) !== void 0,
+    isInstalled: getPackage(name) !== void 0,
     install () {
       nodePackager.installPackage(name)
     }

--- a/app-webpack/lib/helpers/store-provider.js
+++ b/app-webpack/lib/helpers/store-provider.js
@@ -1,15 +1,15 @@
-const getPackage = require('./get-package')
+const getPackagePath = require('./get-package-path')
 const nodePackager = require('./node-packager')
 
 function getStoreProvider () {
   /** @type {'pinia' | 'vuex'} */
-  const name = getPackage('vuex') !== void 0 ? 'vuex' : 'pinia'
+  const name = getPackagePath('vuex') !== void 0 ? 'vuex' : 'pinia'
 
   return {
     name,
     pathKey: name === 'pinia' ? 'stores' : 'store',
 
-    isInstalled: getPackage(name) !== void 0,
+    isInstalled: getPackagePath(name) !== void 0,
     install () {
       nodePackager.installPackage(name)
     }

--- a/app-webpack/lib/helpers/store-provider.js
+++ b/app-webpack/lib/helpers/store-provider.js
@@ -1,15 +1,15 @@
-const getPackageJson = require('./get-package-json')
+const getPackage = require('./get-package')
 const nodePackager = require('./node-packager')
 
-function getStoreProvider() {
+function getStoreProvider () {
   /** @type {'pinia' | 'vuex'} */
-  const name = getPackageJson('vuex') !== void 0 ? 'vuex' : 'pinia'
+  const name = getPackage('vuex') !== void 0 ? 'vuex' : 'pinia'
 
   return {
     name,
     pathKey: name === 'pinia' ? 'stores' : 'store',
 
-    isInstalled: getPackageJson(name) !== void 0,
+    isInstalled: getPackage(name) !== void 0,
     install () {
       nodePackager.installPackage(name)
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

`getPackageJson()` fails for Vuex on Node v18(_v17+_). See: https://github.com/vuejs/vuex/issues/2160

Fixes #13567.