### PR TITLE
fix(VitePlugin): prevent duplicate imports in dev mode (useTreeshaking false) when a component is imported in code and auto-imported from template

### DIFF
--- a/vite-plugin/src/js-transform.js
+++ b/vite-plugin/src/js-transform.js
@@ -2,6 +2,28 @@ import importTransformation from 'quasar/dist/transforms/import-transformation.j
 
 const importQuasarRegex = /import\s*\{([\w,\s]+)\}\s*from\s*(['"])quasar\2;?/g
 
+export function fillQuasarImports (code, importMap) {
+  if (typeof code === 'string') {
+    [...code.matchAll(importQuasarRegex)].forEach(match => {
+      match[1].split(',').forEach(identifier => {
+        const data = identifier.split(' as ')
+        const importName = data[0].trim()
+
+        // might be an empty entry like below
+        // (notice useQuasar is followed by a comma)
+        // import { QTable, useQuasar, } from 'quasar'
+        if (importName !== '') {
+          importMap[importName] = data[1] !== void 0
+            ? data[1].trim()
+            : importName
+        }
+      })
+    })
+  }
+
+  return code
+}
+
 /**
  * Transforms JS code where importing from 'quasar' package
  * Example:

--- a/vite-plugin/src/vue-transform.js
+++ b/vite-plugin/src/vue-transform.js
@@ -1,7 +1,7 @@
 import autoImportData from 'quasar/dist/transforms/auto-import.json'
 import importTransformation from 'quasar/dist/transforms/import-transformation.js'
 
-import { mapQuasarImports } from './js-transform.js'
+import { mapQuasarImports, fillQuasarImports } from './js-transform.js'
 
 const compRegex = {
   'kebab': new RegExp(`_resolveComponent\\("${autoImportData.regex.kebabComponents}"\\)`, 'g'),
@@ -22,7 +22,7 @@ export function vueTransform (content, autoImportComponentCase, useTreeshaking) 
   const reverseMap = {}
   const jsImportTransformed = useTreeshaking === true
     ? mapQuasarImports(content, importMap)
-    : content
+    : fillQuasarImports(content, importMap)
 
   let code = jsImportTransformed
     .replace(compRegex[autoImportComponentCase], (_, match) => {


### PR DESCRIPTION
```
<template>
  <q-btn />
</template

<script>
import { QBtn } from 'quasar'
</script>
```