### PR TITLE
fix(13732): v-ripple crash with vue 3.2.32+ with Composition API

### DIFF
--- a/ui/src/directives/Ripple.js
+++ b/ui/src/directives/Ripple.js
@@ -62,13 +62,15 @@ function showRipple (evt, el, ctx, forceCenter) {
 }
 
 function updateModifiers (ctx, { modifiers, value, arg, instance }) {
-  const cfg = Object.assign({}, instance.$q.config.ripple, modifiers, value)
-  ctx.modifiers = {
-    early: cfg.early === true,
-    stop: cfg.stop === true,
-    center: cfg.center === true,
-    color: cfg.color || arg,
-    keyCodes: [].concat(cfg.keyCodes || 13)
+  if (instance && instance.$q && instance.$q.config) {
+    const cfg = Object.assign({}, instance.$q.config.ripple, modifiers, value)
+    ctx.modifiers = {
+      early: cfg.early === true,
+      stop: cfg.stop === true,
+      center: cfg.center === true,
+      color: cfg.color || arg,
+      keyCodes: [].concat(cfg.keyCodes || 13)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**Other information:**
This is a fix for [13732](https://github.com/quasarframework/quasar/issues/13732).
Tested on the reproduction repo - with `v-ripple` on `q-item`.

Before the change the app wouldn't start.
After the change the app starts and v-ripple works on the q-items.

![output](https://user-images.githubusercontent.com/43420049/174459375-25f24ec9-30a0-4c6f-ad28-3338a3fee90d.gif)

