### PR TITLE
fix(ui/uploader-core): Expose public fields

### DIFF
--- a/ui/src/components/uploader/__tests__/QUploader.spec.js
+++ b/ui/src/components/uploader/__tests__/QUploader.spec.js
@@ -1,3 +1,6 @@
+import { mount } from '@cypress/vue'
+import QUploader from '../QUploader'
+
 describe('Uploader API', () => {
   describe('Props', () => {
     describe('Category: behavior', () => {
@@ -83,8 +86,36 @@ describe('Uploader API', () => {
 
   describe('Slots', () => {
     describe('(slot): header', () => {
-      it.skip(' ', () => {
-        //
+      it('renders correctly using the scope', () => {
+        // Taken from ui/dev/src/pages/form/uploader.vue
+        const headerSlot = `
+<template #header="scope">
+  <div class="row no-wrap items-center q-pa-sm q-gutter-xs">
+    <q-btn v-if="scope.queuedFiles.length > 0" icon="clear_all" @click="scope.removeQueuedFiles" round dense flat />
+    <q-btn v-if="scope.uploadedFiles.length > 0" icon="done_all" @click="scope.removeUploadedFiles" round dense flat />
+    <q-spinner v-if="scope.isUploading" class="q-uploader__spinner" />
+    <div class="col">
+      <div class="q-uploader__title">
+        Upload your files
+      </div>
+      <div class="q-uploader__subtitle">
+        {{ scope.uploadSizeLabel }} / {{ scope.uploadProgressLabel }}
+      </div>
+    </div>
+    <q-btn v-if="scope.canAddFiles" type="a" icon="add_box" @click="scope.pickFiles" round dense flat>
+      <q-uploader-add-trigger />
+    </q-btn>
+    <q-btn v-if="scope.canUpload" icon="cloud_upload" @click="scope.upload" round dense flat />
+    <q-btn v-if="scope.isUploading" icon="clear" @click="scope.abort" round dense flat />
+  </div>
+</template>
+`
+
+        mount(QUploader, {
+          slots: {
+            header: headerSlot
+          }
+        })
       })
     })
 

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -1,4 +1,4 @@
-import { h, ref, isRef, computed, watch, provide, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { h, ref, computed, watch, provide, onBeforeUnmount, getCurrentInstance, unref } from 'vue'
 
 import QBtn from '../btn/QBtn.js'
 import QIcon from '../icon/QIcon.js'
@@ -11,6 +11,7 @@ import useFile, { useFileProps, useFileEmits } from '../../composables/private/u
 import { stop } from '../../utils/event.js'
 import { humanStorageSize } from '../../utils/format.js'
 import { uploaderKey } from '../../utils/private/symbols.js'
+import { injectMultipleProps } from '../../utils/private/inject-obj-prop.js'
 
 function getProgressLabel (p) {
   return (p * 100).toFixed(2) + '%'
@@ -464,6 +465,18 @@ export function getRenderer (getPlugin) {
 
   // expose public methods
   Object.assign(proxy, publicMethods)
+
+  injectMultipleProps(proxy, {
+    canAddFiles: () => canAddFiles.value,
+    canUpload: () => canUpload.value,
+    uploadSizeLabel: () => uploadSizeLabel.value,
+    uploadProgressLabel: () => uploadProgressLabel.value,
+
+    ...Object.entries(state).reduce((acc, [ key, val ]) => {
+      acc[ key ] = () => unref(val)
+      return acc
+    })
+  })
 
   return () => {
     const children = [

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -473,7 +473,7 @@ export function getRenderer (getPlugin) {
     ...Object.entries(state).reduce((acc, [ key, val ]) => {
       acc[ key ] = () => unref(val)
       return acc
-    })
+    }, {})
   })
 
   return () => {

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -453,9 +453,7 @@ export function getRenderer (getPlugin) {
     }
 
     for (const key in state) {
-      acc[ key ] = isRef(state[ key ]) === true
-        ? state[ key ].value
-        : state[ key ]
+      acc[ key ] = unref(state[ key ])
     }
 
     // TODO: (Qv3) Put the QUploader instance under `ref`

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -443,8 +443,6 @@ export function getRenderer (getPlugin) {
     abort: state.abort
   }
 
-  // TODO: the result of this computed, especially the dynamic part, isn't currently typed
-  // This result in an error with Volar when accessing the state (eg. files array)
   const slotScope = computed(() => {
     const acc = {
       canAddFiles: canAddFiles.value,

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -443,24 +443,6 @@ export function getRenderer (getPlugin) {
     abort: state.abort
   }
 
-  const slotScope = computed(() => {
-    const acc = {
-      canAddFiles: canAddFiles.value,
-      canUpload: canUpload.value,
-      uploadSizeLabel: uploadSizeLabel.value,
-      uploadProgressLabel: uploadProgressLabel.value
-    }
-
-    for (const key in state) {
-      acc[ key ] = unref(state[ key ])
-    }
-
-    // TODO: (Qv3) Put the QUploader instance under `ref`
-    // property for consistency and flexibility
-    // return { ref: { ...acc, ...publicMethods } }
-    return { ...acc, ...publicMethods }
-  })
-
   // expose public methods
   Object.assign(proxy, publicMethods)
 
@@ -475,6 +457,10 @@ export function getRenderer (getPlugin) {
       return acc
     }, {})
   })
+
+  // TODO: (Qv3) Put the instance under `ref` property for consistency and flexibility
+  // computed(() => ({ ref: proxy, /* new stuff can be added if needed */ }))
+  const slotScope = computed(() => proxy)
 
   return () => {
     const children = [

--- a/ui/src/utils/dom.js
+++ b/ui/src/utils/dom.js
@@ -1,4 +1,4 @@
-import { isRef } from 'vue'
+import { unref } from 'vue'
 
 export function offset (el) {
   if (el === window) {
@@ -63,10 +63,7 @@ export function getElement (el) {
     }
   }
 
-  const target = isRef(el) === true
-    ? el.value
-    : el
-
+  const target = unref(el)
   if (target) {
     return target.$el || target
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
They were made available on the uploader scope where it is advertised as the QUploader instance itself. This makes it feel like they are accessible on the instance itself.
So, I am exposing those fields in the component instance too, aiming to unify both references.