### PR TITLE
fix(app-vite&app-webpack): Gracefully handle boot import errors

### DIFF
--- a/app-vite/templates/entry/client-entry.js
+++ b/app-vite/templates/entry/client-entry.js
@@ -262,13 +262,19 @@ createQuasarApp(<%=
 %>, quasarUserOptions)
 <% if (bootEntries.length > 0) { %>
   .then(app => {
-    return Promise.all([
+    return Promise.allSettled([
       <% bootEntries.forEach((asset, index) => { %>
       import('<%= asset.path %>')<%= index < bootEntries.length - 1 ? ',' : '' %>
       <% }) %>
     ]).then(bootFiles => {
       const boot = bootFiles
-        .map(entry => entry.default)
+        .map(result => {
+          if (result.status === 'rejected') {
+            console.error('[Quasar] boot error:', result.reason)
+            return undefined
+          }
+          return result.value.default
+        })
         .filter(entry => typeof entry === 'function')
 
       start(app, boot)

--- a/app-vite/templates/entry/client-entry.js
+++ b/app-vite/templates/entry/client-entry.js
@@ -271,7 +271,7 @@ createQuasarApp(<%=
         .map(result => {
           if (result.status === 'rejected') {
             console.error('[Quasar] boot error:', result.reason)
-            return undefined
+            return
           }
           return result.value.default
         })

--- a/app-webpack/templates/entry/client-entry.js
+++ b/app-webpack/templates/entry/client-entry.js
@@ -266,13 +266,19 @@ createQuasarApp(<%=
 %>, quasarUserOptions)
 <% if (bootEntries.length > 0) { %>
   .then(app => {
-    return Promise.all([
+    return Promise.allSettled([
       <% bootEntries.forEach((asset, index) => { %>
       import(/* webpackMode: "eager" */ '<%= asset.path %>')<%= index < bootEntries.length - 1 ? ',' : '' %>
       <% }) %>
     ]).then(bootFiles => {
       const boot = bootFiles
-        .map(entry => entry.default)
+        .map(result => {
+          if (result.status === 'rejected') {
+            console.error('[Quasar] boot error:', result.reason)
+            return undefined
+          }
+          return result.value.default
+        })
         .filter(entry => typeof entry === 'function')
 
       start(app, boot)

--- a/app-webpack/templates/entry/client-entry.js
+++ b/app-webpack/templates/entry/client-entry.js
@@ -275,7 +275,7 @@ createQuasarApp(<%=
         .map(result => {
           if (result.status === 'rejected') {
             console.error('[Quasar] boot error:', result.reason)
-            return undefined
+            return
           }
           return result.value.default
         })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
We are gracefully handling errors by logging them when executing boot file functions. But, if they fail at the import/file level, the app breaks.
Especially when using code-splitting(_whether manual or automatic_), boot files may get into different chunks. If a network error(_perhaps due to an adblocker_) occurs during importing, the whole app will break. One example of this is happening on our docs(_[see the discussion on our Discord server](https://discord.com/channels/415874313728688138/416045430582018059/1019967442430214175)_). The GDPR boot file is on a different chunk, and when an adblocker blocks it by the name(_`gdpr.js`_), by the contents, etc. `components.js` boot file will not load and the app will break. For this reason, this will also be a fix for the docs. But, of course, the use case is not limited to that.