### PR TITLE
ci: Fix and improve tests workflow (fix: #15380)

### DIFF
--- a/.github/workflows/tests-on-pr-report.yml
+++ b/.github/workflows/tests-on-pr-report.yml
@@ -1,0 +1,74 @@
+name: Test results
+
+on:
+  workflow_run:
+    workflows:
+      - UI tests
+    types:
+      - completed
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+
+    permissions:
+      checks: write
+
+      # for commenting the test results
+      pull-requests: write
+
+      # for using the artifacts API
+      actions: read
+
+    steps:
+      - name: Download the tests results artifacts
+        id: results
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { readFile, writeFile, unlink } = require('node:fs/promises');
+            const { resolve } = require('node:path');
+            const __dirname = process.env.GITHUB_WORKSPACE;
+
+            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+
+            const resultArtifacts = artifacts.filter(({ name }) => name.startsWith('test-results-'));
+            for (const artifact of resultArtifacts) {
+              const { data: artifactData } = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip',
+              });
+              const zipPath = resolve(__dirname, './test-results.zip'');
+              await writeFile(zipPath, Buffer.from(artifactData));
+              await exec.exec('unzip', [zipPath, '-d', './test-results']);
+              await unlink(zipPath);
+            }
+
+            const eventDataArtifact = artifacts.find(({ name }) => name === 'event-data');
+            const { data: eventDataArtifactData } = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: eventDataArtifact.id,
+              archive_format: 'zip',
+            });
+            const eventDataZipPath = resolve(__dirname, './event-data.zip'');
+            await writeFile(eventDataZipPath, Buffer.from(eventDataArtifactData));
+            await exec.exec('unzip', [eventDataZipPath, '-d', './event-data']);
+            await unlink(eventDataZipPath);
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: event-data/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: 'test-results/*.json'
+          check_name: 'UI Tests Results'

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -31,10 +31,10 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: npm i
+        run: yarn install --focus
 
       - name: Build the package
-        run: npm run build
+        run: yarn build
 
   tests:
     # If the build pipeline doesn't succeed, we don't need to run tests at all
@@ -45,6 +45,10 @@ jobs:
       actions: read # to correctly identify workflow run (cypress-io/github-action)
 
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ui
 
     strategy:
       fail-fast: false
@@ -62,13 +66,14 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: cd ./ui && npm i
+        run: yarn install --focus
 
       - name: Run tests in ${{ matrix.browser }} browser
         uses: cypress-io/github-action@v5
         with:
+          install: false
           browser: ${{ matrix.browser }}
-          command: npm run test:component:ci --record --parallel
+          command: yarn test:component:ci --record --parallel
           working-directory: ui
           tag: ${{ github.event.name }} # Tag will be either "opened" or "synchronize"
           group: Tests in ${{ matrix.browser }} browser

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -90,7 +90,9 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          command: yarn test:component:run --browser ${{ matrix.browser }} --reporter json --reporter-options output=dist/test-results/${{ matrix.browser }}.json
+          env:
+            CYPRESS_JSON_RESULTS_FILENAME=dist/test-results/${{ matrix.browser }}.json
+          command: yarn test:component:run --browser ${{ matrix.browser }}
           working-directory: ui
 
       # Upload required artifacts to be used in tests-on-pr-report.yml

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -1,4 +1,4 @@
-name: UI Tests
+name: UI tests
 
 on:
   pull_request:
@@ -90,26 +90,19 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          command: yarn test:component:run --browser ${{ matrix.browser }}
+          command: yarn test:component:run --browser ${{ matrix.browser }} --reporter json --reporter-option output=dist/test-results/${{ matrix.browser }}.json
           working-directory: ui
 
-      - name: Add workflow summary
-        env:
-          SUMMARY: |
-            Hi @${{ github.event.pull_request.user.login }} and thanks for the contribution! 👏
+      # Upload required artifacts to be used in tests-on-pr-report.yml
 
-            We've detected file changes inside the `ui` folder, so that triggered our Cypress component tests.
-        run: echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
-        if: always()
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.browser }}
+          path: ui/dist/test-results/${{ matrix.browser }}.json
 
-      - name: Output failure message
-        env:
-          FAILURE: ":bangbang: Seems like some of the tests are failing. Please amend 'em for someone from the team to be able to review it."
-        run: echo "$FAILURE" >> $GITHUB_STEP_SUMMARY
-        if: failure() || cancelled()
-
-      - name: Output success message
-        env:
-          SUCCESS: ':white_check_mark: Seems like all the tests passed successfully, so your PR is ready to be reviewed!'
-        run: echo "$SUCCESS" >> $GITHUB_STEP_SUMMARY
-        if: success()
+      - name: Upload GitHub Actions event data
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-data
+          path: ${{ github.event_path }}

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --focus
+        run: yarn
 
       - name: Build the package
         run: yarn build
