### PR TITLE
fix(QSelect): safari scrolls to top when focusing a 0 dimension element #13693

### DIFF
--- a/ui/src/components/select/QSelect.sass
+++ b/ui/src/components/select/QSelect.sass
@@ -17,8 +17,8 @@
   &__autocomplete-input
     position: absolute
     outline: 0 !important
-    width: 0
-    height: 0
+    width: 1px // Safari scrolls on top if 0
+    height: 1px // Safari scrolls on top if 0
     padding: 0
     border: 0
     opacity: 0


### PR DESCRIPTION
close #13693