### PR TITLE
feat(create-quasar): Add <script setup> option for TS

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/App.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/App.vue
@@ -2,16 +2,18 @@
   <router-view />
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'App'
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'App'
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue } from 'vue-class-component'
 
 export default class App extends Vue {}<% } %>

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
@@ -19,8 +19,30 @@
   </q-item>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+
+  caption: {
+    type: String,
+    default: ''
+  },
+
+  link: {
+    type: String,
+    default: '#'
+  },
+
+  icon: {
+    type: String,
+    default: ''
+  }
+})<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'EssentialLink',
@@ -45,7 +67,8 @@ export default defineComponent({
       default: ''
     }
   }
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'EssentialLink',
@@ -70,7 +93,7 @@ export default defineComponent({
       default: ''
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, prop, Options } from 'vue-class-component';
 
 class Props {

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
@@ -26,8 +26,10 @@ export interface EssentialLinkProps {
   link?: string;
   icon?: string;
 }
-const props = withDefaults(defineProps<EssentialLinkProps>(), {
+withDefaults(defineProps<EssentialLinkProps>(), {
+  caption: '',
   link: '#',
+  icon: '',
 });<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
 import { defineComponent } from 'vue';
 

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
@@ -20,7 +20,6 @@
 </template>
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
-
 export interface EssentialLinkProps {
   title: string;
   caption?: string;

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/EssentialLink.vue
@@ -21,27 +21,15 @@
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
 
-const props = defineProps({
-  title: {
-    type: String,
-    required: true
-  },
-
-  caption: {
-    type: String,
-    default: ''
-  },
-
-  link: {
-    type: String,
-    default: '#'
-  },
-
-  icon: {
-    type: String,
-    default: ''
-  }
-})<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+export interface EssentialLinkProps {
+  title: string;
+  caption?: string;
+  link?: string;
+  icon?: string;
+}
+const props = withDefaults(defineProps<EssentialLinkProps>(), {
+  link: '#',
+});<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
@@ -12,8 +12,41 @@
   </div>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import {
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import {
+  PropType,
+  computed,
+  ref,
+} from 'vue';
+import { Todo, Meta } from './models';
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  todos: {
+    type: Array as PropType<Todo[]>,
+    default: () => []
+  },
+  meta: {
+    type: Object as PropType<Meta>,
+    required: true
+  },
+  active: {
+    type: Boolean
+  }
+})
+
+const clickCount = ref(0);
+function increment() {
+  clickCount.value += 1
+  return clickCount.value;
+}
+
+const todoCount = computed(() => props.todos.length);
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import {
   defineComponent,
   PropType,
   computed,
@@ -60,7 +93,8 @@ export default defineComponent({
   setup (props) {
     return { ...useClickCount(), ...useDisplayTodo(toRef(props, 'todos')) };
   },
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent, PropType } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent, PropType } from 'vue';
 import { Todo, Meta } from './models';
 
 export default defineComponent({
@@ -97,7 +131,8 @@ export default defineComponent({
       return this.todos.length;
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>import { Vue, prop } from 'vue-class-component';
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
+import { Vue, prop } from 'vue-class-component';
 import { Todo, Meta } from './models';
 
 class Props {

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
@@ -40,7 +40,7 @@ const props = defineProps({
 
 const clickCount = ref(0);
 function increment() {
-  clickCount.value += 1
+  clickCount.value += 1;
   return clickCount.value;
 }
 

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
@@ -13,30 +13,18 @@
 </template>
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
-import {
-  PropType,
-  computed,
-  ref,
-} from 'vue';
+import { computed, ref } from 'vue';
 import { Todo, Meta } from './models';
 
-const props = defineProps({
-  title: {
-    type: String,
-    required: true
-  },
-  todos: {
-    type: Array as PropType<Todo[]>,
-    default: () => []
-  },
-  meta: {
-    type: Object as PropType<Meta>,
-    required: true
-  },
-  active: {
-    type: Boolean
-  }
-})
+interface Props {
+  title: string;
+  todos?: Todo[];
+  meta: Meta,
+  active: boolean;
+}
+const props = withDefaults(defineProps<Props>(), {
+  todos: () => [],
+});
 
 const clickCount = ref(0);
 function increment() {

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/components/ExampleComponent.vue
@@ -19,7 +19,7 @@ import { Todo, Meta } from './models';
 interface Props {
   title: string;
   todos?: Todo[];
-  meta: Meta,
+  meta: Meta;
   active: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/layouts/MainLayout.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/layouts/MainLayout.vue
@@ -47,9 +47,9 @@
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
 import { ref } from 'vue';
-import EssentialLink from 'components/EssentialLink.vue';
+import EssentialLink, { EssentialLinkProps } from 'components/EssentialLink.vue';
 
-const essentialLinks = [
+const essentialLinks: EssentialLinkProps[] = [
   {
     title: 'Docs',
     caption: 'quasar.dev',

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/layouts/MainLayout.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/layouts/MainLayout.vue
@@ -45,8 +45,61 @@
   </q-layout>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent, ref } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import { ref } from 'vue';
+import EssentialLink from 'components/EssentialLink.vue';
+
+const essentialLinks = [
+  {
+    title: 'Docs',
+    caption: 'quasar.dev',
+    icon: 'school',
+    link: 'https://quasar.dev'
+  },
+  {
+    title: 'Github',
+    caption: 'github.com/quasarframework',
+    icon: 'code',
+    link: 'https://github.com/quasarframework'
+  },
+  {
+    title: 'Discord Chat Channel',
+    caption: 'chat.quasar.dev',
+    icon: 'chat',
+    link: 'https://chat.quasar.dev'
+  },
+  {
+    title: 'Forum',
+    caption: 'forum.quasar.dev',
+    icon: 'record_voice_over',
+    link: 'https://forum.quasar.dev'
+  },
+  {
+    title: 'Twitter',
+    caption: '@quasarframework',
+    icon: 'rss_feed',
+    link: 'https://twitter.quasar.dev'
+  },
+  {
+    title: 'Facebook',
+    caption: '@QuasarFramework',
+    icon: 'public',
+    link: 'https://facebook.quasar.dev'
+  },
+  {
+    title: 'Quasar Awesome',
+    caption: 'Community Quasar projects',
+    icon: 'favorite',
+    link: 'https://awesome.quasar.dev'
+  }
+];
+
+const leftDrawerOpen = ref(false)
+
+function toggleLeftDrawer() {
+  leftDrawerOpen.value = !leftDrawerOpen.value
+}<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent, ref } from 'vue';
 import EssentialLink from 'components/EssentialLink.vue';
 
 const linksList = [
@@ -112,7 +165,8 @@ export default defineComponent({
       }
     }
   }
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 import EssentialLink from 'components/EssentialLink.vue';
 
 const linksList = [
@@ -179,7 +233,7 @@ export default defineComponent({
       this.leftDrawerOpen = !this.leftDrawerOpen
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, Options } from 'vue-class-component';
 import EssentialLink from 'components/EssentialLink.vue';
 

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/pages/ErrorNotFound.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/pages/ErrorNotFound.vue
@@ -22,16 +22,19 @@
   </div>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ErrorNotFound'
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ErrorNotFound'
-});<% } else if (typescriptConfig === 'class') { %>import { Vue } from 'vue-class-component';
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
+import { Vue } from 'vue-class-component';
 
 export default class ErrorNotFound extends Vue {}<% } %>
 </script>

--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/pages/IndexPage.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/src/pages/IndexPage.vue
@@ -9,8 +9,37 @@
   </q-page>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { Todo, Meta } from 'components/models';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import { Todo, Meta } from 'components/models';
+import ExampleComponent from 'components/ExampleComponent.vue';
+import { ref } from 'vue';
+
+const todos = ref<Todo[]>([
+  {
+    id: 1,
+    content: 'ct1'
+  },
+  {
+    id: 2,
+    content: 'ct2'
+  },
+  {
+    id: 3,
+    content: 'ct3'
+  },
+  {
+    id: 4,
+    content: 'ct4'
+  },
+  {
+    id: 5,
+    content: 'ct5'
+  }
+]);
+const meta = ref<Meta>({
+  totalCount: 1200
+});<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
 import { defineComponent, ref } from 'vue';
 
@@ -45,7 +74,8 @@ export default defineComponent({
     });
     return { todos, meta };
   }
-});<% } else if (typescriptConfig === 'options') { %>import { Todo, Meta } from 'components/models';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
 import { defineComponent } from 'vue';
 
@@ -80,7 +110,7 @@ export default defineComponent({
     };
     return { todos, meta };
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, Options } from 'vue-class-component'
 import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';

--- a/create-quasar/templates/app/quasar-v2/ts-vite/index.js
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/index.js
@@ -7,8 +7,8 @@ module.exports = async function ({ scope, utils }) {
       message: 'Pick a Vue component style:',
       initial: 0,
       choices: [
+        { title: 'Composition API', value: 'composition', description: 'recommended' },
         { title: 'Composition API with <script setup>', value: 'composition-setup', description: 'recommended' },
-        { title: 'Composition API', value: 'composition' },
         { title: 'Options API', value: 'options' },
         { title: 'Class-based', value: 'class', description: 'DEPRECATED; see https://github.com/quasarframework/quasar/discussions/11204', disabled: true }
       ]

--- a/create-quasar/templates/app/quasar-v2/ts-vite/index.js
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/index.js
@@ -7,7 +7,8 @@ module.exports = async function ({ scope, utils }) {
       message: 'Pick a Vue component style:',
       initial: 0,
       choices: [
-        { title: 'Composition API', value: 'composition', description: 'recommended' },
+        { title: 'Composition API with <script setup>', value: 'composition-setup', description: 'recommended' },
+        { title: 'Composition API', value: 'composition' },
         { title: 'Options API', value: 'options' },
         { title: 'Class-based', value: 'class', description: 'DEPRECATED; see https://github.com/quasarframework/quasar/discussions/11204', disabled: true }
       ]

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/App.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/App.vue
@@ -2,16 +2,19 @@
   <router-view />
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'App'
-})<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+})<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'App'
-})<% } else if (typescriptConfig === 'class') { %>import { Vue } from 'vue-class-component';
+})<% } else if (typescriptConfig === 'class') { %><script lang="ts">
+import { Vue } from 'vue-class-component';
 
 export default class App extends Vue {}<% } %>
 </script>

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
@@ -19,8 +19,30 @@
   </q-item>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+
+  caption: {
+    type: String,
+    default: ''
+  },
+
+  link: {
+    type: String,
+    default: '#'
+  },
+
+  icon: {
+    type: String,
+    default: ''
+  }
+})<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'EssentialLink',
@@ -45,7 +67,8 @@ export default defineComponent({
       default: ''
     }
   }
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'EssentialLink',
@@ -70,7 +93,7 @@ export default defineComponent({
       default: ''
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, prop, Options } from 'vue-class-component';
 
 class Props {

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
@@ -20,7 +20,6 @@
 </template>
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
-
 const props = defineProps({
   title: {
     type: String,

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
@@ -26,8 +26,10 @@ export interface EssentialLinkProps {
   link?: string;
   icon?: string;
 }
-const props = withDefaults(defineProps<EssentialLinkProps>(), {
+withDefaults(defineProps<EssentialLinkProps>(), {
+  caption: '',
   link: '#',
+  icon: '',
 });<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
 import { defineComponent } from 'vue';
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/EssentialLink.vue
@@ -20,27 +20,15 @@
 </template>
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
-const props = defineProps({
-  title: {
-    type: String,
-    required: true
-  },
-
-  caption: {
-    type: String,
-    default: ''
-  },
-
-  link: {
-    type: String,
-    default: '#'
-  },
-
-  icon: {
-    type: String,
-    default: ''
-  }
-})<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+export interface EssentialLinkProps {
+  title: string;
+  caption?: string;
+  link?: string;
+  icon?: string;
+}
+const props = withDefaults(defineProps<EssentialLinkProps>(), {
+  link: '#',
+});<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
 import { defineComponent } from 'vue';
 
 export default defineComponent({

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
@@ -13,30 +13,18 @@
 </template>
 
 <% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
-import {
-  PropType,
-  computed,
-  ref,
-} from 'vue';
+import { computed, ref } from 'vue';
 import { Todo, Meta } from './models';
 
-const props = defineProps({
-  title: {
-    type: String,
-    required: true
-  },
-  todos: {
-    type: Array as PropType<Todo[]>,
-    default: () => []
-  },
-  meta: {
-    type: Object as PropType<Meta>,
-    required: true
-  },
-  active: {
-    type: Boolean
-  }
-})
+interface Props {
+  title: string;
+  todos?: Todo[];
+  meta: Meta,
+  active: boolean;
+}
+const props = withDefaults(defineProps<Props>(), {
+  todos: () => [],
+});
 
 const clickCount = ref(0);
 function increment() {

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
@@ -28,7 +28,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const clickCount = ref(0);
 function increment() {
-  clickCount.value += 1
+  clickCount.value += 1;
   return clickCount.value;
 }
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
@@ -19,7 +19,7 @@ import { Todo, Meta } from './models';
 interface Props {
   title: string;
   todos?: Todo[];
-  meta: Meta,
+  meta: Meta;
   active: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/components/ExampleComponent.vue
@@ -12,8 +12,41 @@
   </div>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import {
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import {
+  PropType,
+  computed,
+  ref,
+} from 'vue';
+import { Todo, Meta } from './models';
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  todos: {
+    type: Array as PropType<Todo[]>,
+    default: () => []
+  },
+  meta: {
+    type: Object as PropType<Meta>,
+    required: true
+  },
+  active: {
+    type: Boolean
+  }
+})
+
+const clickCount = ref(0);
+function increment() {
+  clickCount.value += 1
+  return clickCount.value;
+}
+
+const todoCount = computed(() => props.todos.length);
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import {
   defineComponent,
   PropType,
   computed,
@@ -60,7 +93,8 @@ export default defineComponent({
   setup(props) {
     return { ...useClickCount(), ...useDisplayTodo(toRef(props, 'todos')) };
   },
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent, PropType } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent, PropType } from 'vue';
 import { Todo, Meta } from './models';
 
 export default defineComponent({
@@ -97,7 +131,8 @@ export default defineComponent({
       return this.todos.length;
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>import { Vue, prop } from 'vue-class-component';
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
+import { Vue, prop } from 'vue-class-component';
 import { Todo, Meta } from './models';
 
 class Props {

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/layouts/MainLayout.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/layouts/MainLayout.vue
@@ -45,8 +45,61 @@
   </q-layout>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent, ref } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import { ref } from 'vue';
+import EssentialLink from 'components/EssentialLink.vue';
+
+const essentialLinks = [
+  {
+    title: 'Docs',
+    caption: 'quasar.dev',
+    icon: 'school',
+    link: 'https://quasar.dev'
+  },
+  {
+    title: 'Github',
+    caption: 'github.com/quasarframework',
+    icon: 'code',
+    link: 'https://github.com/quasarframework'
+  },
+  {
+    title: 'Discord Chat Channel',
+    caption: 'chat.quasar.dev',
+    icon: 'chat',
+    link: 'https://chat.quasar.dev'
+  },
+  {
+    title: 'Forum',
+    caption: 'forum.quasar.dev',
+    icon: 'record_voice_over',
+    link: 'https://forum.quasar.dev'
+  },
+  {
+    title: 'Twitter',
+    caption: '@quasarframework',
+    icon: 'rss_feed',
+    link: 'https://twitter.quasar.dev'
+  },
+  {
+    title: 'Facebook',
+    caption: '@QuasarFramework',
+    icon: 'public',
+    link: 'https://facebook.quasar.dev'
+  },
+  {
+    title: 'Quasar Awesome',
+    caption: 'Community Quasar projects',
+    icon: 'favorite',
+    link: 'https://awesome.quasar.dev'
+  }
+];
+
+const leftDrawerOpen = ref(false)
+
+function toggleLeftDrawer() {
+  leftDrawerOpen.value = !leftDrawerOpen.value
+}<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent, ref } from 'vue';
 import EssentialLink from 'components/EssentialLink.vue';
 
 const linksList = [
@@ -112,7 +165,8 @@ export default defineComponent({
       }
     }
   }
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 import EssentialLink from 'components/EssentialLink.vue';
 
 const linksList = [
@@ -179,7 +233,7 @@ export default defineComponent({
       this.leftDrawerOpen = !this.leftDrawerOpen
     }
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, Options } from 'vue-class-component';
 import EssentialLink from 'components/EssentialLink.vue';
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/pages/ErrorNotFound.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/pages/ErrorNotFound.vue
@@ -22,16 +22,19 @@
   </div>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { defineComponent } from 'vue';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ErrorNotFound'
-});<% } else if (typescriptConfig === 'options') { %>import { defineComponent } from 'vue';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ErrorNotFound'
-});<% } else if (typescriptConfig === 'class') { %>import { Vue } from 'vue-class-component';
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
+import { Vue } from 'vue-class-component';
 
 export default class ErrorNotFound extends Vue {}<% } %>
 </script>

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/pages/IndexPage.vue
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/src/pages/IndexPage.vue
@@ -9,8 +9,37 @@
   </q-page>
 </template>
 
-<script lang="ts">
-<% if (typescriptConfig === 'composition') { %>import { Todo, Meta } from 'components/models';
+<% if (typescriptConfig === 'composition-setup') { %><script setup lang="ts">
+import { Todo, Meta } from 'components/models';
+import ExampleComponent from 'components/ExampleComponent.vue';
+import { ref } from 'vue';
+
+const todos = ref<Todo[]>([
+  {
+    id: 1,
+    content: 'ct1'
+  },
+  {
+    id: 2,
+    content: 'ct2'
+  },
+  {
+    id: 3,
+    content: 'ct3'
+  },
+  {
+    id: 4,
+    content: 'ct4'
+  },
+  {
+    id: 5,
+    content: 'ct5'
+  }
+]);
+const meta = ref<Meta>({
+  totalCount: 1200
+});<% } else if (typescriptConfig === 'composition') { %><script lang="ts">
+import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
 import { defineComponent, ref } from 'vue';
 
@@ -45,7 +74,8 @@ export default defineComponent({
     });
     return { todos, meta };
   }
-});<% } else if (typescriptConfig === 'options') { %>import { Todo, Meta } from 'components/models';
+});<% } else if (typescriptConfig === 'options') { %><script lang="ts">
+import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
 import { defineComponent } from 'vue';
 
@@ -80,7 +110,7 @@ export default defineComponent({
     };
     return { todos, meta };
   }
-});<% } else if (typescriptConfig === 'class') { %>
+});<% } else if (typescriptConfig === 'class') { %><script lang="ts">
 import { Vue, Options } from 'vue-class-component'
 import { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/index.js
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/index.js
@@ -7,8 +7,8 @@ module.exports = async function ({ scope, utils }) {
       message: 'Pick a Vue component style:',
       initial: 0,
       choices: [
+        { title: 'Composition API', value: 'composition', description: 'recommended' },
         { title: 'Composition API with <script setup>', value: 'composition-setup', description: 'recommended' },
-        { title: 'Composition API', value: 'composition' },
         { title: 'Options API', value: 'options' },
         { title: 'Class-based (DEPRECATED; see https://github.com/quasarframework/quasar/discussions/11204)', value: 'class', disabled: true }
       ]

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/index.js
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/index.js
@@ -7,7 +7,8 @@ module.exports = async function ({ scope, utils }) {
       message: 'Pick a Vue component style:',
       initial: 0,
       choices: [
-        { title: 'Composition API', value: 'composition', description: 'recommended' },
+        { title: 'Composition API with <script setup>', value: 'composition-setup', description: 'recommended' },
+        { title: 'Composition API', value: 'composition' },
         { title: 'Options API', value: 'options' },
         { title: 'Class-based (DEPRECATED; see https://github.com/quasarframework/quasar/discussions/11204)', value: 'class', disabled: true }
       ]

--- a/docs/src/pages/start/how-to-use-vue.md
+++ b/docs/src/pages/start/how-to-use-vue.md
@@ -14,7 +14,7 @@ After reading the Vue documentation, let's clear up some of the most frequently 
 
 You'll be building your Quasar app using `*.vue` files which contain multiple sections: `template` (HTML), `script` (Javascript) and `style` (CSS/SASS/SCSS/Stylus/Less) all in the same file.
 
-Currently it is recommended to use `<script setup>` syntax. Check out [VueJS documentation](https://vuejs.org/api/sfc-script-setup.html) for more information.
+Currently, it is recommended to use Composition API with `<script setup>`. Check out [Vue.js documentation](https://vuejs.org/api/sfc-script-setup.html) for more information.
 
 ```html
 <template>

--- a/docs/src/pages/start/how-to-use-vue.md
+++ b/docs/src/pages/start/how-to-use-vue.md
@@ -14,6 +14,28 @@ After reading the Vue documentation, let's clear up some of the most frequently 
 
 You'll be building your Quasar app using `*.vue` files which contain multiple sections: `template` (HTML), `script` (Javascript) and `style` (CSS/SASS/SCSS/Stylus/Less) all in the same file.
 
+Currently it is recommended to use `<script setup>` syntax. Check out [VueJS documentation](https://vuejs.org/api/sfc-script-setup.html) for more information.
+
+```html
+<template>
+  <!-- you define your Vue template here -->
+</template>
+
+<script setup>
+// This is where your Javascript goes
+// to define your Vue component, which
+// can be a Layout, a Page or your own
+// component used throughout the app.
+</script>
+
+<style>
+/* This is where your CSS goes */
+</style>
+```
+
+But you can still use syntax without `setup` if you wish. The only difference is within the `<script>` tag.
+
+
 ```html
 <template>
   <!-- you define your Vue template here -->

--- a/docs/src/pages/start/how-to-use-vue.md
+++ b/docs/src/pages/start/how-to-use-vue.md
@@ -33,7 +33,7 @@ Currently it is recommended to use `<script setup>` syntax. Check out [VueJS doc
 </style>
 ```
 
-But you can still use syntax without `setup` if you wish. The only difference is within the `<script>` tag.
+But you can still use Composition API without `<script setup>` or Options API if you wish. The only difference is within the `<script>` tag.
 
 ```html
 <template>

--- a/docs/src/pages/start/how-to-use-vue.md
+++ b/docs/src/pages/start/how-to-use-vue.md
@@ -35,7 +35,6 @@ Currently it is recommended to use `<script setup>` syntax. Check out [VueJS doc
 
 But you can still use syntax without `setup` if you wish. The only difference is within the `<script>` tag.
 
-
 ```html
 <template>
   <!-- you define your Vue template here -->


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This PR introduces a new option inside Quasar CLI for initializing a project with [`<script setup>`](https://vuejs.org/api/sfc-script-setup.html) syntax:
```js
choices: [
  { title: 'Composition API with <script setup>', value: 'composition-setup', description: 'recommended' },  // <- NEW CHOICE
  { title: 'Composition API', value: 'composition' },
  { title: 'Options API', value: 'options' },
  { title: 'Class-based', value: 'class', description: 'DEPRECATED; see https://github.com/quasarframework/quasar/discussions/11204', disabled: true }
]
```

Currently only TypeScript projects are supported (both Vite and Webpack). Javascript does not have this prompt implemented (Options vs Composition etc.).
There is also a small note added about `<script setup>` inside the documentation.

`src/pages/IndexPage.vue` as an example:

**Previously:**
```vue
<script lang="ts">
import { Todo, Meta } from 'components/models';
import ExampleComponent from 'components/ExampleComponent.vue';
import { defineComponent, ref } from 'vue';

export default defineComponent({
  name: 'IndexPage',
  components: { ExampleComponent },
  setup () {
    const todos = ref<Todo[]>([
      // ...
    ]);
    const meta = ref<Meta>({
      totalCount: 1200
    });
    return { todos, meta };
  }
});
</script>
```

**After PR:**
```vue
<script setup lang="ts">
import { Todo, Meta } from 'components/models';
import ExampleComponent from 'components/ExampleComponent.vue';
import { ref } from 'vue';

const todos = ref<Todo[]>([
 // ...
]);
const meta = ref<Meta>({
  totalCount: 1200
});
</script>
```
