### PR TITLE
feat(extras): Define exports field in package.json

### DIFF
--- a/extras/package.json
+++ b/extras/package.json
@@ -9,104 +9,104 @@
   "exports": {
     ".": "./index.js",
     "./bootstrap-icons": {
+      "types": "./bootstrap-icons/index.d.ts",
       "import": "./bootstrap-icons/index.mjs",
-      "require": "./bootstrap-icons/index.js",
-      "types": "./bootstrap-icons/index.d.ts"
+      "require": "./bootstrap-icons/index.js"
     },
     "./eva-icons": {
+      "types": "./eva-icons/index.d.ts",
       "import": "./eva-icons/index.mjs",
-      "require": "./eva-icons/index.js",
-      "types": "./eva-icons/index.d.ts"
+      "require": "./eva-icons/index.js"
     },
     "./fontawesome-v5": {
+      "types": "./fontawesome-v5/index.d.ts",
       "import": "./fontawesome-v5/index.mjs",
-      "require": "./fontawesome-v5/index.js",
-      "types": "./fontawesome-v5/index.d.ts"
+      "require": "./fontawesome-v5/index.js"
     },
     "./fontawesome-v6": {
+      "types": "./fontawesome-v6/index.d.ts",
       "import": "./fontawesome-v6/index.mjs",
-      "require": "./fontawesome-v6/index.js",
-      "types": "./fontawesome-v6/index.d.ts"
+      "require": "./fontawesome-v6/index.js"
     },
     "./ionicons-v4": {
+      "types": "./ionicons-v4/index.d.ts",
       "import": "./ionicons-v4/index.mjs",
-      "require": "./ionicons-v4/index.js",
-      "types": "./ionicons-v4/index.d.ts"
-    },
+      "require": "./ionicons-v4/index.js"
+    }
     "./ionicons-v5": {
+      "types": "./ionicons-v5/index.d.ts",
       "import": "./ionicons-v5/index.mjs",
-      "require": "./ionicons-v5/index.js",
-      "types": "./ionicons-v5/index.d.ts"
+      "require": "./ionicons-v5/index.js"
     },
     "./ionicons-v6": {
+      "types": "./ionicons-v6/index.d.ts",
       "import": "./ionicons-v6/index.mjs",
-      "require": "./ionicons-v6/index.js",
-      "types": "./ionicons-v6/index.d.ts"
+      "require": "./ionicons-v6/index.js"
     },
     "./line-awesome": {
+      "types": "./line-awesome/index.d.ts",
       "import": "./line-awesome/index.mjs",
-      "require": "./line-awesome/index.js",
-      "types": "./line-awesome/index.d.ts"
+      "require": "./line-awesome/index.js"
     },
     "./material-icons": {
+      "types": "./material-icons/index.d.ts",
       "import": "./material-icons/index.mjs",
-      "require": "./material-icons/index.js",
-      "types": "./material-icons/index.d.ts"
+      "require": "./material-icons/index.js"
     },
     "./material-icons-outlined": {
+      "types": "./material-icons-outlined/index.d.ts",
       "import": "./material-icons-outlined/index.mjs",
-      "require": "./material-icons-outlined/index.js",
-      "types": "./material-icons-outlined/index.d.ts"
+      "require": "./material-icons-outlined/index.js"
     },
     "./material-icons-round": {
+      "types": "./material-icons-round/index.d.ts",
       "import": "./material-icons-round/index.mjs",
-      "require": "./material-icons-round/index.js",
-      "types": "./material-icons-round/index.d.ts"
+      "require": "./material-icons-round/index.js"
     },
     "./material-icons-sharp": {
+      "types": "./material-icons-sharp/index.d.ts",
       "import": "./material-icons-sharp/index.mjs",
-      "require": "./material-icons-sharp/index.js",
-      "types": "./material-icons-sharp/index.d.ts"
+      "require": "./material-icons-sharp/index.js"
     },
     "./material-symbols-outlined": {
+      "types": "./material-symbols-outlined/index.d.ts",
       "import": "./material-symbols-outlined/index.mjs",
-      "require": "./material-symbols-outlined/index.js",
-      "types": "./material-symbols-outlined/index.d.ts"
+      "require": "./material-symbols-outlined/index.js"
     },
     "./material-symbols-round": {
+      "types": "./material-symbols-round/index.d.ts",
       "import": "./material-symbols-round/index.mjs",
-      "require": "./material-symbols-round/index.js",
-      "types": "./material-symbols-round/index.d.ts"
+      "require": "./material-symbols-round/index.js"
     },
     "./material-symbols-sharp": {
+      "types": "./material-symbols-sharp/index.d.ts",
       "import": "./material-symbols-sharp/index.mjs",
-      "require": "./material-symbols-sharp/index.js",
-      "types": "./material-symbols-sharp/index.d.ts"
+      "require": "./material-symbols-sharp/index.js"
     },
     "./mdi-v3": {
+      "types": "./mdi-v3/index.d.ts",
       "import": "./mdi-v3/index.mjs",
-      "require": "./mdi-v3/index.js",
-      "types": "./mdi-v3/index.d.ts"
+      "require": "./mdi-v3/index.js"
     },
     "./mdi-v4": {
+      "types": "./mdi-v4/index.d.ts",
       "import": "./mdi-v4/index.mjs",
-      "require": "./mdi-v4/index.js",
-      "types": "./mdi-v4/index.d.ts"
+      "require": "./mdi-v4/index.js"
     },
     "./mdi-v5": {
+      "types": "./mdi-v5/index.d.ts",
       "import": "./mdi-v5/index.mjs",
-      "require": "./mdi-v5/index.js",
-      "types": "./mdi-v5/index.d.ts"
+      "require": "./mdi-v5/index.js"
     },
     "./mdi-v6": {
+      "types": "./mdi-v6/index.d.ts",
       "import": "./mdi-v6/index.mjs",
-      "require": "./mdi-v6/index.js",
-      "types": "./mdi-v6/index.d.ts"
+      "require": "./mdi-v6/index.js"
     },
     "./themify": {
+      "types": "./themify/index.d.ts",
       "import": "./themify/index.mjs",
-      "require": "./themify/index.js",
-      "types": "./themify/index.d.ts"
+      "require": "./themify/index.js"
     },
     "./*": "./*"
   },

