### PR TITLE
fix/feat(api/QEditor): Fix and improve definitions prop type (fix #14141)

### DIFF
--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -78,6 +78,8 @@
       "definition": {
         "...commandName": {
           "type": "Object",
+          "tsType": "QEditorCommand",
+          "autoDefineTsType": true,
           "desc": "Command definition",
           "definition": {
             "label": {

--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -76,74 +76,81 @@
         ":definitions=\"{ save: { tip: 'Save your work', icon: 'save', label: 'Save', handler: saveWork }, upload: { tip: 'Upload to cloud', icon: 'cloud_upload', label: 'Upload', handler: uploadIt } }\""
       ],
       "definition": {
-        "label": {
-          "type": "String",
-          "desc": "Label of the button",
-          "examples": [ "Addresses" ]
-        },
-        "tip": {
-          "type": "String",
-          "desc": "Text to be displayed as a tooltip on hover",
-          "examples": [ "Add a contact from the Address Book" ]
-        },
-        "htmlTip": {
-          "type": "String",
-          "desc": "HTML formatted text to be displayed within a tooltip on hover",
-          "examples": [ "Add a <span class=\"red\">user</span> from the address book" ]
-        },
-        "icon": {
-          "type": "String",
-          "desc": "Icon of the button",
-          "examples": [ "fas fa-address-book" ]
-        },
-        "key": {
-          "type": "Number",
-          "desc": "Keycode of a key to be used together with the <ctrl> key for use as a shortcut to trigger this element",
-          "examples": [ "12", "36" ]
-        },
-        "handler": {
-          "type": "Function",
-          "desc": "Either this or \"cmd\" is required. Function for when button gets clicked/tapped.",
-          "params": null,
-          "returns": null,
-          "examples": [ "() => this.uploadFile()" ]
-        },
-        "cmd": {
-          "type": "String",
-          "desc": "Either this or \"handler\" is required. This must be a valid execCommand method according to the designMode API.",
-          "examples": [ "insertHTML", "justifyFull" ]
-        },
-        "param": {
-          "type": "String",
-          "desc": "Only set a param if using a \"cmd\". This is commonly text or HTML to inject, but is highly dependent upon the specific cmd being called.",
-          "examples": [ "<img src=\"://uploads/001.jpg\" alt=\"nice pic\" />" ]
-        },
-        "disable": {
-          "type": [ "Boolean", "Function" ],
-          "desc": "Is button disabled?",
-          "returns": {
-            "type": "Boolean",
-            "desc": "If true, the button will be disabled"
+        "...commandName": {
+          "type": "Object",
+          "desc": "Command definition",
+          "definition": {
+            "label": {
+              "type": "String",
+              "desc": "Label of the button",
+              "examples": [ "Addresses" ]
+            },
+            "tip": {
+              "type": "String",
+              "desc": "Text to be displayed as a tooltip on hover",
+              "examples": [ "Add a contact from the Address Book" ]
+            },
+            "htmlTip": {
+              "type": "String",
+              "desc": "HTML formatted text to be displayed within a tooltip on hover",
+              "examples": [ "Add a <span class=\"red\">user</span> from the address book" ]
+            },
+            "icon": {
+              "type": "String",
+              "desc": "Icon of the button",
+              "examples": [ "fas fa-address-book" ]
+            },
+            "key": {
+              "type": "Number",
+              "desc": "Keycode of a key to be used together with the <ctrl> key for use as a shortcut to trigger this element",
+              "examples": [ "12", "36" ]
+            },
+            "handler": {
+              "type": "Function",
+              "desc": "Either this or \"cmd\" is required. Function for when button gets clicked/tapped.",
+              "params": null,
+              "returns": null,
+              "examples": [ "() => this.uploadFile()" ]
+            },
+            "cmd": {
+              "type": "String",
+              "desc": "Either this or \"handler\" is required. This must be a valid execCommand method according to the designMode API.",
+              "examples": [ "insertHTML", "justifyFull" ]
+            },
+            "param": {
+              "type": "String",
+              "desc": "Only set a param if using a \"cmd\". This is commonly text or HTML to inject, but is highly dependent upon the specific cmd being called.",
+              "examples": [ "<img src=\"://uploads/001.jpg\" alt=\"nice pic\" />" ]
+            },
+            "disable": {
+              "type": [ "Boolean", "Function" ],
+              "desc": "Is button disabled?",
+              "returns": {
+                "type": "Boolean",
+                "desc": "If true, the button will be disabled"
+              },
+              "examples": [ "!user.active", "() => !checkIfUserIsActive()" ]
+            },
+            "type": {
+              "type": "String",
+              "desc": "Pass the value \"no-state\" if the button should not have an \"active\" state",
+              "values": [ null, "no-state" ],
+              "examples": [ "no-state" ]
+            },
+            "fixedLabel": {
+              "type": "Boolean",
+              "desc": "Lock the button label, so it doesn't change based on the child option selected."
+            },
+            "fixedIcon": {
+              "type": "Boolean",
+              "desc": "Lock the button icon, so it doesn't change based on the child option selected."
+            },
+            "highlight": {
+              "type": "Boolean",
+              "desc": "Highlight the toolbar button, when a child option has been selected."
+            }
           },
-          "examples": [ "!user.active", "() => !checkIfUserIsActive()" ]
-        },
-        "type": {
-          "type": "String",
-          "desc": "Pass the value \"no-state\" if the button should not have an \"active\" state",
-          "values": [ null, "no-state" ],
-          "examples": [ "no-state" ]
-        },
-        "fixedLabel": {
-          "type": "Boolean",
-          "desc": "Lock the button label, so it doesn't change based on the child option selected."
-        },
-        "fixedIcon": {
-          "type": "Boolean",
-          "desc": "Lock the button icon, so it doesn't change based on the child option selected."
-        },
-        "highlight": {
-          "type": "Boolean",
-          "desc": "Highlight the toolbar button, when a child option has been selected."
+          "__exemption": [ "examples" ]
         }
       },
       "category": "toolbar"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #14141.

We will also start generating and exporting `QEditorCommand`, which may be used like this:
```ts
import { QEditorProps, QEditorCommand } from 'quasar';

// A common command that can be reused in different places
const save: QEditorCommand = {
  tip: 'Save your work',
  icon: 'save',
  label: 'Save',
  handler: () => { /* ... */ },
};

// <q-editor :definitions="definitions" ... />
const definitions: QEditorProps['definitions'] = {
  foo: { /* ... */ },
  save,
};
```

Diff:
```diff
@@ -3358,60 +3358,11 @@
    */
   definitions?:
     | {
         /**
-         * Label of the button
+         * Command definition
          */
-        label?: string;
-        /**
-         * Text to be displayed as a tooltip on hover
-         */
-        tip?: string;
-        /**
-         * HTML formatted text to be displayed within a tooltip on hover
-         */
-        htmlTip?: string;
-        /**
-         * Icon of the button
-         */
-        icon?: string;
-        /**
-         * Keycode of a key to be used together with the <ctrl> key for use as a shortcut to trigger this element
-         */
-        key?: number;
-        /**
-         * Either this or "cmd" is required. Function for when button gets clicked/tapped.
-         */
-        handler?: () => void;
-        /**
-         * Either this or "handler" is required. This must be a valid execCommand method according to the designMode API.
-         */
-        cmd?: string;
-        /**
-         * Only set a param if using a "cmd". This is commonly text or HTML to inject, but is highly dependent upon the specific cmd being called.
-         */
-        param?: string;
-        /**
-         * Is button disabled?
-         * @returns If true, the button will be disabled
-         */
-        disable?: boolean | (() => boolean);
-        /**
-         * Pass the value "no-state" if the button should not have an "active" state
-         */
-        type?: "no-state";
-        /**
-         * Lock the button label, so it doesn't change based on the child option selected.
-         */
-        fixedLabel?: boolean;
-        /**
-         * Lock the button icon, so it doesn't change based on the child option selected.
-         */
-        fixedIcon?: boolean;
-        /**
-         * Highlight the toolbar button, when a child option has been selected.
-         */
-        highlight?: boolean;
+        [commandName: string]: QEditorCommand;
       }
     | undefined;
   /**
    * Object with definitions of fonts
@@ -13472,8 +13423,64 @@
 }
 
 import { QNotifyUpdateOptions } from "./api";
 import { QNotifyOptions } from "./api";
+export interface QEditorCommand {
+  /**
+   * Label of the button
+   */
+  label?: string;
+  /**
+   * Text to be displayed as a tooltip on hover
+   */
+  tip?: string;
+  /**
+   * HTML formatted text to be displayed within a tooltip on hover
+   */
+  htmlTip?: string;
+  /**
+   * Icon of the button
+   */
+  icon?: string;
+  /**
+   * Keycode of a key to be used together with the <ctrl> key for use as a shortcut to trigger this element
+   */
+  key?: number;
+  /**
+   * Either this or "cmd" is required. Function for when button gets clicked/tapped.
+   */
+  handler?: () => void;
+  /**
+   * Either this or "handler" is required. This must be a valid execCommand method according to the designMode API.
+   */
+  cmd?: string;
+  /**
+   * Only set a param if using a "cmd". This is commonly text or HTML to inject, but is highly dependent upon the specific cmd being called.
+   */
+  param?: string;
+  /**
+   * Is button disabled?
+   * @returns If true, the button will be disabled
+   */
+  disable?: boolean | (() => boolean);
+  /**
+   * Pass the value "no-state" if the button should not have an "active" state
+   */
+  type?: "no-state";
+  /**
+   * Lock the button label, so it doesn't change based on the child option selected.
+   */
+  fixedLabel?: boolean;
+  /**
+   * Lock the button icon, so it doesn't change based on the child option selected.
+   */
+  fixedIcon?: boolean;
+  /**
+   * Highlight the toolbar button, when a child option has been selected.
+   */
+  highlight?: boolean;
+}
+
```