### PR TITLE
Add missing `name-html` attribute for QChatMessage Sanitize

### DIFF
--- a/docs/public/examples/QChatMessage/Sanitize.vue
+++ b/docs/public/examples/QChatMessage/Sanitize.vue
@@ -3,6 +3,7 @@
     <div style="width: 100%; max-width: 400px">
       <q-chat-message
         name="<span class='text-positive'>Untrusted Source</span>"
+        name-html
         avatar="https://cdn.quasar.dev/img/avatar3.jpg"
         :text="['hey, how are <strong>you</strong>?']"
         stamp="7 minutes ago"


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Attribute is missing so it does not render correctly

![image](https://user-images.githubusercontent.com/31566807/184142038-7ac2e90f-0384-4e49-9335-3858e999380b.png)
