### PR TITLE
feat(app-vite&app-webpack): Implement strongly-typed BEX events

### DIFF
--- a/app-vite/templates/bex/manifest-v2/background.js
+++ b/app-vite/templates/bex/manifest-v2/background.js
@@ -11,38 +11,41 @@ chrome.browserAction.onClicked.addListener((/* tab */) => {
 })
 
 export default bexBackground((bridge /* , allActiveConnections */) => {
-  bridge.on('storage.get', event => {
-    const payload = event.data
-    if (payload.key === null) {
-      chrome.storage.local.get(null, r => {
+  bridge.on('storage.get', ({ data, respond }) => {
+    if (data.key === null) {
+      chrome.storage.local.get(null, items => {
         const result = []
 
         // Group the items up into an array to take advantage of the bridge's chunk splitting.
-        for (const itemKey in r) {
-          result.push(r[itemKey])
+        for (const itemKey in items) {
+          result.push(items[itemKey])
         }
-        bridge.send(event.eventResponseKey, result)
+        respond(result)
       })
     } else {
-      chrome.storage.local.get([payload.key], r => {
-        bridge.send(event.eventResponseKey, r[payload.key])
+      chrome.storage.local.get([data.key], items => {
+        respond(items[data.key])
       })
     }
   })
+  // Usage:
+  // const { data } = await bridge.send('storage.get', { key: 'someKey' })
 
-  bridge.on('storage.set', event => {
-    const payload = event.data
-    chrome.storage.local.set({ [payload.key]: payload.data }, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.set', ({ data, respond }) => {
+    chrome.storage.local.set({ [data.key]: data.value }, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.set', { key: 'someKey', value: 'someValue' })
 
-  bridge.on('storage.remove', event => {
-    const payload = event.data
-    chrome.storage.local.remove(payload.key, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.remove', ({ data, respond }) => {
+    chrome.storage.local.remove(data.key, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.remove', { key: 'someKey' })
 
   /*
   // EXAMPLES

--- a/app-vite/templates/bex/manifest-v3/background.js
+++ b/app-vite/templates/bex/manifest-v3/background.js
@@ -13,38 +13,41 @@ chrome.runtime.onInstalled.addListener(() => {
 })
 
 export default bexBackground((bridge /* , allActiveConnections */) => {
-  bridge.on('storage.get', event => {
-    const payload = event.data
-    if (payload.key === null) {
-      chrome.storage.local.get(null, r => {
+  bridge.on('storage.get', ({ data, respond }) => {
+    if (data.key === null) {
+      chrome.storage.local.get(null, result => {
         const result = []
 
         // Group the items up into an array to take advantage of the bridge's chunk splitting.
-        for (const itemKey in r) {
-          result.push(r[itemKey])
+        for (const itemKey in result) {
+          result.push(result[itemKey])
         }
-        bridge.send(event.eventResponseKey, result)
+        respond(result)
       })
     } else {
-      chrome.storage.local.get([payload.key], r => {
-        bridge.send(event.eventResponseKey, r[payload.key])
+      chrome.storage.local.get([data.key], result => {
+        respond(result[data.key])
       })
     }
   })
+  // Usage:
+  // const { data } = await bridge.send('storage.get', { key: 'someKey' })
 
-  bridge.on('storage.set', event => {
-    const payload = event.data
-    chrome.storage.local.set({ [payload.key]: payload.data }, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.set', ({ data, respond }) => {
+    chrome.storage.local.set({ [data.key]: data.value }, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.set', { key: 'someKey', value: 'someValue' })
 
-  bridge.on('storage.remove', event => {
-    const payload = event.data
-    chrome.storage.local.remove(payload.key, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.remove', ({ data, respond }) => {
+    chrome.storage.local.remove(data.key, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.remove', { key: 'someKey' })
 
   /*
   // EXAMPLES

--- a/app-vite/templates/entry/bex/bridge.js
+++ b/app-vite/templates/entry/bex/bridge.js
@@ -114,7 +114,12 @@ export default class Bridge extends EventEmitter {
             ...{
               payload: {
                 data: m.payload,
-                eventResponseKey
+                eventResponseKey,
+                // Convenient alternative to the manual usage of `eventResponseKey`
+                respond: async (payload /* optional */) => {
+                  // Not returning the value here as we don't want the respond to be "respondable"
+                  await this.send(eventResponseKey, payload)
+                }
               }
             }
           }

--- a/app-vite/templates/entry/bex/bridge.js
+++ b/app-vite/templates/entry/bex/bridge.js
@@ -66,10 +66,7 @@ export default class Bridge extends EventEmitter {
         // Convenient alternative to the manual usage of `eventResponseKey`
         // We can't send this in `_nextSend` which will then be sent using `port.postMessage()`, which can't serialize functions.
         // So, we hook into the underlying listener and include the function there, which happens after the send operation.
-        respond: async (payload /* optional */) => {
-          // Not returning the value here as we don't want the respond to be "respondable"
-          await this.send(originalPayload.eventResponseKey, payload)
-        }
+        respond: (payload /* optional */) => this.send(originalPayload.eventResponseKey, payload)
       })
     })
   }

--- a/app-vite/types/bex.d.ts
+++ b/app-vite/types/bex.d.ts
@@ -19,14 +19,20 @@ interface BexWall {
  *   }
  * }
  *
- * bridge.send('without-payload-and-response')
+ * bridge.send('without-payload-and-response');
  *
  * bridge.on('with-payload-without-response', ({ data }) => {
  *   data // type: { test: number[] }
- * })
+ * });
  *
+ * bridge.on('with-payload-and-response', ({ data, respond }) => {
+ *   const { foo } = data; // { foo: ['a', 'b'] }
+ *
+ *   const result = foo[0].charCodeAt() + foo[1].charCodeAt(); // 97 + 98
+ *   void respond(result);
+ * });
  * const response = await bridge.send('with-payload-and-response', { foo: ['a', 'b'] });
- * console.log(typeof response) // 'number'
+ * console.log(response); // 195
  */
 export interface BexEventMap {}
 
@@ -44,7 +50,12 @@ type BexEventResponse<T extends BexEventName> = BexEventEntry<T>[1];
 
 type BexPayload<TData, TResponse> = {
   data: TData;
+  /** @deprecated Use {@link BexPayload.respond} instead */
   eventResponseKey: string;
+  /**
+   * Calling this will resolve the Promise of the `send()` call.
+   * You can use this to communicate back with the sender.
+   */
   respond: (
     ...payload: TResponse extends never ? [] : [TResponse]
   ) => Promise<BexPayload<TData, TResponse>>;

--- a/app-vite/types/bex.d.ts
+++ b/app-vite/types/bex.d.ts
@@ -42,7 +42,14 @@ type BexEventEntry<
 type BexEventData<T extends BexEventName> = BexEventEntry<T>[0];
 type BexEventResponse<T extends BexEventName> = BexEventEntry<T>[1];
 
-type BexEventListener<T extends BexEventName> = (payload: { data: BexEventData<T>; eventResponseKey: string; }) => void;
+type BexEventListener<T extends BexEventName> = (payload: {
+  data: BexEventData<T>;
+  eventResponseKey: string;
+  respond: (
+    ...payload: BexEventResponse<T> extends never ? [] : [BexEventResponse<T>]
+  ) => Promise<void>;
+}) => void;
+
 export interface BexBridge extends EventEmitter {
   constructor(wall: BexWall): BexBridge;
 

--- a/app-vite/types/bex.d.ts
+++ b/app-vite/types/bex.d.ts
@@ -1,11 +1,11 @@
-import type { EventEmitter } from 'events';
-import type { LiteralUnion } from 'quasar';
+import type { EventEmitter } from "events";
+import type { LiteralUnion } from "quasar";
 
 type BexObjectMessage = { event: string; payload: any };
 type BexMessage = string | BexObjectMessage;
 interface BexWall {
-  listen (callback: (messages: BexMessage | BexMessage[]) => void): void;
-  send (data: BexObjectMessage[]): void;
+  listen(callback: (messages: BexMessage | BexMessage[]) => void): void;
+  send(data: BexObjectMessage[]): void;
 }
 
 /**
@@ -92,7 +92,7 @@ export type BexBackgroundCallback = (
       app?: BexConnection;
       contentScript?: BexConnection;
     };
-  },
+  }
 ) => void;
 
 export type BexContentCallback = (bridge: BexBridge) => void;

--- a/app-vite/types/bex.d.ts
+++ b/app-vite/types/bex.d.ts
@@ -42,13 +42,16 @@ type BexEventEntry<
 type BexEventData<T extends BexEventName> = BexEventEntry<T>[0];
 type BexEventResponse<T extends BexEventName> = BexEventEntry<T>[1];
 
-type BexEventListener<T extends BexEventName> = (payload: {
-  data: BexEventData<T>;
+type BexPayload<TData, TResponse> = {
+  data: TData;
   eventResponseKey: string;
   respond: (
-    ...payload: BexEventResponse<T> extends never ? [] : [BexEventResponse<T>]
-  ) => Promise<void>;
-}) => void;
+    ...payload: TResponse extends never ? [] : [TResponse]
+  ) => Promise<BexPayload<TData, TResponse>>;
+};
+type BexEventListener<T extends BexEventName> = (
+  payload: BexPayload<BexEventData<T>, BexEventResponse<T>>
+) => void;
 
 export interface BexBridge extends EventEmitter {
   constructor(wall: BexWall): BexBridge;
@@ -62,7 +65,7 @@ export interface BexBridge extends EventEmitter {
   send<T extends BexEventName>(
     eventName: T,
     ...payload: BexEventData<T> extends never ? [] : [BexEventData<T>]
-  ): Promise<BexEventResponse<T>>;
+  ): Promise<BexPayload<BexEventResponse<T>, BexEventData<T>>>;
 
   on<T extends BexEventName>(eventName: T, listener: BexEventListener<T>): this;
   once<T extends BexEventName>(

--- a/app-webpack/templates/bex/js/background-hooks.js
+++ b/app-webpack/templates/bex/js/background-hooks.js
@@ -5,38 +5,41 @@
 import { bexBackground } from 'quasar/wrappers'
 
 export default bexBackground((bridge /* , allActiveConnections */) => {
-  bridge.on('storage.get', event => {
-    const payload = event.data
-    if (payload.key === null) {
-      chrome.storage.local.get(null, r => {
+  bridge.on('storage.get', ({ data, respond }) => {
+    if (data.key === null) {
+      chrome.storage.local.get(null, items => {
         const result = []
 
         // Group the items up into an array to take advantage of the bridge's chunk splitting.
-        for (const itemKey in r) {
-          result.push(r[itemKey])
+        for (const itemKey in items) {
+          result.push(items[itemKey])
         }
-        bridge.send(event.eventResponseKey, result)
+        respond(result)
       })
     } else {
-      chrome.storage.local.get([payload.key], r => {
-        bridge.send(event.eventResponseKey, r[payload.key])
+      chrome.storage.local.get([data.key], items => {
+        respond(items[data.key])
       })
     }
   })
+  // Usage:
+  // const { data } = await bridge.send('storage.get', { key: 'someKey' })
 
-  bridge.on('storage.set', event => {
-    const payload = event.data
-    chrome.storage.local.set({ [payload.key]: payload.data }, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.set', ({ data, respond }) => {
+    chrome.storage.local.set({ [data.key]: data.value }, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.set', { key: 'someKey', value: 'someValue' })
 
-  bridge.on('storage.remove', event => {
-    const payload = event.data
-    chrome.storage.local.remove(payload.key, () => {
-      bridge.send(event.eventResponseKey, payload.data)
+  bridge.on('storage.remove', ({ data, respond }) => {
+    chrome.storage.local.remove(data.key, () => {
+      respond()
     })
   })
+  // Usage:
+  // await bridge.send('storage.remove', { key: 'someKey' })
 
   /*
   // EXAMPLES

--- a/app-webpack/templates/entry/bex/bridge.js
+++ b/app-webpack/templates/entry/bex/bridge.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * THIS FILE IS GENERATED AUTOMATICALLY.
  * DO NOT EDIT.
@@ -56,6 +57,18 @@ export default class Bridge extends EventEmitter {
    */
   getEvents () {
     return this._events
+  }
+
+  on(eventName, listener) {
+    return super.on(eventName, (originalPayload) => {
+      listener({
+        ...originalPayload,
+        // Convenient alternative to the manual usage of `eventResponseKey`
+        // We can't send this in `_nextSend` which will then be sent using `port.postMessage()`, which can't serialize functions.
+        // So, we hook into the underlying listener and include the function there, which happens after the send operation.
+        respond: (payload /* optional */) => this.send(originalPayload.eventResponseKey, payload)
+      })
+    })
   }
 
   _emit (message) {

--- a/app-webpack/types/bex.d.ts
+++ b/app-webpack/types/bex.d.ts
@@ -10,7 +10,7 @@ interface BexWall {
 
 /**
  * @example
- * declare module '@quasar/app-vite' {
+ * declare module '@quasar/app-webpack' {
  *   interface BexEventMap {
  *     'without-payload-and-response': never;
  *     'without-payload-with-response': [never, number];

--- a/app-webpack/types/bex.d.ts
+++ b/app-webpack/types/bex.d.ts
@@ -1,23 +1,92 @@
-import type { EventEmitter } from 'events';
+import type { EventEmitter } from "events";
+import type { LiteralUnion } from "quasar";
 
 type BexObjectMessage = { event: string; payload: any };
 type BexMessage = string | BexObjectMessage;
 interface BexWall {
-  listen (callback: (messages: BexMessage | BexMessage[]) => void): void;
-  send (data: BexObjectMessage[]): void;
+  listen(callback: (messages: BexMessage | BexMessage[]) => void): void;
+  send(data: BexObjectMessage[]): void;
 }
 
-type BexEventPayload = { data: any; eventResponseKey: string; };
-type BexEventListener = (payload: BexEventPayload) => void;
+/**
+ * @example
+ * declare module '@quasar/app-vite' {
+ *   interface BexEventMap {
+ *     'without-payload-and-response': never;
+ *     'without-payload-with-response': [never, number];
+ *     'with-payload-without-response': [{ test: number[] }, never];
+ *     'with-payload-and-response': [{ foo: string[] }, number];
+ *   }
+ * }
+ *
+ * bridge.send('without-payload-and-response');
+ *
+ * bridge.on('with-payload-without-response', ({ data }) => {
+ *   data // type: { test: number[] }
+ * });
+ *
+ * bridge.on('with-payload-and-response', ({ data, respond }) => {
+ *   const { foo } = data; // { foo: ['a', 'b'] }
+ *
+ *   const result = foo[0].charCodeAt() + foo[1].charCodeAt(); // 97 + 98
+ *   void respond(result);
+ * });
+ * const response = await bridge.send('with-payload-and-response', { foo: ['a', 'b'] });
+ * console.log(response); // 195
+ */
+export interface BexEventMap {}
+
+type BexEventName = LiteralUnion<Exclude<keyof BexEventMap, number>>;
+type BexEventEntry<
+  K extends BexEventName,
+  P = K extends keyof BexEventMap ? BexEventMap[K] : any[]
+> = P extends never
+  ? [never, never]
+  : P extends [unknown, unknown]
+  ? P
+  : [any, any];
+type BexEventData<T extends BexEventName> = BexEventEntry<T>[0];
+type BexEventResponse<T extends BexEventName> = BexEventEntry<T>[1];
+
+type BexPayload<TData, TResponse> = {
+  data: TData;
+  /** @deprecated Use {@link BexPayload.respond} instead */
+  eventResponseKey: string;
+  /**
+   * Calling this will resolve the Promise of the `send()` call.
+   * You can use this to communicate back with the sender.
+   */
+  respond: (
+    ...payload: TResponse extends never ? [] : [TResponse]
+  ) => Promise<BexPayload<TData, TResponse>>;
+};
+type BexEventListener<T extends BexEventName> = (
+  payload: BexPayload<BexEventData<T>, BexEventResponse<T>>
+) => void;
+
 export interface BexBridge extends EventEmitter {
   constructor(wall: BexWall): BexBridge;
 
-  send(eventName: string, payload?: Record<string, any>): Promise<any>;
-  getEvents(): { [eventName: string]: (payload?: any) => void };
+  getEvents(): {
+    [T in BexEventName]: (
+      ...payload: BexEventData<T> extends never ? [] : [BexEventData<T>]
+    ) => void;
+  };
 
-  on(eventName: string | symbol, listener: BexEventListener): this;
-  once(eventName: string | symbol, listener: BexEventListener): this;
-  off(eventName: string | symbol, listener: BexEventListener): this;
+  send<T extends BexEventName>(
+    eventName: T,
+    ...payload: BexEventData<T> extends never ? [] : [BexEventData<T>]
+  ): Promise<BexPayload<BexEventResponse<T>, BexEventData<T>>>;
+
+  on<T extends BexEventName>(eventName: T, listener: BexEventListener<T>): this;
+  once<T extends BexEventName>(
+    eventName: T,
+    listener: BexEventListener<T>
+  ): this;
+  off<T extends BexEventName>(
+    eventName: T,
+    listener: BexEventListener<T>
+  ): this;
 }
 
 export type GlobalQuasarBex = BexBridge;
@@ -37,7 +106,7 @@ export type BexBackgroundCallback = (
       app?: BexConnection;
       contentScript?: BexConnection;
     };
-  },
+  }
 ) => void;
 
 export type BexContentCallback = (bridge: BexBridge) => void;

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/background-script.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/background-script.md
@@ -8,14 +8,16 @@ desc: (@quasar/app-vite) How to communicate using your background script with ot
 The added benefit of this file is this function:
 
 ```js
-export default function (bridge, activeConnections) {
+import { bexBackground } from 'quasar/wrappers'
+
+export default bexBackground((bridge, activeConnections) => {
   //
-}
+})
 ```
 
 This function is called automatically via the Quasar BEX build chain and injects a bridge which is shared between all parts of the BEX meaning you can communicate with any part of your BEX.
 
-The `bridge` param is the bridge to use for communication. The `activeConnections` param provides an array of all the BEX connections registered via the bridge i.e All the Web Page, Options, Popup and Dev Tools BEX's used by the same Quasar App.
+The `bridge` param is the bridge to use for communication. The `activeConnections` param provides a map of all the BEX connections registered via the bridge i.e All the Web Page, Options, Popup and Dev Tools BEX's used by the same Quasar App.
 
 For example, let's say we want to listen for a new tab being opened in the web browser and then react to it in our Quasar App. First, we'd need to listen for the new tab being opened and emit a new event to tell the Quasar App this has happened:
 

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/bex-communication.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/bex-communication.md
@@ -37,33 +37,32 @@ Let's see how it works.
 ### Trigger an event and wait for the response
 
 ```js
-bridge.send('some.event', { someKey: 'aValue' }).then(response => {
-  console.log('Some response from the other side')
-})
+const { data } = await bridge.send('some.event', { someKey: 'aValue' })
+console.log('Some response from the other side', data)
 ```
 
 ### Listen for an event and sending a response
 
+You can respond to let the caller know the operation is done. You can optionally return back some data too.
+
 ```js
-bridge.on('some.event', event => {
-  console.log('Event Receieved, responding ...')
-  bridge.send(event.eventResponseKey)
+bridge.on('some.event', ({ data, respond }) => {
+  console.log('Event receieved, responding...')
+  respond(data.someKey + ' hey!')
 })
 ```
+
+::: warning
+If you omit `respond()` the promise on `.send()` will not resolve.
+:::
+
+The Quasar bridge does some work behind the scenes to convert the normal event based communication into promises and as such, in order for the promise to resolve, we need to call `respond`.
 
 ### Clean up your listeners
 
 ```js
 bridge.off('some.event', this.someFunction)
 ```
-
-Wait, what's `bridge.send(event.eventResponseKey)`?
-
-The Quasar bridge does some work behind the scenes to convert the normal event based communication into promises and as such, in order for the promise to resolve, we need to send a *new* event which is captured and promisified.
-
-::: warning
-If you omit `bridge.send(event.eventResponseKey)` the promise on `.send()` will not resolve.
-:::
 
 ::: tip
 The bridge also does some work to split large data which is too big to be transmitted in one go due to the browser extension 60mb data transfer limit. In order for this to happen, the payload must be an array.

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
@@ -57,7 +57,7 @@ export default bexContent((bridge) => {
       el.classList.add('bex-highlight')
     }
 
-    // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
+    // Let's resolve the `send()` call's promise, this way we can await it on the other side then display a notification.
     respond()
   })
 })

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
@@ -12,8 +12,11 @@ You can have multiple content scripts with the name of your desire (that include
 The added benefit of this file is this function:
 
 ```js
-export default function (bridge) {
-}
+import { bexContent } from 'quasar/wrappers'
+
+export default bexContent((bridge) => {
+  //
+})
 ```
 
 This function is called automatically via the Quasar BEX build chain and injects a bridge which is shared between your Quasar App instance and the background script of the BEX.
@@ -45,8 +48,9 @@ setup () {
 
 ```js
 // src-bex/my-content-script.js:
+import { bexContent } from 'quasar/wrappers'
 
-export default function (bridge) {
+export default bexContent((bridge) => {
   bridge.on('highlight.content', ({ data, respond }) => {
     const el = document.querySelector(data.selector)
     if (el !== null) {
@@ -56,7 +60,7 @@ export default function (bridge) {
     // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
     respond()
   })
-}
+})
 ```
 
 Content scripts live in an [isolated world](https://developer.chrome.com/extensions/content_scripts#isolated_world), allowing a content script to makes changes to its JavaScript environment without conflicting with the page or additional content scripts.

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/content-scripts.md
@@ -26,10 +26,9 @@ For example, let's say we want to react to a button being pressed on our Quasar 
 setup () {
   const $q = useQuasar()
 
-  function myButtonClickHandler () {
-    $q.bex.send('highlight.content.event', { someData: 'someValue '}).then(r => {
-      console.log('Text has been highlighted')
-    })
+  async function myButtonClickHandler () {
+    await $q.bex.send('highlight.content', { selector: '.some-class' })
+    $q.notify('Text has been highlighted')
   }
 
   return { myButtonClickHandler }
@@ -48,15 +47,14 @@ setup () {
 // src-bex/my-content-script.js:
 
 export default function (bridge) {
-  bridge.on('highlight.content.event', event => {
-    // Find a .some-class element and add our highlight CSS class.
-    const el = document.querySelector('.some-class')
+  bridge.on('highlight.content', ({ data, respond }) => {
+    const el = document.querySelector(data.selector)
     if (el !== null) {
       el.classList.add('bex-highlight')
     }
 
-    // Not required but resolve our promise.
-    bridge.send(event.eventResponseKey)
+    // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
+    respond()
   })
 }
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/dom-script.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/dom-script.md
@@ -6,8 +6,11 @@ desc: (@quasar/app-vite) How to communicate to the underlying web page using dom
 `src-bex/dom.js` is a file that is injected into the underlying web page automatically by Quasar but as with all the other hook files has access to the bridge via:
 
 ```js
-export default function (bridge) {
-}
+import { bexDom } from 'quasar/wrappers'
+
+export default bexDom((bridge) => {
+  //
+})
 ```
 
 If you ever find yourself needing to inject a JS file into your underlying web page, you can use the dom script instead as it means you can maintain that chain of communication in the BEX.
@@ -65,7 +68,7 @@ export default function detectQuasar (bridge) {
 
         const quasar = isVue3 ? Vue.config.globalProperties.$q : Vue.prototype.$q
         if (quasar) {
-          initQuasar(bridge, quasar, Vue)
+          initQuasar(bridge, quasar)
         }
       }
     }, 100)
@@ -76,10 +79,12 @@ export default function detectQuasar (bridge) {
 ```js
 // src-bex/dom.js:
 
+import { bexDom } from 'quasar/wrappers'
 import detectQuasar from './dom/detect-quasar'
-export default function (bridge) {
+
+export default bexDom((bridge) => {
   detectQuasar(bridge)
-}
+})
 ```
 
 The bridge above will notify all listeners in the BEX that Quasar has been found and along with that send the instance information.

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
@@ -112,7 +112,7 @@ Object.assign(iFrame.style, {
 
 ;(function () {
   // When the page loads, insert our browser extension app.
-  iFrame.src = chrome.runtime.getURL(`www/index.html`)
+  iFrame.src = chrome.runtime.getURL('www/index.html')
   document.body.prepend(iFrame)
 })()
 
@@ -121,14 +121,13 @@ export default function (bridge) {
    * When the drawer is toggled set the iFrame height to take the whole page.
    * Reset when the drawer is closed.
    */
-  bridge.on('wb.drawer.toggle', event => {
-    const payload = event.data
-    if (payload.open) {
+  bridge.on('wb.drawer.toggle', ({ data, respond }) => {
+    if (data.open) {
       setIFrameHeight('100%')
     } else {
       resetIFrameHeight()
     }
-    bridge.send(event.eventResponseKey)
+    respond()
   })
 }
 ```
@@ -164,15 +163,13 @@ setup () {
   const $q = useQuasar()
   const drawerIsOpen = ref(true)
 
-  function drawerToggled () {
-    $q.bex
-      .send('wb.drawer.toggle', {
-        open: drawerIsOpen.value // So it knows to make it bigger / smaller
-      })
-      .then(r => {
-        // Only set this once the promise has resolved so we can see the entire slide animation.
-        drawerIsOpen.value = !drawerIsOpen.value
-      })
+  async function drawerToggled () {
+    await $q.bex.send('wb.drawer.toggle', {
+      open: drawerIsOpen.value // So it knows to make it bigger / smaller
+    })
+
+    // Only set this once the promise has resolved so we can see the entire slide animation.
+    drawerIsOpen.value = !drawerIsOpen.value
   }
 
   return { drawerToggled }

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
@@ -70,6 +70,7 @@ Given our Quasar App might need to take the full height of the window (and thus 
 
 // Hooks added here have a bridge allowing communication between the BEX Content Script and the Quasar Application.
 // More info: https://quasar.dev/quasar-cli/developing-browser-extensions/content-hooks
+import { bexContent } from 'quasar/wrappers'
 
 const
   iFrame = document.createElement('iframe'),
@@ -116,7 +117,7 @@ Object.assign(iFrame.style, {
   document.body.prepend(iFrame)
 })()
 
-export default function (bridge) {
+export default bexContent((bridge) => {
   /**
    * When the drawer is toggled set the iFrame height to take the whole page.
    * Reset when the drawer is closed.
@@ -129,7 +130,7 @@ export default function (bridge) {
     }
     respond()
   })
-}
+})
 ```
 
 We can call this event from our Quasar App any time we know we're opening the drawer and thus changing the height of the IFrame to allow the whole draw to be visible.

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/background-hooks.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/background-hooks.md
@@ -8,13 +8,16 @@ desc: (@quasar/app-webpack) How to communicate using your background script with
 The added benefit of this file is this function:
 
 ```js
-export default function attachBackgroundHooks (bridge, activeConnections) {
-}
+import { bexBackground } from 'quasar/wrappers'
+
+export default bexBackground((bridge, activeConnections) => {
+  //
+})
 ```
 
 This function is called automatically via the Quasar BEX build chain and injects a bridge which is shared between all parts of the BEX meaning you can communicate with any part of your BEX.
 
-The `bridge` param is the bridge to use for communication. The `activeConnections` param provides an array of all the BEX connections registered via the bridge i.e All the Web Page, Options, Popup and Dev Tools BEX's used by the same Quasar App.
+The `bridge` param is the bridge to use for communication. The `activeConnections` param provides a map of all the BEX connections registered via the bridge i.e All the Web Page, Options, Popup and Dev Tools BEX's used by the same Quasar App.
 
 For example, let's say we want to listen for a new tab being opened in the web browser and then react to it in our Quasar App. First, we'd need to listen for the new tab being opened and emit a new event to tell the Quasar App this has happened:
 

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/bex-communication.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/bex-communication.md
@@ -37,33 +37,32 @@ Let's see how it works.
 ### Trigger an event and wait for the response
 
 ```js
-bridge.send('some.event', { someKey: 'aValue' }).then(response => {
-  console.log('Some response from the other side')
-})
+const { data } = await bridge.send('some.event', { someKey: 'aValue' })
+console.log('Some response from the other side', data)
 ```
 
 ### Listen for an event and sending a response
 
+You can respond to let the caller know the operation is done. You can optionally return back some data too.
+
 ```js
-bridge.on('some.event', event => {
-  console.log('Event Receieved, responding ...')
-  bridge.send(event.eventResponseKey)
+bridge.on('some.event', ({ data, respond }) => {
+  console.log('Event receieved, responding...')
+  respond(data.someKey + ' hey!')
 })
 ```
+
+::: warning
+If you omit `respond()` the promise on `.send()` will not resolve.
+:::
+
+The Quasar bridge does some work behind the scenes to convert the normal event based communication into promises and as such, in order for the promise to resolve, we need to call `respond`.
 
 ### Clean up your listeners
 
 ```js
 bridge.off('some.event', this.someFunction)
 ```
-
-Wait, what's `bridge.send(event.eventResponseKey)`?
-
-The Quasar bridge does some work behind the scenes to convert the normal event based communication into promises and as such, in order for the promise to resolve, we need to send a *new* event which is captured and promisified.
-
-::: warning
-If you omit `bridge.send(event.eventResponseKey)` the promise on `.send()` will not resolve.
-:::
 
 ::: tip
 The bridge also does some work to split large data which is too big to be transmitted in one go due to the browser extension 60mb data transfer limit. In order for this to happen, the payload must be an array.

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
@@ -53,7 +53,7 @@ export default bexContent((bridge) => {
       el.classList.add('bex-highlight')
     }
 
-    // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
+    // Let's resolve the `send()` call's promise, this way we can await it on the other side then display a notification.
     respond()
   })
 })

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
@@ -8,8 +8,11 @@ desc: (@quasar/app-webpack) How to communicate using your content script with yo
 The added benefit of this file is this function:
 
 ```js
-export default function attachContentHooks (bridge) {
-}
+import { bexContent } from 'quasar/wrappers'
+
+export default bexContent((bridge) => {
+  //
+})
 ```
 
 This function is called automatically via the Quasar BEX build chain and injects a bridge which is shared between your Quasar App instance and the background script of the BEX.
@@ -41,8 +44,9 @@ setup () {
 
 ```js
 // src-bex/js/content-hooks.js:
+import { bexContent } from 'quasar/wrappers'
 
-export default function attachContentHooks (bridge) {
+export default bexContent((bridge) => {
   bridge.on('highlight.content', ({ data, respond }) => {
     const el = document.querySelector(data.selector)
     if (el !== null) {
@@ -52,7 +56,7 @@ export default function attachContentHooks (bridge) {
     // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
     respond()
   })
-}
+})
 ```
 
 Content scripts live in an [isolated world](https://developer.chrome.com/extensions/content_scripts#isolated_world), allowing a content script to makes changes to its JavaScript environment without conflicting with the page or additional content scripts.

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/content-hooks.md
@@ -22,10 +22,9 @@ For example, let's say we want to react to a button being pressed on our Quasar 
 setup () {
   const $q = useQuasar()
 
-  function myButtonClickHandler () {
-    $q.bex.send('highlight.content.event', { someData: 'someValue '}).then(r => {
-      console.log('Text has been highlighted')
-    })
+  async function myButtonClickHandler () {
+    await $q.bex.send('highlight.content', { selector: '.some-class' })
+    $q.notify('Text has been highlighted')
   }
 
   return { myButtonClickHandler }
@@ -44,15 +43,14 @@ setup () {
 // src-bex/js/content-hooks.js:
 
 export default function attachContentHooks (bridge) {
-  bridge.on('highlight.content.event', event => {
-    // Find a .some-class element and add our highlight CSS class.
-    const el = document.querySelector('.some-class')
+  bridge.on('highlight.content', ({ data, respond }) => {
+    const el = document.querySelector(data.selector)
     if (el !== null) {
       el.classList.add('bex-highlight')
     }
 
-    // Not required but resolve our promise.
-    bridge.send(event.eventResponseKey)
+    // Let's resolve the `send()` call's promise, this way we can await it on the otherside then display a notification.
+    respond()
   })
 }
 ```

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/dom-hooks.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/dom-hooks.md
@@ -6,8 +6,11 @@ desc: (@quasar/app-webpack) How to communicate to the underlying web page using 
 `src-bex/js/dom-hooks.js` is a javascript file that is injected into the underlying web page automatically by Quasar but as with all the other hook files has access to the bridge via:
 
 ```js
-export default function attachDomHooks (bridge) {
-}
+import { bexDom } from 'quasar/wrappers'
+
+export default bexDom((bridge) => {
+  //
+})
 ```
 
 If you ever find yourself needing to inject a JS file into your underlying web page, you can use dom hooks instead as it means you can maintain that chain of communication in the BEX.
@@ -74,11 +77,12 @@ export default function detectQuasar (bridge) {
 
 ```js
 // dom-hooks.js:
-
+import { bexDom } from 'quasar/wrappers'
 import detectQuasar from './dom/detect-quasar'
-export default function attachDomHooks (bridge) {
+
+export default bexDom((bridge) => {
   detectQuasar(bridge)
-}
+})
 ```
 
 The bridge above will notify all listeners in the BEX that Quasar has been found and along with that send the instance information.

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/types-of-bex.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/types-of-bex.md
@@ -54,6 +54,8 @@ Given our Quasar App might need to take the full height of the window (and thus 
 We can call this event from our Quasar App any time we know we're opening the drawer and thus changing the height of the IFrame to allow the whole draw to be visible.
 
 ```js
+import { bexContent } from 'quasar/wrappers'
+
 const
   iFrame = document.createElement('iframe'),
   defaultFrameHeight = '62px'
@@ -100,11 +102,7 @@ Object.assign(iFrame.style, {
   document.body.prepend(iFrame)
 })()
 
-/**
- * Content hooks which listen for messages from the BEX in the iFrame
- * @param bridge
- */
-export default function attachContentHooks (bridge) {
+export default bexContent((bridge) => {
   /**
    * When the drawer is toggled set the iFrame height to take the whole page.
    * Reset when the drawer is closed.
@@ -117,7 +115,7 @@ export default function attachContentHooks (bridge) {
     }
     respond()
   })
-}
+})
 ```
 
 * `src-bex/css/content-css.css`


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Documentation

**Does this PR introduce a breaking change?** 

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

- Implemented a strongly-typed event system.
	- Users can augment the `BexEventMap` from `@quasar/app-vite`/`@quasar/app-webpack` to map their events to their input and output types.
	- They can get auto-completion and type checking on `bridge.on`, `bridge.send`, etc.
- To make the sending back response/output process strongly-typeable, implemented `respond`.
	- This simplifies `bridge.send(eventResponseKey)` to `respond()`. So, non-JS users can also benefit from that, even if they would not read the return types and such that IDE provides.
	- Updated the file templates and the docs to replace the manual usage with `respond()`.
- Updated the docs to use the BEX wrappers from #13829 in the code snippets.

I will add the example code for augmenting the types for the templated default `storage.*` example events when implementing the TS templates for BEX. So, the TS users will directly know how or where they will add the types, how they will use them, etc.

The implementation is inspired by https://github.com/dreamonkey/vue-signalr#type-safety