### PR TITLE
feat: Improve quasarConfOptions, generate types for it, improve docs (fix: #14069)

### DIFF
--- a/app-vite/types/configuration/framework-conf.d.ts
+++ b/app-vite/types/configuration/framework-conf.d.ts
@@ -2,113 +2,11 @@ import {
   QuasarIconSets,
   QuasarLanguageCodes,
   QuasarPluginOptions,
+  QuasarUIConfiguration,
 } from "quasar";
-import { Component } from "vue";
-
-interface QuasarMobileFrameworkInnerConfiguration {
-  iosStatusBarPadding: boolean;
-  backButton: boolean;
-  backButtonExit: boolean | "*" | string[];
-}
-
-interface RippleQuasarConf {
-  early?: boolean;
-  stop?: boolean;
-  center?: boolean;
-  color?: string;
-  keyCodes?: number[] | number;
-}
-
-type VueClassObjectProp = {
-  [value: string]: any
-}
-
-type VueClassProp =
-  | string
-  | Array<VueClassProp>
-  | VueClassObjectProp;
-
-type VueStyleObjectProp = Partial<CSSStyleDeclaration>;
-
-type VueStyleProp =
-  | string
-  | Array<VueStyleProp>
-  | VueStyleObjectProp;
-
-interface QuasarFrameworkInnerConfiguration {
-  brand?: {
-    primary?: string;
-    secondary?: string;
-    accent?: string;
-    dark?: string;
-    positive?: string;
-    negative?: string;
-    info?: string;
-    warning?: string;
-  };
-  capacitor?: QuasarMobileFrameworkInnerConfiguration;
-  cordova?: QuasarMobileFrameworkInnerConfiguration;
-  dark?: boolean | "auto";
-  lang?: {
-    noHtmlAttrs?: boolean;
-  };
-  loading?: {
-    delay?: number;
-    message?: false | string;
-    html?: boolean;
-    boxClass?: string;
-    spinnerSize?: number;
-    spinnerColor?: string;
-    messageColor?: string;
-    backgroundColor?: string;
-    spinner?: Component;
-    customClass?: string;
-  };
-  ripple?: boolean | RippleQuasarConf;
-  loadingBar?: {
-    position?: string;
-    size?: string;
-    color?: string;
-    reverse?: boolean;
-    skipHijack?: boolean;
-  };
-  notify?: {
-    type?: string;
-    color?: string;
-    textColor?: string;
-    message?: string;
-    caption?: string;
-    html?: boolean;
-    icon?: string;
-    iconColor?: string;
-    iconSize?: string;
-    avatar?: string;
-    spinner?: boolean;
-    spinnerColor?: string;
-    spinnerSize?: string;
-    position?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right" | "center";
-    group?: boolean | string | number;
-    badgeColor?: string;
-    badgeTextColor?: string;
-    badgePosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    badgeStyle?: VueStyleProp;
-    badgeClass?: VueClassProp;
-    progress?: boolean;
-    progressClass?: VueClassProp;
-    classes?: string;
-    attrs?: object;
-    timeout?: number;
-    closeBtn?: boolean | string;
-    multiLine?: boolean;
-    actions?: { icon: string; color: string }[];
-  };
-  screen?: {
-    bodyClasses?: boolean;
-  };
-}
 
 interface QuasarFrameworkConfiguration {
-  config?: QuasarFrameworkInnerConfiguration;
+  config?: QuasarUIConfiguration;
   iconSet?: QuasarIconSets;
   lang?: QuasarLanguageCodes;
   cssAddon?: boolean;

--- a/app-webpack/types/configuration/framework-conf.d.ts
+++ b/app-webpack/types/configuration/framework-conf.d.ts
@@ -2,113 +2,11 @@ import {
   QuasarIconSets,
   QuasarLanguageCodes,
   QuasarPluginOptions,
+  QuasarUIConfiguration,
 } from "quasar";
-import { Component } from "vue";
-
-interface QuasarMobileFrameworkInnerConfiguration {
-  iosStatusBarPadding: boolean;
-  backButton: boolean;
-  backButtonExit: boolean | "*" | string[];
-}
-
-interface RippleQuasarConf {
-  early?: boolean;
-  stop?: boolean;
-  center?: boolean;
-  color?: string;
-  keyCodes?: number[] | number;
-}
-
-type VueClassObjectProp = {
-  [value: string]: any
-}
-
-type VueClassProp =
-  | string
-  | Array<VueClassProp>
-  | VueClassObjectProp;
-
-type VueStyleObjectProp = Partial<CSSStyleDeclaration>;
-
-type VueStyleProp =
-  | string
-  | Array<VueStyleProp>
-  | VueStyleObjectProp;
-
-interface QuasarFrameworkInnerConfiguration {
-  brand?: {
-    primary?: string;
-    secondary?: string;
-    accent?: string;
-    dark?: string;
-    positive?: string;
-    negative?: string;
-    info?: string;
-    warning?: string;
-  };
-  capacitor?: QuasarMobileFrameworkInnerConfiguration;
-  cordova?: QuasarMobileFrameworkInnerConfiguration;
-  dark?: boolean | "auto";
-  lang?: {
-    noHtmlAttrs?: boolean;
-  };
-  loading?: {
-    delay?: number;
-    message?: false | string;
-    html?: boolean;
-    boxClass?: string;
-    spinnerSize?: number;
-    spinnerColor?: string;
-    messageColor?: string;
-    backgroundColor?: string;
-    spinner?: Component;
-    customClass?: string;
-  };
-  ripple?: boolean | RippleQuasarConf;
-  loadingBar?: {
-    position?: string;
-    size?: string;
-    color?: string;
-    reverse?: boolean;
-    skipHijack?: boolean;
-  };
-  notify?: {
-    type?: string;
-    color?: string;
-    textColor?: string;
-    message?: string;
-    caption?: string;
-    html?: boolean;
-    icon?: string;
-    iconColor?: string;
-    iconSize?: string;
-    avatar?: string;
-    spinner?: boolean;
-    spinnerColor?: string;
-    spinnerSize?: string;
-    position?: "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right" | "center";
-    group?: boolean | string | number;
-    badgeColor?: string;
-    badgeTextColor?: string;
-    badgePosition?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    badgeStyle?: VueStyleProp;
-    badgeClass?: VueClassProp;
-    progress?: boolean;
-    progressClass?: VueClassProp;
-    classes?: string;
-    attrs?: object;
-    timeout?: number;
-    closeBtn?: boolean | string;
-    multiLine?: boolean;
-    actions?: { icon: string; color: string }[];
-  };
-  screen?: {
-    bodyClasses?: boolean;
-  };
-}
 
 interface QuasarFrameworkConfiguration {
-  config?: QuasarFrameworkInnerConfiguration;
+  config?: QuasarUIConfiguration;
   iconSet?: QuasarIconSets;
   lang?: QuasarLanguageCodes;
   cssAddon?: boolean;

--- a/docs/build/md/md-plugin-heading.js
+++ b/docs/build/md/md-plugin-heading.js
@@ -7,7 +7,7 @@ const { slugify } = require('../utils')
 const titleRE = /<\/?[^>]+(>|$)/g
 const apiRE = /^<doc-api /
 const apiNameRE = /file="([^"]+)"/
-const installationRE = /^<doc-installation /
+const installationRE = /^<doc-installation(?:\s+title="([^"]*)")?\s*/
 
 function parseContent (str) {
   const title = String(str)
@@ -54,8 +54,11 @@ module.exports = function (md) {
         md.$data.toc.push({ id: slugify(title), title, deep: true })
       }
     }
