### PR TITLE
fix(QDialog): listen for click on backdrop on ios because the refocus does not make sense and ios in non-desktop mode does not focus the backdrop on tap #13619

### DIFF
--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -372,7 +372,7 @@ export default Vue.extend({
             staticClass: 'q-dialog__backdrop fixed-full',
             attrs: backdropAttrs,
             on: cache(this, 'bkdrop', {
-              focusin: this.__onBackdropClick
+              [ this.$q.platform.is.ios === true ? 'click' : 'focusin' ]: this.__onBackdropClick
             })
           })
         ] : null),


### PR DESCRIPTION
close #13619