### PR TITLE
feat(ui): Improve QInput and QFile nativeEl types (fix #15128)

### DIFF
--- a/ui/src/components/file/QFile.json
+++ b/ui/src/components/file/QFile.json
@@ -168,6 +168,7 @@
       "desc": "DEPRECATED; Access 'nativeEl' directly; Gets the native input DOM Element",
       "returns": {
         "type": "Element",
+        "tsType": "QFileNativeElement",
         "desc": "The underlying native input DOM Element"
       }
     }
@@ -176,6 +177,7 @@
   "computedProps": {
     "nativeEl": {
       "type": "Element",
+      "tsType": "QFileNativeElement",
       "desc": "The native input DOM Element",
       "addedIn": "v2.10.1"
     }

--- a/ui/src/components/input/QInput.json
+++ b/ui/src/components/input/QInput.json
@@ -118,6 +118,7 @@
       "desc": "DEPRECATED; Access 'nativeEl' directly instead; Get the native input/textarea DOM Element",
       "returns": {
         "type": "Element",
+        "tsType": "QInputNativeElement",
         "desc": "The underlying native input/textarea DOM Element"
       }
     }
@@ -126,6 +127,7 @@
   "computedProps": {
     "nativeEl": {
       "type": "Element",
+      "tsType": "QInputNativeElement",
       "desc": "The native input/textarea DOM Element",
       "addedIn": "v2.10.1"
     }

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -2,6 +2,7 @@ export * from "./api/vue-prop-types";
 export * from "./api/cookies";
 export * from "./api/dialog";
 export * from "./api/qfile";
+export * from "./api/qinput";
 export * from "./api/qselect";
 export * from "./api/qtable";
 export * from "./api/qtree";

--- a/ui/types/api/qfile.d.ts
+++ b/ui/types/api/qfile.d.ts
@@ -6,3 +6,8 @@ export interface QRejectedEntry {
     | "filter";
   file: File;
 }
+
+export type QFileNativeElement = Omit<
+  Omit<HTMLInputElement, "files"> & { files: FileList },
+  "type"
+> & { type: "file" };

--- a/ui/types/api/qinput.d.ts
+++ b/ui/types/api/qinput.d.ts
@@ -1,0 +1,25 @@
+// Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
+// The import will work correctly at runtime
+import { QInputProps } from "quasar";
+
+type QInputType = NonNullable<QInputProps["type"]>;
+
+type WithKnownType<
+  TElement extends HTMLInputElement | HTMLTextAreaElement,
+  TType extends QInputType
+> = Omit<TElement, "type"> & { type: TType };
+
+/**
+ * @example
+ * ```ts
+ * QInputNativeElement                      // HTMLInputElement | HTMLTextAreaElement
+ * QInputNativeElement<"textarea">          // HTMLTextAreaElement
+ * QInputNativeElement<"text">              // Omit<HTMLInputElement, "type"> & { type: "text" }
+ * QInputNativeElement<"text" | "number">   // Omit<HTMLInputElement, "type"> & { type: "text" | "number" }
+ * QInputNativeElement<"text" | "textarea"> // (Omit<HTMLInputElement, "type"> & { type: "text" }) | HTMLTextAreaElement
+ * ```
+ */
+export type QInputNativeElement<T extends QInputType = QInputType> =
+  T extends "textarea"
+    ? WithKnownType<HTMLTextAreaElement, "textarea">
+    : WithKnownType<HTMLInputElement, T>;

--- a/ui/types/api/qinput.d.ts
+++ b/ui/types/api/qinput.d.ts
@@ -22,4 +22,6 @@ type WithKnownType<
 export type QInputNativeElement<T extends QInputType = QInputType> =
   T extends "textarea"
     ? WithKnownType<HTMLTextAreaElement, "textarea">
-    : WithKnownType<HTMLInputElement, T>;
+    : Omit<WithKnownType<HTMLInputElement, T>, "files"> & {
+        files: T extends "file" ? FileList : null;
+      };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Resolves #15128

Ships two new types: `QFileNativeElement` and `QInputNativeElement`

`QInputNativeElement` accepts a generic parameter:
```ts
QInputNativeElement                      // HTMLInputElement | HTMLTextAreaElement
QInputNativeElement<"textarea">          // HTMLTextAreaElement
QInputNativeElement<"text">              // Omit<HTMLInputElement, "type"> & { type: "text" }
QInputNativeElement<"text" | "number">   // Omit<HTMLInputElement, "type"> & { type: "text" | "number" }
QInputNativeElement<"text" | "textarea"> // (Omit<HTMLInputElement, "type"> & { type: "text" }) | HTMLTextAreaElement
```
We can't make use of the generic param for `QInput.nativeEl` because we don't have generic component types yet(_not fully complete in Vue in a straightforward either_). But, users can use this type for advanced/flexible use cases by casting their types, typing their helper functions parameters, etc. Also, further narrowing is possible by checking against the `type` prop:
```ts
const inputRef = ref() as Ref<QInput>;
// ...
const { nativeEl } = inputRef.value
if (nativeEl.type === 'textarea') {
  nativeEl // HTMLTextAreaElement
} else if (nativeEl.type === 'files') {
  nativeEl.files // FileList
} else {
  nativeEl.files // null
}
```