### PR TITLE
fix(api/QTable): Add missing rowsNumber to requestServerInteraction()

### DIFF
--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -2220,6 +2220,11 @@
                   "type": "Number",
                   "desc": "How many rows per page? 0 means Infinite",
                   "examples": [ 10 ]
+                },
+                "rowsNumber": {
+                  "type": "Number",
+                  "desc": "For server-side fetching only. How many total database rows are there to be added to the table.",
+                  "examples": [ 100, 200 ]
                 }
               }
             },


### PR DESCRIPTION
- [X] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Add the "rowsNumber" in the props param in the requestServerInteraction function for the QTable description