### PR TITLE
docs: Make a warning block render correctly in animations page

### DIFF
--- a/docs/src/pages/options/animations.md
+++ b/docs/src/pages/options/animations.md
@@ -41,7 +41,7 @@ If you are building a website, you can also skip configuring quasar.config.js an
 It should be noted that when you import Animate.css through the `<link>` tag, all animation CSS classes must be prefixed with `animate__`. This is a breaking change in the migration of Animate.css from v3 to v4. If you want to avoid using prefixes, you can import the [compat version](https://animate.style/#migration). However, if you're using the **Quasar CLI**, no additional changes are needed.
 :::
 
-::: tip
+::: warning
 **Windows Developers**
 If you're developing on Windows and the animations don't appear to be working, it's likely an OS level setting that's to blame. 
 Try changing **Visual Effects** to **Adjust for Best Appearance**.

--- a/docs/src/pages/options/animations.md
+++ b/docs/src/pages/options/animations.md
@@ -41,7 +41,7 @@ If you are building a website, you can also skip configuring quasar.config.js an
 It should be noted that when you import Animate.css through the `<link>` tag, all animation CSS classes must be prefixed with `animate__`. This is a breaking change in the migration of Animate.css from v3 to v4. If you want to avoid using prefixes, you can import the [compat version](https://animate.style/#migration). However, if you're using the **Quasar CLI**, no additional changes are needed.
 :::
 
-::: info
+::: tip
 **Windows Developers**
 If you're developing on Windows and the animations don't appear to be working, it's likely an OS level setting that's to blame. 
 Try changing **Visual Effects** to **Adjust for Best Appearance**.


### PR DESCRIPTION
change '::: info' block to '::: tip' because info block was not rendering correctly

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "::: info block" to "::: tip" block to render it correctly -->

![Screenshot 2022-12-10 152234](https://user-images.githubusercontent.com/71591172/206849951-20c9d0c5-f71d-434e-abe0-bf87183a9c14.png)

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
