### PR TITLE
fix(ui/ts): allow data-* attributes in dialog plugin prompt/options

### DIFF
--- a/ui/types/api/dialog.d.ts
+++ b/ui/types/api/dialog.d.ts
@@ -1,12 +1,7 @@
 // Error on "quasar" import shown in IDE is normal, as we only have Components/Directives/Plugins types after the build step
 // The import will work correctly at runtime
 import { QInputProps, QOptionGroupProps } from "quasar";
-
-// Taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types
-type NonFunctionPropertyNames<T> = {
-  [K in keyof T]: T[K] extends Function ? never : K;
-}[keyof T];
-type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;
+import { InputHTMLAttributes, HTMLAttributes } from "vue";
 
 // https://html.spec.whatwg.org/multipage/input.html#attr-input-type
 type InputType =
@@ -56,7 +51,7 @@ export type QDialogInputPrompt<T = string> = {
    */
   isValid?: (value: T) => boolean;
 } & Partial<Omit<QInputProps, "modelValue" | "onUpdate:modelValue" | "type">> &
-  Partial<NonFunctionProperties<HTMLInputElement>> & {
+  Omit<InputHTMLAttributes, "type"> & {
     // Has type-checking but no autocompletion: https://github.com/microsoft/TypeScript/issues/41620
     [dataAttributes in `data-${string}`]?: any;
   } & {
@@ -103,4 +98,4 @@ export type QDialogSelectionPrompt<
     "modelValue" | "onUpdate:modelValue" | "type" | "options"
   >
 > &
-  Partial<NonFunctionProperties<HTMLElement>>;
+  HTMLAttributes;

--- a/ui/types/api/dialog.d.ts
+++ b/ui/types/api/dialog.d.ts
@@ -55,6 +55,9 @@ export type QDialogInputPrompt<T = string> = {
    * @returns The text passed validation or not
    */
   isValid?: (value: T) => boolean;
+  
+  /** Allow to provide non-standard native attributes, e.g. `data-cy`  */
+  [ index: string ]: any;
 } & Partial<Omit<QInputProps, "modelValue" | "onUpdate:modelValue" | "type">> &
   Partial<NonFunctionProperties<HTMLInputElement>>;
 

--- a/ui/types/api/dialog.d.ts
+++ b/ui/types/api/dialog.d.ts
@@ -31,6 +31,13 @@ type DatalessInputType = Extract<InputType, "submit" | "reset">;
 
 type PromptInputType = "textarea" | Exclude<InputType, DatalessInputType>;
 
+type DataAttributes = {
+  // Has type-checking but no autocompletion: https://github.com/microsoft/TypeScript/issues/41620
+  [dataAttributes in `data-${string}`]?: any;
+} & {
+  "data-cy"?: string;
+};
+
 export type QDialogInputPrompt<T = string> = {
   /**
    * The initial value of the input
@@ -51,12 +58,8 @@ export type QDialogInputPrompt<T = string> = {
    */
   isValid?: (value: T) => boolean;
 } & Partial<Omit<QInputProps, "modelValue" | "onUpdate:modelValue" | "type">> &
-  Omit<InputHTMLAttributes, "type"> & {
-    // Has type-checking but no autocompletion: https://github.com/microsoft/TypeScript/issues/41620
-    [dataAttributes in `data-${string}`]?: any;
-  } & {
-    "data-cy"?: string;
-  };
+  Omit<InputHTMLAttributes, "type"> &
+  DataAttributes;
 
 type SelectionPromptType = NonNullable<QOptionGroupProps["type"]>;
 export type QDialogSelectionPrompt<
@@ -98,4 +101,5 @@ export type QDialogSelectionPrompt<
     "modelValue" | "onUpdate:modelValue" | "type" | "options"
   >
 > &
-  HTMLAttributes;
+  HTMLAttributes &
+  DataAttributes;

--- a/ui/types/api/dialog.d.ts
+++ b/ui/types/api/dialog.d.ts
@@ -55,13 +55,15 @@ export type QDialogInputPrompt<T = string> = {
    * @returns The text passed validation or not
    */
   isValid?: (value: T) => boolean;
-  
-  /** Allow to provide non-standard native attributes, e.g. `data-cy`  */
-  [ index: string ]: any;
 } & Partial<Omit<QInputProps, "modelValue" | "onUpdate:modelValue" | "type">> &
-  Partial<NonFunctionProperties<HTMLInputElement>>;
+  Partial<NonFunctionProperties<HTMLInputElement>> & {
+    // Has type-checking but no autocompletion: https://github.com/microsoft/TypeScript/issues/41620
+    [dataAttributes in `data-${string}`]?: any;
+  } & {
+    "data-cy"?: string;
+  };
 
-type SelectionPromptType = NonNullable<QOptionGroupProps["type"]>
+type SelectionPromptType = NonNullable<QOptionGroupProps["type"]>;
 export type QDialogSelectionPrompt<
   // As this gets used as is in generated types, we must define default values for generic params.
   // Example: `options?: QDialogSelectionPrompt;` <- notice the missing type params.


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Loosen up the type a bit to allow for attributes which aren't well-known
I also noticed we let in the autocomplete some properties which shouldn't be there, like `datalist`, but I'm not sure if we're able to filter them out automatically or we would need to remove them one by one