### PR TITLE
fix(ui): Add missing QUploader.isUploading API entry (fix #13217)

### DIFF
--- a/ui/src/components/uploader/QUploader.json
+++ b/ui/src/components/uploader/QUploader.json
@@ -258,6 +258,11 @@
     "isBusy": {
       "type": "Boolean",
       "desc": "The component state is set as busy; User should not be able to interact with the component"
+    },
+
+    "isUploading": {
+      "type": "Boolean",
+      "desc": "The component is uploading files"
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
https://github.com/quasarframework/quasar/issues/13217#issuecomment-1247993950
```diff
+  /**
+   * The component is uploading files
+   */
+  readonly isUploading: boolean;
```