### PR TITLE
feat(ui): Add type support for EventBus class

### DIFF
--- a/docs/src/pages/quasar-utils/event-bus-util.md
+++ b/docs/src/pages/quasar-utils/event-bus-util.md
@@ -31,6 +31,18 @@ bus.on('some-event', (arg1, arg2, arg3) => {
 
 bus.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value')
 ```
+Events can also be typed strictly.
+```ts
+import { EventBus } from 'quasar'
+
+const bus = new EventBus<{
+    'some-event': (arg1: string, arg2: string, arg3: string) => void;
+    'other': (arg: boolean) => void;
+}>()
+
+bus.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value')
+```
+
 
 ### Convenience usage
 

--- a/docs/src/pages/quasar-utils/event-bus-util.md
+++ b/docs/src/pages/quasar-utils/event-bus-util.md
@@ -31,8 +31,11 @@ bus.on('some-event', (arg1, arg2, arg3) => {
 
 bus.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value')
 ```
-Events can also be typed strictly.
-```ts
+
+If using Typescript, then events can also be typed strictly:
+
+```js
+// Quasar v2.11.11+
 import { EventBus } from 'quasar'
 
 const bus = new EventBus<{
@@ -42,7 +45,6 @@ const bus = new EventBus<{
 
 bus.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value')
 ```
-
 
 ### Convenience usage
 

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -103,11 +103,15 @@ export function setCssVar(
   element?: Element
 ): void;
 
-export class EventBus {
-  on(event: string, callback: Function, ctx?: any): this;
-  once(event: string, callback: Function, ctx?: any): this;
-  emit(event: string, ...args: any[]): this;
-  off(event: string, callback?: Function): this;
+interface Callbacks {
+  [key: string]: (...args: any[]) => void;
+}
+
+export class EventBus<T extends Callbacks> {
+  on<K extends keyof T>(event: K, callback: T[K], ctx?: any): this;
+  once<K extends keyof T>(event: K, callback: T[K], ctx?: any): this;
+  emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): this;
+  off<K extends keyof T>(event: K, callback: T[K]): this;
 }
 
 interface CreateMetaMixinContext extends ComponentPublicInstance {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

This PR makes it possible to strictly type events for the `EventBus` class.  
Example from docs:
```ts
import { EventBus } from 'quasar'

const bus = new EventBus<{
    'some-event': (arg1: string, arg2: string, arg3: string) => void;
    other: (arg: boolean) => void;
}>()

bus.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value')
```

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
