### PR TITLE
chore: Use explicit permissions for GitHub Workflows

### DIFF
--- a/.github/workflows/process-created-issue.yml
+++ b/.github/workflows/process-created-issue.yml
@@ -3,8 +3,15 @@ on:
   issues:
     types:
       - opened
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   issue-automation:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      issues: write # to comment and add labels to issues
     if: >-
       ${{
         contains(github.event.issue.labels.*.name, 'kind/bug 🐞') ||

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -9,8 +9,15 @@ on:
       - 'ui/**.js'
       - '!.github/**'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   tests:      
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      actions: read # to correctly identify workflow run (cypress-io/github-action)
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.