### PR TITLE
docs qDate monthpicker example

### DIFF
--- a/docs/public/examples/QDate/Monthpicker.vue
+++ b/docs/public/examples/QDate/Monthpicker.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="q-pa-md">
+    <div>Date Model: {{ date }}</div>
+    <q-date v-model="date" years-in-month-view default-view="Months" emit-immediately
+      @update:model-value="onUpdateMv"
+      :key="dpKey" minimal mask="YYYY/MM" />
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue'
+
+export default {
+  setup () {
+    const date = ref('2022/02')
+    const dpKey = ref(Date.now())
+
+    function onUpdateMv (v) {
+      dpKey.value = Date.now()
+    }
+    return {
+      dpKey,
+      onUpdateMv,
+      date
+    }
+  }
+}
+</script>

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -198,3 +198,9 @@ When using the persian calendar, the mask for QDate is forced to `YYYY/MM/DD`.
 When dealing with a native form which has an `action` and a `method` (eg. when using Quasar with ASP.NET controllers), you need to specify the `name` property on QDate, otherwise formData will not contain it (if it should):
 
 <doc-example title="Native form" file="QDate/NativeForm" />
+
+### Monthpicker
+
+In the example below a monthpicker is shown.
+
+<doc-example title="Monthpicker" file="QDate/Monthpicker" />


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
I think the monthpicker should be listed in the docs too. 
The example comes from discord from @metalsadman 

https://discord.com/channels/415874313728688138/806171748046733332/986968897305575424 
https://codepen.io/metalsadman/pen/xxYBqMo 