@@ -78,7 +78,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --focus
+        run: yarn
 
       - name: Download build artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -88,8 +88,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          browser: ${{ matrix.browser }}
-          command: yarn test:component:run --record --parallel
+          command: yarn test:component:run --record --parallel --browser ${{ matrix.browser }}
           working-directory: ui
           tag: ${{ github.event.name }} # Tag will be either "opened" or "synchronize"
           group: Tests in ${{ matrix.browser }} browser

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -18,13 +18,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: ui
-
     # Check if the build cache exists, and if it does, do nothing else.
     # Otherwise, run the build and cache it.
-    name: Build the UI package
+    name: Build the packages
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -38,14 +34,25 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Build the package
+      - name: Build the UI package
+        working-directory: ui
         run: yarn build
 
-      - name: Upload build artifact
+      - name: Upload UI build artifact
         uses: actions/upload-artifact@v3
         with:
           name: ui-build
           path: ui/dist
+
+      - name: Build vite-plugin package
+        working-directory: vite-plugin
+        run: yarn build
+
+      - name: Upload vite-plugin build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vite-plugin-build
+          path: vite-plugin/dist
 
   tests:
     # If the build pipeline doesn't succeed, we don't need to run tests at all
@@ -80,11 +87,17 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Download build artifact
+      - name: Download UI build artifact
         uses: actions/download-artifact@v3
         with:
           name: ui-build
           path: ui/dist
+
+      - name: Download vite-plugin build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: vite-plugin-build
+          path: vite-plugin/dist
 
       - name: Run tests in ${{ matrix.browser }} browser
         uses: cypress-io/github-action@v5

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -6,8 +6,10 @@ on:
     branches:
       - 'dev'
     paths:
-      - 'ui/**.js'
-      - '!.github/**'
+      - '.github/workflows/tests-on-pr.yml'
+      - 'ui/**/*.js'
+      - 'ui/package.json'
+      - 'ui/dev/package.json'
 
 jobs:
   build:

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -1,7 +1,7 @@
 name: UI Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
     branches:
       - 'dev'
@@ -88,16 +88,8 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          command: yarn test:component:run --record --parallel --browser ${{ matrix.browser }}
+          command: yarn test:component:run --browser ${{ matrix.browser }}
           working-directory: ui
-          tag: ${{ github.event.name }} # Tag will be either "opened" or "synchronize"
-          group: Tests in ${{ matrix.browser }} browser
-        env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }} # Dashboard record key as an environment variable
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # To allow accurately detecting a build vs a re-run build
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_AUTHOR: ${{ github.event.pull_request.user.login }}
-          COMMIT_INFO_TIMESTAMP: ${{ github.event.pull_request.created_at }}
 
       - name: Add workflow summary
         env:

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -90,7 +90,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          command: yarn test:component:run --browser ${{ matrix.browser }} --reporter json --reporter-option output=dist/test-results/${{ matrix.browser }}.json
+          command: yarn test:component:run --browser ${{ matrix.browser }} --reporter json --reporter-options output=dist/test-results/${{ matrix.browser }}.json
           working-directory: ui
 
       # Upload required artifacts to be used in tests-on-pr-report.yml

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -20,21 +20,30 @@ jobs:
       run:
         working-directory: ui
 
+    # Check if the build cache exists, and if it does, do nothing else.
+    # Otherwise, run the build and cache it.
     name: Build the UI package
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup node
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --focus
 
       - name: Build the package
         run: yarn build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-build
+          path: ui/dist
 
   tests:
     # If the build pipeline doesn't succeed, we don't need to run tests at all
@@ -60,20 +69,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup node
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --focus
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ui-build
+          path: ui/dist
 
       - name: Run tests in ${{ matrix.browser }} browser
         uses: cypress-io/github-action@v5
         with:
           install: false
           browser: ${{ matrix.browser }}
-          command: yarn test:component:ci --record --parallel
+          command: yarn test:component:run --record --parallel
           working-directory: ui
           tag: ${{ github.event.name }} # Tag will be either "opened" or "synchronize"
           group: Tests in ${{ matrix.browser }} browser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Hi! We are really excited that you are interested in contributing to Quasar 👏
 
 ## Development Setup
 
