### PR TITLE
feat: support quasar.conf(ig).cjs

### DIFF
--- a/app-vite/lib/app-paths.js
+++ b/app-vite/lib/app-paths.js
@@ -19,10 +19,6 @@ function getAppDir () {
       quasarConfigFilename = 'quasar.conf.js'
       return dir
     }
-    if (fs.existsSync(join(dir, 'quasar.conf.cjs'))) {
-      quasarConfigFilename = 'quasar.conf.cjs'
-      return dir
-    }
 
     dir = normalize(join(dir, '..'))
   }

--- a/app-vite/lib/app-paths.js
+++ b/app-vite/lib/app-paths.js
@@ -11,8 +11,16 @@ function getAppDir () {
       quasarConfigFilename = 'quasar.config.js'
       return dir
     }
+    if (fs.existsSync(join(dir, 'quasar.config.cjs'))) {
+      quasarConfigFilename = 'quasar.config.cjs'
+      return dir
+    }
     if (fs.existsSync(join(dir, 'quasar.conf.js'))) {
       quasarConfigFilename = 'quasar.conf.js'
+      return dir
+    }
+    if (fs.existsSync(join(dir, 'quasar.conf.cjs'))) {
+      quasarConfigFilename = 'quasar.conf.cjs'
       return dir
     }
 


### PR DESCRIPTION
#9455 I would like to use Quasar with `"type": "module"` in my `package.json`.

Without converting file to `cjs` I get an error from Node:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/zerdox/p/cryp/table-cups/quasar.config.js from /Users/zerdox/p/cryp/table-cups/node_modules/@quasar/app-vite/lib/quasar-config-file.js not supported.
quasar.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename quasar.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/zerdox/p/cryp/table-cups/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at QuasarConfFile.read (/Users/zerdox/p/cryp/table-cups/node_modules/@quasar/app-vite/lib/quasar-config-file.js:204:30)
    at build (/Users/zerdox/p/cryp/table-cups/node_modules/@quasar/app-vite/lib/cmd/build.js:134:43) {
  code: 'ERR_REQUIRE_ESM'
}

 App • ⚠️   FAIL  quasar.config.js has JS errors
```

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
Please let people stick with ESM :)

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Not supporting ESM is a bug obv