### PR TITLE
Update vs-code-configuration.md

### DIFF
--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -110,10 +110,9 @@ In the example below, replace `package-name` with the `name` property from your 
   "request": "launch",
   "name": "Quasar App: chrome",
   "url": "http://localhost:8080",
-  // To properly reflect changes after HMR with Vite:
+  // To properly reflect changes after HMR with Vite
   "enableContentValidation": false,
   "webRoot": "${workspaceFolder}/src",
-  "breakOnLoad": true,
   // No need to configure sourcemap explicitly for vite.
   "sourceMapPathOverrides": {
     "webpack://package-name/./src/*": "${webRoot}/*"

--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -110,6 +110,8 @@ In the example below, replace `package-name` with the `name` property from your 
   "request": "launch",
   "name": "Quasar App: chrome",
   "url": "http://localhost:8080",
+  // To properly reflect changes after HMR with Vite:
+  "enableContentValidation": false,
   "webRoot": "${workspaceFolder}/src",
   "breakOnLoad": true,
   // No need to configure sourcemap explicitly for vite.

--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -104,7 +104,7 @@ Then you need to tell VSCode to add a configuration to the debugger. The easiest
 
 In the example below, replace `package-name` with the `name` property from your `package.json` file:
 
-```json
+```jsonc
 {
   "type": "chrome",
   "request": "launch",

--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -104,7 +104,7 @@ Then you need to tell VSCode to add a configuration to the debugger. The easiest
 
 In the example below, replace `package-name` with the `name` property from your `package.json` file:
 
-```jsonc
+```json
 {
   "type": "chrome",
   "request": "launch",


### PR DESCRIPTION
Improve developer experience by setting `"enableContentValidation": false`. Without this, when Vite reloads a module with HMR, VSCode will open the script in a new read-only window.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch "enableContentValidation": false)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
