### PR TITLE
fix(QUploader): issue with q-uploader background inconsistency (#12515)

### DIFF
--- a/ui/src/components/uploader/QUploader.sass
+++ b/ui/src/components/uploader/QUploader.sass
@@ -33,7 +33,6 @@
       bottom: 0
       left: 0
       pointer-events: none
-      background: currentColor
       opacity: .04
 
   &__header


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
When using `currentColor` as background color of  `<div class="q-uploader__header" ::before>`, background color would change slightly as the text-color of q-uploader changes.
from [W3 Specifications](https://www.w3.org/TR/css-color-3/#currentcolor):
> The value of the ‘[color](https://www.w3.org/TR/css-color-3/#color)’ property. The used value of the ‘[currentColor](https://www.w3.org/TR/css-color-3/#currentColor-def)’ keyword is the computed value of the ‘[color](https://www.w3.org/TR/css-color-3/#color)’ property. If the ‘[currentColor](https://www.w3.org/TR/css-color-3/#currentColor-def)’ keyword is set on the ‘[color](https://www.w3.org/TR/css-color-3/#color)’ property itself, it is treated as ‘color: inherit’. 

There is no color on `::before` element, from my understanding, color would be inherited from parent element (`<div class="q-uploader__header">`), which is being configured from `text-color` prop of `QUploader`, I think this is why when changing text-color property, we see a change on q-uploader header background.
but background-color of parent (`.q-uploader__header` class) is being applied to `::before` element too, thus making a weird situation where both the background and color of parent element (`<div class="q-uploader__header">`) would affect the background of the child (`<div class="q-uploader__header" ::before>`)
I've removed the `currentColor` from parent element.