### PR TITLE
fix(ui): Add missing QLoadingUpdateOptions type

### DIFF
--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -6,6 +6,7 @@ export * from "./api/qtable";
 export * from "./api/qtree";
 export * from "./api/quploader";
 export * from "./api/qnotify";
+export * from "./api/qloading";
 export * from "./api/touchswipe";
 export * from "./api/web-storage";
 export * from "./api/validation";

--- a/ui/types/api/qloading.d.ts
+++ b/ui/types/api/qloading.d.ts
@@ -1,0 +1,5 @@
+// Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
+// The import will work correctly at runtime
+import { QLoadingShowOptions } from "quasar";
+
+export type QLoadingUpdateOptions = Omit<QLoadingShowOptions, 'group'>;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Type reference introduced in https://github.com/quasarframework/quasar/commit/dc2da2948cf3f37245c49aa1079327a75df19347

```ts
// Missing type definition
import { QLoadingUpdateOptions } from "./api";
// ...
show: (opts?: QLoadingShowOptions) => (props?: QLoadingUpdateOptions) => void;
```