### PR TITLE
docs(flex column): Additional warning about defining height when use column type flex

### DIFF
--- a/docs/src/pages/layout/grid/column.md
+++ b/docs/src/pages/layout/grid/column.md
@@ -21,6 +21,8 @@ For example, here are two grid layouts that apply to every device and viewport, 
 ## Setting one row height
 Auto-layout for flexbox grid rows also means you can set the height of one row and the others will automatically resize around it. You may use predefined grid classes (as shown below) or inline heights. Note that the other rows will resize no matter the height of the center row.
 
+::: warning When using column type flex you must define a height for the container. The height must be large enough to hold the longest column. For example, you can use `window-height` class. :::
+
 <doc-example title="Setting one row height" file="grid/ColumnRowWidth" />
 
 ## Variable height content

--- a/docs/src/pages/layout/grid/column.md
+++ b/docs/src/pages/layout/grid/column.md
@@ -21,7 +21,7 @@ For example, here are two grid layouts that apply to every device and viewport, 
 ## Setting one row height
 Auto-layout for flexbox grid rows also means you can set the height of one row and the others will automatically resize around it. You may use predefined grid classes (as shown below) or inline heights. Note that the other rows will resize no matter the height of the center row.
 
-::: warning When using column type flex you must define a height for the container. The height must be large enough to hold the longest column. For example, you can use `window-height` class. :::
+::: warning When using column type flex you must define a height for the container. The height must be large enough to hold the longest column. :::
 
 <doc-example title="Setting one row height" file="grid/ColumnRowWidth" />
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Such warning mentioned in Flexbox Patterns. But I spent a lot of time to find why my flex column doesn't work. I think this additional warning will be helpful.