### PR TITLE
docs(Transitions): Make individual transition images clickable

### DIFF
--- a/docs/src/components/page-parts/transitions/TransitionList.vue
+++ b/docs/src/components/page-parts/transitions/TransitionList.vue
@@ -4,85 +4,83 @@
     src="https://cdn.quasar.dev/img/parallax1.jpg"
   )
 
-  q-btn.q-mb-lg(push, color="teal", label="Trigger", @click="trigger")
+  q-btn.q-mb-lg(push, color="teal", label="Trigger", @click="triggerAll")
 
   .q-gutter-md.row.items-start
 
     .transition-list-box.relative-position.overflow-hidden.rounded-borders.shadow-2(
-      v-for="transition in transitions"
+      v-for="(transition,index) in transitions"
       :key="transition"
     )
       transition(:name="'q-transition--' + transition")
-        img.transition-list-box__img.absolute-full(
-          :key="globalIndex + transition"
-          :src="url"
+        img.transition-list-box__img.absolute-full.cursor-pointer(
+          :key="url[index]"
+          :src="url[index]"
+          @click="trigger(index)"
         )
 
       .transition-list-box__label.absolute-bottom.q-pa-sm.text-center.text-body2
         | {{ transition }}
-</template>
+
+  </template>
 
 <script>
-import { ref } from 'vue'
-
+import { ref } from "vue";
 export default {
-  name: 'TransitionList',
+  name: "TransitionList",
+  setup() {
+    const transitions = [
+      "slide-right",
+      "slide-left",
+      "slide-up",
+      "slide-down",
+      "fade",
+      "scale",
+      "rotate",
+      "flip-right",
+      "flip-left",
+      "flip-up",
+      "flip-down",
+      "jump-right",
+      "jump-left",
+      "jump-up",
+      "jump-down",
+    ];
+    const url = ref([
+      ...transitions.map((_) => "https://cdn.quasar.dev/img/parallax2.jpg"),
+    ]);
 
-  setup () {
-    let index = 0
-
-    const url = ref('https://cdn.quasar.dev/img/parallax2.jpg')
-    const globalIndex = ref('q_0_')
+    const trigger = (index) => {
+      url.value[index] =
+        url.value[index] === "https://cdn.quasar.dev/img/parallax2.jpg"
+          ? "https://cdn.quasar.dev/img/parallax1.jpg"
+          : "https://cdn.quasar.dev/img/parallax2.jpg";
+    };
 
     return {
       url,
-      globalIndex,
-
-      transitions: [
-        'slide-right',
-        'slide-left',
-        'slide-up',
-        'slide-down',
-        'fade',
-        'scale',
-        'rotate',
-        'flip-right',
-        'flip-left',
-        'flip-up',
-        'flip-down',
-        'jump-right',
-        'jump-left',
-        'jump-up',
-        'jump-down'
-      ],
-
-      trigger () {
-        globalIndex.value = 'q_' + (++index) + '_'
-        url.value = url.value === 'https://cdn.quasar.dev/img/parallax2.jpg'
-          ? 'https://cdn.quasar.dev/img/parallax1.jpg'
-          : 'https://cdn.quasar.dev/img/parallax2.jpg'
-      }
-    }
-  }
-}
+      transitions,
+      trigger,
+      triggerAll() {
+        for (let i = 0; i < transitions.length; i++) trigger(i);
+      },
+    };
+  },
+};
 </script>
 
 <style lang="sass">
 .transition-list-box
-
   width: 150px
   height: 150px
-
   &__img
     height: inherit
     width: inherit
     object-fit: cover
     object-position: 50% 50%
-
   &__label
     color: #fff
-    background-color: rgba(0,0,0,.2)
-
+    background-color: rgba(0,0,0,0.2)
   &__ensure-img-loaded
     opacity: 0
     width: 10px


### PR DESCRIPTION
Everytime I visit the Transitions docs (https://quasar.dev/options/transitions#introduction) and want to choose a transition I can only trigger them all at the same time, which makes my brain hurt.

This PR makes the individual images clickable so it's easier to see how each type of transition works.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
