### PR TITLE
feat(QEditor): add events for the link toolbar

### DIFF
--- a/ui/dev/src/pages/form/editor-part4.vue
+++ b/ui/dev/src/pages/form/editor-part4.vue
@@ -3,10 +3,12 @@
     <q-editor
       v-model="qeditor"
       :dense="$q.screen.lt.md"
-      @dropdown-before-show="beforeShow"
-      @dropdown-before-hide="beforeHide"
-      @dropdown-hide="hide"
-      @dropdown-show="show"
+      @dropdown-before-show="dropdownBeforeShow"
+      @dropdown-before-hide="dropdownBeforeHide"
+      @dropdown-hide="dropdownHide"
+      @dropdown-show="dropdownShow"
+      @link-show="linkShow"
+      @link-hide="linkHide"
       :toolbar="[
         [
           {
@@ -103,17 +105,23 @@ export default {
     }
   },
   methods: {
-    beforeShow (evt) {
-      console.log('beforeShow', evt)
+    dropdownBeforeShow (evt) {
+      console.log('dropdownBeforeShow', evt)
     },
-    beforeHide (evt) {
-      console.log('beforeHide', evt)
+    dropdownBeforeHide (evt) {
+      console.log('dropdownBeforeHide', evt)
     },
-    show (evt) {
-      console.log('show', evt)
+    dropdownShow (evt) {
+      console.log('dropdownShow', evt)
     },
-    hide (evt) {
-      console.log('hide', evt)
+    dropdownHide (evt) {
+      console.log('dropdownHide', evt)
+    },
+    linkShow () {
+      console.log('linkShow')
+    },
+    linkHide () {
+      console.log('linkHide')
     }
   }
 }

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -80,7 +80,9 @@ export default createComponent({
     'dropdownShow',
     'dropdownHide',
     'dropdownBeforeShow',
-    'dropdownBeforeHide'
+    'dropdownBeforeHide',
+    'linkShow',
+    'linkHide'
   ],
 
   setup (props, { slots, emit, attrs }) {
@@ -256,6 +258,10 @@ export default createComponent({
         lastEmit = v
         setContent(v, true)
       }
+    })
+
+    watch(editLinkUrl, v => {
+      v ? emit('link-show') : emit('link-hide')
     })
 
     const hasToolbar = computed(() => props.toolbar && props.toolbar.length > 0)

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -261,7 +261,7 @@ export default createComponent({
     })
 
     watch(editLinkUrl, v => {
-      v ? emit('link-show') : emit('link-hide')
+      emit(`link-${ v ? 'Show' : 'Hide' }`)
     })
 
     const hasToolbar = computed(() => props.toolbar && props.toolbar.length > 0)

--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -309,6 +309,16 @@
         }
       },
       "addedIn": "v2.11.8"
+    },
+
+    "link-show": {
+      "desc": "Emitted when the toolbar for editing a link is shown",
+      "addedIn": "v2.11.9"
+    },
+
+    "link-hide": {
+      "desc": "Emitted when the toolbar for editing a link is hidden",
+      "addedIn": "v2.11.9"
     }
   },
 


### PR DESCRIPTION
**Reason for the feature**
I am currently implementing a inline editor using the QEditor, I do this by positioning the toolbar of the editor absolutely, so it hovers above the rest of the editor. 

When the editor field higher than the viewport this absolute position needs to be calculated based on the offset of the editor relative to the viewport. When doing this I have to keep in mind the height of the toolbar, but that height will change when a link is edited. This PR gives me a way to know when the link toolbar is shown/hidden so I can update my calculations accordingly.

It adds two events:

- linkShow event when toolbar is shown
- linkHide event when toolbar is closed

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
