### PR TITLE
Fix(qUploader): Dereferenced publicApi getters #14967

### DIFF
--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -461,6 +461,13 @@ export function getRenderer (getPlugin) {
   // expose public api (methods & computed props)
   Object.assign(proxy, publicApi)
 
+  // Re-assign getters enumerable on proxy object
+  for (const key in state) {
+    if (isRef(state[ key ]) === true) {
+      injectProp(proxy, key, () => state[ key ].value)
+    }
+  }
+
   return () => {
     const children = [
       h('div', { class: colorClass.value }, getHeader()),


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Object.assign is going to copy the getter value, not the getter itself (hence the broken references). Easy fix is just doing a subsequent re-assign on proxy so the getters are available for both internal state and on the proxy.

Looks like this commit https://github.com/quasarframework/quasar/commit/d3765c1bcd174c757c8597f50feeaec468b65da5#diff-10454ab8334f9a1ee3fd3ff5844907913ca6e069f8509927e7d3db1be38e8171 introduced the problem. Would have gone unnoticed by tests since the properties _do_ exist, just are broken references.