### PR TITLE
fix(app-vite): eslint warn/error mode is all or nothing

### DIFF
--- a/app-vite/lib/config-tools.js
+++ b/app-vite/lib/config-tools.js
@@ -165,7 +165,7 @@ function createViteConfig (quasarConf, quasarRunMode) {
 
   if (quasarRunMode !== 'ssr-server') {
     const { warnings, errors } = quasarConf.eslint
-    if (warnings === true && errors === true) {
+    if (warnings === true || errors === true) {
       // require only if actually needed (as it imports app's eslint pkg)
       const quasarVitePluginESLint = require('./plugins/vite.eslint')
       viteConf.plugins.push(


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

If you want only errors (or only warnings...?) you won't get it.

I'm guessing this is what you wanted to write,
but didn't notice as the default is both?

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No(ish) - if you had selected only errors, and have errors in your code which previously weren't checked, it would break now... but I guess it's unlikely and more a good thing.

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**