### PR TITLE
Fix crash when null is passed to setAnchorEl(el)

### DIFF
--- a/ui/src/composables/private/use-anchor.js
+++ b/ui/src/composables/private/use-anchor.js
@@ -140,7 +140,7 @@ export default function ({
     if (props.target === false || props.target === '') {
       anchorEl.value = null
     }
-    else if (props.target === true) {
+    else if (props.target === true && proxy.$el.parentNode != null) {
       setAnchorEl(proxy.$el.parentNode)
     }
     else {


### PR DESCRIPTION
Null is passed when QInfiniteScroll has to load content twice in a row after the first load did not fill the target element.
This then crashes the whole application (in setAnchorEl:133):
>Error in mounted hook: "TypeError: Cannot read property 'classList' of null" 

I do not know the exact reason this happens but this change is not intrusive in any way and simply fixes all issues of this type.
I could not find any reports of another setAnchorEl problem except in #9396.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.