### PR TITLE
fix(vue-i18n): add globalInjection to template and update documentation (fix #13908)

### DIFF
--- a/create-quasar/templates/app/quasar-v2/js-vite/i18n/src/boot/i18n.js
+++ b/create-quasar/templates/app/quasar-v2/js-vite/i18n/src/boot/i18n.js
@@ -5,6 +5,7 @@ import messages from 'src/i18n'
 export default boot(({ app }) => {
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages
   })
 

--- a/create-quasar/templates/app/quasar-v2/js-webpack/i18n/src/boot/i18n.js
+++ b/create-quasar/templates/app/quasar-v2/js-webpack/i18n/src/boot/i18n.js
@@ -5,6 +5,7 @@ import messages from 'src/i18n'
 export default boot(({ app }) => {
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages
   })
 

--- a/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
@@ -6,6 +6,7 @@ import messages from 'src/i18n';
 export default boot(({ app }) => {
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages,
   });
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
@@ -6,6 +6,7 @@ import messages from 'src/i18n';
 export default boot(({ app }) => {
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages,
   });
 

--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -191,7 +191,6 @@ export default {
 ```
 
 ## UPPERCASE
-
 Many languages, such as Greek, German and Dutch have non-intuitive rules for uppercase display, and there is an edge case that you should be aware of:
 
 QBtn component will use the CSS `text-transform: uppercase` rule to automatically turn its label into all-caps. According to the [MDN webdocs](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform), "The language is defined by the lang HTML attribute or the xml:lang XML attribute." Unfortunately, this has spotty implementation across browsers, and the 2017 ISO standard for the uppercase German eszett `ß` has not really entered the canon. At the moment you have two options:
@@ -200,7 +199,6 @@ QBtn component will use the CSS `text-transform: uppercase` rule to automaticall
 2. use the prop `no-caps` in your label and rewrite the string with [toLocaleUpperCase](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) by using the locale as detected by `$q.lang.getLocale()`
 
 ## Detecting Locale
-
 There's also a method to determine user locale which is supplied by Quasar out of the box:
 
 ```js

--- a/docs/src/pages/options/app-internationalization.md
+++ b/docs/src/pages/options/app-internationalization.md
@@ -38,6 +38,7 @@ export default ({ app }) => {
   // Create I18n instance
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages
   })
 
@@ -190,6 +191,7 @@ export default {
 ```
 
 ## UPPERCASE
+
 Many languages, such as Greek, German and Dutch have non-intuitive rules for uppercase display, and there is an edge case that you should be aware of:
 
 QBtn component will use the CSS `text-transform: uppercase` rule to automatically turn its label into all-caps. According to the [MDN webdocs](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform), "The language is defined by the lang HTML attribute or the xml:lang XML attribute." Unfortunately, this has spotty implementation across browsers, and the 2017 ISO standard for the uppercase German eszett `ß` has not really entered the canon. At the moment you have two options:
@@ -198,6 +200,7 @@ QBtn component will use the CSS `text-transform: uppercase` rule to automaticall
 2. use the prop `no-caps` in your label and rewrite the string with [toLocaleUpperCase](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) by using the locale as detected by `$q.lang.getLocale()`
 
 ## Detecting Locale
+
 There's also a method to determine user locale which is supplied by Quasar out of the box:
 
 ```js

--- a/docs/src/pages/start/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide.md
@@ -422,6 +422,7 @@ export default ({ app }) => {
   // Create I18n instance
   const i18n = createI18n({
     locale: 'en-US',
+    globalInjection: true,
     messages
   })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Currently in the documentation about internationalisation uses the global vue-i18n `$t(..)` therefore it would make sense to use `globalInjection: true` in new templates, as dependent on the version of vue-i18n the standard value is different.

See issue: https://github.com/quasarframework/quasar/issues/13908

For Vite I did not change the build for production as I cannot test all environments and do not want to introduce possible breaking changes: https://github.com/quasarframework/quasar/issues/13908#issuecomment-1179728224

