### PR TITLE
Update division operator (slash) to math.div function

### DIFF
--- a/ui/src/css/core/flex.sass
+++ b/ui/src/css/core/flex.sass
@@ -1,4 +1,5 @@
 @import '../helpers/string.sass'
+@use "sass:math"
 
 @mixin fg($name, $size)
   $noProcNotZero: $size > 0
@@ -30,13 +31,13 @@
       .row
         #{str-fe('> .col<name>-<i>', $name, $noProcNotZero, $ic)}
           height: auto
-          width: toFixed(percentage($i / $flex-cols), 10000)
+          width: toFixed(percentage(math.div($i,$flex-cols)), 10000)
         @if $i != 0 or $name != ''
           #{str-fe('> .offset<name>-<i>', $name, $noProcNotZero, $ic)}
-            margin-left: toFixed(percentage($i / $flex-cols), 10000)
+            margin-left: toFixed(percentage(math.div($i, $flex-cols)), 10000)
       .column
         #{str-fe('> .col<name>-<i>', $name, $noProcNotZero, $ic)}
-          height: toFixed(percentage($i / $flex-cols), 10000)
+          height: toFixed(percentage(math.div($i, $flex-cols)), 10000)
           width: auto
       @if $size == 0 and $i == $flex-cols
         .row > .col-all

--- a/ui/src/css/core/flex.sass
+++ b/ui/src/css/core/flex.sass
@@ -1,5 +1,5 @@
-@import '../helpers/string.sass'
 @use "sass:math"
+@import '../helpers/string.sass'
 
 @mixin fg($name, $size)
   $noProcNotZero: $size > 0

--- a/ui/src/css/helpers/math.sass
+++ b/ui/src/css/helpers/math.sass
@@ -1,3 +1,5 @@
+@use "sass:math"
+
 $PI: 3.14159265359
 
 @function pow($number, $exp)

--- a/ui/src/css/helpers/math.sass
+++ b/ui/src/css/helpers/math.sass
@@ -7,7 +7,7 @@ $PI: 3.14159265359
       $value: $value * $number
   @else if $exp < 0
     @for $i from 1 through -$exp
-      $value: $value / $number
+      $value: math.div($value, $number)
   @return $value
 
 @function fact($number)
@@ -21,22 +21,22 @@ $PI: 3.14159265359
 // toFixed(0.12345, 100) -> 0.12
 // toFixed(0.12345, 1000) -> 0.123
 @function toFixed($number, $power)
-  @return round($number * $power) / $power
+  @return math.div(round($number * $power), $power)
 
 @function sin($angle)
   $sin: 0
   // angle -> radians
-  $rad: $angle / 180 * $PI
+  $rad: math.div($angle, 180) * $PI
   // interval determines precision
   @for $i from 0 through 25
-    $sin: $sin + pow(-1, $i) * pow($rad, (2 * $i + 1)) / fact(2 * $i + 1)
+    $sin: $sin + math.div(pow(-1, $i) * pow($rad, (2 * $i + 1)), fact(2 * $i + 1))
   @return $sin
 
 @function cos($angle)
   $cos: 0
   // angle -> radians
-  $rad: $angle / 180 * $PI
+  $rad: math.div($angle, 180) * $PI
   // interval determines precision
   @for $i from 0 through 25
-    $cos: $cos + pow(-1, $i) * pow($rad, 2 * $i) / fact(2 * $i)
+    $cos: $cos + math.div(pow(-1, $i) * pow($rad, 2 * $i), fact(2 * $i))
   @return $cos


### PR DESCRIPTION
Change occurrences of division operator (slash) in math to use the math.div function instead.

See sass breaking change: https://sass-lang.com/documentation/breaking-changes/slash-div


<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Deprecation fix

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

Relevant deprecation warnings:

```shell
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($angle, 180) or calc($angle / 180)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
29 │   $rad: $angle / 180 * $PI
   │         ^^^^^^^^^^^^
   ╵
    node_modules/quasar/src/css/helpers/math.sass 29:9         sin()
    node_modules/quasar/src/components/time/QTime.sass 128:16  @import
    node_modules/quasar/src/css/index.sass 72:9                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(pow(-1, $i) * pow($rad, (2 * $i + 1)), fact(2 * $i + 1)) or calc(pow(-1, $i) * pow($rad, (2 * $i + 1)) / fact(2 * $i + 1))

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
32 │     $sin: $sin + pow(-1, $i) * pow($rad, (2 * $i + 1)) / fact(2 * $i + 1)
   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/quasar/src/css/helpers/math.sass 32:18        sin()
    node_modules/quasar/src/components/time/QTime.sass 128:16  @import
    node_modules/quasar/src/css/index.sass 72:9                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($angle, 180) or calc($angle / 180)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
38 │   $rad: $angle / 180 * $PI
   │         ^^^^^^^^^^^^
   ╵
    node_modules/quasar/src/css/helpers/math.sass 38:9         cos()
    node_modules/quasar/src/components/time/QTime.sass 129:17  @import
    node_modules/quasar/src/css/index.sass 72:9                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(pow(-1, $i) * pow($rad, 2 * $i), fact(2 * $i)) or calc(pow(-1, $i) * pow($rad, 2 * $i) / fact(2 * $i))

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
41 │     $cos: $cos + pow(-1, $i) * pow($rad, 2 * $i) / fact(2 * $i)
   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/quasar/src/css/helpers/math.sass 41:18        cos()
    node_modules/quasar/src/components/time/QTime.sass 129:17  @import
    node_modules/quasar/src/css/index.sass 72:9                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(round($number * $power), $power) or calc(round($number * $power) / $power)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
24 │   @return round($number * $power) / $power
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/quasar/src/css/helpers/math.sass 24:11        toFixed()
    node_modules/quasar/src/components/time/QTime.sass 132:12  @import
    node_modules/quasar/src/css/index.sass 72:9                root stylesheet
```