### PR TITLE
docs: Use `undefined` as `rejectFn` for `openURL` (fix #14292)

### DIFF
--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -36,7 +36,7 @@ The optional `windowFeatures` parameter should be an Object with keys from [wind
 
 openURL(
   'http://...',
-  null, // in this example we don't care about the rejectFn()
+  undefined, // in this example we don't care about the rejectFn()
 
   // this is the windowFeatures Object param:
   {


### PR DESCRIPTION
Closes: https://github.com/quasarframework/quasar/issues/14292#issuecomment-1234091155

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
