### PR TITLE
Add keep-color prop to QTree

### DIFF
--- a/ui/dev/src/pages/components/tree.vue
+++ b/ui/dev/src/pages/components/tree.vue
@@ -19,6 +19,7 @@
             <q-toggle v-model="selectableNodes" label="Selectable nodes" />
             <q-toggle v-model="noSelectionUnset" label="noSelectionUnset" />
             <q-toggle v-model="noConnectors" label="No connectors" />
+            <q-toggle v-model="keepColor" label="Keep color" />
           </div>
           <div class="col-xs-12 col-md-4">
             <q-input v-model="filter" label="Filter" />
@@ -56,6 +57,7 @@
           :dense="dense"
           :accordion="accordion"
           :color="color"
+          :keep-color="keepColor"
           :filter="filter"
           :no-connectors="noConnectors"
           :no-transition="noTransition"
@@ -150,6 +152,7 @@ export default {
     findNode('KEY: Node 1.3 - tap on me!', smallTree).handler = () => this.$q.notify('Tapped on node 1.3')
 
     return {
+      keepColor: true,
       noConnectors: false,
       noTransition: false,
       selected: null,

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -44,7 +44,10 @@ export default createComponent({
 
     color: String,
     controlColor: String,
-    keepColor: { type: Boolean, default: true },
+    keepColor: {
+      type: Boolean,
+      default: true
+    },
     textColor: String,
     selectedColor: String,
 

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -44,6 +44,7 @@ export default createComponent({
 
     color: String,
     controlColor: String,
+    keepColor: { type: Boolean, default: true },
     textColor: String,
     selectedColor: String,
 
@@ -562,7 +563,7 @@ export default createComponent({
               color: computedControlColor.value,
               dark: isDark.value,
               dense: true,
-              keepColor: true,
+              keepColor: props.keepColor,
               disable: m.tickable !== true,
               onKeydown: stopAndPrevent,
               'onUpdate:modelValue': v => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The checkboxes in the QTree component do not keep color when using the default color. See here: https://quasar.dev/vue-components/tree#example--syncing-node-properties (the "Pleasing decor" leaf is unticked and has a grey color)

However, when selecting a different color using the control-color prop, then keep-color is automatically applied.

This is inconsistent. Also, users may wish to switch off the keep-color prop the same way they can for the QCheckbox component.

This PR adds a new keep-color Boolean prop to Qtree, defaulting to true to avoid affecting existing QTree instances. This new prop is applied to the keep-color prop of all checkboxes in the QTree.
