### PR TITLE
fix(QDialog) : Impossible to open QDialog since quasar 2.7.6 - fix: #14124

### DIFF
--- a/ui/src/utils/private/global-dialog.js
+++ b/ui/src/utils/private/global-dialog.js
@@ -1,4 +1,4 @@
-import { h, ref } from 'vue'
+import { h, ref, nextTick } from 'vue'
 
 import { createChildApp } from '../../install-quasar.js'
 import { createGlobalNode, removeGlobalNode } from './global-nodes.js'
@@ -151,11 +151,11 @@ export default function (DefaultComponent, supportsCustomComponent, parentApp) {
         onOk,
         onHide,
         onVnodeMounted (...args) {
-          if (typeof props.onVnodeMounted === 'function') {
+          if (props && typeof props.onVnodeMounted === 'function') {
             props.onVnodeMounted(...args)
           }
 
-          applyState('show')
+          nextTick(() => applyState('show'))
         }
       })
     }, parentApp)


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

fixes #14124 
Bug created in PR #13900 : this PR removed a `nextTick` call important when applying a new state, and `props` might be `undefined`, so we check it before using it.