### PR TITLE
test(QBtn): add unit-test for Qbtn.js - use-btn.js

### DIFF
--- a/ui/src/components/btn/__tests__/QBtn.spec.js
+++ b/ui/src/components/btn/__tests__/QBtn.spec.js
@@ -87,7 +87,7 @@ describe('Btn API', () => {
           }
         })
 
-        cy.get('.q-btn').contains(loadingSlot)
+        cy.get('.q-btn').should('contain', loadingSlot).contains(defaultOptions.label).should('not.be.visible')
       })
     })
   })

--- a/ui/src/components/btn/__tests__/QBtn.spec.js
+++ b/ui/src/components/btn/__tests__/QBtn.spec.js
@@ -1,23 +1,65 @@
+import { mount } from '@cypress/vue'
+import QBtn from '../QBtn.js'
+
+const defaultOptions = {
+  label: 'simple Btn'
+}
+
+function mountQBtn (options = {}) {
+  options.props = {
+    ...defaultOptions,
+    ...options.props
+  }
+
+  return mount(QBtn, options)
+}
+
 describe('Btn API', () => {
   describe('Props', () => {
     describe('Category: behavior', () => {
       describe('(prop): percentage', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with a percentage when "loading" prop is set to true', () => {
+          const percentage = 50
+
+          mountQBtn({
+            props: {
+              percentage,
+              loading: true
+            }
+          })
+
+          cy.get('.q-btn').should('have.attr', 'aria-valuenow', percentage)
         })
       })
 
       describe('(prop): dark-percentage', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with a dark percentage when "loading" prop is set to true', () => {
+          const percentage = 50
+
+          mountQBtn({
+            props: {
+              percentage,
+              loading: true,
+              darkPercentage: true
+            }
+          })
+
+          cy.get('.q-btn').should('have.attr', 'aria-valuenow', percentage)
+            .get('.q-btn__progress').should('have.class', 'q-btn__progress--dark')
         })
       })
     })
 
     describe('Category: style', () => {
       describe('(prop): round', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a circle shaped button when "round" prop is set to true', () => {
+          mountQBtn({
+            props: {
+              round: true
+            }
+          })
+
+          cy.get('.q-btn').should('have.class', 'q-btn--round')
         })
       })
     })
