### PR TITLE
fix(ui): Fix $q.loading type

### DIFF
--- a/ui/src/plugins/Loading.json
+++ b/ui/src/plugins/Loading.json
@@ -74,7 +74,6 @@
 
   "methods": {
     "show": {
-      "tsInjectionPoint": true,
       "desc": "Activate and show",
       "params": {
         "opts": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

```diff
-    loading: (
-      opts?: QLoadingShowOptions
-    ) => (props?: QLoadingUpdateOptions) => void;
+    loading: Loading;
```

`tsInjectionPoint` is for usage like `$q.loading()`, but we don't have that for the Loading plugin, we do `$q.loading.show()`, `$q.loading.hide()`, etc. instead. So, we must not use `tsInjectionPoint`.

Introduced in https://github.com/quasarframework/quasar/commit/dc2da2948cf3f37245c49aa1079327a75df19347