### PR TITLE
fix(create-quasar): define $dark-page in templates

### DIFF
--- a/create-quasar/templates/app/quasar-v1/js/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v1/js/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v1/js/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v1/js/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;

--- a/create-quasar/templates/app/quasar-v1/ts/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v1/ts/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v1/ts/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v1/ts/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;

--- a/create-quasar/templates/app/quasar-v2/js-vite/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v2/js-vite/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v2/js-vite/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v2/js-vite/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;

--- a/create-quasar/templates/app/quasar-v2/js-webpack/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v2/js-webpack/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v2/js-webpack/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v2/js-webpack/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;

--- a/create-quasar/templates/app/quasar-v2/ts-vite/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v2/ts-vite/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/sass/src/css/quasar.variables.sass
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/sass/src/css/quasar.variables.sass
@@ -17,6 +17,7 @@ $secondary : #26A69A
 $accent    : #9C27B0
 
 $dark      : #1D1D1D
+$dark-page : #121212
 
 $positive  : #21BA45
 $negative  : #C10015

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/scss/src/css/quasar.variables.scss
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/scss/src/css/quasar.variables.scss
@@ -17,6 +17,7 @@ $secondary : #26A69A;
 $accent    : #9C27B0;
 
 $dark      : #1D1D1D;
+$dark-page : #121212;
 
 $positive  : #21BA45;
 $negative  : #C10015;


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: --q-dark-page is responsible for the background color when in dark mode, it is missing in the template

![quasar-toh-theme-dark-color](https://user-images.githubusercontent.com/43420049/174205609-87bd56e1-e967-455a-b370-ac67caf15920.png)
![quasar-toh-theme-dark-custom-color](https://user-images.githubusercontent.com/43420049/174205650-10076f6e-011f-4009-89ff-826f507bed42.png)

**Does this PR introduce a breaking change?** <!-- Check one -->


- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
