### PR TITLE
Update vs-code-configuration.md

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -94,8 +94,8 @@ The first step to properly start debugging is enabling source maps. Quasar autom
 build: {
   // ...
 
-  // this is a configuration passed on
-  // to the underlying Webpack
+  // this is a configuration passed on to the underlying Webpack.
+  // No need to set this if you are using vite.
   devtool: 'source-map'
 }
 ```
@@ -112,6 +112,7 @@ In the example below, replace `package-name` with the `name` property from your 
   "url": "http://localhost:8080",
   "webRoot": "${workspaceFolder}/src",
   "breakOnLoad": true,
+  // No need to configure sourcemap explicitly for vite.
   "sourceMapPathOverrides": {
     "webpack://package-name/./src/*": "${webRoot}/*"
   }


### PR DESCRIPTION
Add annotaion for debugging in vscode with vite.

As mentioned in https://github.com/quasarframework/quasar/issues/15695, the configuration for debugging with vite is a little different from webpack, leading to less configuration work.

Some annotations have been added to the configuration json file in order to avoid the unneccessary (and also wrong) setting.

The configuration detail can be found here: https://github.com/vitejs/vite/discussions/4065

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
