### PR TITLE
feat(QEditor): emit events from dropdowns inside the toolbar

### DIFF
--- a/ui/dev/src/pages/form/editor-part4.vue
+++ b/ui/dev/src/pages/form/editor-part4.vue
@@ -3,6 +3,10 @@
     <q-editor
       v-model="qeditor"
       :dense="$q.screen.lt.md"
+      @dropdown-before-show="beforeShow"
+      @dropdown-before-hide="beforeHide"
+      @dropdown-hide="hide"
+      @dropdown-show="show"
       :toolbar="[
         [
           {
@@ -96,6 +100,20 @@ export default {
     return {
       qeditor: '<pre>Check out the two different types of dropdowns'
         + ' in each of the "Align" buttons.</pre> '
+    }
+  },
+  methods: {
+    beforeShow (evt) {
+      console.log('beforeShow', evt)
+    },
+    beforeHide (evt) {
+      console.log('beforeHide', evt)
+    },
+    show (evt) {
+      console.log('show', evt)
+    },
+    hide (evt) {
+      console.log('hide', evt)
     }
   }
 }

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -76,7 +76,11 @@ export default createComponent({
     ...useFullscreenEmits,
     'update:modelValue',
     'keydown', 'click', 'mouseup', 'keyup', 'touchend',
-    'focus', 'blur'
+    'focus', 'blur',
+    'dropdown-show',
+    'dropdown-hide',
+    'dropdown-before-show',
+    'dropdown-before-hide'
   ],
 
   setup (props, { slots, emit, attrs }) {
@@ -233,6 +237,7 @@ export default createComponent({
       $q,
       props,
       slots,
+      emit,
       // caret (will get injected after mount)
       inFullscreen,
       toggleFullscreen,

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -77,10 +77,10 @@ export default createComponent({
     'update:modelValue',
     'keydown', 'click', 'mouseup', 'keyup', 'touchend',
     'focus', 'blur',
-    'dropdown-show',
-    'dropdown-hide',
-    'dropdown-before-show',
-    'dropdown-before-hide'
+    'dropdownShow',
+    'dropdownHide',
+    'dropdownBeforeShow',
+    'dropdownBeforeHide'
   ],
 
   setup (props, { slots, emit, attrs }) {

--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -269,6 +269,42 @@
           "desc": "The pure HTML of the content"
         }
       }
+    },
+
+    "dropdown-show": {
+      "desc": "Emitted after a dropdown in the toolbar has triggered show()",
+      "params": {
+        "evt": {
+          "extends": "evt"
+        }
+      }
+    },
+
+    "dropdown-before-show": {
+      "desc": "Emitted when a dropdown in the toolbar triggers show() but before it finishes doing it",
+      "params": {
+        "evt": {
+          "extends": "evt"
+        }
+      }
+    },
+
+    "dropdown-hide": {
+      "desc": "Emitted after a dropdown in the toolbar has triggered hide()",
+      "params": {
+        "evt": {
+          "extends": "evt"
+        }
+      }
+    },
+
+    "dropdown-before-hide": {
+      "desc": "Emitted when a dropdown in the toolbar triggers hide() but before it finishes doing it",
+      "params": {
+        "evt": {
+          "extends": "evt"
+        }
+      }
     }
   },
 

--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -277,7 +277,8 @@
         "evt": {
           "extends": "evt"
         }
-      }
+      },
+      "addedIn": "v2.11.8"
     },
 
     "dropdown-before-show": {
@@ -286,7 +287,8 @@
         "evt": {
           "extends": "evt"
         }
-      }
+      },
+      "addedIn": "v2.11.8"
     },
 
     "dropdown-hide": {
@@ -295,7 +297,8 @@
         "evt": {
           "extends": "evt"
         }
-      }
+      },
+      "addedIn": "v2.11.8"
     },
 
     "dropdown-before-hide": {
@@ -304,7 +307,8 @@
         "evt": {
           "extends": "evt"
         }
-      }
+      },
+      "addedIn": "v2.11.8"
     }
   },
 

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -150,6 +150,10 @@ function getDropdown (eVm, btn) {
   const highlight = btn.highlight && label !== btn.label
   const Dropdown = h(QBtnDropdown, {
     ...eVm.buttonProps.value,
+    onShow: (evt) => eVm.emit('dropdown-show', evt),
+    onHide: (evt) => eVm.emit('dropdown-hide', evt),
+    onBeforeShow: (evt) => eVm.emit('dropdown-before-show', evt),
+    onBeforeHide: (evt) => eVm.emit('dropdown-before-hide', evt),
     noCaps: true,
     noWrap: true,
     color: highlight ? eVm.props.toolbarToggleColor : eVm.props.toolbarColor,

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -157,10 +157,10 @@ function getDropdown (eVm, btn) {
     label: btn.fixedLabel ? btn.label : label,
     icon: btn.fixedIcon ? (btn.icon !== null ? btn.icon : void 0) : icon,
     contentClass,
-    onShow: evt => eVm.emit('dropdown-show', evt),
-    onHide: evt => eVm.emit('dropdown-hide', evt),
-    onBeforeShow: evt => eVm.emit('dropdown-before-show', evt),
-    onBeforeHide: evt => eVm.emit('dropdown-before-hide', evt)
+    onShow: evt => eVm.emit('dropdownShow', evt),
+    onHide: evt => eVm.emit('dropdownHide', evt),
+    onBeforeShow: evt => eVm.emit('dropdownBeforeShow', evt),
+    onBeforeHide: evt => eVm.emit('dropdownBeforeHide', evt)
   }, () => Items)
 
   return Dropdown

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -150,17 +150,17 @@ function getDropdown (eVm, btn) {
   const highlight = btn.highlight && label !== btn.label
   const Dropdown = h(QBtnDropdown, {
     ...eVm.buttonProps.value,
-    onShow: (evt) => eVm.emit('dropdown-show', evt),
-    onHide: (evt) => eVm.emit('dropdown-hide', evt),
-    onBeforeShow: (evt) => eVm.emit('dropdown-before-show', evt),
-    onBeforeHide: (evt) => eVm.emit('dropdown-before-hide', evt),
     noCaps: true,
     noWrap: true,
     color: highlight ? eVm.props.toolbarToggleColor : eVm.props.toolbarColor,
     textColor: highlight && !eVm.props.toolbarPush ? null : eVm.props.toolbarTextColor,
     label: btn.fixedLabel ? btn.label : label,
     icon: btn.fixedIcon ? (btn.icon !== null ? btn.icon : void 0) : icon,
-    contentClass
+    contentClass,
+    onShow: evt => eVm.emit('dropdown-show', evt),
+    onHide: evt => eVm.emit('dropdown-hide', evt),
+    onBeforeShow: evt => eVm.emit('dropdown-before-show', evt),
+    onBeforeHide: evt => eVm.emit('dropdown-before-hide', evt)
   }, () => Items)
 
   return Dropdown

--- a/ui/src/composables/private/use-fullscreen.json
+++ b/ui/src/composables/private/use-fullscreen.json
@@ -17,6 +17,18 @@
     }
   },
 
+  "events": {
+    "fullscreen": {
+      "desc": "Emitted when fullscreen state changes",
+      "params": {
+        "value": {
+          "type": "Boolean",
+          "desc": "Fullscreen state (showing/hidden)"
+        }
+      }
+    }
+  },
+
   "methods": {
     "toggleFullscreen": {
       "desc": "Toggle the view to be fullscreen or not fullscreen"


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

Two things:

1. Add the `fullscreen` event to the `use-fullscreen` composable because this was missing in the API currently.
2. Expose events for when a user opens/closes a dropdown inside the generated toolbar. 

**Why the second one?**

The second feature is necessary when using the QEditor inside/along some component that will implement a focus-lock. For instance a fullscreen modal will need a focus-lock to preventing keyboard users from tabbing out of the modal. When the modal closes the lock is released. But when a QEditor is used inside such a modal the dropdown will open and also try to gain focus. This will result in a `maximum call stack size exceeded` error. To prevent this the focus-lock needs to be temporarily disabled when a dropdown is shown. This PR makes it possible to do that. 

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