--- a/extras/package.json
+++ b/extras/package.json
@@ -6,6 +6,110 @@
     "build": "node build/index.js"
   },
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*",
+    "./bootstrap-icons": {
+      "import": "./bootstrap-icons/index.mjs",
+      "require": "./bootstrap-icons/index.js",
+      "types": "./bootstrap-icons/index.d.ts"
+    },
+    "./eva-icons": {
+      "import": "./eva-icons/index.mjs",
+      "require": "./eva-icons/index.js",
+      "types": "./eva-icons/index.d.ts"
+    },
+    "./fontawesome-v5": {
+      "import": "./fontawesome-v5/index.mjs",
+      "require": "./fontawesome-v5/index.js",
+      "types": "./fontawesome-v5/index.d.ts"
+    },
+    "./fontawesome-v6": {
+      "import": "./fontawesome-v6/index.mjs",
+      "require": "./fontawesome-v6/index.js",
+      "types": "./fontawesome-v6/index.d.ts"
+    },
+    "./ionicons-v4": {
+      "import": "./ionicons-v4/index.mjs",
+      "require": "./ionicons-v4/index.js",
+      "types": "./ionicons-v4/index.d.ts"
+    },
+    "./ionicons-v5": {
+      "import": "./ionicons-v5/index.mjs",
+      "require": "./ionicons-v5/index.js",
+      "types": "./ionicons-v5/index.d.ts"
+    },
+    "./ionicons-v6": {
+      "import": "./ionicons-v6/index.mjs",
+      "require": "./ionicons-v6/index.js",
+      "types": "./ionicons-v6/index.d.ts"
+    },
+    "./line-awesome": {
+      "import": "./line-awesome/index.mjs",
+      "require": "./line-awesome/index.js",
+      "types": "./line-awesome/index.d.ts"
+    },
+    "./material-icons": {
+      "import": "./material-icons/index.mjs",
+      "require": "./material-icons/index.js",
+      "types": "./material-icons/index.d.ts"
+    },
+    "./material-icons-outlined": {
+      "import": "./material-icons-outlined/index.mjs",
+      "require": "./material-icons-outlined/index.js",
+      "types": "./material-icons-outlined/index.d.ts"
+    },
+    "./material-icons-round": {
+      "import": "./material-icons-round/index.mjs",
+      "require": "./material-icons-round/index.js",
+      "types": "./material-icons-round/index.d.ts"
+    },
+    "./material-icons-sharp": {
+      "import": "./material-icons-sharp/index.mjs",
+      "require": "./material-icons-sharp/index.js",
+      "types": "./material-icons-sharp/index.d.ts"
+    },
+    "./material-symbols-outlined": {
+      "import": "./material-symbols-outlined/index.mjs",
+      "require": "./material-symbols-outlined/index.js",
+      "types": "./material-symbols-outlined/index.d.ts"
+    },
+    "./material-symbols-round": {
+      "import": "./material-symbols-round/index.mjs",
+      "require": "./material-symbols-round/index.js",
+      "types": "./material-symbols-round/index.d.ts"
+    },
+    "./material-symbols-sharp": {
+      "import": "./material-symbols-sharp/index.mjs",
+      "require": "./material-symbols-sharp/index.js",
+      "types": "./material-symbols-sharp/index.d.ts"
+    },
+    "./mdi-v3": {
+      "import": "./mdi-v3/index.mjs",
+      "require": "./mdi-v3/index.js",
+      "types": "./mdi-v3/index.d.ts"
+    },
+    "./mdi-v4": {
+      "import": "./mdi-v4/index.mjs",
+      "require": "./mdi-v4/index.js",
+      "types": "./mdi-v4/index.d.ts"
+    },
+    "./mdi-v5": {
+      "import": "./mdi-v5/index.mjs",
+      "require": "./mdi-v5/index.js",
+      "types": "./mdi-v5/index.d.ts"
+    },
+    "./mdi-v6": {
+      "import": "./mdi-v6/index.mjs",
+      "require": "./mdi-v6/index.js",
+      "types": "./mdi-v6/index.d.ts"
+    },
+    "./themify": {
+      "import": "./themify/index.mjs",
+      "require": "./themify/index.js",
+      "types": "./themify/index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/quasarframework/quasar.git"
@@ -24,7 +128,8 @@
       "email": "jeff@quasar.dev",
       "url": "https://jeffgalbraith.dev"
     }
