### PR TITLE
warn users about swFilename change

### DIFF
--- a/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
+++ b/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
@@ -64,7 +64,9 @@ A Quasar CLI with Webpack project relies on `/package.json > browserslist` to sp
 More info: [Configuring SSR](/quasar-cli-vite/developing-ssr/configuring-ssr)
 
 ### 6. PWA related
+
 * **VERY important: BEFORE porting your files over, run command `quasar mode add pwa`. Otherwise all the needed packages will not be added, and your build will fail.**
+* If migrating from webpack, please note that the name of the service worker file has changed for vite (to `sw.js`). This can break your update process the first time the new app is loaded. To ensure smooth upgrades from previous webpack builds, make sure the name matches the name of your previous service worker file (usually `service-worker.js`). Look for option `swFilename: 'sw.js'` in `quasar.config.js > pwa`.
 * Quasar CLI with Webpack relies on `quasar.config.js > manifest` to specify the manifest, but you will need to use `/src-pwa/manifest.json` to declare it for Quasar CLI with Vite. After declaring the manifest in `/src-pwa/manifest.json`, delete `quasar.config.js > manifest` section.
 * There were also some props in `quasar.config.js` that are no longer available. Most notably: `metaVariables`, `metaVariablesFn`. Simply edit `/index.html` and add those tags directly there.
 

--- a/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
+++ b/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
@@ -66,7 +66,7 @@ More info: [Configuring SSR](/quasar-cli-vite/developing-ssr/configuring-ssr)
 ### 6. PWA related
 
 * **VERY important: BEFORE porting your files over, run command `quasar mode add pwa`. Otherwise all the needed packages will not be added, and your build will fail.**
-* The default name of the outputted service worker file has changed from `service-worker.js` to `sw.js`. This can break your update process the first time the new app is loaded. So, if your app is in production, to ensure smooth upgrades from the previous Webpack builds, make sure the name matches the name of your previous service worker file. You can set it through [`quasar.config.js > pwa > swFilename`](/quasar-cli-vite/developing-pwa/configuring-pwa#quasar-config-js).
+* The default name of the outputted service worker file has changed from `service-worker.js` to `sw.js`. This can break your update process the first time the new app is loaded. So, if your app is in production, to ensure smooth upgrades from the previous Webpack builds, make sure the name matches the name of your previous service worker file. You can set it through [quasar.config.js > pwa > swFilename](/quasar-cli-vite/developing-pwa/configuring-pwa#quasar-config-js).
 * Quasar CLI with Webpack relies on `quasar.config.js > manifest` to specify the manifest, but you will need to use `/src-pwa/manifest.json` to declare it for Quasar CLI with Vite. After declaring the manifest in `/src-pwa/manifest.json`, delete `quasar.config.js > manifest` section.
 * There were also some props in `quasar.config.js` that are no longer available. Most notably: `metaVariables`, `metaVariablesFn`. Simply edit `/index.html` and add those tags directly there.
 

--- a/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
+++ b/docs/src/pages/quasar-cli-vite/convert-to-quasar-cli-with-vite.md
@@ -66,7 +66,7 @@ More info: [Configuring SSR](/quasar-cli-vite/developing-ssr/configuring-ssr)
 ### 6. PWA related
 
 * **VERY important: BEFORE porting your files over, run command `quasar mode add pwa`. Otherwise all the needed packages will not be added, and your build will fail.**
-* If migrating from webpack, please note that the name of the service worker file has changed for vite (to `sw.js`). This can break your update process the first time the new app is loaded. To ensure smooth upgrades from previous webpack builds, make sure the name matches the name of your previous service worker file (usually `service-worker.js`). Look for option `swFilename: 'sw.js'` in `quasar.config.js > pwa`.
+* The default name of the outputted service worker file has changed from `service-worker.js` to `sw.js`. This can break your update process the first time the new app is loaded. So, if your app is in production, to ensure smooth upgrades from the previous Webpack builds, make sure the name matches the name of your previous service worker file. You can set it through [`quasar.config.js > pwa > swFilename`](/quasar-cli-vite/developing-pwa/configuring-pwa#quasar-config-js).
 * Quasar CLI with Webpack relies on `quasar.config.js > manifest` to specify the manifest, but you will need to use `/src-pwa/manifest.json` to declare it for Quasar CLI with Vite. After declaring the manifest in `/src-pwa/manifest.json`, delete `quasar.config.js > manifest` section.
 * There were also some props in `quasar.config.js` that are no longer available. Most notably: `metaVariables`, `metaVariablesFn`. Simply edit `/index.html` and add those tags directly there.
 


### PR DESCRIPTION
Add a warning to let users know that their PWA upgrade process may be broken if not using the same name for the service worker file they used with Webpack. See https://github.com/quasarframework/quasar/discussions/14046#discussioncomment-3355410

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.
