### PR TITLE
fix(vite-plugin): support for tsx <script lang="tsx">

### DIFF
--- a/vite-plugin/src/query.js
+++ b/vite-plugin/src/query.js
@@ -33,7 +33,7 @@ export function parseViteRequest (id) {
           query.type === 'template' ||
           // On prod, TS code turns into a separate 'script' request.
           // See: https://github.com/vitejs/vite/pull/7909
-          (query.type === 'script' && query['lang.ts'] !== void 0),
+          (query.type === 'script' && isOfExt({ query, extensions: ['.ts', '.tsx'] })),
         script: (extensions = scriptExt) =>
           (query.type === void 0 || query.type === 'script') &&
           isOfExt({ query, extensions }) === true,

--- a/vite-plugin/src/query.js
+++ b/vite-plugin/src/query.js
@@ -33,7 +33,7 @@ export function parseViteRequest (id) {
           query.type === 'template' ||
           // On prod, TS code turns into a separate 'script' request.
           // See: https://github.com/vitejs/vite/pull/7909
-          (query.type === 'script' && isOfExt({ query, extensions: ['.ts', '.tsx'] })),
+          (query.type === 'script' && (query['lang.ts'] !== void 0 || query['lang.tsx'] !== void 0)),
         script: (extensions = scriptExt) =>
           (query.type === void 0 || query.type === 'script') &&
           isOfExt({ query, extensions }) === true,


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

After building this example, `<q-th>` tag is not transformed to `<th>`

Example:
```vue
<template>
  <q-th
    :key="props.col.name"
    :props="scope"
  >
    <test />
  </q-th>
</template>

<script lang="tsx" setup>
import type { QTableSlots } from 'quasar';

interface IProps {
  props: Parameters<QTableSlots['header-cell']>[0];
}

defineProps<IProps>();

const test = () => (
  <div>123</div>
);
</script>
```
