### PR TITLE
feat: ability to accept cookies and pick dark theme by passing in que…

### DIFF
--- a/docs/src/boot/gdpr.js
+++ b/docs/src/boot/gdpr.js
@@ -1,31 +1,36 @@
 import { Cookies, Notify, openURL } from 'quasar'
+import { pathContainsQuery } from 'src/components/utils'
 
-if (Cookies.has('gdpr') !== true) {
-  const policyUrl = 'https://www.iubenda.com/privacy-policy/40685560/cookie-policy?an=no&s_ck=false&newmarkup=yes'
+export default async ({ urlPath }) => {
+  if (pathContainsQuery(urlPath, 'accept-cookies')) return
 
-  Notify.create({
-    message: 'Our third-party tools use cookies, which are necessary for its functioning' +
-      ' and required to achieve the purposes illustrated in the cookie policy.',
-    multiline: true,
-    classes: 'doc-gdpr doc-typography',
-    timeout: 0,
-    position: 'bottom-right',
-    actions: [
-      {
-        label: 'Accept',
-        color: 'yellow',
-        handler () {
-          Cookies.set('gdpr', true, { expires: 5 * 365 })
+  if (Cookies.has('gdpr') !== true) {
+    const policyUrl = 'https://www.iubenda.com/privacy-policy/40685560/cookie-policy?an=no&s_ck=false&newmarkup=yes'
+
+    Notify.create({
+      message: 'Our third-party tools use cookies, which are necessary for its functioning' +
+        ' and required to achieve the purposes illustrated in the cookie policy.',
+      multiline: true,
+      classes: 'doc-gdpr doc-typography',
+      timeout: 0,
+      position: 'bottom-right',
+      actions: [
+        {
+          label: 'Accept',
+          color: 'yellow',
+          handler () {
+            Cookies.set('gdpr', true, { expires: 5 * 365 })
+          }
+        },
+        {
+          label: 'Learn more',
+          color: 'grey',
+          noDismiss: true,
+          handler () {
+            openURL(policyUrl)
+          }
         }
-      },
-      {
-        label: 'Learn more',
-        color: 'grey',
-        noDismiss: true,
-        handler () {
-          openURL(policyUrl)
-        }
-      }
-    ]
-  })
+      ]
+    })
+  }
 }

--- a/docs/src/components/utils.js
+++ b/docs/src/components/utils.js
@@ -1,0 +1,12 @@
+const pathContainsQuery = (path, query) => {
+  let queryParams = path.split('?')
+  if (queryParams.length > 1) {
+    queryParams = queryParams[ 1 ].split('&')
+    return queryParams.includes(query)
+  }
+  return false
+}
+
+export {
+  pathContainsQuery
+}

--- a/docs/src/layouts/doc-layout/store/index.js
+++ b/docs/src/layouts/doc-layout/store/index.js
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import injectToc from './inject-toc'
 import injectScroll from './inject-scroll'
+import { pathContainsQuery } from 'src/components/utils'
 
 export const docStoreKey = '_q_ds_'
 
@@ -51,6 +52,11 @@ export function provideDocStore () {
   }
   else {
     store.state = ref(store.state)
+
+    if (pathContainsQuery($route.fullPath, 'dark')) {
+      store.state.dark = true
+    }
+
     store.dark = computed(() => (store.state.value.dark || $route.meta.dark))
     watch(store.dark, val => { $q.dark.set(val) }, { immediate: true })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Convincing reason**
There is a plugin for Quasar Docs in VSCode to allow for a nice developer experience when using VSCode for Quasar development.

The extension opens it in a 'webview', in which it loads the component doc url inside of an iframe. It has some limitations.

To improve the developer experience, I've added a non-breaking option to pass in the 'accept-cookies' and 'dark' query parameters to:
- not show the cookies popup (it will show on every doc page loaded in the extension, because each webview is a new context)
- load the docs in dark mode, without having to manually toggle each time (it will show light by default and not remember the dark preference, because each webview is a new context)

**Other information:**
The extension is used by 3.4k Quasar Developers (https://marketplace.visualstudio.com/items?itemName=CodeCoaching.quasar-docs), I'm trying to improve their experience with the extension.