### PR TITLE
(fix: #14521) Browser hangs when QTree is loaded with relatively large data

### DIFF
--- a/ui/dev/mock-data/tree/smallTree.json
+++ b/ui/dev/mock-data/tree/smallTree.json
@@ -1,0 +1,387 @@
+[
+  {
+    "key": "KEY: Node 01",
+    "label": "Node 01",
+    "avatar": "https://cdn.quasar.dev/img/boy-avatar.png"
+  },
+  {
+    "key": "KEY: Node 02",
+    "label": "Node 02",
+    "icon": "alarm",
+    "iconColor": "red"
+  },
+  {
+    "key": "KEY: Node 03",
+    "label": "Node 03"
+  },
+  {
+    "key": "KEY: Node 04",
+    "label": "Node 04",
+    "avatar": "https://cdn.quasar.dev/img/boy-avatar.png",
+    "subnodes": [
+      {
+        "key": "KEY: Node 04.01",
+        "label": "Node 04.01",
+        "avatar": "https://cdn.quasar.dev/img/boy-avatar.png"
+      },
+      {
+        "key": "KEY: Node 04.02",
+        "label": "Node 04.02",
+        "icon": "alarm",
+        "iconColor": "red"
+      },
+      {
+        "key": "KEY: Node 04.03",
+        "label": "Node 04.03"
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node 05",
+    "label": "Node 05",
+    "icon": "alarm",
+    "iconColor": "red",
+    "subnodes": [
+      {
+        "key": "KEY: Node 05.01",
+        "label": "Node 05.01",
+        "avatar": "https://cdn.quasar.dev/img/boy-avatar.png"
+      },
+      {
+        "key": "KEY: Node 05.02",
+        "label": "Node 05.02",
+        "icon": "alarm",
+        "iconColor": "red"
+      },
+      {
+        "key": "KEY: Node 05.03",
+        "label": "Node 05.03"
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node 06",
+    "label": "Node 06",
+    "subnodes": [
+      {
+        "key": "KEY: Node 06.01",
+        "label": "Node 06.01",
+        "avatar": "https://cdn.quasar.dev/img/boy-avatar.png"
+      },
+      {
+        "key": "KEY: Node 06.02",
+        "label": "Node 06.02",
+        "icon": "alarm",
+        "iconColor": "red"
+      },
+      {
+        "key": "KEY: Node 06.03",
+        "label": "Node 06.03"
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node 1 - filter",
+    "label": "Node 1 - filter",
+    "icon": "alarm",
+    "iconColor": "red",
+    "subnodes": [
+      {
+        "key": "KEY: Node 1.1 - accordion test on children",
+        "label": "Node 1.1 - accordion test on children",
+        "avatar": "https://cdn.quasar.dev/img/boy-avatar.png",
+        "subnodes": [
+          {
+            "key": "KEY: Node 1.1.1 - tick strategy leaf-filtered",
+            "label": "Node 1.1.1 - tick strategy leaf-filtered",
+            "tickStrategy": "leaf-filtered",
+            "subnodes": [
+              {
+                "key": "KEY: Node 1.1.1.1 - lots of leafs",
+                "label": "Node 1.1.1.1 - lots of leafs"
+              }
+            ]
+          },
+          {
+            "key": "KEY: Node 1.1.2 - tick strategy leaf",
+            "label": "Node 1.1.2 - tick strategy leaf",
+            "tickStrategy": "leaf",
+            "subnodes": [
+              {
+                "key": "KEY: Node 1.1.2.1",
+                "label": "Node 1.1.2.1"
+              }
+            ]
+          },
+          {
+            "key": "KEY: Node 1.1.3 -- not selectable",
+            "label": "Node 1.1.3 -- not selectable",
+            "selectable": false
+          },
+          {
+            "key": "KEY: Node 1.1.4 - not tickable",
+            "label": "Node 1.1.4 - not tickable",
+            "tickable": false,
+            "subnodes": [
+              {
+                "key": "KEY: Node 1.1.4.1",
+                "label": "Node 1.1.4.1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "key": "KEY: Node 1.2",
+        "label": "Node 1.2",
+        "icon": "map",
+        "header": "custom"
+      },
+      {
+        "key": "KEY: Node 1.3 - tap on me!",
+        "label": "Node 1.3 - tap on me!",
+        "img": "https://cdn.quasar.dev/img/mountains.jpg"
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node 2",
+    "label": "Node 2",
+    "subnodes": [
+      {
+        "key": "KEY: Node 2.1",
+        "label": "Node 2.1",
+        "subnodes": [
+          {
+            "key": "KEY: Node 2.1.1",
+            "label": "Node 2.1.1"
+          },
+          {
+            "key": "KEY: Node 2.1.1 BIS - no tick present",
+            "label": "Node 2.1.1 BIS - no tick present",
+            "noTick": true
+          },
+          {
+            "key": "KEY: Node 2.1.2 - tick strategy strict",
+            "label": "Node 2.1.2 - tick strategy strict",
+            "tickStrategy": "strict",
+            "subnodes": [
+              {
+                "key": "KEY: Node 2.1.2.1 - body slot",
+                "label": "Node 2.1.2.1 - body slot",
+                "body": "2-1-2-1",
+                "subnodes": [
+                  {
+                    "key": "KEY: Node q",
+                    "label": "Node q",
+                    "lazy": true
+                  },
+                  {
+                    "key": "KEY: Node a",
+                    "label": "Node a",
+                    "lazy": true
+                  }
+                ]
+              },
+              {
+                "key": "KEY: Node 2.1.2.2 - body slot & children",
+                "label": "Node 2.1.2.2 - body slot & children",
+                "body": "2-1-2-1",
+                "subnodes": [
+                  {
+                    "key": "KEY: Node 2.1.2.2.1",
+                    "body": "2-1-2-2-1",
+                    "label": "Node 2.1.2.2.1"
+                  },
+                  {
+                    "key": "KEY: Node 2.1.2.2.2",
+                    "label": "Node 2.1.2.2.2"
+                  }
+                ]
+              },
+              {
+                "key": "KEY: Node 2.1.2.3 - header slot",
+                "label": "Node 2.1.2.3 - header slot",
+                "header": "2-1-2-2"
+              }
+            ]
+          },
+          {
+            "key": "KEY: Node 2.1.x - Disabled",
+            "label": "Node 2.1.x - Disabled",
+            "disabled": true,
+            "subnodes": [
+              {
+                "key": "KEY: Node 2.1.x.1",
+                "label": "Node 2.1.x.1"
+              },
+              {
+                "key": "KEY: Node 2.1.x.2",
+                "label": "Node 2.1.x.2"
+              }
+            ]
+          },
+          {
+            "key": "KEY: Node 2.1.3 - freeze exp / tickable",
+            "label": "Node 2.1.3 - freeze exp / tickable",
+            "expandable": false,
+            "tickable": true,
+            "subnodes": [
+              {
+                "key": "KEY: Node 2.1.3.1",
+                "label": "Node 2.1.3.1"
+              },
+              {
+                "key": "KEY: Node 2.1.3.2",
+                "label": "Node 2.1.3.2"
+              }
+            ]
+          },
+          {
+            "key": "KEY: Node 2.1.4 - Disabled",
+            "label": "Node 2.1.4 - Disabled",
+            "disabled": true,
+            "subnodes": [
+              {
+                "key": "KEY: Node 2.1.4.1",
+                "label": "Node 2.1.4.1"
+              },
+              {
+                "key": "KEY: Node 2.1.4.2",
+                "label": "Node 2.1.4.2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "key": "KEY: Node 2.2",
+        "label": "Node 2.2"
+      },
+      {
+        "key": "KEY: Node 2.3",
+        "label": "Node 2.3",
+        "subnodes": [
+          {
+            "key": "KEY: Node 2.3.1",
+            "label": "Node 2.3.1",
+            "body": "2-1-2-1"
+          },
+          {
+            "key": "KEY: Node 2.3.2",
+            "label": "Node 2.3.2",
+            "body": "2-1-2-1"
+          }
+        ]
+      },
+      {
+        "key": "KEY: Node 2.4 - Lazy load",
+        "label": "Node 2.4 - Lazy load",
+        "lazy": true
+      },
+      {
+        "key": "KEY: Node 2.5 - Lazy load empty",
+        "label": "Node 2.5 - Lazy load empty",
+        "lazy": true
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node parent - untickable ticked child",
+    "label": "Node parent - untickable ticked child",
+    "subnodes": [
+      {
+        "key": "KEY: Node child - 1 - 'disabled':",
+        "label": "Node child - 1 - 'disabled':",
+        "disabled": true
+      },
+      {
+        "key": "KEY: Node child - 1 - enabled - 1",
+        "label": "Node child - 1 - enabled - 1"
+      },
+      {
+        "key": "KEY: Node child - 1 - enabled - 2",
+        "label": "Node child - 1 - enabled - 2"
+      },
+      {
+        "key": "KEY: Node child - 1 - enabled - untickable",
+        "label": "Node child - 1 - enabled - untickable",
+        "tickable": false
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node parent - untickable unticked child",
+    "label": "Node parent - untickable unticked child",
+    "subnodes": [
+      {
+        "key": "KEY: Node child - 2 - 'disabled':",
+        "label": "Node child - 2 - 'disabled':",
+        "disabled": true
+      },
+      {
+        "key": "KEY: Node child - 2 - enabled - 1",
+        "label": "Node child - 2 - enabled - 1"
+      },
+      {
+        "key": "KEY: Node child - 2 - enabled - 2",
+        "label": "Node child - 2 - enabled - 2"
+      },
+      {
+        "key": "KEY: Node child - 2 - enabled - untickable",
+        "label": "Node child - 2 - enabled - untickable",
+        "tickable": false
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node parent - all untickable ticked children",
+    "label": "Node parent - all untickable ticked children",
+    "subnodes": [
+      {
+        "key": "KEY: Node child - 3 - 'disabled':",
+        "label": "Node child - 3 - 'disabled':",
+        "disabled": true
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node parent - all untickable mix ticked children",
+    "label": "Node parent - all untickable mix ticked children",
+    "subnodes": [
+      {
+        "key": "KEY: Node child - 4 - 'disabled':",
+        "label": "Node child - 4 - 'disabled':",
+        "disabled": true
+      },
+      {
+        "key": "KEY: Node child - 4 - enabled - untickable",
+        "label": "Node child - 4 - enabled - untickable",
+        "tickable": false
+      }
+    ]
+  },
+  {
+    "key": "KEY: Node parent - all untickable unticked children",
+    "label": "Node parent - all untickable unticked children",
+    "subnodes": [
+      {
+        "key": "KEY: Node child - 5 - 'disabled':",
+        "label": "Node child - 5 - 'disabled':",
+        "disabled": true,
+        "subnodes": [
+          {
+            "key": "KEY: Node child - 5.1 - 'disabled':",
+            "label": "Node child - 5.1 - 'disabled':",
+            "disabled": true
+          },
+          {
+            "key": "KEY: Node child - 5.2 - enabled - untickable",
+            "label": "Node child - 5.2 - enabled - untickable",
+            "tickable": false
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/ui/dev/src/pages/components/tree.vue
+++ b/ui/dev/src/pages/components/tree.vue
@@ -32,9 +32,12 @@
           <div v-if="selectableNodes" class="col-xs-12 col-md-6" style="min-height: 60px">
             <span class="text-bold">Selected</span>:<br>{{ selected || 'null' }}
           </div>
-          <div class="col-xs-12 col-md-6">
+          <div class="col-xs-12 col-md-6 q-gutter-x-sm">
             <q-btn @click="getNodeByKey" no-caps label="getNodeByKey test" />
+            <q-toggle v-model="isBigTree" label="Load Big Tree"/>
+            <q-toggle v-model="noTransition" label="noTransition"/>
             <q-btn @click="expandAll" no-caps label="Expand all" />
+            <q-btn @click="collapseAll" no-caps label="Collapse all" />
           </div>
         </div>
       </div>
@@ -55,6 +58,7 @@
           :color="color"
           :filter="filter"
           :no-connectors="noConnectors"
+          :no-transition="noTransition"
           :no-selection-unset="noSelectionUnset"
           @lazy-load="onLazyLoad"
         >
@@ -104,6 +108,18 @@
 </template>
 
 <script>
+import smallTree from '../../../mock-data/tree/smallTree.json'
+
+const findNode = (key, nodes) => {
+  for (let node of nodes) {
+    if (node.key === key) return node
+    if (node.subnodes) {
+      node = findNode(key, node.subnodes)
+      if (node) return node
+    }
+  }
+}
+
 export default {
   computed: {
     color () {
@@ -115,6 +131,9 @@ export default {
       this.selected = v
         ? this.selected || null
         : undefined
+    },
+    async isBigTree (v) {
+      this.nodes = v ? (await import('../../../mock-data/tree/bigTree.json')).default : smallTree
     }
   },
   data () {
@@ -127,9 +146,12 @@ export default {
       })
     }
     */
+    // Patch the smallTree's node 1.3 as we can't save function to JSON
+    findNode('KEY: Node 1.3 - tap on me!', smallTree).handler = () => this.$q.notify('Tapped on node 1.3')
 
     return {
       noConnectors: false,
+      noTransition: false,
       selected: null,
       noSelectionUnset: false,
       tickStrategy: 'leaf',
@@ -156,397 +178,8 @@ export default {
       accordion: false,
       filter: '',
       defaultExpandAll: false,
-      nodes: [
-        {
-          key: 'KEY: Node 01',
-          label: 'Node 01',
-          avatar: 'https://cdn.quasar.dev/img/boy-avatar.png'
-        },
-        {
-          key: 'KEY: Node 02',
-          label: 'Node 02',
-          icon: 'alarm',
-          iconColor: 'red'
-        },
-        {
-          key: 'KEY: Node 03',
-          label: 'Node 03'
-        },
-        {
-          key: 'KEY: Node 04',
-          label: 'Node 04',
-          avatar: 'https://cdn.quasar.dev/img/boy-avatar.png',
-          subnodes: [
-            {
-              key: 'KEY: Node 04.01',
-              label: 'Node 04.01',
-              avatar: 'https://cdn.quasar.dev/img/boy-avatar.png'
-            },
-            {
-              key: 'KEY: Node 04.02',
-              label: 'Node 04.02',
-              icon: 'alarm',
-              iconColor: 'red'
-            },
-            {
-              key: 'KEY: Node 04.03',
-              label: 'Node 04.03'
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node 05',
-          label: 'Node 05',
-          icon: 'alarm',
-          iconColor: 'red',
-          subnodes: [
-            {
-              key: 'KEY: Node 05.01',
-              label: 'Node 05.01',
-              avatar: 'https://cdn.quasar.dev/img/boy-avatar.png'
-            },
-            {
-              key: 'KEY: Node 05.02',
-              label: 'Node 05.02',
-              icon: 'alarm',
-              iconColor: 'red'
-            },
-            {
-              key: 'KEY: Node 05.03',
-              label: 'Node 05.03'
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node 06',
-          label: 'Node 06',
-          subnodes: [
-            {
-              key: 'KEY: Node 06.01',
-              label: 'Node 06.01',
-              avatar: 'https://cdn.quasar.dev/img/boy-avatar.png'
-            },
-            {
-              key: 'KEY: Node 06.02',
-              label: 'Node 06.02',
-              icon: 'alarm',
-              iconColor: 'red'
-            },
-            {
-              key: 'KEY: Node 06.03',
-              label: 'Node 06.03'
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node 1 - filter',
-          label: 'Node 1 - filter',
-          icon: 'alarm',
-          iconColor: 'red',
-          subnodes: [
-            {
-              key: 'KEY: Node 1.1 - accordion test on children',
-              label: 'Node 1.1 - accordion test on children',
-              avatar: 'https://cdn.quasar.dev/img/boy-avatar.png',
-              subnodes: [
-                {
-                  key: 'KEY: Node 1.1.1 - tick strategy leaf-filtered',
-                  label: 'Node 1.1.1 - tick strategy leaf-filtered',
-                  tickStrategy: 'leaf-filtered',
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 1.1.1.1 - lots of leafs',
-                      label: 'Node 1.1.1.1 - lots of leafs'/* ,
-                      children */
-                    }
-                  ]
-                },
-                {
-                  key: 'KEY: Node 1.1.2 - tick strategy leaf',
-                  label: 'Node 1.1.2 - tick strategy leaf',
-                  tickStrategy: 'leaf',
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 1.1.2.1',
-                      label: 'Node 1.1.2.1'
-                    }
-                  ]
-                },
-                {
-                  key: 'KEY: Node 1.1.3 -- not selectable',
-                  label: 'Node 1.1.3 -- not selectable',
-                  selectable: false
-                },
-                {
-                  key: 'KEY: Node 1.1.4 - not tickable',
-                  label: 'Node 1.1.4 - not tickable',
-                  tickable: false,
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 1.1.4.1',
-                      label: 'Node 1.1.4.1'
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              key: 'KEY: Node 1.2',
-              label: 'Node 1.2',
-              icon: 'map',
-              header: 'custom'
-            },
-            {
-              key: 'KEY: Node 1.3 - tap on me!',
-              label: 'Node 1.3 - tap on me!',
-              img: 'https://cdn.quasar.dev/img/mountains.jpg',
-              handler: () => {
-                this.$q.notify('Tapped on node 1.3')
-              }
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node 2',
-          label: 'Node 2',
-          subnodes: [
-            {
-              key: 'KEY: Node 2.1',
-              label: 'Node 2.1',
-              subnodes: [
-                {
-                  key: 'KEY: Node 2.1.1',
-                  label: 'Node 2.1.1'
-                },
-                {
-                  key: 'KEY: Node 2.1.1 BIS - no tick present',
-                  label: 'Node 2.1.1 BIS - no tick present',
-                  noTick: true
-                },
-                {
-                  key: 'KEY: Node 2.1.2 - tick strategy strict',
-                  label: 'Node 2.1.2 - tick strategy strict',
-                  tickStrategy: 'strict',
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 2.1.2.1 - body slot',
-                      label: 'Node 2.1.2.1 - body slot',
-                      body: '2-1-2-1',
-                      subnodes: [
-                        {
-                          key: 'KEY: Node q',
-                          label: 'Node q',
-                          lazy: true
-                        },
-                        {
-                          key: 'KEY: Node a',
-                          label: 'Node a',
-                          lazy: true
-                        }
-                      ]
-                    },
-                    {
-                      key: 'KEY: Node 2.1.2.2 - body slot & children',
-                      label: 'Node 2.1.2.2 - body slot & children',
-                      body: '2-1-2-1',
-                      subnodes: [
-                        {
-                          key: 'KEY: Node 2.1.2.2.1',
-                          body: '2-1-2-2-1',
-                          label: 'Node 2.1.2.2.1'
-                        },
-                        {
-                          key: 'KEY: Node 2.1.2.2.2',
-                          label: 'Node 2.1.2.2.2'
-                        }
-                      ]
-                    },
-                    {
-                      key: 'KEY: Node 2.1.2.3 - header slot',
-                      label: 'Node 2.1.2.3 - header slot',
-                      header: '2-1-2-2'
-                    }
-                  ]
-                },
-                {
-                  key: 'KEY: Node 2.1.x - Disabled',
-                  label: 'Node 2.1.x - Disabled',
-                  disabled: true,
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 2.1.x.1',
-                      label: 'Node 2.1.x.1'
-                    },
-                    {
-                      key: 'KEY: Node 2.1.x.2',
-                      label: 'Node 2.1.x.2'
-                    }
-                  ]
-                },
-                {
-                  key: 'KEY: Node 2.1.3 - freeze exp / tickable',
-                  label: 'Node 2.1.3 - freeze exp / tickable',
-                  expandable: false,
-                  tickable: true,
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 2.1.3.1',
-                      label: 'Node 2.1.3.1'
-                    },
-                    {
-                      key: 'KEY: Node 2.1.3.2',
-                      label: 'Node 2.1.3.2'
-                    }
-                  ]
-                },
-                {
-                  key: 'KEY: Node 2.1.4 - Disabled',
-                  label: 'Node 2.1.4 - Disabled',
-                  disabled: true,
-                  subnodes: [
-                    {
-                      key: 'KEY: Node 2.1.4.1',
-                      label: 'Node 2.1.4.1'
-                    },
-                    {
-                      key: 'KEY: Node 2.1.4.2',
-                      label: 'Node 2.1.4.2'
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              key: 'KEY: Node 2.2',
-              label: 'Node 2.2'
-            },
-            {
-              key: 'KEY: Node 2.3',
-              label: 'Node 2.3',
-              subnodes: [
-                {
-                  key: 'KEY: Node 2.3.1',
-                  label: 'Node 2.3.1',
-                  body: '2-1-2-1'
-                },
-                {
-                  key: 'KEY: Node 2.3.2',
-                  label: 'Node 2.3.2',
-                  body: '2-1-2-1'
-                }
-              ]
-            },
-            {
-              key: 'KEY: Node 2.4 - Lazy load',
-              label: 'Node 2.4 - Lazy load',
-              lazy: true
-            },
-            {
-              key: 'KEY: Node 2.5 - Lazy load empty',
-              label: 'Node 2.5 - Lazy load empty',
-              lazy: true
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node parent - untickable ticked child',
-          label: 'Node parent - untickable ticked child',
-          subnodes: [
-            {
-              key: 'KEY: Node child - 1 - disabled',
-              label: 'Node child - 1 - disabled',
-              disabled: true
-            },
-            {
-              key: 'KEY: Node child - 1 - enabled - 1',
-              label: 'Node child - 1 - enabled - 1'
-            },
-            {
-              key: 'KEY: Node child - 1 - enabled - 2',
-              label: 'Node child - 1 - enabled - 2'
-            },
-            {
-              key: 'KEY: Node child - 1 - enabled - untickable',
-              label: 'Node child - 1 - enabled - untickable',
-              tickable: false
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node parent - untickable unticked child',
-          label: 'Node parent - untickable unticked child',
-          subnodes: [
-            {
-              key: 'KEY: Node child - 2 - disabled',
-              label: 'Node child - 2 - disabled',
-              disabled: true
-            },
-            {
-              key: 'KEY: Node child - 2 - enabled - 1',
-              label: 'Node child - 2 - enabled - 1'
-            },
-            {
-              key: 'KEY: Node child - 2 - enabled - 2',
-              label: 'Node child - 2 - enabled - 2'
-            },
-            {
-              key: 'KEY: Node child - 2 - enabled - untickable',
-              label: 'Node child - 2 - enabled - untickable',
-              tickable: false
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node parent - all untickable ticked children',
-          label: 'Node parent - all untickable ticked children',
-          subnodes: [
-            {
-              key: 'KEY: Node child - 3 - disabled',
-              label: 'Node child - 3 - disabled',
-              disabled: true
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node parent - all untickable mix ticked children',
-          label: 'Node parent - all untickable mix ticked children',
-          subnodes: [
-            {
-              key: 'KEY: Node child - 4 - disabled',
-              label: 'Node child - 4 - disabled',
-              disabled: true
-            },
-            {
-              key: 'KEY: Node child - 4 - enabled - untickable',
-              label: 'Node child - 4 - enabled - untickable',
-              tickable: false
-            }
-          ]
-        },
-        {
-          key: 'KEY: Node parent - all untickable unticked children',
-          label: 'Node parent - all untickable unticked children',
-          subnodes: [
-            {
-              key: 'KEY: Node child - 5 - disabled',
-              label: 'Node child - 5 - disabled',
-              disabled: true,
-              subnodes: [
-                {
-                  key: 'KEY: Node child - 5.1 - disabled',
-                  label: 'Node child - 5.1 - disabled',
-                  disabled: true
-                },
-                {
-                  key: 'KEY: Node child - 5.2 - enabled - untickable',
-                  label: 'Node child - 5.2 - enabled - untickable',
-                  tickable: false
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      isBigTree: false,
+      nodes: smallTree
     }
   },
   methods: {
@@ -555,6 +188,9 @@ export default {
     },
     expandAll () {
       this.$refs.tree.expandAll()
+    },
+    collapseAll () {
+      this.$refs.tree.collapseAll()
     },
     onLazyLoad ({ node, key, done, fail }) {
       // call fail() if any error occurs

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -68,10 +68,7 @@ export default createComponent({
 
     duration: Number,
     noConnectors: Boolean,
-    noTransition: {
-      type: Boolean,
-      default: false
-    },
+    noTransition: Boolean,
 
     noNodesLabel: String,
     noResultsLabel: String

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -137,7 +137,6 @@ export default createComponent({
     ))
 
     const meta = computed(() => {
-      const perf = performance.now()
       const meta = {}
 
       const travel = (node, parent) => {
@@ -246,7 +245,6 @@ export default createComponent({
       }
 
       props.nodes.forEach(node => travel(node, null))
-      console.log(`meta built in: ${ performance.now() - perf } ms`)
       return meta
     })
 

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -129,8 +129,8 @@
     "noTransition": {
       "type": "Boolean",
       "desc": "Turn off transition effects when expand nodes",
-      "default": false,
-      "category": "behavior"
+      "category": "behavior",
+      "addedIn": "v2.9.3"
     },
 
     "filter": {

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -126,6 +126,13 @@
       "category": "behavior"
     },
 
+    "noTransition": {
+      "type": "Boolean",
+      "desc": "Turn off transition effects when expand nodes",
+      "default": false,
+      "category": "behavior"
+    },
+
     "filter": {
       "type": "String",
       "desc": "The text value to be used for filtering nodes",

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -128,7 +128,7 @@
 
     "noTransition": {
       "type": "Boolean",
-      "desc": "Turn off transition effects when expand nodes",
+      "desc": "Turn off transition effects when expand nodes; Also enhances perf by a lot as a side-effect; Recommended for big trees",
       "category": "behavior",
       "addedIn": "v2.9.3"
     },

--- a/ui/src/components/tree/QTree.json
+++ b/ui/src/components/tree/QTree.json
@@ -130,7 +130,7 @@
       "type": "Boolean",
       "desc": "Turn off transition effects when expand nodes; Also enhances perf by a lot as a side-effect; Recommended for big trees",
       "category": "behavior",
-      "addedIn": "v2.9.3"
+      "addedIn": "v2.9.2"
     },
 
     "filter": {


### PR DESCRIPTION
**What kind of change does this PR introduce?** 

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** 

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The issue #14521 is mitigated by adding a noTransition prop where tree nodes are not wrapped by QSlideTransition.

This work-around doesn't address QTree's further performance enhancement needs due to the current design & implementation. It seems hard to do so without introducing breaking changes. For example, tree is coupled with nodes, therefore meta, the flat state of tree, is discarded, travelled and rebuilt each time when a node is expanded or ticked, which is too expensive. On a mid-spec PC, rebuilding of 30K nodes tree could take about 200-600ms, causing noticeable lags when expand a parent node.