### PR TITLE
warn users about swFilename change

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-pwa/configuring-pwa.md
+++ b/docs/src/pages/quasar-cli-vite/developing-pwa/configuring-pwa.md
@@ -30,11 +30,15 @@ Read more on `register-service-worker.[js|ts]` and how to interact with the Serv
 ## quasar.config.js
 This is the place where you can configure Workbox behavior and also tweak your manifest.json.
 
+::: warning
+If migrating from webpack, please note that the name of the service worker file has changed for vite (to `sw.js`). This can break your update process the first time the new app is loaded. To ensure smooth upgrades from previous webpack builds, make sure the name matches the name of your previous service worker file (usually `service-worker.js`)
+:::
+
 ```js
 pwa: {
   workboxMode: 'generateSW', // or 'injectManifest'
   injectPwaMetaTags: true,
-  swFilename: 'sw.js',
+  swFilename: 'sw.js', // if migrating from webpack 'service-worker.js' may be a better choice
   manifestFilename: 'manifest.json',
   useCredentialsForManifestTag: false,
   extendGenerateSWOptions (cfg) {},


### PR DESCRIPTION
Add warning to let users know that their PWA upgrade process may be broken if not using the same name for the service worker file they used with webpack

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
https://github.com/quasarframework/quasar/discussions/14046#discussioncomment-3355410