-You will need [Node.js](http://nodejs.org) **version 12.22.1+** along [Yarn](https://yarnpkg.com/) or [NPM](https://docs.npmjs.com/getting-started/installing-node). Read `package.json` and take notice of the scripts you can use.
+You will need [Node.js](http://nodejs.org) **v16+** along [Yarn](https://yarnpkg.com/) or [NPM](https://docs.npmjs.com/getting-started/installing-node). Read `package.json` and take notice of the scripts you can use.
 
 After cloning the repo, in each subfolder run:
 

--- a/ui/dev/cypress.config.js
+++ b/ui/dev/cypress.config.js
@@ -21,6 +21,13 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents (on, config) {
       registerCodeCoverageTasks(on, config)
+
+      if (process.env.CYPRESS_JSON_RESULTS_FILENAME !== undefined) {
+        require('cypress-json-results')({
+          on,
+          filename: process.env.CYPRESS_JSON_RESULTS_FILENAME
+        })
+      }
     },
     baseUrl: 'http://localhost:9000/',
     supportFile: '../test/cypress/support/e2e.js',
@@ -29,6 +36,13 @@ module.exports = defineConfig({
   component: {
     setupNodeEvents (on, config) {
       registerCodeCoverageTasks(on, config)
+
+      if (process.env.CYPRESS_JSON_RESULTS_FILENAME !== undefined) {
+        require('cypress-json-results')({
+          on,
+          filename: process.env.CYPRESS_JSON_RESULTS_FILENAME
+        })
+      }
     },
     supportFile: '../test/cypress/support/component.js',
     specPattern: '../src/components/**/*.cy.{js,jsx,ts,tsx}',

--- a/ui/package.json
+++ b/ui/package.json
@@ -82,6 +82,7 @@
     "cross-env": "^7.0.3",
     "cssnano": "^5.1.14",
     "cypress": "^12.7.0",
+    "cypress-json-results": "^1.2.1",
     "diff": "^5.1.0",
     "eslint": "^7.4.0",
     "eslint-config-standard": "^17.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -71,8 +71,8 @@
   },
   "homepage": "https://quasar.dev",
   "devDependencies": {
-    "@quasar/app-vite": "^1.2.0",
-    "@quasar/extras": "^1.15.11",
+    "@quasar/app-vite": "^1.3.0",
+    "@quasar/extras": "^1.16.3",
     "@quasar/quasar-app-extension-testing-e2e-cypress": "^5.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,7 +2092,7 @@ commander@~2.13.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
   integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
-common-tags@^1.8.0:
+common-tags@^1.8.0, common-tags@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
@@ -2316,6 +2316,13 @@ csstype@^2.6.8:
   version "2.6.21"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
   integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
+
+cypress-json-results@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cypress-json-results/-/cypress-json-results-1.2.1.tgz#21b0afd516b7f5a8bdbfd2a43eea4ae641ceb9c4"
+  integrity sha512-A88O5g4qTDv1jX8mZpOvIGT9rlCm714h2MQGZRkU/EOKbdgvXU4B+vmcanNNoSm/SdxvK5tW2k26D7RCHIOSsA==
+  dependencies:
+    common-tags "^1.8.2"
 
 cypress@^12.10.0:
   version "12.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,17 +489,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@positron/stack-trace@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@positron/stack-trace/-/stack-trace-1.0.0.tgz#14fcc712a530038ef9be1ce6952315a839f466a8"
-  integrity sha512-nWlGg+aMfQDhGYa5FtBhZwldeo2MtdjHdxmEQvhBXEnxgD5IhIYl0PHvex8SdwyN7qcSoMykMWdjyAX7ZxkpMw==
-
-"@quasar/app-vite@^1.2.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@quasar/app-vite/-/app-vite-1.2.2.tgz#34301c57a0618d202fa72fcfccae7cef69a11795"
-  integrity sha512-fT5hMLxDLyeJje0pdsbpcKh2rhY1tOuU/pHYJubz8xId1yRFLE9ThYsmjlGjqN6DQ09BK22nioKnkuR6tnUnMQ==
+"@quasar/app-vite@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@quasar/app-vite/-/app-vite-1.3.0.tgz#546a81290b6e5fc451e04082fd2679348289ed1c"
+  integrity sha512-2ZkFuWzMCJmy8ve8zguYzNX3uALKbKeGQ3jQ6GDnCCNEt6yO8dBeWIqJ/epFv0/1TXYRYFCeGONmdSHDMiy2NA==
   dependencies:
     "@quasar/fastclick" "1.1.5"
+    "@quasar/render-ssr-error" "^1.0.0"
     "@quasar/vite-plugin" "^1.3.1"
     "@rollup/pluginutils" "^4.1.2"
     "@types/chrome" "^0.0.208"
@@ -525,7 +521,6 @@
     lodash "^4.17.21"
     minimist "^1.2.6"
     open "^8.4.0"
-    ouch "^2.0.0"
     register-service-worker "^1.7.2"
     rollup-plugin-visualizer "^5.5.4"
     sass "1.32.12"
@@ -535,15 +530,15 @@
     vite "^2.9.13"
     webpack-merge "^5.8.0"
 
-"@quasar/extras@^1.15.11":
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/@quasar/extras/-/extras-1.16.3.tgz#72216e2d450a2ee70613957da88191339b90de41"
-  integrity sha512-c9p2j4KWrWqOcCcCD9IMjgPZzAiXKSMEMc3uYbqa5mHlEJ1kl88OMaeJUcmP+INRQ29AFSEQ9tZE20jLmdnLXw==
-
 "@quasar/extras@^1.16.2":
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/@quasar/extras/-/extras-1.16.2.tgz#fcc6374a882253051f9d7302cb9ba828f0010cdf"
   integrity sha512-spDc1DrwxGts0MjmOAJ11xpxJANhCI1vEadxaw89wRQJ/QfKd0HZrwN7uN1U15cRozGRkJpdbsnP4cVXpkPysA==
+
+"@quasar/extras@^1.16.3":
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/@quasar/extras/-/extras-1.16.3.tgz#72216e2d450a2ee70613957da88191339b90de41"
+  integrity sha512-c9p2j4KWrWqOcCcCD9IMjgPZzAiXKSMEMc3uYbqa5mHlEJ1kl88OMaeJUcmP+INRQ29AFSEQ9tZE20jLmdnLXw==
 
 "@quasar/fastclick@1.1.5":
   version "1.1.5"
@@ -561,6 +556,13 @@
     nyc "^15.1.0"
     start-server-and-test "^1.15.2"
     vite-plugin-istanbul "^3.0.4"
+
+"@quasar/render-ssr-error@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@quasar/render-ssr-error/-/render-ssr-error-1.0.0.tgz#640d9c5df67cf0817e853e2880e7b37cf7e4477d"
+  integrity sha512-UoZqXCOS4ixpxFG6xZmd+sLAVCYgRD0VPElHfovvhfvNBn2RsTrKo8DFlLpAxsB/Ebb5QzZG7vsiuWEpKGzPhA==
+  dependencies:
+    stack-trace "^1.0.0-pre2"
 
 "@rollup/plugin-node-resolve@^11.2.1":
   version "11.2.1"
@@ -1862,7 +1864,7 @@ chai@^4.3.7:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
-chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2601,13 +2603,6 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.7:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
-  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
-  dependencies:
-    jake "^10.8.5"
-
 electron-to-chromium@^1.4.284:
   version "1.4.373"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.373.tgz#58eb1c180e56550fdbf8cd6e4f04a84abd414bb9"
@@ -3005,7 +3000,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@^1.0.1, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -3488,13 +3483,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-filelist@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
-  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
-  dependencies:
-    minimatch "^5.0.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -4335,16 +4323,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jake@^10.8.5:
-  version "10.8.5"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
-  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
-  dependencies:
-    async "^3.2.3"
-    chalk "^4.0.2"
-    filelist "^1.0.1"
-    minimatch "^3.0.4"
-
 joi@^17.7.0:
   version "17.9.2"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.9.2.tgz#8b2e4724188369f55451aebd1d0b1d9482470690"
@@ -4578,7 +4556,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4734,7 +4712,7 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
+minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -4991,16 +4969,6 @@ ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
-
-ouch@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ouch/-/ouch-2.0.1.tgz#9107089819b99146e3d10da57e8f75b39f610993"
-  integrity sha512-SdkEqpEhsmkEpjTPSvB1DMA//w9ChMUr16m4TayNRVfaULzJ3AnNr3CI4cz1QSZ9a+E/g06c6SQzxjkIc3/GMw==
-  dependencies:
-    "@positron/stack-trace" "1.0.0"
-    ejs "^3.1.7"
-    escape-html "^1.0.1"
-    lodash "^4.17.10"
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -6005,6 +5973,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-trace@^1.0.0-pre2:
+  version "1.0.0-pre2"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-1.0.0-pre2.tgz#46a83a79f1b287807e9aaafc6a5dd8bcde626f9c"
+  integrity sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==
 
 stackback@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- CI

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Resolves #15380

We decided to drop Cypress Cloud on PR runs. It's either a security risk or doesn't make sense to have workflow at all depending on which path is used, see the linked issue for some info. Cypress doesn't offer a way to output Cypress Cloud-ready results into a file, so we can't use the `pull_request` + `workflow_run` pattern. So, the only feasible way left is using `pull_request` + `workflow_run` but dropping Cypress Cloud, using custom reporting instead. We lose other benefits of Cypress Cloud, but this is about the best we can do right now. If Cypress starts offering a way to save/upload Cypress Cloud-ready results, we can adjust the workflows to use it.