### PR TITLE
fix(docs): Passing prop as a string to date constructor in example, backport from v2 #14090

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -332,7 +332,7 @@ To mutate the original date object by setting it to the start of a unit of time 
 ```js
 import { date } from 'quasar'
 
-let newDate = new Date(2000)
+let newDate = new Date('2000')
 // set to beginning of year 2000 (January 1st, 2000, 00:00:00.000)
 newDate = date.startOfDate(newDate, 'year')
 // set to end of year 2000 (December 31st, 2000, 23:59:59.999)


### PR DESCRIPTION
Closes https://github.com/quasarframework/quasar/issues/14086

@yusufkandemir 