### PR TITLE
Slots for error, hint and counter should only be enabled if 'bottom-slots' prop is used

### DIFF
--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -184,6 +184,8 @@ export default function (state) {
     || props.error !== null
   )
 
+  const shouldRenderErrorHintOrCounter = computed(() => props.bottomSlots === true)
+
   const styleType = computed(() => {
     if (props.filled === true) { return 'filled' }
     if (props.outlined === true) { return 'outlined' }
@@ -470,7 +472,7 @@ export default function (state) {
   function getBottom () {
     let msg, key
 
-    if (hasError.value === true) {
+    if (hasError.value === true && shouldRenderErrorHintOrCounter.value) {
       if (errorMessage.value !== null) {
         msg = [ h('div', { role: 'alert' }, errorMessage.value) ]
         key = `q--slot-error-${ errorMessage.value }`
@@ -480,7 +482,7 @@ export default function (state) {
         key = 'q--slot-error'
       }
     }
-    else if (props.hideHint !== true || state.focused.value === true) {
+    else if ((props.hideHint !== true || state.focused.value === true) && shouldRenderErrorHintOrCounter.value) {
       if (props.hint !== void 0) {
         msg = [ h('div', props.hint) ]
         key = `q--slot-hint-${ props.hint }`
@@ -491,7 +493,7 @@ export default function (state) {
       }
     }
 
-    const hasCounter = props.counter === true || slots.counter !== void 0
+    const hasCounter = (props.counter === true || slots.counter !== void 0) && shouldRenderErrorHintOrCounter.value
 
     if (props.hideBottomSpace === true && hasCounter === false && msg === void 0) {
       return


### PR DESCRIPTION
Fix for #14897

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
