### PR TITLE
fix(app-vite): impossible to use normal sourcemap mode

### DIFF
--- a/app-vite/lib/config-tools.js
+++ b/app-vite/lib/config-tools.js
@@ -116,9 +116,7 @@ function createViteConfig (quasarConf, quasarRunMode) {
       polyfillModulePreload: build.polyfillModulePreload,
       emptyOutDir: false,
       minify: build.minify,
-      sourcemap: build.sourcemap === true
-        ? 'inline'
-        : build.sourcemap || false
+      sourcemap: build.sourcemap || false
     },
 
     optimizeDeps: {


### PR DESCRIPTION
I don't get why you would make this the default.
Setting `sourcemap` to true like [described in the docs](https://github.com/quasarframework/quasar/blob/fc2b0b7be8635d1ec777e1d79836809c0d53c69f/app-vite/types/configuration/build.d.ts#L177), will generate inlined sourcemaps now. Our production index.js was suddenly 5MB.

The only workaround currently is to use `"hidden"` as value, but I want to use normal sourcemaps.

### Reproduction:
https://gitlab.com/TeNNoX/quasar-repro-inlined-sourcemaps
```
quasar build
rg -i sourcemap dist/spa/assets/index.*.js | less
```

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix (ish)
- [x] Build-related changes

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] Yes

<!-- If yes, please describe the impact and migration path for existing applications: -->
It will stop inlining sourcemaps when the config option is set to `true`, but it will now be consistent with the docs as opposed to not - so I don't think it's a problem.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