-    else if (installationRE.test(token.content) === true) {
-      md.$data.toc.push({ id: 'installation', title: 'Installation', deep: true })
+
+    const match = token.content.match(installationRE)
+    if (match !== null) {
+      const title = match[ 1 ] ?? 'Installation'
+      md.$data.toc.push({ id: slugify(title), title, deep: true })
     }
 
     return tokens[ idx ].content

--- a/docs/src/components/DocApi.vue
+++ b/docs/src/components/DocApi.vue
@@ -269,7 +269,8 @@ function parseApiFile (name, { type, behavior, meta, addedIn, ...api }) {
   nameBanner.value = `${ name } API`
   docPath.value = meta.docsUrl.replace(/^https:\/\/v[\d]+\.quasar\.dev/, '')
 
-  const tabs = Object.keys(api)
+  const { internal: _, ...apiSections } = api
+  const tabs = Object.keys(apiSections)
 
   if (tabs.length === 0) {
     nothingToShow.value = true

--- a/docs/src/components/DocApiEntry.js
+++ b/docs/src/components/DocApiEntry.js
@@ -482,25 +482,12 @@ describe.injection = (_, injection) => {
 }
 
 describe.quasarConfOptions = (openState, conf) => {
-  const child = []
   const entry = [
-    getNameDiv(conf, conf.propName, 0, false, 'quasar.config file > framework > config > ')
+    getNameDiv(conf, conf.propName, 0, false, 'quasar.config file > framework > config > '),
+    getDiv(12, 'Type', getStringType(conf.type ?? 'Object')),
+    conf.desc ? getDiv(12, 'Description', conf.desc) : null,
+    getPropDetails(openState, 'quasarConfOptions', conf, 0)
   ]
-
-  for (const def in conf.definition) {
-    child.push(
-      getProp(openState, 'quasarConfOptions', conf.definition[ def ], def, 0)
-    )
-  }
-
-  entry.push(
-    getDiv(
-      12,
-      'Definition',
-      void 0,
-      h('div', { class: 'doc-api-entry__subitem' }, child)
-    )
-  )
 
   return [
     h('div', { class: 'doc-api-entry row' }, entry)

--- a/docs/src/components/DocInstallation.vue
+++ b/docs/src/components/DocInstallation.vue
@@ -1,7 +1,7 @@
 <template>
-  <q-card id="installation" class="doc-installation q-my-xl" flat bordered>
+  <q-card :id="slugify(title)" class="doc-installation q-my-xl" flat bordered>
     <div class="header-toolbar row items-center">
-      <doc-card-title title="Installation" />
+      <doc-card-title :title="title" />
     </div>
 
     <q-tabs class="header-tabs" v-model="currentTab" align="left" active-color="brand-primary" indicator-color="brand-primary" dense :breakpoint="0" shrink>
@@ -33,12 +33,17 @@ import { ref, computed } from 'vue'
 
 import DocCode from './DocCode.vue'
 import DocCardTitle from './DocCardTitle.vue'
+import { slugify } from 'src/assets/page-utils'
 
 const props = defineProps({
   components: [ Array, String ],
   directives: [ Array, String ],
   plugins: [ Array, String ],
-  config: String
+  config: String,
+  title: {
+    type: String,
+    default: 'Installation'
+  }
 })
 
 const tabList = [ 'Quasar CLI', 'Vite plugin / Vue CLI', 'UMD' ]
@@ -114,7 +119,8 @@ app.use(Quasar, {
 })
 
 const ExternalCli = computed(() => {
-  const types = [], imports = []
+  const types = []
+  const imports = ['Quasar']
 
   ;[ 'components', 'directives', 'plugins' ].forEach(type => {
     if (props[ type ] !== void 0) {
@@ -134,7 +140,6 @@ const ExternalCli = computed(() => {
   return `// main.js
 
 import {
-  Quasar,
   ${imports.join(',\n  ')}
 } from 'quasar'
 

--- a/docs/src/pages/options/quasar-language-packs.md
+++ b/docs/src/pages/options/quasar-language-packs.md
@@ -9,7 +9,7 @@ A Quasar Language Pack refers to the internationalization of Quasar's own compon
 
 <doc-api file="Lang" />
 
-<doc-installation config="lang" />
+<doc-installation title="Configuration" config="lang" />
 
 ::: warning
 It should be noted that what is described below is the internationalization of Quasar components only. If you need to internationalize your own components, read [App Internationalization](/options/app-internationalization) documentation page.

--- a/docs/src/pages/options/quasar-language-packs.md
+++ b/docs/src/pages/options/quasar-language-packs.md
@@ -7,6 +7,10 @@ related:
 ---
 A Quasar Language Pack refers to the internationalization of Quasar's own components, some of which have labels.
 
+<doc-api file="Lang" />
+
+<doc-installation config="lang" />
+
 ::: warning
 It should be noted that what is described below is the internationalization of Quasar components only. If you need to internationalize your own components, read [App Internationalization](/options/app-internationalization) documentation page.
 :::
@@ -275,30 +279,4 @@ setup () {
   const $q = useQuasar()
   $q.lang.getLocale() // returns a string
 }
-```
-
-## Disabling HTML attributes <q-badge label="v2.11.3+" />
-
-By default, Quasar will add `dir` and `lang` HTML attributes to the `<html>` tag for you. The `dir` attribute is especially important to the way CSS is preprocesses with Sass when [RTL is enabled](/options/rtl-support).
-
-If, for whatever reason you want this behavior disabled, then you can:
-
-```js
-// Quasar CLI > quasar.config file
-framework: {
-  config: {
-    lang: {
-      noHtmlAttrs: true // add this
-    }
-  }
-}
-
-// Vite plugin / Vue plugin / UMD
-app.use(Quasar, {
-  config: {
-    lang: {
-      noHtmlAttrs: true // add this
-    }
-  }
-})
 ```

--- a/docs/src/pages/options/screen-plugin.md
+++ b/docs/src/pages/options/screen-plugin.md
@@ -4,7 +4,6 @@ desc: Quasar plugin that helps in writing a dynamic and responsive UI through Ja
 ---
 The Quasar Screen plugin allows you to have a dynamic and responsive UI when dealing with your Javascript code. When possible, it is recommended to use the [responsive CSS classes](/style/visibility#window-width-related) instead, for performance reasons.
 
-## API
 <doc-api file="Screen" />
 
 ## Usage

--- a/docs/src/pages/quasar-plugins/dark.md
+++ b/docs/src/pages/quasar-plugins/dark.md
@@ -13,7 +13,7 @@ For a better understanding of this Quasar plugin, please head to the Style & Ide
 
 <doc-api file="Dark" />
 
-<doc-installation config="dark" />
+<doc-installation title="Configuration" config="dark" />
 
 ## Usage
 

--- a/docs/src/pages/quasar-plugins/dark.md
+++ b/docs/src/pages/quasar-plugins/dark.md
@@ -13,6 +13,8 @@ For a better understanding of this Quasar plugin, please head to the Style & Ide
 
 <doc-api file="Dark" />
 
+<doc-installation config="dark" />
+
 ## Usage
 
 ::: warning
@@ -76,23 +78,11 @@ Dark.set(true) // or false or "auto"
 Dark.toggle()
 ```
 
-### Through quasar.config file
-
-You can also use the `/quasar.config` file to set the Dark mode status:
-
-```js
-framework: {
-  config: {
-    dark: 'auto' // or Boolean true/false
-  }
-}
-```
-
 ## Note about SSR
 
 When on a SSR build:
 
-* `import { Dark } from 'quasar'` method of using Dark mode will not error out but it will not work (won't do anything). But you can use the other two ways (see previous section). We recommend through the `/quasar.config` file.
+* `import { Dark } from 'quasar'` method of using Dark mode will not error out but it will not work (won't do anything). But, you can use the [Inside of a Vue file](/quasar-plugins/dark#inside-of-a-vue-file) approach or the [Configuration](/quasar-plugins/dark#configuration)(recommended) approach.
 * It's preferred to avoid setting Dark mode to 'auto' for SSR builds. It's because the client dark mode preference cannot be inferred, so SSR will always render in light mode then when the client takes over, it will switch to Dark (if it will be the case). As a result, a quick flicker of the screen will occur.
 
 ## Watching for status change

--- a/docs/src/pages/style/color-palette/color-palette.md
+++ b/docs/src/pages/style/color-palette/color-palette.md
@@ -9,6 +9,10 @@ related:
 ---
 Quasar Framework offers a wide selection of colors out of the box. You can use them both as Sass/SCSS variables in your CSS code or directly as CSS classes in your HTML templates.
 
+<doc-api file="Brand" />
+
+<doc-installation config="brand" />
+
 ## Brand Colors
 Most of the colors that Quasar Components use are strongly linked with these three colors that you can change. Choosing these colors is the first step one should take when differentiating the design of an App. You'll notice immediately upon changing their default values that Quasar Components follow these colors as a guideline.
 
@@ -160,45 +164,29 @@ setCssVar('primary-darkened', lighten(newPrimaryColor, -10))
 
 ## Setting Up Defaults
 
-This is how you can set up some brand colors without tampering with the Sass variables:
+You can set up some brand colors without tampering with the Sass/SCSS variables.
+
+See the [Configuration](/style/color-palette#configuration) section above for setting it during initial configuration for Quasar CLI, Vite plugin/Vue CLI, and UMD projects.
+
+If you are using Quasar CLI, you can also use a [@quasar/app-vite Boot File](/quasar-cli-vite/boot-files) or a [@quasar/app-webpack Boot File](/quasar-cli-webpack/boot-files).
+This is especially useful if you want to change the colors dynamically at initial load time, perhaps after fetching them from an API.
 
 ```js
-// Quasar CLI - /quasar.config file
-return {
-  framework: {
-    config: {
-      brand: {
-        primary: '#ff0000',
-        // ...
-      }
-    }
-  }
-}
-```
-
-Or with a [@quasar/app-vite Boot File](/quasar-cli-vite/boot-files) or a [@quasar/app-webpack Boot File](/quasar-cli-webpack/boot-files):
-
-```js
-// For Quasar CLI
-// Do NOT run this boot file for SSR mode
+// src/boot/brand-colors.js - or any other name
 
 import { setCssVar } from 'quasar'
+import { boot } from 'quasar/wrappers'
 
-export default () => {
+export default boot(() => {
   setCssVar('primary', '#ff0000')
-}
+})
 ```
 
-If you are using the Quasar UMD version or the Quasar Vite plugin or Vue CLI:
-
+If using SSR mode, disable this boot file when running on server-side:
 ```js
-// UMD or Quasar Vite plugin or Vue CLI
-app.use(Quasar, {
-  config: {
-    brand: {
-      primary: '#ff0000',
-      // ...
-    }
-  }
-})
+// quasar.config file
+boot: [
+  { server: false, path: 'brand-colors' }, // or the name you gave it
+  // ...
+],
 ```

--- a/docs/src/pages/style/color-palette/color-palette.md
+++ b/docs/src/pages/style/color-palette/color-palette.md
@@ -11,7 +11,7 @@ Quasar Framework offers a wide selection of colors out of the box. You can use t
 
 <doc-api file="Brand" />
 
-<doc-installation config="brand" />
+<doc-installation title="Configuration" config="brand" />
 
 ## Brand Colors
 Most of the colors that Quasar Components use are strongly linked with these three colors that you can change. Choosing these colors is the first step one should take when differentiating the design of an App. You'll notice immediately upon changing their default values that Quasar Components follow these colors as a guideline.

--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -145,8 +145,10 @@ const objectTypes = {
   },
 
   quasarConfOptions: {
-    props: [ 'propName', 'definition', 'link', 'addedIn' ],
-    required: [ 'propName', 'definition' ]
+    props: [ 'propName', 'definition', 'values', 'tsType', 'desc', 'examples', 'link', 'addedIn' ],
+    required: [ 'propName' ],
+    isObject: [ 'definition' ],
+    isArray: [ 'values' ]
   }
 }
 

--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -37,7 +37,7 @@ function getMixedInAPI (api, mainFile) {
 }
 
 const topSections = {
-  plugin: [ 'meta', 'injection', 'quasarConfOptions', 'addedIn', 'props', 'methods' ],
+  plugin: [ 'meta', 'injection', 'quasarConfOptions', 'addedIn', 'props', 'methods', 'internal' ],
   component: [ 'meta', 'quasarConfOptions', 'addedIn', 'props', 'slots', 'events', 'methods', 'computedProps' ],
   directive: [ 'meta', 'quasarConfOptions', 'addedIn', 'value', 'arg', 'modifiers' ]
 }
@@ -705,7 +705,11 @@ module.exports.generate = function () {
   return new Promise((resolve) => {
     const list = []
 
-    const plugins = glob.sync(resolvePath('src/plugins/*.json'))
+    const plugins = [
+      ...glob.sync(resolvePath('src/plugins/*.json')),
+      resolvePath('src/Brand.json'),
+      resolvePath('src/Lang.json')
+    ]
       .filter(file => !path.basename(file).startsWith('__'))
       .map(fillAPI('plugin', list))
 

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -335,7 +335,9 @@ function getIndexDts (apis) {
       write(directives, propTypeDef)
     }
     else if (content.type === 'plugin') {
-      write(plugins, propTypeDef)
+      if (content.internal !== true) {
+        write(plugins, propTypeDef)
+      }
 
       const makeRequiredRecursive = (definition) => transformObject(definition, (prop) => {
         makeRequired(prop)
@@ -364,7 +366,9 @@ function getIndexDts (apis) {
     })
 
     // Declare class
-    writeLine(quasarTypeContents, `export const ${ typeName }: ${ typeValue }`)
+    if (content.internal !== true) {
+      writeLine(quasarTypeContents, `export const ${ typeName }: ${ typeValue }`)
+    }
 
     if (content.events) {
       for (const [ name, definition ] of Object.entries(content.events)) {
@@ -449,7 +453,7 @@ function getIndexDts (apis) {
 
       writeLine(contents, `export interface ${ typeName } extends ComponentPublicInstance<${ propsTypeName }> {`)
     }
-    else {
+    else if (content.internal !== true) {
       writeLine(contents, `export interface ${ typeName } {`)
 
       // Write props to the body directly
@@ -470,8 +474,10 @@ function getIndexDts (apis) {
     }
 
     // Close class declaration
-    writeLine(contents, '}')
-    writeLine(contents)
+    if (content.internal !== true) {
+      writeLine(contents, '}')
+      writeLine(contents)
+    }
 
     // Copy Injections for type declaration
     if (content.type === 'plugin' && content.injection) {

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -104,7 +104,8 @@ function getTypeVal (def) {
 function getPropDefinition ({ name, definition, docs = true, isMethodParam = false, isCompProps = false, escapeName = true, isReadonly = false }) {
   let propName = escapeName ? toCamelCase(name) : name
 
-  if (propName.startsWith('...')) {
+  const isRestParam = propName.startsWith('...')
+  if (isRestParam) {
     if (isMethodParam) {
       // A rest parameter must be of an array type. e.g. '...params: any[]'
       definition.type = 'Array'
@@ -113,8 +114,10 @@ function getPropDefinition ({ name, definition, docs = true, isMethodParam = fal
     }
     else {
       propName = `[${ propName.replace('...', '') || 'key' }: string]`
-      // Optionality with index signature types works differently and use of '?:' is invalid and not required, so always mark it as required
-      definition.required = true
+      // Optionality with index signature types works differently and use of '?:' is invalid and not required.
+      // So, we have to not use '?:' for index signature types but use '| undefined' for the property type instead.
+      // e.g. '[key: string]: any | undefined'
+      // It's being handled in the return statement on the bottom of this function.
     }
   }
 
@@ -122,7 +125,7 @@ function getPropDefinition ({ name, definition, docs = true, isMethodParam = fal
 
   let propType = getTypeVal(definition)
 
-  if (isCompProps === true && name !== 'model-value' && !definition.required && propType.indexOf(' undefined') === -1) {
+  if ((isCompProps === true || isRestParam) && name !== 'model-value' && !definition.required && propType.indexOf(' undefined') === -1) {
     propType += ' | undefined;'
   }
 
@@ -151,7 +154,7 @@ function getPropDefinition ({ name, definition, docs = true, isMethodParam = fal
     }
   }
 
-  return `${ jsDoc }${ isReadonly ? 'readonly ' : '' }${ propName }${ !definition.required ? '?' : '' }: ${ propType }`
+  return `${ jsDoc }${ isReadonly ? 'readonly ' : '' }${ propName }${ !definition.required && !isRestParam ? '?' : '' }: ${ propType }`
 }
 
 function getPropDefinitions ({ definitions, docs = true, areMethodParams = false, isCompProps = false }) {

--- a/ui/src/Brand.json
+++ b/ui/src/Brand.json
@@ -3,6 +3,8 @@
     "docsUrl": "https://v2.quasar.dev/style/color-palette"
   },
 
+  "internal": true,
+
   "quasarConfOptions": {
     "propName": "brand",
     "type": "Object",

--- a/ui/src/Brand.json
+++ b/ui/src/Brand.json
@@ -1,0 +1,44 @@
+{
+  "meta": {
+    "docsUrl": "https://v2.quasar.dev/style/color-palette"
+  },
+
+  "quasarConfOptions": {
+    "propName": "brand",
+    "type": "Object",
+    "definition": {
+      "primary": {
+        "type": "String",
+        "desc": "Main color of your app"
+      },
+      "secondary": {
+        "type": "String",
+        "desc": "Secondary color of your app"
+      },
+      "accent": {
+        "type": "String",
+        "desc": "Accent color of your app"
+      },
+      "dark": {
+        "type": "String",
+        "desc": "Dark color of your app"
+      },
+      "positive": {
+        "type": "String",
+        "desc": "Positive color of your app"
+      },
+      "negative": {
+        "type": "String",
+        "desc": "Negative color of your app"
+      },
+      "info": {
+        "type": "String",
+        "desc": "Info color of your app"
+      },
+      "warning": {
+        "type": "String",
+        "desc": "Warning color of your app"
+      }
+    }
+  }
+}

--- a/ui/src/Brand.json
+++ b/ui/src/Brand.json
@@ -40,6 +40,10 @@
       "warning": {
         "type": "String",
         "desc": "Warning color of your app"
+      },
+      "...customColors": {
+        "type": "String",
+        "desc": "Custom colors of your app, if any"
       }
     }
   }

--- a/ui/src/Lang.json
+++ b/ui/src/Lang.json
@@ -12,7 +12,7 @@
       "noHtmlAttrs": {
         "type": "Boolean",
         "addedIn": "v2.11.3",
-        "desc": "Whether to disable `dir` and `lang` HTML attributes getting added to the `<html>` tag. Disable this only if you know what you are doing."
+        "desc": "Whether to disable `dir` and `lang` HTML attributes getting added to the `<html>` tag. `dir` attribute is crucial when using RTL support. Disable this only if you need to handle these yourself for some reason."
       }
     }
   }

--- a/ui/src/Lang.json
+++ b/ui/src/Lang.json
@@ -3,6 +3,8 @@
     "docsUrl": "https://v2.quasar.dev/options/quasar-language-packs"
   },
 
+  "internal": true,
+
   "quasarConfOptions": {
     "propName": "lang",
     "type": "Object",

--- a/ui/src/Lang.json
+++ b/ui/src/Lang.json
@@ -1,0 +1,17 @@
+{
+  "meta": {
+    "docsUrl": "https://v2.quasar.dev/options/quasar-language-packs"
+  },
+
+  "quasarConfOptions": {
+    "propName": "lang",
+    "type": "Object",
+    "definition": {
+      "noHtmlAttrs": {
+        "type": "Boolean",
+        "addedIn": "v2.11.3",
+        "desc": "Whether to disable `dir` and `lang` HTML attributes getting added to the `<html>` tag. Disable this only if you know what you are doing."
+      }
+    }
+  }
+}

--- a/ui/src/directives/Ripple.json
+++ b/ui/src/directives/Ripple.json
@@ -5,6 +5,7 @@
 
   "quasarConfOptions": {
     "propName": "ripple",
+    "type": ["Boolean", "Object"],
     "definition": {
       "early": {
         "type": "Boolean",

--- a/ui/src/plugins/Dark.json
+++ b/ui/src/plugins/Dark.json
@@ -5,6 +5,13 @@
 
   "injection": "$q.dark",
 
+  "quasarConfOptions": {
+    "propName": "dark",
+    "type": [ "Boolean", "String" ],
+    "desc": "\"'auto'\" uses the OS/browser preference. \"true\" forces dark mode. \"false\" forces light mode.",
+    "values": [ "auto", "(Boolean) true", "(Boolean) false" ]
+  },
+
   "props": {
     "isActive": {
       "type": "Boolean",

--- a/ui/src/plugins/Loading.json
+++ b/ui/src/plugins/Loading.json
@@ -7,6 +7,7 @@
 
   "quasarConfOptions": {
     "propName": "loading",
+    "type": "Object",
     "definition": {
       "delay": {
         "type": "Number",

--- a/ui/src/plugins/LoadingBar.json
+++ b/ui/src/plugins/LoadingBar.json
@@ -7,12 +7,10 @@
 
   "quasarConfOptions": {
     "propName": "loadingBar",
-    "definition": {
-      "...props": {
-        "type": "Object",
-        "desc": "QAjaxBar component props, EXCEPT for 'hijack-filter'"
-      }
-    }
+    "type": "Object",
+    "tsType": "QLoadingBarOptions",
+    "desc": "QAjaxBar component props, EXCEPT for 'hijack-filter'",
+    "examples": [ "{ position: 'bottom', reverse: true }" ]
   },
 
   "props": {

--- a/ui/src/plugins/LoadingBar.json
+++ b/ui/src/plugins/LoadingBar.json
@@ -54,8 +54,9 @@
       "params": {
         "props": {
           "type": "Object",
+          "tsType": "QLoadingBarOptions",
           "required": true,
-          "desc": "QAjaxBar component props",
+          "desc": "QAjaxBar component props, EXCEPT for 'hijack-filter'",
           "examples": [ "{ position: 'bottom', reverse: true }" ]
         }
       }

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -7,6 +7,7 @@
 
   "quasarConfOptions": {
     "propName": "notify",
+    "type": "Object",
     "definition": {
       "type": {
         "type": "String",

--- a/ui/src/plugins/Screen.json
+++ b/ui/src/plugins/Screen.json
@@ -5,6 +5,16 @@
 
   "injection": "$q.screen",
 
+  "quasarConfOptions": {
+    "propName": "screen",
+    "definition": {
+      "bodyClasses": {
+        "type": "Boolean",
+        "desc": "Whether to apply CSS classes for the current window breakpoint to the body element"
+      }
+    }
+  },
+
   "props": {
     "width": {
       "type": "Number",

--- a/ui/src/plugins/Screen.json
+++ b/ui/src/plugins/Screen.json
@@ -7,6 +7,7 @@
 
   "quasarConfOptions": {
     "propName": "screen",
+    "type": "Object",
     "definition": {
       "bodyClasses": {
         "type": "Boolean",

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -12,6 +12,7 @@ export * from "./api/qnotify";
 export * from "./api/qpopupproxy";
 export * from "./api/qeditor";
 export * from "./api/qloading";
+export * from "./api/qloadingbar";
 export * from "./api/touchswipe";
 export * from "./api/web-storage";
 export * from "./api/validation";

--- a/ui/types/api/qloadingbar.d.ts
+++ b/ui/types/api/qloadingbar.d.ts
@@ -1,0 +1,3 @@
+import { QAjaxBarProps } from "quasar";
+
+export type QLoadingBarOptions = Omit<QAjaxBarProps, "hijackFilter">;

--- a/ui/types/config.d.ts
+++ b/ui/types/config.d.ts
@@ -1,0 +1,15 @@
+interface NativeMobileWrapperConfiguration {
+  iosStatusBarPadding: boolean;
+  backButton: boolean;
+  backButtonExit: boolean | "*" | string[];
+}
+
+export interface QuasarUIConfiguration {
+  // These two are oddly structured and doesn't fit the API structure, so they don't have API definitions
+  capacitor?: NativeMobileWrapperConfiguration;
+  cordova?: NativeMobileWrapperConfiguration;
+
+  // TODO: Involve brand and lang in code generation
+
+  // The rest will be augmented by auto-generated code
+}

--- a/ui/types/config.d.ts
+++ b/ui/types/config.d.ts
@@ -9,7 +9,5 @@ export interface QuasarUIConfiguration {
   capacitor?: NativeMobileWrapperConfiguration;
   cordova?: NativeMobileWrapperConfiguration;
 
-  // TODO: Involve brand and lang in code generation
-
   // The rest will be augmented by auto-generated code
 }

--- a/ui/types/plugin.d.ts
+++ b/ui/types/plugin.d.ts
@@ -1,3 +1,4 @@
+import { QuasarUIConfiguration } from "./config";
 import { QuasarIconSet } from "./extras";
 import { QuasarLanguage } from "./lang";
 
@@ -9,7 +10,7 @@ export interface QuasarPlugins {}
 
 export interface QuasarPluginOptions {
   lang: QuasarLanguage;
-  config: any;
+  config: QuasarUIConfiguration;
   iconSet: QuasarIconSet;
   components: QuasarComponents;
   directives: QuasarDirectives;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature
- Documentation
- Refactor

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Resolves #14069.

Previously undocumented non-object configuration example(Dark plugin):
![image](https://github.com/quasarframework/quasar/assets/6266078/36b2117e-616b-49b4-8b6b-0ed93d6e0520)
Previously undocumented "plugin-like" examples:
![image](https://github.com/quasarframework/quasar/assets/6266078/44334771-caaa-425f-be58-ad0bca10a6c0)
![image](https://github.com/quasarframework/quasar/assets/6266078/a3a74bba-5c4b-4fc5-a4de-1060f28224c6)

Config-only installation cards use the title "Configuration" for improved clarity.

We are now generating and exporting a new type called `QuasarUIConfiguration` from `quasar` that holds the configurable options. That type will now be used by the `config` key of the Vue plugin installation, so Vite plugin/Vue CLI users will get config type-safety now. app-vite and app-webpack will use this type for quasar.config file types, so the types will always be in-sync without effort, and be compatible with the UI package version used in the app.