### PR TITLE
fix(app-vite&create-quasar): Utilize tsconfig-preset of app-vite and make fixes

### DIFF
--- a/app-vite/tsconfig-preset.json
+++ b/app-vite/tsconfig-preset.json
@@ -18,7 +18,6 @@
     // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
     "jsx": "preserve",
     "lib": ["esnext", "dom"],
-    "types": ["vite/client", "node"],
     "paths": {
       "src/*": ["src/*"],
       "app/*": ["*"],

--- a/app-vite/tsconfig-preset.json
+++ b/app-vite/tsconfig-preset.json
@@ -18,9 +18,19 @@
     // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
     "jsx": "preserve",
     "lib": ["esnext", "dom"],
-    "types": ["vite/client", "node"]
+    "types": ["vite/client", "node"],
+    "paths": {
+      "src/*": ["src/*"],
+      "app/*": ["*"],
+      "components/*": ["src/components/*"],
+      "layouts/*": ["src/layouts/*"],
+      "pages/*": ["src/pages/*"],
+      "assets/*": ["src/assets/*"],
+      "boot/*": ["src/boot/*"],
+      "stores/*": ["src/stores/*"]
+    }
   },
-  // Needed to avoid files copied into 'dist' folder (eg. a `.d.ts` file inside `src-ssr` folder)
+  // Needed to avoid files copied into 'dist' folder (e.g. a `.d.ts` file inside `src-ssr` folder)
   // to be evaluated by TS when their original files has been updated
   "exclude": ["/dist", ".quasar", "node_modules"]
 }

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_tsconfig.json
@@ -1,22 +1,8 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "src/*": ["src/*"],
-      "app/*": ["*"],
-      "components/*": ["src/components/*"],
-      "layouts/*": ["src/layouts/*"],
-      "pages/*": ["src/pages/*"],
-      "assets/*": ["src/assets/*"],
-      "boot/*": ["src/boot/*"],
-      "stores/*": ["src/stores/*"]
-    }<% if (typescriptConfig === 'class') { %>,
+    "baseUrl": "."<% if (typescriptConfig === 'class') { %>,
     "experimentalDecorators": true,
     "useDefineForClassFields": true<% } %>
-  },
-  "include": [
-    "src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue",
-    "src-pwa/*.d.ts", "src-bex/*.d.ts", "src-ssr/*.d.ts"
-  ]
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
There used to be some problems with the 'extends' key, mostly regarding the lack of the .json extension. They are now fixed into Vite, so we should utilize the tsconfig-preset, and do it correctly.

This PR also removes the `types` property, which was limiting the types to only `node` and `vite/client`. TypeScript wasn't properly handling it for some time, it will be fixed in TS 4.8. So, if we don't change it now, it might break other stuff later. `vite/client` is already handled through a tripple-slash directive in the ts-vite template. So, no other changes are required.

The `include` configuration wasn't inclusive enough. It wasn't counting in `electron`, `cordova`, and `capacitor` feature flags. It wasn't counting in the actual TS files of other files, so it would not be possible to get proper TS checking or linting on them. By falling back to the `exclude` property in the preset, everything will now work properly. We might want to tell the users to remove `include` from their `tsconfig.json` to avoid possible issues. They can also get rid of `paths` for simplicity.