### PR TITLE
docs: QVirtualScroll description 'options' -> 'items'

### DIFF
--- a/ui/src/components/virtual-scroll/QVirtualScroll.json
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.json
@@ -93,11 +93,11 @@
       "scope": {
         "index": {
           "type": "Number",
-          "desc": "Item index in the options list"
+          "desc": "Item index in the items list"
         },
         "item": {
           "type": "Any",
-          "desc": "Item data -- its value is taken from 'options' prop"
+          "desc": "Item data - its value is taken from \`items\` prop"
         }
       }
     }

--- a/ui/src/components/virtual-scroll/QVirtualScroll.json
+++ b/ui/src/components/virtual-scroll/QVirtualScroll.json
@@ -97,7 +97,7 @@
         },
         "item": {
           "type": "Any",
-          "desc": "Item data - its value is taken from \`items\` prop"
+          "desc": "Item data -- its value is taken from 'items' prop"
         }
       }
     }


### PR DESCRIPTION
Incorrect description of scoped slots for default slot of QVirtualScroll in jsdocs.

It says that item is value of `options` prop but the name of the prop is actually `items`.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
