### PR TITLE
fix: Validate function not making fields dirty because of lazy-rules

### DIFF
--- a/ui/src/composables/private/use-validate.js
+++ b/ui/src/composables/private/use-validate.js
@@ -119,7 +119,7 @@ export default function (focused, innerLoading) {
 
     const index = ++validateIndex
 
-    if (innerLoading.value !== true && props.lazyRules !== true) {
+    if (innerLoading.value !== true) {
       isDirtyModel.value = true
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** 
- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs]


**Other information:**
A small edge case / bug when using greedy form validation, reactive-rules and lazy-rules together.

When you use greedy validation and validate every input in your form, the inputs that have lazy-rules and reactives-rules but have not been touched (focus) will not react to changes in their rules.

The reason behind this is that when you use the function validate on inputs that have lazy-rules, they will not become dirty and then any changes in their rules(reactive-rules) will not trigger a new validation.

I propose to simply make the input dirty even when using lazy-rules after calling the function validate since error messages would already be shown and makes the focus / unfocus aspect of lazy-rules useless.

How to reproduce the bug / edge case:
1. Go on [https://codesandbox.io/s/cf0q11](url)
2. Press the button to active the greedy validation
3. Change the language with the q-select
4. Observe that only one of the inputs has had change (translation) in it's errors. 
5. In other words, the input that has never been interacted with (Last name) is not dirty and so it's rules will not react even if it has already been validated/error messages are already shown.

My **VERY** small change, in my eyes, has no impact on the way lazy-rules function but if I am wrong by all means correct me and close this PR :).