### PR TITLE
chore(app): upgrade vue-router to support Vue 2.7

### DIFF
--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -89,9 +89,7 @@ module.exports = function (cfg, configName) {
   if (cfg.framework.importStrategy === 'all') {
     chain.resolve.alias.set('quasar$', 'quasar/dist/quasar.esm.js')
   }
-  if (cfg.build.vueCompiler) {
-    chain.resolve.alias.set('vue$', 'vue/dist/vue.esm.js')
-  }
+  chain.resolve.alias.set('vue$', 'vue/dist/vue.esm.js')
 
   chain.resolveLoader.modules
     .merge(resolveModules)

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -89,7 +89,7 @@ module.exports = function (cfg, configName) {
   if (cfg.framework.importStrategy === 'all') {
     chain.resolve.alias.set('quasar$', 'quasar/dist/quasar.esm.js')
   }
-  chain.resolve.alias.set('vue$', 'vue/dist/vue.esm.js')
+  chain.resolve.alias.set('vue$', vueCompiler ? 'vue/dist/vue.esm.js' : 'vue/dist/vue.runtime.esm.js')
 
   chain.resolveLoader.modules
     .merge(resolveModules)

--- a/app/lib/webpack/create-chain.js
+++ b/app/lib/webpack/create-chain.js
@@ -89,7 +89,11 @@ module.exports = function (cfg, configName) {
   if (cfg.framework.importStrategy === 'all') {
     chain.resolve.alias.set('quasar$', 'quasar/dist/quasar.esm.js')
   }
-  chain.resolve.alias.set('vue$', vueCompiler ? 'vue/dist/vue.esm.js' : 'vue/dist/vue.runtime.esm.js')
+
+  chain.resolve.alias.set(
+    'vue$',
+    cfg.build.vueCompiler ? 'vue/dist/vue.esm.js' : 'vue/dist/vue.runtime.esm.js'
+  )
 
   chain.resolveLoader.modules
     .merge(resolveModules)

--- a/app/package.json
+++ b/app/package.json
@@ -106,7 +106,7 @@
     "url-loader": "4.1.1",
     "vue": "^2.7.1",
     "vue-loader": "^15.10.0",
-    "vue-router": "3.5.3",
+    "vue-router": "3.6.4",
     "vue-server-renderer": "^2.7.1",
     "vue-style-loader": "4.1.3",
     "vue-template-compiler": "^2.7.1",

--- a/app/types/configuration/build.d.ts
+++ b/app/types/configuration/build.d.ts
@@ -136,8 +136,6 @@ interface QuasarStaticBuildConfiguration {
    * When providing an object, it represents webpack-bundle-analyzer config options.
    */
   analyze: boolean | BundleAnalyzerPlugin.Options;
-  /** Include vue runtime + compiler version, instead of default Vue runtime-only. */
-  vueCompiler: boolean;
   /**
    * Minification options. [Full list](https://github.com/webpack-contrib/terser-webpack-plugin/#minify).
    */

--- a/app/types/configuration/build.d.ts
+++ b/app/types/configuration/build.d.ts
@@ -136,6 +136,8 @@ interface QuasarStaticBuildConfiguration {
    * When providing an object, it represents webpack-bundle-analyzer config options.
    */
   analyze: boolean | BundleAnalyzerPlugin.Options;
+  /** Include vue runtime + compiler version, instead of default Vue runtime-only. */
+  vueCompiler: boolean;
   /**
    * Minification options. [Full list](https://github.com/webpack-contrib/terser-webpack-plugin/#minify).
    */


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
A new version of Qv1 has been released which ships with Vue 2.7.
Unluckily the new Vue version removed `root` context parameter which was used to access the router instance

```ts
setup(props, { root }) {
  // Access "root.$route.path" in some way
}
```

A new patch version for vue-router has been released which ships Composition API helpers compatible with Vue 2.7, we should upgrade to use it.

**IT SEEMS THERE ARE PROBLEMS**, that's why the PR is in draft mode, I'm still investigating
Apparently `vue-router` will call `getCurrentInstance` to guard against usage outside a setup method, but the current instance is apparently `null` when called from `vue-router` code but defined when called from the user code

I saw this kind of problems when CJS and ESM dist get mixed up in some way, this could be the case too
IIRC Quasar short-circuits vue-router calls to its CJS dist, instead of re-building it from scratch, this could be the problem, since vue-router composables are exposed via a named subfolder, we may need to shortcircuit that too

---

EDIT1: repro showing the problem: https://github.com/IlCallo/qv1-vue2_7-current-instance/blob/main/src/layouts/MainLayout.vue#L48-L60

---

EDIT2: found proof it's a CJS/ESM mix problem, userland code access Vue ESM dist ("vue.runtime.esm.js"), deps code access Vue CJS dist ("vue.runtime.common.js"). The latter won't have a defined Vue instance and everything falls apart

---

EDIT3: adding `cfg.resolve.alias['vue$'] = 'vue/dist/vue.esm.js'` into `extendWebpack` or switching `vueCompiler` to `true` into `quasar.config.js` (which does the same thing) solve the problem

I'd say we should remove `vueCompiler` option and always add the `vue` webpack alias in this point

I think the problem has been introduced into https://github.com/vuejs/vue/commit/d3172377e0c2df9e84244ede6fc9a091344e6f1c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

Seems like node_modules imports of `vue` follow this resolution path:
https://github.com/vuejs/vue/commit/d3172377e0c2df9e84244ede6fc9a091344e6f1c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R24

While user defined imports of `vue` follow this resolution path:
https://github.com/vuejs/vue/commit/d3172377e0c2df9e84244ede6fc9a091344e6f1c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R22

I don't get the full picture about why this happens, but this seems to be the case