### PR TITLE
feat(create-quasar): PNPM support

### DIFF
--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -113,6 +113,13 @@
     "npm": ">= 6.14.12",
     "yarn": ">= 1.17.3"
   },
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "rollup"
+      ]
+    }
+  },
   "volta": {
     "node": "lts"
   },

--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -72,7 +72,6 @@
     "minimist": "^1.2.6",
     "open": "^8.4.0",
     "ouch": "^2.0.0",
-    "postcss": "^8.4.4",
     "register-service-worker": "^1.7.2",
     "rollup-plugin-visualizer": "^5.5.4",
     "sass": "1.32.12",

--- a/create-quasar/index.js
+++ b/create-quasar/index.js
@@ -88,6 +88,7 @@ async function run () {
             ]
             : [
               { title: 'Yes, use Yarn (recommended)', value: 'yarn' },
+              { title: 'Yes, use PNPM', value: 'pnpm' },
               { title: 'Yes, use NPM', value: 'npm' },
               { title: 'No, I will handle that myself', value: false }
             ]

--- a/create-quasar/templates/app/quasar-v2/js-vite/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/js-vite/BASE/_.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/js-vite/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/js-vite/BASE/_.npmrc
@@ -1,2 +1,3 @@
+# pnpm-related options
 shamefully-hoist=true
 strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/js-vite/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/js-vite/BASE/_package.json
@@ -39,7 +39,8 @@
     <% } } %>
     <% if (preset.i18n) { %>"@intlify/vite-plugin-vue-i18n": "^3.3.1",<% } %>
     "@quasar/app-vite": "^1.0.0",
-    "autoprefixer": "^10.4.2"
+    "autoprefixer": "^10.4.2",
+    "postcss": "^8.4.14"
   },
   "engines": {
     "node": "^18 || ^16 || ^14.19",

--- a/create-quasar/templates/app/quasar-v2/js-webpack/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/js-webpack/BASE/_.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/js-webpack/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/js-webpack/BASE/_.npmrc
@@ -1,2 +1,3 @@
+# pnpm-related options
 shamefully-hoist=true
 strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_.npmrc
@@ -1,2 +1,3 @@
+# pnpm-related options
 shamefully-hoist=true
 strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_.npmrc
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_.npmrc
@@ -1,2 +1,3 @@
+# pnpm-related options
 shamefully-hoist=true
 strict-peer-dependencies=false


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

`shamefully-hoist=true` is for allowing app code to access dependencies in `@quasar/app-*` packages. One example would be `@quasar/fastclick`, which is used for iOS on PWA and Cordova. We inject this into auto-generated entry files, which are actually part of the app, so it will not be able to access the dependency defined in `@quasar/app-*` packages and will result in errors. We can choose to make it a peer dependency of `@quasar/app-*` packages and make it part of the starter kit. But, since that's not the only thing, we would be making the starter kits confusing and bloated, and they will be harder to update/manage, if it becomes not needed, we can't simply remove it, etc.

For app-webpack there are lots of packages, so I don't see really see hope in a "shamefully-hoist-less" app-webpack. ~~For app-vite however, if I am not missing something, the only dependency with a runtime reference is `@quasar/fastclick`, so we can decide to move it to devland to be able to go "shamefully-hoist-less".~~ There are also `express`, `compress`, etc. and their respective `@types/*` packages too. So, we would need to go on a longer route, which is probably not a good idea, at least for now.

Nuxt is also doing [`shamefully-hoist=true`](https://github.com/nuxt/starter/tree/90f48a598c32f38982801c35b2a61be7ac923776#setup), in fact, their starter kit only has `nuxt` as a dev dependency, the rest including vue and vue-router is shared(_not using exact pins_). It would have at least been a problem in terms of import suggestions(_like we had in #9235_), but that's not a problem because they offer auto-imports.

`strict-peer-dependencies=false` is for avoiding the need for installing internal libraries like webpack, vite, etc. on devland. Installing webpack, vite, etc. loaders/plugins start enforcing this, so it's annoying without any real benefit at the app level for a framework like this IMO.

Needs these for full PNPM support experience:
- #13609
- #13106
- #12809
- More documentation changes
- Messages/logs inside q-app messages/instructions. An instruction like "_Run `npm run x` or `yarn x`_" should also cover PNPM. Ideally, we should only display the instructions for the package manager the user is using.