### PR TITLE
feat(QCircularProgress): line-cap support 

### DIFF
--- a/ui/dev/src/pages/components/circular-progress.vue
+++ b/ui/dev/src/pages/components/circular-progress.vue
@@ -78,6 +78,22 @@
       />
 
       <q-circular-progress
+        class="q-ma-sm"
+        :value="value"
+        :size="size + 'px'"
+        :thickness="thickness"
+        :angle="angle"
+        :min="range.min"
+        :max="range.max"
+        :reverse="reverse"
+        :show-value="showValue"
+        :indeterminate="indeterminate"
+        track-color="grey-4"
+        rounded
+        color="orange"
+      />
+
+      <q-circular-progress
         class="q-ma-sm text-orange"
         :value="value"
         :size="size / 1.5 + 'px'"

--- a/ui/src/components/circular-progress/QCircularProgress.js
+++ b/ui/src/components/circular-progress/QCircularProgress.js
@@ -66,7 +66,7 @@ export default createComponent({
 
     const strokeWidth = computed(() => props.thickness / 2 * viewBox.value)
 
-    function getCircle ({ thickness, offset, color, cls }) {
+    function getCircle ({ thickness, offset, color, cls, rounded }) {
       return h('circle', {
         class: 'q-circular-progress__' + cls + (color !== void 0 ? ` text-${ color }` : ''),
         style: circleStyle.value,
@@ -75,6 +75,7 @@ export default createComponent({
         'stroke-width': thickness,
         'stroke-dasharray': strokeDashArray,
         'stroke-dashoffset': offset,
+        'stroke-linecap': rounded ? 'round' : undefined,
         cx: viewBox.value,
         cy: viewBox.value,
         r: radius
@@ -108,7 +109,8 @@ export default createComponent({
           cls: 'circle',
           thickness: strokeWidth.value,
           offset: strokeDashOffset.value,
-          color: props.color
+          color: props.color,
+          rounded: props.rounded
         })
       )
 

--- a/ui/src/components/circular-progress/QCircularProgress.js
+++ b/ui/src/components/circular-progress/QCircularProgress.js
@@ -75,7 +75,7 @@ export default createComponent({
         'stroke-width': thickness,
         'stroke-dasharray': strokeDashArray,
         'stroke-dashoffset': offset,
-        'stroke-linecap': rounded ? 'round' : undefined,
+        'stroke-linecap': rounded,
         cx: viewBox.value,
         cy: viewBox.value,
         r: radius
@@ -110,7 +110,7 @@ export default createComponent({
           thickness: strokeWidth.value,
           offset: strokeDashOffset.value,
           color: props.color,
-          rounded: props.rounded
+          rounded: props.rounded === true ? 'round' : void 0
         })
       )
 

--- a/ui/src/components/circular-progress/QCircularProgress.json
+++ b/ui/src/components/circular-progress/QCircularProgress.json
@@ -58,7 +58,8 @@
       "desc": "Rounding the arc of progress",
       "default": false,
       "examples": [ true ],
-      "category": "style"
+      "category": "style",
+      "addedIn": "v2.8.4"
     },
 
     "thickness": {

--- a/ui/src/components/circular-progress/QCircularProgress.json
+++ b/ui/src/components/circular-progress/QCircularProgress.json
@@ -53,6 +53,14 @@
       "category": "style"
     },
 
+    "rounded": {
+      "type": "Boolean",
+      "desc": "Rounding the arc of progress",
+      "default": false,
+      "examples": [ true ],
+      "category": "style"
+    },
+
     "thickness": {
       "type": "Number",
       "default": 0.2,

--- a/ui/src/components/circular-progress/use-circular-progress.js
+++ b/ui/src/components/circular-progress/use-circular-progress.js
@@ -18,6 +18,7 @@ export const useCircularCommonProps = {
   trackColor: String,
 
   fontSize: String,
+  rounded: Boolean,
 
   // ratio
   thickness: {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->
PR for #14425
Tested on /ui `yarn dev` and added one example.
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Add  [stroke-linecap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap) to Circular Progress
stroke-linecap="round"

https://github.com/quasarframework/quasar/blob/baf2f9967ae2db0ed1ec483f0ee06263ffd84fcc/ui/src/components/circular-progress/QCircularProgress.js#L69-L82

Example: 
![Screenshot 2022-09-18 at 18 55 43](https://user-images.githubusercontent.com/11452353/190916234-0d795d7c-b6ae-4485-9fc5-6c3e741ec8f8.png)