### PR TITLE
Fix `currentIndex` calculation

### DIFF
--- a/docs/public/examples/QTable/KeyboardNavigation.vue
+++ b/docs/public/examples/QTable/KeyboardNavigation.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, toRaw } from 'vue'
 
 const columns = [
   {
@@ -138,7 +138,7 @@ export default {
           return
         }
 
-        const currentIndex = selected.value.length > 0 ? computedRows.findIndex(r => r.id === selected.value[ 0 ].id) : -1
+        const currentIndex = selected.value.length > 0 ? computedRows.indexOf(toRaw(selected.value[ 0 ])) : -1
         const currentPage = pagination.value.page
         const rowsPerPage = pagination.value.rowsPerPage === 0 ? computedRowsNumber : pagination.value.rowsPerPage
         const lastIndex = computedRows.length - 1
@@ -194,6 +194,7 @@ export default {
           nextTick(() => {
             const { computedRows } = tableRef.value
             selected.value = [computedRows[ Math.min(index, computedRows.length - 1) ]]
+            tableRef.value.$el.focus()
           })
         }
         else {

--- a/docs/public/examples/QTable/KeyboardNavigation.vue
+++ b/docs/public/examples/QTable/KeyboardNavigation.vue
@@ -138,7 +138,7 @@ export default {
           return
         }
 
-        const currentIndex = selected.value.length > 0 ? computedRows.indexOf(selected.value[ 0 ]) : -1
+        const currentIndex = selected.value.length > 0 ? computedRows.findIndex(r => r.id === selected.value[ 0 ].id) : -1
         const currentPage = pagination.value.page
         const rowsPerPage = pagination.value.rowsPerPage === 0 ? computedRowsNumber : pagination.value.rowsPerPage
         const lastIndex = computedRows.length - 1


### PR DESCRIPTION
For some reason, `selected` and `computedRows` do not contain the same objects, so `indexOf()` always fails. Locating the correct entry by `id` however works. Is `computedRows` rebuilt under the hood with new objects?

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
I did not look for existing bug reports. I found the example not to work with Firefox 108.0.2 (64-Bit) on openSUSE Tumbleweed, so I debugged it in https://codepen.io/eijk/pen/RwBOdbm and found this change to restore keyboard navigation.
