### PR TITLE
feat(create-quasar): support new vue-i18n TS features

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/BASE/_package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     <% if (typescriptConfig === 'class') { %>"vue-class-component": "^8.0.0-rc.1",<% } %>
     <% if (preset.axios) { %>"axios": "^0.21.1",<% } %>
-    <% if (preset.i18n) { %>"vue-i18n": "^9.0.0",<% } %>
+    <% if (preset.i18n) { %>"vue-i18n": "^9.2.2",<% } %>
     <% if (preset.pinia) { %>"pinia": "^2.0.11",<% } %>
     <% if (preset.vuex) { %>"vuex": "^4.0.1",<% } %>
     "@quasar/extras": "^1.0.0",

--- a/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
@@ -3,10 +3,30 @@ import { createI18n } from 'vue-i18n';
 
 import messages from 'src/i18n';
 
+export type MessageLanguages = keyof typeof messages;
+// Type-define 'en-US' as the master schema for the resource
+export type MessageSchema = typeof messages["en-US"];
+
+// See https://vue-i18n.intlify.dev/guide/advanced/typescript.html#global-resource-schema-type-definition
+/* eslint-disable @typescript-eslint/no-empty-interface */
+declare module "vue-i18n" {
+  // define the locale messages schema
+  export interface DefineLocaleMessage extends MessageSchema {}
+
+  // define the datetime format schema
+  export interface DefineDateTimeFormat {}
+
+  // define the number format schema
+  export interface DefineNumberFormat {}
+}
+/* eslint-enable @typescript-eslint/no-empty-interface */
+
 export default boot(({ app }) => {
   const i18n = createI18n({
     locale: 'en-US',
-    globalInjection: true,
+    <% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
+    legacy: false,
+    <% } %>
     messages,
   });
 

--- a/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite/i18n/src/boot/i18n.ts
@@ -23,10 +23,8 @@ declare module "vue-i18n" {
 
 export default boot(({ app }) => {
   const i18n = createI18n({
-    locale: 'en-US',
-    <% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
-    legacy: false,
-    <% } %>
+    locale: 'en-US',<% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
+    legacy: false,<% } %>
     messages,
   });
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/BASE/_package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     <% if (typescriptConfig === 'class') { %>"vue-class-component": "^8.0.0-rc.1",<% } %>
     <% if (preset.axios) { %>"axios": "^0.21.1",<% } %>
-    <% if (preset.i18n) { %>"vue-i18n": "^9.0.0",<% } %>
+    <% if (preset.i18n) { %>"vue-i18n": "^9.2.2",<% } %>
     <% if (preset.pinia) { %>"pinia": "^2.0.11",<% } %>
     <% if (preset.vuex) { %>"vuex": "^4.0.1",<% } %>
     "@quasar/extras": "^1.0.0",

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
@@ -23,10 +23,8 @@ declare module "vue-i18n" {
 
 export default boot(({ app }) => {
   const i18n = createI18n<{ message: MessageSchema }, MessageLanguages>({
-    locale: 'en-US',
-    <% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
-    legacy: false,
-    <% } %>
+    locale: 'en-US',<% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
+    legacy: false,<% } %>
     messages,
   });
 

--- a/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack/i18n/src/boot/i18n.ts
@@ -3,10 +3,30 @@ import { createI18n } from 'vue-i18n';
 
 import messages from 'src/i18n';
 
+export type MessageLanguages = keyof typeof messages;
+// Type-define 'en-US' as the master schema for the resource
+export type MessageSchema = typeof messages["en-US"];
+
+// See https://vue-i18n.intlify.dev/guide/advanced/typescript.html#global-resource-schema-type-definition
+/* eslint-disable @typescript-eslint/no-empty-interface */
+declare module "vue-i18n" {
+  // define the locale messages schema
+  export interface DefineLocaleMessage extends MessageSchema {}
+
+  // define the datetime format schema
+  export interface DefineDateTimeFormat {}
+
+  // define the number format schema
+  export interface DefineNumberFormat {}
+}
+/* eslint-enable @typescript-eslint/no-empty-interface */
+
 export default boot(({ app }) => {
-  const i18n = createI18n({
+  const i18n = createI18n<{ message: MessageSchema }, MessageLanguages>({
     locale: 'en-US',
-    globalInjection: true,
+    <% if (typescriptConfig === 'composition' || typescriptConfig === 'composition-setup') { %>
+    legacy: false,
+    <% } %>
     messages,
   });
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
vue-i18n changed some defaults and required some others
It also adds suggestions for message paths when using `useI18n` and errors out when you're missing translations for secondary languages 