### PR TITLE
Update vs-code-configuration.md

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -21,7 +21,6 @@ This guide assumes you have already installed VS Code(Visual Studio Code).
 - [TODO Highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight)
 - [GitLens — Git supercharged](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 - [Import Cost](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)
-- [npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
 - [VS Code Icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
 - [Quasar Docs](https://marketplace.visualstudio.com/items?itemName=CodeCoaching.quasar-docs)
 


### PR DESCRIPTION
VSCode npm extension has been deprecated. As per the notice on the extension page:

>❗IMPORTANT: This extension has been deprecated. Support for running npm scripts is now provided by VS Code. You can run npm scripts as tasks using task auto detection or from the npm scripts explorer.

https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script