-  ],"license": "MIT",
+  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/quasarframework/quasar/issues"
   },

--- a/extras/package.json
+++ b/extras/package.json
@@ -8,7 +8,6 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./*": "./*",
     "./bootstrap-icons": {
       "import": "./bootstrap-icons/index.mjs",
       "require": "./bootstrap-icons/index.js",
@@ -108,7 +107,8 @@
       "import": "./themify/index.mjs",
       "require": "./themify/index.js",
       "types": "./themify/index.d.ts"
-    }
+    },
+    "./*": "./*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Typescript recently released 4.7 which allows compiling to esm output for node. With this I have to set moduleResolution to use nodenext. With the new esm module resolution this requires extensions to be used on everything, a way to get around this is to setup exports object mapping the import paths to the files. You can also setup conditional mapping so that require will pull in the cjs version, import the esm version and where the types are located. I went through and added the export mapping for all the different icon imports.

I had to do this due to an error I was receiving about not able to import my desired icons while trying to run tests with vitest  due to it missing the extension (the import from your code due to me marking quasar/extras as an external package at build time). I added all of them for the different icon imports to map to each index file of it. Note that this forces all possible imports to be defined in the exports field, so for backwards compatibility `"./*": "./*"` was added, but ideally quasar will explicitly state what can all be imported in the exports field and not need the wildcard allowing everything. Guessing this change would be looked at when quasar 3.0 is being looked at.

https://nodejs.org/api/packages.html#package-entry-points the spec defined by nodejs.

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
