### PR TITLE
fix(ui/QTable): Use correct definition for @request's filter

### DIFF
--- a/docs/public/examples/QTable/Synchronizing.vue
+++ b/docs/public/examples/QTable/Synchronizing.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="q-pa-md">
     <q-table
+      ref="tableRef"
       title="Treats"
       :rows="rows"
       :columns="columns"
@@ -8,8 +9,8 @@
       v-model:pagination="pagination"
       :loading="loading"
       :filter="filter"
-      @request="onRequest"
       binary-state-sort
+      @request="onRequest"
     >
       <template v-slot:top-right>
         <q-input borderless dense debounce="300" v-model="filter" placeholder="Search">
@@ -90,6 +91,7 @@ const originalRows = [
 
 export default {
   setup () {
+    const tableRef = ref()
     const rows = ref([])
     const filter = ref('')
     const loading = ref(false)
@@ -175,13 +177,11 @@ export default {
 
     onMounted(() => {
       // get initial data from server (1st page)
-      onRequest({
-        pagination: pagination.value,
-        filter: undefined
-      })
+      tableRef.value.requestServerInteraction()
     })
 
     return {
+      tableRef,
       filter,
       loading,
       pagination,

--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -1971,56 +1971,9 @@
               }
             },
             "filter": {
-              "type": "Function",
-              "required": true,
-              "desc": "Filter method (the 'filter-method' prop)",
-              "params": {
-                "rows": {
-                  "type": "Array",
-                  "required": true,
-                  "desc": "Array of rows",
-                  "__exemption": [ "examples" ]
-                },
-                "terms": {
-                  "type": [ "String", "Object" ],
-                  "required": true,
-                  "desc": "Terms to filter with (is essentially the 'filter' prop value)",
-                  "__exemption": [ "examples" ]
-                },
-                "cols": {
-                  "type": "Array",
-                  "desc": "Optional column definitions",
-                  "__exemption": [ "examples" ]
-                },
-                "getCellValue": {
-                  "type": "Function",
-                  "desc": "Optional function to get a cell value",
-                  "params": {
-                    "col": {
-                      "type": "Object",
-                      "required": true,
-                      "desc": "Column name from column definitions",
-                      "__exemption": [ "examples" ]
-                    },
-                    "row": {
-                      "type": "Object",
-                      "required": true,
-                      "desc": "The row object",
-                      "__exemption": [ "examples" ]
-                    }
-                  },
-                  "returns": {
-                    "type": "Any",
-                    "desc": "Parsed/Processed cell value",
-                    "examples": [ "Ice Cream Sandwich" ]
-                  }
-                }
-              },
-              "returns": {
-                "type": "Array",
-                "desc": "Filtered rows",
-                "__exemption": [ "examples" ]
-              }
+              "type": [ "String", "Object" ],
+              "desc": "String/Object to filter table with (the 'filter' prop)",
+              "__exemption": [ "examples" ]
             },
             "getCellValue": {
               "type": "Function",

--- a/ui/src/components/table/table-pagination.js
+++ b/ui/src/components/table/table-pagination.js
@@ -64,10 +64,6 @@ export function useTablePaginationState (vm, getCellValue) {
     nextTick(() => {
       emit('request', {
         pagination: prop.pagination || computedPagination.value,
-        // FIXME: 'props.filter' is string/object, but 'prop.filter' can be controlled by the user, and the docs are suggesting 'prop.filter' is a function
-        // So, value of 'filter' becomes function/string/object, which makes a lot of things unpredictable and can break things
-        // Either update the docs to say 'prop.filter' should be a string/object, or use 'prop.filter || props.filterMethod' or maybe get 'computedFilterFunction' here and use that instead of 'props.filterMethod'
-        // The examples on our docs are using 'filter' as a string in onRequest handler, but the JSON API is saying 'filter' is a function
         filter: prop.filter || props.filter,
         getCellValue
       })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Documentation

**Does this PR introduce a breaking change?**

- No

Anyone who was misled by the API docs(_code examples were correct_) and has passed a function instead of a string/object **should be warned**. **Their code will still work** since they can send a function filter to `requestServerInteraction` and expect the function they've sent in `onRequest` and use it as they wish, but **we should advise against this**. That is because if they don't pass in a function when calling `requestServerInteraction` or QTable triggers `@request` itself, they will receive QTable's `filter` prop, which can be string/object/undefined.

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Other information:**

In the past, I have made some investigations about the type and had a discussion with @rstoenescu:
[`ab3708d` (#11347)](https://github.com/quasarframework/quasar/pull/11347/commits/ab3708d8a01e5fda0ed286085f76a40f4292a935)

But, yesterday, someone from the community [posted this problem](https://discord.com/channels/415874313728688138/807654245640962059/1017061771313418260). After some investigation and discussion today, I am pretty confident that JSON API and docs examples are wrong. I created this PR to fix&clarify this problem.

@metalsadman also tagging you here since we had a [brief discussion about this on our Discord server](https://discord.com/channels/415874313728688138/807654245640962059/1017328496852336710).