### PR TITLE
refactor(create-quasar): Remove old vue/ref-macros reference

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/shims-vue.d.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/shims-vue.d.ts
@@ -5,8 +5,7 @@
 
 // Mocks all files ending in `.vue` showing them as plain Vue instances
 declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-  const component: DefineComponent<{}, {}, any>
-  export default component
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
 }

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/shims-vue.d.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/shims-vue.d.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
 
 /// <reference types="vite/client" />
-/// <reference types="vue/ref-macros" />
 
 // Mocks all files ending in `.vue` showing them as plain Vue instances
 declare module '*.vue' {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Refactor
- Code style changes

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

It was used for reactivity transform macros, but that feature is still experimental and is behind a feature flag. So, the users can add the reference along with the configuration only when they need to avoid polluting the globals.

Also, the new name for this is `vue/macros-global`, see https://github.com/vuejs/core/blob/bdffc143ef3aa27c347b22f19d0052194b54836e/packages/vue/ref-macros.d.ts#L1
The up-to-date way is explained properly in [Vue docs](https://vuejs.org/guide/extras/reactivity-transform.html#typescript-integration), so we don't need to do anything else, at least until the API hits stable and gets available without extra configuration.