### PR TITLE
Change link to electron-packager to `main` branch

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/configuring-electron.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/configuring-electron.md
@@ -24,7 +24,7 @@ electron: {
   bundler: 'packager', // or 'builder'
 
   // electron-packager options
-  // https://electron.github.io/electron-packager/master/
+  // https://electron.github.io/electron-packager/main/
   packager: {
     //...
   },

--- a/docs/src/pages/quasar-cli-webpack/developing-electron-apps/configuring-electron.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-electron-apps/configuring-electron.md
@@ -24,7 +24,7 @@ electron: {
   bundler: 'packager', // or 'builder'
 
   // electron-packager options
-  // https://electron.github.io/electron-packager/master/
+  // https://electron.github.io/electron-packager/main/
   packager: {
     //...
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This is a small change to update the link to the documentation for electron-packager from the
`master` branch to the `main` branch. Currently this is an optional update, as
electron.github.io/electron-packager/master redirects to electron.github.io/electron-packager/main/.
