### PR TITLE
 feat(quasar-cli): PNPM support #15055

### DIFF
--- a/cli/lib/node-packager.js
+++ b/cli/lib/node-packager.js
@@ -14,8 +14,14 @@ function isInstalled (cmd) {
 }
 
 function getPackager (root) {
+
+
   if (fs.existsSync(join(root, 'yarn.lock'))) {
     return 'yarn'
+  }
+
+  if (fs.existsSync(join(root, 'pnpm-lock.yaml'))) {
+    return 'pnpm'
   }
 
   if (fs.existsSync(join(root, 'package-lock.json'))) {
@@ -26,11 +32,15 @@ function getPackager (root) {
     return 'yarn'
   }
 
+  if (isInstalled('pnpm')) {
+    return 'pnpm'
+  }
+
   if (isInstalled('npm')) {
     return 'npm'
   }
 
-  fatal('⚠️  Please install Yarn or NPM before running this command.\n')
+  fatal('⚠️  Please install Yarn or Pnpm or NPM before running this command.\n')
 }
 
 module.exports = getPackager

--- a/cli/lib/node-packager.js
+++ b/cli/lib/node-packager.js
@@ -14,8 +14,6 @@ function isInstalled (cmd) {
 }
 
 function getPackager (root) {
-
-
   if (fs.existsSync(join(root, 'yarn.lock'))) {
     return 'yarn'
   }
@@ -32,12 +30,12 @@ function getPackager (root) {
     return 'yarn'
   }
 
-  if (isInstalled('pnpm')) {
-    return 'pnpm'
-  }
-
   if (isInstalled('npm')) {
     return 'npm'
+  }
+
+  if (isInstalled('pnpm')) {
+    return 'pnpm'
   }
 
   fatal('⚠️  Please install Yarn or Pnpm or NPM before running this command.\n')


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
This commit has an effect to `quasar upgrade` command.
We can use pnpm as quasar's dependence manageer now,but when we use  `quasar upgrade`, it can not use pnpm to upgrade. Using yarn upgrade a pnpm installed project will make a mistake,so this feature is important!
can fix #15055