### PR TITLE
fix(QFile): incomplete union type in QRejectedEntry['failedPropValida…

### DIFF
--- a/ui/types/api/qfile.d.ts
+++ b/ui/types/api/qfile.d.ts
@@ -3,7 +3,9 @@ export interface QRejectedEntry {
     | "accept"
     | "max-file-size"
     | "max-total-size"
-    | "filter";
+    | "filter"
+    | "max-files"
+    | "duplicate";
   file: File;
 }
 


### PR DESCRIPTION
The `processFiles` function in ui/src/composables/private/use-file.js can reject 7 different props ("accept" | "max-file-size" | "max-total-size" | "filter" | "max-files" | "duplicate"), but only 4 declared in types. This fix amends the `QRejectedEntry["failedPropValidation"]` type to match the actual behavior