### PR TITLE
feat(docs): Overlapping avatar images - backport from Q2

### DIFF
--- a/docs/src/examples/QAvatar/Overlapping.vue
+++ b/docs/src/examples/QAvatar/Overlapping.vue
@@ -7,7 +7,7 @@
       class="overlapping"
       :style="`left: ${n * 25}px`"
     >
-      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`" />
+      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`">
     </q-avatar>
   </div>
 </template>

--- a/docs/src/examples/QAvatar/Overlapping.vue
+++ b/docs/src/examples/QAvatar/Overlapping.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="q-pa-md q-gutter-sm" style="height: 80px">
+    <q-avatar
+      v-for="n in 5"
+      :key="n"
+      size="40px"
+      class="overlapping"
+      :style="`left: ${n * 25}px`"
+    >
+      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`" />
+    </q-avatar>
+  </div>
+</template>
+
+<style lang="sass" scoped>
+.overlapping
+  border: 2px solid white
+  position: absolute
+</style>

--- a/docs/src/pages/vue-components/avatar.md
+++ b/docs/src/pages/vue-components/avatar.md
@@ -24,3 +24,5 @@ The `size` property will determine the height and the width of the Avatar. The `
 <doc-example title="Rounded" file="QAvatar/Rounded" />
 
 <doc-example title="With other components" file="QAvatar/Integrated" />
+
+<doc-example title="Overlapping avatars" file="QAvatar/Overlapping" />


### PR DESCRIPTION
An example of overlapping avatar images.

![Screenshot 2022-07-18 at 08 58 06](https://user-images.githubusercontent.com/62475782/179459145-8edfc0ea-5a9f-43c2-94af-0bafddabea5c.png)
