### PR TITLE
fix(QDialog): listen for click on backdrop on ios because the refocus does not make sense and ios in non-desktop mode does not focus the backdrop on tap #13619

### DIFF
--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -383,7 +383,7 @@ export default createComponent({
               style: transitionStyle.value,
               'aria-hidden': 'true',
               tabindex: -1,
-              onFocusin: onBackdropClick
+              [ vm.proxy.$q.platform.is.ios === true ? 'onClick' : 'onFocusin' ]: onBackdropClick
             })
             : null
         )),


### PR DESCRIPTION
close #13619