### PR TITLE
refactor(ci): Changed testing workflow trigger

### DIFF
--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -1,7 +1,7 @@
 name: UI Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
     branches:
       - 'dev'


### PR DESCRIPTION
Changing the trigger for testing workflof from `pull_request_target` to `pull_request`, so the tests are ran on the PR code, not the base branch itself.

This should introduce the need for workflow runs to be approved by maintainers.