### PR TITLE
fix(vite-plugin): let Quasar be pre-bundled in dev mode

### DIFF
--- a/vite-plugin/src/plugin.js
+++ b/vite-plugin/src/plugin.js
@@ -58,19 +58,26 @@ function getScssTransformsPlugin (opts) {
 }
 
 function getScriptTransformsPlugin (opts) {
+  let config
+
   return {
     name: 'vite:quasar:script',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+    },
     transform (src, id) {
-      if (vueTransformRegex.test(id) === true) {
-        return {
-          code: vueTransform(src, opts.autoImportComponentCase),
-          map: null // provide source map if available
+      if (config.mode !== 'development') {
+        if (vueTransformRegex.test(id) === true) {
+          return {
+            code: vueTransform(src, opts.autoImportComponentCase),
+            map: null // provide source map if available
+          }
         }
-      }
-      else if (jsTransformRegex.test(id) === true) {
-        return {
-          code: jsTransform(src),
-          map: null // provide source map if available
+        else if (jsTransformRegex.test(id) === true) {
+          return {
+            code: jsTransform(src),
+            map: null // provide source map if available
+          }
         }
       }
 

--- a/vite-plugin/src/vite-config.js
+++ b/vite-plugin/src/vite-config.js
@@ -23,8 +23,10 @@ export function getViteConfig (runMode, externalViteCfg) {
     })
   }
   else {
-    viteCfg.optimizeDeps = {
-      exclude: [ 'quasar' ]
+    if (externalViteCfg.mode !== 'development') {
+      viteCfg.optimizeDeps = {
+        exclude: [ 'quasar' ]
+      }
     }
 
     if (runMode === 'ssr-client') {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

A bit of context here: https://github.com/quasarframework/quasar/discussions/14084

But TLDR:

- One of the goals of @quasar/vite-plugin is to make quasar tree-shakeable. This is not necessary in dev and makes development slower. It's faster to have a single pre-bundled dependency than make 1XX requests for each component and composable. (See https://vitejs.dev/guide/dep-pre-bundling.html#the-why)
- This PR disables this behavior in development mode, but keeps the current behavior as is for production.

In my actual use case, my first page load went from 300 requests to 170 requests so it's a nice improvement.

I tested this PR by building @quasar/vite-plugin locally then copying the dist/index.js in the node_modules/@quasar/vite-plugin/dist folder of my project.
