### PR TITLE
feat(QDrawer): add prop to disable mini animation

### DIFF
--- a/ui/dev/src/pages/layout/layout-drawer-mini.vue
+++ b/ui/dev/src/pages/layout/layout-drawer-mini.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="q-layout-padding">
+    <q-toggle v-model="disableMiniAnimation">
+      Disable mini animation
+    </q-toggle>
+    <q-toggle v-model="miniToOverlay">
+      Mini to overlay
+    </q-toggle>
+
+    <q-layout view="hHh lpr fFf" container :style="containerStyle" class="q-mt-xl shadow-2">
+      <q-header class="bg-black">
+        <q-toolbar>
+          <q-btn flat @click="miniState = !miniState" round dense icon="menu" />
+          <q-toolbar-title>Header</q-toolbar-title>
+        </q-toolbar>
+      </q-header>
+
+      <q-drawer
+        side="left"
+        :model-value="true"
+        :mini="miniState"
+        :mini-to-overlay="miniToOverlay"
+        :width="200"
+        :disable-mini-animation="disableMiniAnimation"
+        :breakpoint="0"
+        bordered
+      >
+      <q-scroll-area class="fit" :horizontal-thumb-style="{ opacity: 0 }">
+          <q-list padding>
+            <q-item clickable v-ripple>
+              <q-item-section avatar>
+                <q-icon name="inbox" />
+              </q-item-section>
+
+              <q-item-section>
+                Inbox
+              </q-item-section>
+            </q-item>
+
+            <q-item active clickable v-ripple>
+              <q-item-section avatar>
+                <q-icon name="star" />
+              </q-item-section>
+
+              <q-item-section>
+                Star
+              </q-item-section>
+            </q-item>
+
+            <q-item clickable v-ripple>
+              <q-item-section avatar>
+                <q-icon name="send" />
+              </q-item-section>
+
+              <q-item-section>
+                Send
+              </q-item-section>
+            </q-item>
+
+            <q-item clickable v-ripple>
+              <q-item-section avatar>
+                <q-icon name="drafts" />
+              </q-item-section>
+
+              <q-item-section>
+                Drafts
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-scroll-area>
+      </q-drawer>
+
+      <q-page-container>
+        <q-page padding>
+          <div v-for="n in contentSize" :key="n">
+            My page My page My page My page My page My page
+            My page My page My page My page My page My page {{ n }} / {{ contentSize }}
+          </div>
+        </q-page>
+      </q-page-container>
+    </q-layout>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      miniState: true,
+      miniToOverlay: true,
+      width: 1030,
+      contentSize: 30,
+      disableMiniAnimation: false
+    }
+  },
+
+  computed: {
+    containerStyle () {
+      return {
+        height: '800px',
+        width: this.width + 'px'
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -41,6 +41,7 @@ export default createComponent({
       type: Number,
       default: 57
     },
+    disableMiniAnimation: Boolean,
 
     breakpoint: {
       type: Number,
@@ -417,6 +418,7 @@ export default createComponent({
     watch(() => $q.lang.rtl, () => { applyPosition() })
 
     watch(() => props.mini, () => {
+      if (props.disableMiniAnimation) return
       if (props.modelValue === true) {
         animateMini()
         $layout.animate()

--- a/ui/src/components/drawer/QDrawer.json
+++ b/ui/src/components/drawer/QDrawer.json
@@ -108,6 +108,13 @@
       "type": "Boolean",
       "desc": "Disables the default behavior where drawer backdrop can be swiped",
       "category": "behavior"
+    },
+
+    "disable-mini-animation": {
+      "type": "Boolean",
+      "desc": "Disables animation of the drawer when toggling mini mode",
+      "category": "behavior",
+      "addedIn": "v2.11.11"
     }
   },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->
Currently the QDrawer animates when switching from mini mode to non mini mode. This behaviour is not (reasonably simple) tweakable using css. This PR makes it possible to disable this animation.

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
