### PR TITLE
(fix: #11445) Correct height of autogrow input during resize

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -5,6 +5,7 @@ import useMask, { useMaskProps } from './use-mask.js'
 import { useFormProps, useFormInputNameAttr } from '../../composables/private/use-form.js'
 import useFileFormDomProps from '../../composables/private/use-file-dom-props.js'
 import useKeyComposition from '../../composables/private/use-key-composition.js'
+import QResizeObserver from '../resize-observer/QResizeObserver.js'
 
 import { createComponent } from '../../utils/private/create.js'
 import { stop } from '../../utils/event.js'
@@ -355,6 +356,11 @@ export default createComponent({
       props.autogrow === true && adjustHeight()
     })
 
+    function onResize () {
+      // textarea only
+      props.autogrow === true && adjustHeight()
+    }
+
     Object.assign(state, {
       innerValue,
 
@@ -381,7 +387,7 @@ export default createComponent({
       ),
 
       getControl: () => {
-        return h(isTextarea.value === true ? 'textarea' : 'input', {
+        return [ h(isTextarea.value === true ? 'textarea' : 'input', {
           ref: inputRef,
           class: [
             'q-field__native q-placeholder',
@@ -395,7 +401,10 @@ export default createComponent({
               ? { value: getCurValue() }
               : formDomProps.value
           )
-        })
+        }), ...(props.autogrow === true ? [ h(QResizeObserver, {
+          debounce: 0,
+          onResize
+        }) ] : []) ]
       },
 
       getShadowControl: () => {


### PR DESCRIPTION
Fixing issue #11445 when autogrow input element doesn't grow during element resizing (see related issue for the example).

It is fixed by conditionally adding QResizeObserver next to native input element:
if element doesn't have autogrow property set, no observer is installed to avoid any drop of performance.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
