### PR TITLE
feat(docs&api&ts): Add new top-level section 'fields'

### DIFF
--- a/docs/src/components/DocApiEntry.js
+++ b/docs/src/components/DocApiEntry.js
@@ -277,7 +277,7 @@ function copyPropName (propName) {
 
 const describe = {}
 
-describe.props = props => {
+const describePropsLike = props => {
   const child = []
 
   for (const propName in props) {
@@ -288,18 +288,9 @@ describe.props = props => {
 
   return child
 }
-
-describe.slots = slots => {
-  const child = []
-
-  for (const slot in slots) {
-    child.push(
-      getProp(slots[ slot ], slot, 0)
-    )
-  }
-
-  return child
-}
+describe.props = describePropsLike
+describe.fields = describePropsLike
+describe.slots = describePropsLike
 
 describe.events = events => {
   const child = []

--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -38,7 +38,7 @@ function getMixedInAPI (api, mainFile) {
 
 const topSections = {
   plugin: [ 'meta', 'injection', 'quasarConfOptions', 'addedIn', 'props', 'methods' ],
-  component: [ 'meta', 'quasarConfOptions', 'addedIn', 'props', 'slots', 'events', 'methods' ],
+  component: [ 'meta', 'quasarConfOptions', 'addedIn', 'props', 'slots', 'events', 'methods', 'fields' ],
   directive: [ 'meta', 'quasarConfOptions', 'addedIn', 'value', 'arg', 'modifiers' ]
 }
 
@@ -127,6 +127,14 @@ const objectTypes = {
     required: [ 'desc' ],
     isObject: [ 'params' ],
     isBoolean: [ 'internal' ]
+  },
+
+  // component only
+  fields: {
+    props: [ 'desc', 'tsType', 'examples', 'addedIn', 'internal' ],
+    required: [ 'desc' ],
+    isBoolean: [ 'internal' ],
+    isArray: [ 'examples' ]
   },
 
   methods: {
@@ -472,7 +480,7 @@ function parseAPI (file, apiType) {
         banner: `${ banner } "${ type }"/"${ itemName }"`,
         api: api[ type ],
         itemName,
-        masterType: type,
+        masterType: type === 'fields' ? 'props' : type,
         verifyCategory: type === 'props' && isComponent
       })
     }

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -2414,5 +2414,25 @@
         }
       }
     }
+  },
+
+  "fields": {
+    "filteredSortedRows": {
+      "desc": "The filtered and sorted rows (same as the rows prop if using server-side fetching)",
+      "type": "Array",
+      "examples": [ "[ { name: 'Ice Cream Sandwich', calories: 237, fat: 9.0, carbs: 37, protein: 4.3, sodium: 129, calcium: 8, iron: 1 }, ... ]" ]
+    },
+
+    "computedRows": {
+      "desc": "Paginated, filtered, and sorted rows (same as the rows prop if using server-side fetching)",
+      "type": "Array",
+      "examples": [ "[ { name: 'Ice Cream Sandwich', calories: 237, fat: 9.0, carbs: 37, protein: 4.3, sodium: 129, calcium: 8, iron: 1 }, ... ]" ]
+    },
+
+    "computedRowsNumber": {
+      "desc": "The number of computed rows",
+      "type": "Number",
+      "examples": [ 10 ]
+    }
   }
 }

--- a/ui/src/components/uploader/QUploader.json
+++ b/ui/src/components/uploader/QUploader.json
@@ -152,5 +152,53 @@
         }
       }
     }
+  },
+
+  "fields": {
+    "files": {
+      "type": "Array",
+      "desc": "List of all files",
+      "__exemption": [ "examples" ]
+    },
+
+    "queuedFiles": {
+      "type": "Array",
+      "desc": "List of files that are waiting to be uploaded",
+      "__exemption": [ "examples" ]
+    },
+
+    "uploadedFiles": {
+      "type": "Array",
+      "desc": "List of files that have been uploaded",
+      "__exemption": [ "examples" ]
+    },
+
+    "uploadedSize": {
+      "type": "Number",
+      "desc": "Size of all uploaded files in bytes",
+      "examples": [ 1024 ]
+    },
+
+    "uploadSizeLabel": {
+      "type": "String",
+      "desc": "Label for the size total of all files",
+      "examples": [ "1.0MB" ]
+    },
+
+    "uploadProgressLabel": {
+      "type": "String",
+      "desc": "Label for the upload progress (in %)",
+      "examples": [ "52.76%" ]
+    },
+
+    "canAddFiles": {
+      "type": "Boolean",
+      "desc": "Whether new files can be added to the list"
+    },
+
+    "canUpload": {
+      "type": "Boolean",
+      "desc": "Whether the files can be uploaded"
+    }
   }
 }

--- a/ui/src/composables/private/use-validate.json
+++ b/ui/src/composables/private/use-validate.json
@@ -74,5 +74,12 @@
         ]
       }
     }
+  },
+
+  "fields": {
+    "hasError": {
+      "type": "Boolean",
+      "desc": "Whether the component is in error state"
+    }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Documentation

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Closes #11510, #13217

Depends on #14241 because QUploader isn't exposing the fields.

This adds a top-level property called "fields" to our JSON API system. I analyzed all components that have public instance fields and added JSON API content for them. The docs API cards now have a section called "fields" at the end if applicable. We are also generating the types for fields in the instance type interfaces, e.g. `QUploader`