### PR TITLE
Removed pathname from URL in readFileSync and changed replaceAll to replace

### DIFF
--- a/utils/render-ssr-error/src/index.js
+++ b/utils/render-ssr-error/src/index.js
@@ -7,7 +7,7 @@ import { getEnv } from './env.js'
 
 function readFile (target) {
   return readFileSync(
-    new URL(`../compiled-assets/${ target }-injection`, import.meta.url).pathname,
+    new URL(`../compiled-assets/${ target }-injection`, import.meta.url),
     'utf8'
   )
 }
@@ -29,7 +29,7 @@ export default function renderSSRError ({ err, req, res, projectRootFolder }) {
 
   res.status(500).send(
     before
-    + JSON.stringify(data).replaceAll(/<\/script>/g, '<\\/script>')
+    + JSON.stringify(data).replace(/<\/script>/g, '<\\/script>')
     + after
   )
 }


### PR DESCRIPTION
This was not working in node 14 on Windows. Believe that readFileSync works with the URLs without using pathname - using pathname causes an ENOENT. For replaceAll, there's no need to use it as the regex contains /g, using replace is good enough and works with node 14.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