@@ -25,30 +67,61 @@ describe('Btn API', () => {
 
   describe('Slots', () => {
     describe('(slot): default', () => {
-      it.skip(' ', () => {
-        //
+      it('should render a button with a label', () => {
+        mountQBtn()
+
+        cy.get('.q-btn').should('contain', defaultOptions.label)
       })
     })
 
     describe('(slot): loading', () => {
-      it.skip(' ', () => {
-        //
+      it('should render a button with a loading slot', () => {
+        const loadingSlot = 'loading slot'
+
+        mountQBtn({
+          props: {
+            loading: true
+          },
+          slots: {
+            loading: loadingSlot
+          }
+        })
+
+        cy.get('.q-btn').contains(loadingSlot)
       })
     })
   })
 
   describe('Events', () => {
     describe('(event): click', () => {
-      it.skip(' ', () => {
-        //
+      it('should emit a click event when the button is clicked', () => {
+        const fn = cy.stub()
+
+        mountQBtn({
+          props: {
+            onClick: fn
+          }
+        })
+
+        cy.get('.q-btn').click()
+          .then(() => expect(fn).to.be.calledOnce)
       })
     })
   })
 
   describe('Methods', () => {
     describe('(method): click', () => {
-      it.skip(' ', () => {
-        //
+      it('should click the button', () => {
+        const fn = cy.stub()
+
+        mountQBtn({
+          props: {
+            onClick: fn
+          }
+        })
+
+        cy.get('.q-btn').invoke('click')
+          .then(() => expect(fn).to.be.calledOnce)
       })
     })
   })

--- a/ui/src/components/btn/__tests__/use-btn.spec.js
+++ b/ui/src/components/btn/__tests__/use-btn.spec.js
@@ -1,187 +1,513 @@
+import { mount } from '@cypress/vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { alignMap, alignValues } from '../../../composables/private/use-align.js'
+import QBtn from '../QBtn.js'
+import { btnPadding as paddingMap } from '../use-btn.js'
+
+const defaultOptions = {
+  label: 'simple Btn'
+}
+
+const typesValues = [ 'button', 'submit', 'reset' ]
+
+const paddingValues = Object.keys(paddingMap)
+
+function mountQBtn (options = {}) {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.plugins = options.global.plugins || []
+
+  options.props = {
+    ...defaultOptions,
+    ...options.props
+  }
+
+  if (!options.router) {
+    options.router = createRouter({
+      routes: [],
+      history: createMemoryHistory()
+    })
+  }
+
+  // Add router plugin
+  options.global.plugins.push({
+    install (app) {
+      app.use(options.router)
+    }
+  })
+
+  return mount(QBtn, options)
+}
+
 describe('use-btn API', () => {
   describe('Props', () => {
     describe('Category: behavior|state', () => {
       describe('(prop): loading', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with "loading" slot when "loading" prop is set to true', () => {
+          mountQBtn({
+            props: {
+              loading: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .get('.absolute-full.flex.flex-center').should('exist')
         })
       })
     })
 
     describe('Category: content', () => {
       describe('(prop): label', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a label inside the button', () => {
+          const label = 'Custom Label'
+          mountQBtn({
+            props: {
+              label
+            }
+          })
+
+          cy.get('.q-btn').should('contain', label)
         })
       })
 
       describe('(prop): icon', () => {
-        it.skip(' ', () => {
-          //
+        it('should render an icon on the left', () => {
+          const icon = 'home'
+
+          mountQBtn({
+            props: {
+              icon
+            }
+          })
+
+          cy.get('.q-btn').should('contain', icon)
         })
       })
 
       describe('(prop): icon-right', () => {
-        it.skip(' ', () => {
-          //
+        it('should render an icon on the right', () => {
+          const iconRight = 'home'
+
+          mountQBtn({
+            props: {
+              iconRight
+            }
+          })
+
+          cy.get('.q-btn').should('contain', iconRight)
         })
       })
 
       describe('(prop): no-caps', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with no uppercase text', () => {
+          mountQBtn({
+            props: {
+              noCaps: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--no-uppercase')
         })
       })
 
       describe('(prop): no-wrap', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with no wrapping text', () => {
+          mountQBtn({
+            props: {
+              noWrap: true
+            }
+          })
+
+          cy.get('.q-btn .q-btn__content')
+            .should('have.class', 'no-wrap')
+            .should('have.class', 'text-no-wrap')
         })
       })
 
       describe('(prop): align', () => {
-        it.skip(' ', () => {
-          //
+        it(`should render a badge aligned based on defined values: ${ alignValues.join(', ') }`, () => {
+          mountQBtn()
+
+          for (const align of alignValues) {
+            cy.get('.q-btn .q-btn__content')
+              .then(() => Cypress.vueWrapper.setProps({ align }))
+              .should('have.class', `justify-${ alignMap[ align ] }`)
+          }
         })
       })
 
       describe('(prop): stack', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with icon and label stacked vertically', () => {
+          mountQBtn({
+            props: {
+              stack: true
+            }
+          })
+
+          cy.get('.q-btn .q-btn__content')
+            .should('have.class', 'column')
         })
       })
 
       describe('(prop): stretch', () => {
-        it.skip(' ', () => {
-          //
+        it('should render stretch height button when used in flexbox container', () => {
+          mountQBtn({
+            props: {
+              stretch: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'no-border-radius')
+            .should('have.class', 'self-stretch')
         })
       })
     })
 
     describe('Category: general', () => {
       describe('(prop): type', () => {
-        it.skip(' ', () => {
-          //
+        it(`should render a button with a type based on defined values: ${ typesValues.join(', ') }`, () => {
+          mountQBtn()
+
+          for (const type of typesValues) {
+            cy.get('.q-btn')
+              .then(() => Cypress.vueWrapper.setProps({ type }))
+              .should('have.attr', 'type', type)
+          }
+        })
+
+        it('should render a component with <a> tag when "type" prop is set to "a"', () => {
+          mountQBtn({
+            props: {
+              type: 'a'
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.prop', 'tagName').should('eq', 'A')
         })
       })
 
       describe('(prop): tabindex', () => {
-        it.skip(' ', () => {
-          //
+        it('should set the tabindex', () => {
+          mountQBtn({
+            props: {
+              tabindex: 1
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.attr', 'tabindex', '1')
         })
       })
     })
 
     describe('Category: navigation', () => {
       describe('(prop): to', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a component with <a> tag when "to" prop is set', () => {
+          const link = '/test'
+
+          mountQBtn({
+            props: {
+              to: link
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.attr', 'href', link)
+            .should('have.prop', 'tagName').should('eq', 'A')
         })
       })
 
       describe('(prop): replace', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a component with <a> tag when "replace" prop is set', () => {
+          const link = '/test'
+
+          mountQBtn({
+            props: {
+              to: link,
+              replace: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.attr', 'href', link)
+            .should('have.prop', 'tagName').should('eq', 'A')
         })
       })
 
       describe('(prop): href', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a component with <a> tag and "href" attribute', () => {
+          const href = 'https://quasar.dev'
+
+          mountQBtn({
+            props: {
+              href
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.attr', 'href', href)
+            .should('have.prop', 'tagName').should('eq', 'A')
         })
       })
 
       describe('(prop): target', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a component with <a> tag and "target" attribute', () => {
+          const href = 'https://quasar.dev'
+
+          mountQBtn({
+            props: {
+              href,
+              target: '_blank'
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.attr', 'target', '_blank')
+            .should('have.prop', 'tagName').should('eq', 'A')
         })
       })
     })
 
     describe('Category: state', () => {
       describe('(prop): disable', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a disabled button', () => {
+          mountQBtn({
+            props: {
+              disable: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'disabled')
+            .should('have.attr', 'disabled')
         })
       })
     })
 
     describe('Category: style', () => {
       describe('(prop): outline', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with outline style', () => {
+          mountQBtn({
+            props: {
+              outline: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--outline')
         })
       })
 
       describe('(prop): flat', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with flat style', () => {
+          mountQBtn({
+            props: {
+              flat: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--flat')
         })
       })
 
       describe('(prop): unelevated', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with unelevated style', () => {
+          mountQBtn({
+            props: {
+              unelevated: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--unelevated')
         })
       })
 
       describe('(prop): rounded', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with rounded style', () => {
+          mountQBtn({
+            props: {
+              rounded: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--rounded')
         })
       })
 
       describe('(prop): push', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with push style', () => {
+          mountQBtn({
+            props: {
+              push: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--push')
+        })
+      })
+
+      describe('(prop): square', () => {
+        it('should render a button with square style', () => {
+          mountQBtn({
+            props: {
+              square: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--square')
         })
       })
 
       describe('(prop): glossy', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with glossy style', () => {
+          mountQBtn({
+            props: {
+              glossy: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'glossy')
         })
       })
 
       describe('(prop): fab', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with fab style', () => {
+          mountQBtn({
+            props: {
+              fab: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--fab')
         })
       })
 
       describe('(prop): fab-mini', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with fab-mini style', () => {
+          mountQBtn({
+            props: {
+              fabMini: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--fab-mini')
         })
       })
 
       describe('(prop): padding', () => {
-        it.skip(' ', () => {
-          //
+        it(`should render a button with padding based on defined values: ${ paddingValues.join(', ') }`, () => {
+          mountQBtn()
+
+          for (const padding of paddingValues) {
+            cy.get('.q-btn')
+              .then(() => Cypress.vueWrapper.setProps({ padding }))
+              .should('have.css', 'padding', `${ paddingMap[ padding ] }px`)
+          }
+        })
+
+        it('should render a button with padding based custom value', () => {
+          const padding = '10px'
+
+          mountQBtn({
+            props: {
+              padding
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.css', 'padding', padding)
+        })
+
+        it('should render a button with padding vertically and horizontally based on defined values" ', () => {
+          mountQBtn()
+
+          for (const paddingVertically of paddingValues) {
+            for (const paddingHorizontally of paddingValues) {
+              if (paddingVertically === paddingHorizontally) { continue }
+
+              const padding = `${ paddingVertically } ${ paddingHorizontally }`
+
+              cy.get('.q-btn')
+                .then(() => Cypress.vueWrapper.setProps({ padding }))
+                .should('have.css', 'padding',
+                  `${ paddingMap[ paddingVertically ] }px ${ paddingMap[ paddingHorizontally ] }px`)
+            }
+          }
+        })
+
+        it('should render a button with "minWidth" and "minHeight" props set to "0"', () => {
+          mountQBtn({
+            props: {
+              padding: '0'
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.css', 'min-width', '0px')
+            .should('have.css', 'min-height', '0px')
         })
       })
 
       describe('(prop): color', () => {
-        it.skip(' ', () => {
-          //
+        it('should change text color based on Quasar Color Palette', () => {
+          const color = 'red'
+
+          mountQBtn({
+            props: { color }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', `bg-${ color }`)
         })
       })
 
       describe('(prop): text-color', () => {
-        it.skip(' ', () => {
-          //
+        it('should change text color based on Quasar Color Palette', () => {
+          const textColor = 'red'
+
+          mountQBtn({
+            props: { textColor }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', `text-${ textColor }`)
         })
       })
 
       describe('(prop): dense', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with dense style', () => {
+          mountQBtn({
+            props: {
+              dense: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .should('have.class', 'q-btn--dense')
         })
       })
 
       describe('(prop): ripple', () => {
-        it.skip(' ', () => {
-          //
+        it('should render a button with ripple effect', () => {
+          mountQBtn({
+            props: {
+              ripple: true
+            }
+          })
+
+          cy.get('.q-btn')
+            .click().get('.q-ripple').should('exist')
         })
       })
     })

--- a/ui/src/components/btn/__tests__/use-btn.spec.js
+++ b/ui/src/components/btn/__tests__/use-btn.spec.js
@@ -50,8 +50,7 @@ describe('use-btn API', () => {
             }
           })
 
-          cy.get('.q-btn')
-            .get('.absolute-full.flex.flex-center').should('exist')
+          cy.get('.q-btn .q-spinner')
         })
       })
     })
@@ -80,7 +79,7 @@ describe('use-btn API', () => {
             }
           })
 
-          cy.get('.q-btn').should('contain', icon)
+          cy.get('.q-btn .on-left').should('contain', icon)
         })
       })
 
@@ -94,7 +93,7 @@ describe('use-btn API', () => {
             }
           })
 
-          cy.get('.q-btn').should('contain', iconRight)
+          cy.get('.q-btn .on-right').should('contain', iconRight)
         })
       })
 
@@ -191,14 +190,16 @@ describe('use-btn API', () => {
 
       describe('(prop): tabindex', () => {
         it('should set the tabindex', () => {
+          const tabindex = 1
+
           mountQBtn({
             props: {
-              tabindex: 1
+              tabindex
             }
           })
 
           cy.get('.q-btn')
-            .should('have.attr', 'tabindex', '1')
+            .should('have.attr', 'tabindex', tabindex)
         })
       })
     })
@@ -238,7 +239,7 @@ describe('use-btn API', () => {
       })
 
       describe('(prop): href', () => {
-        it('should render a component with <a> tag and "href" attribute', () => {
+        it('should render a component with <a> tag when "href" attribute is set', () => {
           const href = 'https://quasar.dev'
 
           mountQBtn({
@@ -254,7 +255,7 @@ describe('use-btn API', () => {
       })
 
       describe('(prop): target', () => {
-        it('should render a component with <a> tag and "target" attribute', () => {
+        it('should render a component with <a> tag when "href" and "target" attributes are set', () => {
           const href = 'https://quasar.dev'
 
           mountQBtn({


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other: Testing

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

## Known Issues
I didn't figure out how to test "replace" functionality in the "Navigation Group" props.
Any help would be appreciated
