### PR TITLE
fix(QEditor): Event names for link toolbar cause warning

### DIFF
--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -261,7 +261,7 @@ export default createComponent({
     })
 
     watch(editLinkUrl, v => {
-      emit(`link-${ v ? 'Show' : 'Hide' }`)
+      emit(`link${ v ? 'Show' : 'Hide' }`)
     })
 
     const hasToolbar = computed(() => props.toolbar && props.toolbar.length !== 0)


### PR DESCRIPTION
The event names for the link toolbar (#15615) were causing warnings in the console because they did not match the event names listed in the emits option. Changing them from `link-Show` and `link-Hide` to `linkShow` and `linkHide` fixes the issue.

Warnings:
> [Vue warn]: Component emitted event "link-Show" but it is neither declared in the emits option nor as an "onLink-Show" prop.

and

> [Vue warn]: Component emitted event "link-Hide" but it is neither declared in the emits option nor as an "onLink-Hide" prop.

respectively.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
