### PR TITLE
feat(docs): Overlapping avatar images

### DIFF
--- a/docs/public/examples/QAvatar/Overlapping.vue
+++ b/docs/public/examples/QAvatar/Overlapping.vue
@@ -7,7 +7,7 @@
       class="overlapping"
       :style="`left: ${n * 25}px`"
     >
-      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`" />
+      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`">
     </q-avatar>
   </div>
 </template>

--- a/docs/public/examples/QAvatar/Overlapping.vue
+++ b/docs/public/examples/QAvatar/Overlapping.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="q-pa-md q-gutter-sm" style="height: 80px">
+    <q-avatar
+      v-for="n in 5"
+      :key="n"
+      size="40px"
+      class="overlapping"
+      :style="`left: ${n * 25}px`"
+    >
+      <img :src="`https://cdn.quasar.dev/img/avatar${n + 1}.jpg`" />
+    </q-avatar>
+  </div>
+</template>
+
+<style lang="sass" scoped>
+.overlapping
+  border: 2px solid white
+  position: absolute
+</style>

--- a/docs/src/pages/vue-components/avatar.md
+++ b/docs/src/pages/vue-components/avatar.md
@@ -26,3 +26,5 @@ The `size` property will determine the height and the width of the Avatar. The `
 <doc-example title="Rounded" file="QAvatar/Rounded" />
 
 <doc-example title="With other components" file="QAvatar/Integrated" />
+
+<doc-example title="Overlapping avatars" file="QAvatar/Overlapping" />


### PR DESCRIPTION
An example of overlapping avatar images.

![179459145-8edfc0ea-5a9f-43c2-94af-0bafddabea5c](https://user-images.githubusercontent.com/62475782/179466347-7deaeb88-7448-4037-9eac-0fae89d8d4ed.png)
