### PR TITLE
(fix: #7947) support custom ios app name with capacitor

### DIFF
--- a/app-vite/lib/modes/capacitor/capacitor-builder.js
+++ b/app-vite/lib/modes/capacitor/capacitor-builder.js
@@ -43,6 +43,10 @@ class CapacitorBuilder extends AppBuilder {
 
     this.#capacitorConfigFile.prepare(this.quasarConf)
 
+    if (target == 'ios' && this.quasarConf.ctx.prod) {
+      this.quasarConf.capacitor.ios = this.#capacitorConfigFile.getCapIosConfig()
+    }
+
     await this.#runCapacitorCommand(this.quasarConf.capacitor.capacitorCliPreparationParams)
 
     this.#capacitorConfigFile.prepareSSL(false, target)
@@ -87,7 +91,8 @@ class CapacitorBuilder extends AppBuilder {
 
   async #buildIos () {
     const buildType = this.ctx.debug ? 'debug' : 'release'
-    const args = `xcodebuild -workspace App.xcworkspace -scheme App -configuration ${buildType} -derivedDataPath`
+    const scheme = this.quasarConf.capacitor.ios?.scheme || 'App'
+    const args = `xcodebuild -workspace App.xcworkspace -scheme ${scheme} -configuration ${buildType} -derivedDataPath`
 
     log('Building iOS app...')
 

--- a/app-vite/lib/modes/capacitor/config-file.js
+++ b/app-vite/lib/modes/capacitor/config-file.js
@@ -61,16 +61,24 @@ class CapacitorConfigFile {
     this.#tamperedFiles = []
 
     const capJsonPath = appPaths.resolve.capacitor('capacitor.config.json')
-    const capJson = require(capJsonPath)
+    this.capJson = require(capJsonPath)
 
     this.#tamperedFiles.push({
       path: capJsonPath,
       name: 'capacitor.config.json',
-      content: this.#updateCapJson(quasarConf, capJson),
-      originalContent: JSON.stringify(capJson, null, 2)
+      content: this.#updateCapJson(quasarConf, this.capJson),
+      originalContent: JSON.stringify(this.capJson, null, 2)
     })
 
     this.#save()
+  }
+
+  getCapIosConfig(){
+    if (!this.capJson) {
+      return {'scheme': 'App'}
+    }
+
+    return this.capJson.ios
   }
 
   reset () {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on a Capacitor (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Quasar / Capacitor / iOS developers who wish to change their app's name following the [Capacitor instructions (v4)](https://capacitorjs.com/docs/ios/configuration) will encounter the following xcodebuild error `xcodebuild: error: The workspace named "App" does not contain a scheme named "App".` This is due to "App" being hardcoded in the iOS build function. 

To resolve, I first looked at adding the ios scheme to quasar.config.js and dynamically updating capacitor.config.js but for the change to work in xcode you also need to update the app name in the podfile, which seems tricker than updating the quasar config in memory using the capacitor config file and dynamically updating the scheme in the iOS build function. 