### PR TITLE
Fix(ui): Check if metaKey or altKey are pressed before tabs navigation

### DIFF
--- a/ui/src/components/tabs/use-tab.js
+++ b/ui/src/components/tabs/use-tab.js
@@ -138,9 +138,16 @@ export default function (props, slots, emit, routerProps) {
     if (isKeyCode(e, [ 13, 32 ])) {
       onClick(e, true)
     }
-    else if (shouldIgnoreKey(e) !== true && e.keyCode >= 35 && e.keyCode <= 40 && (e.altKey !== true && e.metaKey !== true)) {
+    else if (
+      shouldIgnoreKey(e) !== true
+      && e.keyCode >= 35
+      && e.keyCode <= 40
+      && e.altKey !== true
+      && e.metaKey !== true
+    ) {
       $tabs.onKbdNavigate(e.keyCode, proxy.$el) === true && stopAndPrevent(e)
     }
+
     emit('keydown', e)
   }
 

--- a/ui/src/components/tabs/use-tab.js
+++ b/ui/src/components/tabs/use-tab.js
@@ -138,7 +138,7 @@ export default function (props, slots, emit, routerProps) {
     if (isKeyCode(e, [ 13, 32 ])) {
       onClick(e, true)
     }
-    else if (shouldIgnoreKey(e) !== true && e.keyCode >= 35 && e.keyCode <= 40) {
+    else if (shouldIgnoreKey(e) !== true && e.keyCode >= 35 && e.keyCode <= 40 && (e.altKey !== true && e.metaKey !== true)) {
       $tabs.onKbdNavigate(e.keyCode, proxy.$el) === true && stopAndPrevent(e)
     }
     emit('keydown', e)


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**Other information:**
You are not able no navigate between pages with browser hotkeys: (alt | command + leftArrow | rightArrow) when focused on QTab.

I think we need to check - if altKey or metaKey are pressed - we do default browser behavior (back and forward)

Else If those keys are not pressed - we do QTab navigation like it was before
