### PR TITLE
Fix github code highlighting for jsonc

### DIFF
--- a/docs/build/md/highlight.js
+++ b/docs/build/md/highlight.js
@@ -1,7 +1,7 @@
 const prism = require('prismjs')
 const loadLanguages = require('prismjs/components/index')
 
-loadLanguages([ 'markup', 'bash', 'javascript', 'typescript', 'sass', 'scss', 'css', 'json', 'xml', 'nginx' ])
+loadLanguages([ 'markup', 'bash', 'javascript', 'typescript', 'sass', 'scss', 'css', 'json', 'xml' ])
 
 module.exports = function (str, lang) {
   if (lang === '') {

--- a/docs/build/md/highlight.js
+++ b/docs/build/md/highlight.js
@@ -10,6 +10,11 @@ module.exports = function (str, lang) {
   else if (lang === 'vue' || lang === 'html') {
     lang = 'html'
   }
+  else if (lang === 'jsonc') {
+    // Prism permits comments in json blocks
+    // But github requires jsonc
+    lang = 'json'
+  }
 
   if (prism.languages[ lang ] !== void 0) {
     const code = prism.highlight(str, prism.languages[ lang ], lang)

--- a/docs/build/md/highlight.js
+++ b/docs/build/md/highlight.js
@@ -1,7 +1,7 @@
 const prism = require('prismjs')
 const loadLanguages = require('prismjs/components/index')
 
-loadLanguages([ 'markup', 'bash', 'javascript', 'typescript', 'sass', 'scss', 'css', 'json', 'xml' ])
+loadLanguages([ 'markup', 'bash', 'javascript', 'typescript', 'sass', 'scss', 'css', 'json', 'xml', 'nginx' ])
 
 module.exports = function (str, lang) {
   if (lang === '') {

--- a/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
+++ b/docs/src/pages/quasar-cli-vite/developing-browser-extensions/types-of-bex.md
@@ -27,7 +27,7 @@ You could configure your `manifest.json` file with the following so the options 
 
 #### manifest v2
 
-```json
+```jsonc
 {
   "manifest_version": 2,
 
@@ -41,7 +41,7 @@ You could configure your `manifest.json` file with the following so the options 
 
 #### manifest v3
 
-```json
+```jsonc
 {
   "manifest_version": 3,
 

--- a/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
@@ -28,7 +28,7 @@ The web server requires no special setup (unless you built with Vue Router in "h
 
 An example config for nginx may look like this:
 
-```
+```nginx
 server {
     listen 80 http2;
     server_name quasar.myapp.com;

--- a/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
@@ -116,11 +116,11 @@ You should consider adding some additional configurations to your project.
 * Important: Vercel expects the build results to be in `/public` directory, and _Quasar_ has it in `/dist/spa` by default, so you will need to override the `Output Directory` in your Vercel project. Set it to `dist/spa` through the Vercel web ui under your project's settings > Build & Development Settings.
 
 * Since Vercel expects the _build_ script to be defined, you may add in `package.json` the following scripts:
-```json
+```jsonc
   {
-    ..
+    // ...
     "scripts": {
-      ...
+      //... 
       "build": "quasar build",
       "deploy": "vercel"
     }
@@ -164,7 +164,7 @@ app.listen(port)
 
 Heroku assumes a set of npm scripts to be available, so we have to alter our `package.json` and add the following under the `script` section:
 
-```js
+```jsonc
 "build": "quasar build",
 "start": "node server.js",
 "heroku-postbuild": "yarn && yarn build"
@@ -241,7 +241,7 @@ $ yarn add --dev push-dir
 
 Then add a `deploy` script command to your `package.json`:
 
-```json
+```jsonc
 "scripts": {
   "deploy": "push-dir --dir=dist/spa --remote=gh-pages --branch=master"
 }

--- a/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli-vite/developing-spa/deploying.md
@@ -28,7 +28,7 @@ The web server requires no special setup (unless you built with Vue Router in "h
 
 An example config for nginx may look like this:
 
-```nginx
+```
 server {
     listen 80 http2;
     server_name quasar.myapp.com;

--- a/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/types-of-bex.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-browser-extensions/types-of-bex.md
@@ -25,7 +25,7 @@ const routes = [
 
 You could configure your `manifest.json` file with the following so the options page is loaded from that route:
 
-```json
+```jsonc
 {
   "name": "My extension",
   ...

--- a/docs/src/pages/quasar-cli-webpack/developing-spa/deploying.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-spa/deploying.md
@@ -116,11 +116,11 @@ You should consider adding some additional configurations to your project.
 * Important: Vercel expects the build results to be in `/public` directory, and _Quasar_ has it in `/dist/spa` by default, so you will need to override the `Output Directory` in your Vercel project. Set it to `dist/spa` through the Vercel web ui under your project's settings > Build & Development Settings.
 
 * Since Vercel expects the _build_ script to be defined, you may add in `package.json` the following scripts:
-```json
+```jsonc
   {
-    ..
+    // ...
     "scripts": {
-      ...
+      // ...
       "build": "quasar build",
       "deploy": "vercel"
     }
@@ -241,7 +241,7 @@ $ yarn add --dev push-dir
 
 Then add a `deploy` script command to your `package.json`:
 
-```json
+```jsonc
 "scripts": {
   "deploy": "push-dir --dir=dist/spa --remote=gh-pages --branch=master"
 }

--- a/docs/src/pages/quasar-cli-webpack/supporting-ts.md
+++ b/docs/src/pages/quasar-cli-webpack/supporting-ts.md
@@ -26,7 +26,7 @@ module.exports = function (ctx) {
 
 Then create `/tsconfig.json` file at the root of you project with this content:
 
-```json
+```jsonc
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {

--- a/docs/src/pages/start/vs-code-configuration.md
+++ b/docs/src/pages/start/vs-code-configuration.md
@@ -38,7 +38,7 @@ Depending on which features/presets you are using, you can add the related optio
 
 ### Common Configuration
 
-```json
+```jsonc
 {
   "editor.bracketPairColorization.enabled": true,
   "editor.guides.bracketPairs": true
@@ -47,7 +47,7 @@ Depending on which features/presets you are using, you can add the related optio
 
 ### ESLint
 
-```json
+```jsonc
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": [
@@ -59,7 +59,7 @@ Depending on which features/presets you are using, you can add the related optio
 
 #### Without Prettier
 
-```json
+```jsonc
 {
   "editor.defaultFormatter": "dbaeumer.vscode-eslint"
 }
@@ -67,7 +67,7 @@ Depending on which features/presets you are using, you can add the related optio
 
 #### With Prettier
 
-```json
+```jsonc
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode"
 }
@@ -75,7 +75,7 @@ Depending on which features/presets you are using, you can add the related optio
 
 ### TypeScript
 
-```json
+```jsonc
 {
   "typescript.tsdk": "node_modules/typescript/lib"
 }
@@ -104,7 +104,7 @@ Then you need to tell VSCode to add a configuration to the debugger. The easiest
 
 In the example below, replace `package-name` with the `name` property from your `package.json` file:
 
-```json
+```jsonc
 {
   "type": "chrome",
   "request": "launch",


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
