### PR TITLE
fix(QInput): cursor movement and selection #15453

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -142,6 +142,8 @@ export default Vue.extend({
 
       if (this.hasMask === true) {
         on.keydown = this.__onMaskedKeydown
+        // reset selection anchor on pointer selection
+        on.click = this.__onMaskedClick
       }
 
       if (this.autogrow === true) {


### PR DESCRIPTION
- __moveCursor functions only move the active end of selection
- make selection kbd moves behave like native ones (only move the active end of selection)
- fix cursor position after paste
