### PR TITLE
feat(QRipple): Add condition to allow for global disablement of ripple styling

### DIFF
--- a/ui/src/directives/Ripple.js
+++ b/ui/src/directives/Ripple.js
@@ -80,6 +80,7 @@ export default createDirective(__QUASAR_SSR_SERVER__
       beforeMount (el, binding) {
         const ctx = {
           cfg: binding.instance.$.appContext.config.globalProperties.$q.config,
+          global: binding.instance.$.appContext.config.globalProperties.$q.config?.directives?.ripple ?? true,
           enabled: binding.value !== false,
           modifiers: {},
           abort: [],
@@ -87,6 +88,7 @@ export default createDirective(__QUASAR_SSR_SERVER__
           start (evt) {
             if (
               ctx.enabled === true
+              && ctx.global
               && evt.qSkipRipple !== true
               && evt.type === (ctx.modifiers.early === true ? 'pointerdown' : 'click')
             ) {
@@ -97,6 +99,7 @@ export default createDirective(__QUASAR_SSR_SERVER__
           keystart: throttle(evt => {
             if (
               ctx.enabled === true
+              && ctx.global
               && evt.qSkipRipple !== true
               && isKeyCode(evt, ctx.modifiers.keyCodes) === true
               && evt.type === `key${ ctx.modifiers.early === true ? 'down' : 'up' }`


### PR DESCRIPTION
update ripple to recognize global defined configuration properties for global disable/enable

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [] It's been tested on a Cordova (iOS, Android) app
- [] It's been tested on an Electron app
- [] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

This PR will allow a user to disable the forced ripple material design pattern styling from the `quasar.conf.js` file

e.g.

```js
// https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework
    framework: {
      config: {
        directives: {
          ripple: false
        }
      },
```

For certain projects that have strict design requirements, it is not enough / consuming to have to disable ripple across every button, moreover, not every quasar element offers the option to disable ripple (e.g. QStepper)

I was between adding a PR to allow for disabling ripple on that singular component, but thought I would propose a solution to disable across the project for specific scenarios. The default is enabled, and the user doesn't have to specify anything to instantiate the default, making it non-breaking.

If this discussion is approved, I will go ahead and test all the scenarios as well as update the documentation.