### PR TITLE
fix(QTree): use correct margin right for spinner when not dense

### DIFF
--- a/ui/src/components/tree/QTree.sass
+++ b/ui/src/components/tree/QTree.sass
@@ -102,10 +102,10 @@
   &__arrow,
   &__spinner
     font-size: 16px
+    margin-right: 4px
 
   &__arrow
     transition: transform .3s
-    margin-right: 4px
 
     &--rotate
       transform: rotate3d(0, 0, 1, 90deg)

--- a/ui/src/components/tree/QTree.styl
+++ b/ui/src/components/tree/QTree.styl
@@ -102,10 +102,10 @@
   &__arrow,
   &__spinner
     font-size: 16px
+    margin-right: 4px
 
   &__arrow
     transition: transform .3s
-    margin-right: 4px
 
     &--rotate
       transform: rotate3d(0, 0, 1, 90deg)


### PR DESCRIPTION
V2 is already fixed