### PR TITLE
feat(QSelect): new prop blurAdds to add input on blur

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -80,6 +80,7 @@ export default createComponent({
     popupContentClass: String,
     popupContentStyle: [ String, Array, Object ],
 
+    blurAdds: Boolean,
     useInput: Boolean,
     useChips: Boolean,
 
@@ -1464,7 +1465,14 @@ export default createComponent({
         onFocusin (e) { state.onControlFocusin(e) },
         onFocusout (e) {
           state.onControlFocusout(e, () => {
-            resetInputValue()
+            if(!props.blurAdds)
+              resetInputValue()
+            else {
+              if(props.newValueMode === 'toggle')
+                toggleOption(inputValue.value)
+              else
+                add(inputValue.value, props.newValueMode === 'add-unique')
+            }
             closeMenu()
           })
         },

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -1465,7 +1465,7 @@ export default createComponent({
         onFocusin (e) { state.onControlFocusin(e) },
         onFocusout (e) {
           state.onControlFocusout(e, () => {
-            if(!props.blurAdds)
+            if(!props.blurAdds || !inputValue.value.length)
               resetInputValue()
             else {
               if(props.newValueMode === 'toggle')


### PR DESCRIPTION
I dont want my qselect field to reset on blur.
I added a prop to add the value on blur.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
