### PR TITLE
update(Docs/Quasar CLI) - Setting Windows path

### DIFF
--- a/docs/src/pages/start/quasar-cli.md
+++ b/docs/src/pages/start/quasar-cli.md
@@ -98,6 +98,16 @@ Pick `Quasar CLI with Vite` if you want:
     ```
     <br>
     Under Windows, modify user's PATH environment variable. If you are using yarn then add `%LOCALAPPDATA%\yarn\bin`, otherwise if you're using npm then add `%APPDATA%\npm`.
+    
+    Or to do this easily, enter the following code in the terminal.
+    
+    ```bash
+    # If you're using Yarn:
+    setx path "%path%;%LocalAppData%\yarn\bin"
+    
+    # Or if you're using NPM:
+    setx path "%path%;%AppData%\npm",
+    ```
     :::
 
     ::: tip WSL2

--- a/docs/src/pages/start/quasar-cli.md
+++ b/docs/src/pages/start/quasar-cli.md
@@ -98,8 +98,8 @@ Pick `Quasar CLI with Vite` if you want:
     ```
     <br>
     Under Windows, modify user's PATH environment variable. If you are using yarn then add `%LOCALAPPDATA%\yarn\bin`, otherwise if you're using npm then add `%APPDATA%\npm`.
-    
-    Or to do this easily, enter the following code in the terminal.
+    <br>
+    Or to do this easily, enter the following code in the terminal:
     
     ```bash
     # If you're using Yarn:


### PR DESCRIPTION
Now, Windows users are able to set path environment using CMD(Command Prompt / Terminal).

<!-- PULL REQUEST TEMPLATE -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Documentation

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] No

**The PR fulfills these requirements:**

- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.