### PR TITLE
fix(vite-plugin): compatible with vite 3.0 changes

### DIFF
--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "quasar": "^2.0.0",
-    "vite": "^2.0.0",
+    "vite": "^2.0.0 || ^3.0.0",
     "vue": "^3.0.0"
   },
   "license": "MIT",

--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -3,7 +3,7 @@ import importTransformation from 'quasar/dist/transforms/import-transformation.j
 
 import { jsTransform } from './js-transform.js'
 
-export const vueTransformRegex = /\.vue(\?vue&type=template&lang.js)?$/
+export const vueTransformRegex = /\.vue(?:\?vue&type=(?:template|script)(?:&setup=true)?&lang\.(?:j|t)s)?$/;
 
 const compRegex = {
   'kebab': new RegExp(`_resolveComponent\\("${autoImportData.regex.kebabComponents}"\\)`, 'g'),

--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -3,7 +3,7 @@ import importTransformation from 'quasar/dist/transforms/import-transformation.j
 
 import { jsTransform } from './js-transform.js'
 
-export const vueTransformRegex = /\.vue(?:\?vue&type=(?:template|script)(?:&setup=true)?&lang\.(?:j|t)s)?$/;
+export const vueTransformRegex = /\.vue(?:\?vue&type=(?:template|script)(?:&setup=true)?&lang\.(?:j|t)s)?$/
 
 const compRegex = {
   'kebab': new RegExp(`_resolveComponent\\("${autoImportData.regex.kebabComponents}"\\)`, 'g'),


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

fixes #13955 
Changed peer dependency to allow vite 3.0.0 and 2.0.0 versions

Also noticed that if you have typescript in your script vue SFC the auto imports of quasar components broke with any version past the @vitejs/plugin-vue 3.0.0 alpha.  Found this [PR](https://github.com/vitejs/vite/pull/7909) which I believe caused the auto imports to break. Have to also look for script along with template now since its not inlined together anymore. Updated regex to look for both.