### PR TITLE
docs(app-extension): remove links to deprecated AEs

### DIFF
--- a/docs/src/pages/app-extensions/discover.md
+++ b/docs/src/pages/app-extensions/discover.md
@@ -20,14 +20,7 @@ Below is a list of official app-extensions created by members of the Quasar team
 | Alias | Description |
 | --- | --- |
 | [@quasar/testing](https://github.com/quasarframework/quasar-testing) | Includes pre-configured sub-extensions for all of your testing needs |
-| [@quasar/typescript](https://github.com/quasarframework/app-extension-typescript) | Transform your project into typescript awesomeness |
-| [@quasar/wizard](https://github.com/quasarframework/app-extension-wizard) | Search and find all known App Extensions, Install Collections, keep everything up to date |
-
-### Project Rigging
-
-| Alias | Description |
-| --- | --- |
-| [@quasar/obyte](https://github.com/quasarframework/app-extension-obyte) | Work with the Obyte Blockchain |
+| [@quasar/apollo](https://github.com/quasarframework/app-extension-apollo/tree/v2) | Includes pre-configured Apollo integration |
 
 ### Components
 
@@ -42,7 +35,4 @@ Below is a list of official app-extensions created by members of the Quasar team
 | [@quasar/qcalendar](https://github.com/quasarframework/quasar-ui-qcalendar) | Calendar for Quasar |
 | [@quasar/qscroller](https://github.com/quasarframework/app-extension-qscroller) | Many scrolling components, including QScroller, QTimeScroller, QDateScroller, QDateTimeScroller and scrolling time ranges |
 | [@quasar/qwindow](https://github.com/quasarframework/app-extension-qwindow) | Floating, movable, resizable interactive windows for Quasar |
-| [@quasar/qplaceholder](https://github.com/quasarframework/app-extension-qplaceholder) | Display a placeholder before your data arrives |
 | [@quasar/qiconpicker](https://github.com/quasarframework/quasar-ui-qiconpicker) | Icon Picker for your Quasar apps |
-| [@quasar/qribbon](https://github.com/quasarframework/app-extension-qribbon) | QRibbon UI component for your Quasar apps |
-| [@quasar/qzoom](https://github.com/quasarframework/app-extension-qzoom) | Zoom any content (image, video, text, components, ...) |


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
