### PR TITLE
test(ui/use-field&QField): add tests for use-field composable and QField

### DIFF
--- a/ui/dev/cypress.config.cjs
+++ b/ui/dev/cypress.config.cjs
@@ -46,7 +46,7 @@ module.exports = defineConfig({
       }
     },
     supportFile: '../test/cypress/support/component.js',
-    specPattern: '../src/components/**/*.cy.{js,jsx,ts,tsx}',
+    specPattern: [ '../src/components/**/*.cy.{js,jsx,ts,tsx}', '../src/composables/**/*.cy.{js,jsx,ts,tsx}' ],
     indexHtmlFile: '../test/cypress/support/component-index.html',
     devServer: {
       framework: 'vue',

--- a/ui/src/components/field/__tests__/QField.cy.js
+++ b/ui/src/components/field/__tests__/QField.cy.js
@@ -1,0 +1,168 @@
+import QField from '../QField'
+import { vModelAdapter } from '@quasar/quasar-app-extension-testing-e2e-cypress'
+import { ref } from 'vue'
+import Icons from '../../../../icon-set/material-icons.mjs'
+
+function getHostElement () {
+  return cy.get('.q-field')
+}
+
+function mountQField (options) {
+  return cy.mount(QField, options)
+}
+
+describe('Field API', () => {
+  describe('Props', () => {
+    describe('Category: model', () => {
+      describe('(prop): maxlength', () => {
+        it.skip(' ', () => {
+          //
+        })
+      })
+    })
+  })
+
+  describe('Slots', () => {
+    describe('(slot): control', () => {
+      it('should use control slot as content of the field', () => {
+        const controlSlot = 'Hello there'
+        mountQField({
+          slots: {
+            control: () => controlSlot
+          }
+        })
+
+        getHostElement().get('.q-field__control-container').should('contain', controlSlot)
+      })
+    })
+
+    describe('(slot): rawControl', () => {
+      it('should use raw control slot', () => {
+        const rawControlSlot = 'Hello there'
+        mountQField({
+          slots: {
+            rawControl: () => rawControlSlot
+          }
+        })
+
+        getHostElement().get('.q-field__control-container').should('contain', rawControlSlot)
+      })
+    })
+  })
+
+  describe('Events', () => {
+    describe('(event): update:model-value', () => {
+      it('should emit onUpdate:modelValue event', () => {
+        const model = ref('text')
+        const fn = cy.stub()
+        mountQField({
+          props: {
+            ...vModelAdapter(model),
+            'onUpdate:modelValue': fn,
+            clearable: true
+          }
+        })
+
+        getHostElement().get('button[type="button"]')
+          .contains(Icons.field.clear).click()
+          .then(() => {
+            expect(fn).to.be.calledWith()
+          })
+      })
+    })
+
+    describe('(event): focus', () => {
+      it('should emit the focus event', () => {
+        const fn = cy.stub()
+
+        mountQField({
+          props: {
+            onfocus: fn
+          },
+          slots: {
+            control: 'text'
+          }
+        })
+
+        getHostElement().click()
+
+        getHostElement().then(() => {
+          expect(fn).to.be.calledWith()
+        })
+      })
+    })
+
+    describe('(event): blur', () => {
+      it('should emit blur event', () => {
+        const fn = cy.stub()
+        mountQField({
+          props: {
+            onblur: fn
+          },
+          slots: {
+            control: 'text'
+          }
+        })
+
+        getHostElement()
+          .click()
+
+        getHostElement().then(() => {
+          Cypress.vueWrapper.vm.blur()
+        })
+
+        getHostElement()
+          .then(() => {
+            expect(fn).to.be.calledWith()
+          })
+      })
+    })
+  })
+
+  describe('Methods', () => {
+    describe('(method): focus', () => {
+      it('should focus the component', () => {
+        mountQField({
+          slots: {
+            control: 'text'
+          }
+        })
+
+        getHostElement()
+          .get('.q-field--focused')
+          .should('not.exist')
+
+        getHostElement()
+          .then(() => {
+            Cypress.vueWrapper.vm.focus()
+          })
+        getHostElement()
+          .get('.q-field--focused')
+          .should('exist')
+      })
+    })
+
+    describe('(method): blur', () => {
+      it('should blur the component', () => {
+        mountQField({
+          slots: {
+            control: 'text'
+          }
+        })
+
+        getHostElement().click()
+
+        getHostElement()
+          .get('.q-field--focused')
+          .should('exist')
+
+        getHostElement()
+          .then(() => {
+            Cypress.vueWrapper.vm.blur()
+          })
+
+        cy.get('.q-field--focused').should('not.exist')
+      })
+    })
+  })
+})

--- a/ui/src/components/field/__tests__/QField.cy.js
+++ b/ui/src/components/field/__tests__/QField.cy.js
@@ -16,7 +16,8 @@ describe('Field API', () => {
     describe('Category: model', () => {
       describe('(prop): maxlength', () => {
         it.skip(' ', () => {
-          //
+          // It is tricky to test this since it will require that we setup a control slot with v-model.
+          // This is already tested in QInput and others using use-field composable, so are not not testing it.
         })
       })
     })
@@ -33,19 +34,6 @@ describe('Field API', () => {
         })
 
         getHostElement().get('.q-field__control-container').should('contain', controlSlot)
-      })
-    })
-
-    describe('(slot): rawControl', () => {
-      it('should use raw control slot', () => {
-        const rawControlSlot = 'Hello there'
-        mountQField({
-          slots: {
-            rawControl: () => rawControlSlot
-          }
-        })
-
-        getHostElement().get('.q-field__control-container').should('contain', rawControlSlot)
       })
     })
   })

--- a/ui/src/composables/private/__tests__/FieldWrapper.vue
+++ b/ui/src/composables/private/__tests__/FieldWrapper.vue
@@ -40,7 +40,14 @@ export default defineComponent({
       compRef.value.blur()
     }
 
-    return { compRef, show, hide, toggle, focusMethod, blur }
+    function validate () {
+      compRef.value.validate()
+    }
+
+    function resetValidation () {
+      compRef.value.resetValidation()
+    }
+    return { compRef, show, hide, toggle, focusMethod, blur, validate, resetValidation }
   }
 })
 

--- a/ui/src/composables/private/__tests__/FieldWrapper.vue
+++ b/ui/src/composables/private/__tests__/FieldWrapper.vue
@@ -1,6 +1,10 @@
 <template>
   <div style="margin: 150px auto" class="row justify-center" data-cy="wrapper">
-    <q-select data-cy="select" class="select-root" ref="compRef" v-bind="$attrs" style="min-width: 300px"></q-select>
+    <q-select data-cy="select" class="select-root" ref="compRef" v-bind="$attrs" style="min-width: 300px">
+      <template v-for="(_, name) in $slots" #[name]>
+        <slot :name="name" />
+      </template>
+    </q-select>
   </div>
   <q-btn class="hidden" data-cy="method-show" @click="show" />
   <q-btn class="hidden" data-cy="method-hide" @click="hide" />
@@ -32,7 +36,11 @@ export default defineComponent({
       compRef.value.focus()
     }
 
-    return { compRef, show, hide, toggle, focusMethod }
+    function blur () {
+      compRef.value.blur()
+    }
+
+    return { compRef, show, hide, toggle, focusMethod, blur }
   }
 })
 

--- a/ui/src/composables/private/__tests__/use-field.cy.js
+++ b/ui/src/composables/private/__tests__/use-field.cy.js
@@ -515,7 +515,6 @@ describe('use-field API', () => {
           .should('not.have.focus')
         getHostElement()
           .then(() => {
-            console.log(Cypress.vueWrapper.vm)
             Cypress.vueWrapper.vm.focusMethod()
           })
         getHostElement()

--- a/ui/src/composables/private/__tests__/use-field.cy.js
+++ b/ui/src/composables/private/__tests__/use-field.cy.js
@@ -1,37 +1,113 @@
 import FieldWrapper from './FieldWrapper.vue'
+import { ref } from 'vue'
+import { vModelAdapter } from '@quasar/quasar-app-extension-testing-e2e-cypress'
+import Icons from '../../../../icon-set/material-icons.mjs'
+
+function mountQFieldWrapper (options) {
+  return cy.mount(FieldWrapper, options)
+}
+
+function getHostElement () {
+  return cy.get('.select-root')
+}
+
+const selectOptions = [ 'Option 1', 'Option 2' ]
 
 describe('use-field API', () => {
   describe('Props', () => {
     describe('Category: behavior', () => {
       describe('(prop): autofocus', () => {
-        it.skip(' ', () => {
-          //
+        it('should autofocus on component', () => {
+          mountQFieldWrapper({
+            props: {
+              autofocus: true
+            }
+          })
+
+          getHostElement()
+            .get('.q-field--focused')
+            .should('exist')
+            .get('input')
+            .should('have.focus')
         })
       })
 
       describe('(prop): for', () => {
-        it.skip(' ', () => {
-          //
+        it('should set the for attribute for the value and the id of the control', () => {
+          const forProp = 'hello-there'
+
+          mountQFieldWrapper({
+            props: {
+              for: forProp
+            }
+          })
+
+          getHostElement().should('have.attr', 'for', forProp)
+          getHostElement().get('input').should('have.id', forProp)
         })
       })
 
       describe('(prop): name', () => {
-        it.skip(' ', () => {
-          //
+        it('should use the value of the for prop as control name if name is not set', () => {
+          const forProp = 'hello-there'
+          const model = ref(selectOptions[ 0 ])
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              for: forProp
+            }
+          })
+
+          getHostElement().get('select').should('have.attr', 'name', forProp)
+        })
+
+        it('should set the name of the control', () => {
+          const name = 'hello-there'
+          const model = ref(selectOptions[ 0 ])
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              name
+            }
+          })
+
+          getHostElement().get('select').should('have.attr', 'name', name)
         })
       })
     })
 
     describe('Category: behavior|content', () => {
       describe('(prop): loading', () => {
-        it.skip(' ', () => {
-          //
+        it('should should set the component into a loading state', () => {
+          mountQFieldWrapper({
+            props: {
+              loading: true
+            }
+          })
+
+          getHostElement().get('.q-spinner').should('exist')
         })
       })
 
       describe('(prop): clearable', () => {
-        it.skip(' ', () => {
-          //
+        it('should append a clear icon', () => {
+          const model = ref(selectOptions[ 0 ])
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              clearable: true,
+              options: selectOptions
+            }
+          })
+
+          getHostElement().find('input').should('exist').should('have.value', model.value)
+          getHostElement().get('button[type="button"]').contains(Icons.field.clear).click()
+          getHostElement().get('input').should('not.have.value', model.value)
         })
       })
     })
@@ -133,102 +209,206 @@ describe('use-field API', () => {
       })
 
       describe('(prop): prefix', () => {
-        it.skip(' ', () => {
-          //
+        it('should display a prefix', () => {
+          const prefix = 'Hello there!'
+          mountQFieldWrapper({
+            props: {
+              prefix
+            }
+          })
+
+          getHostElement().get('.q-field__prefix').should('exist').should('contain', prefix)
         })
       })
 
       describe('(prop): suffix', () => {
-        it.skip(' ', () => {
-          //
+        it('should display a suffix', () => {
+          const suffix = 'Hello there!'
+          mountQFieldWrapper({
+            props: {
+              suffix
+            }
+          })
+
+          getHostElement().get('.q-field__suffix').should('exist').should('contain', suffix)
         })
       })
 
       describe('(prop): clear-icon', () => {
-        it.skip(' ', () => {
-          //
+        it('should display custom clear-icon when one is set', () => {
+          const model = ref(selectOptions[ 0 ])
+          const clearIcon = 'custom-clear-icon'
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              clearable: true,
+              clearIcon
+            }
+          })
+
+          getHostElement().get('.q-field__append').get('button').should('contain', clearIcon)
         })
       })
 
       describe('(prop): label-slot', () => {
-        it.skip(' ', () => {
-          //
+        it('should force the use of the label slot even when a label prop is set', () => {
+          const model = ref(selectOptions[ 0 ])
+          const labelSlot = 'Hello world'
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              labelSlot: true,
+              label: 'Hello there'
+            },
+            slots: {
+              label: () => labelSlot
+            }
+          })
+
+          getHostElement().find('.q-field__label').should('contain.text', labelSlot)
         })
       })
 
       describe('(prop): bottom-slots', () => {
-        it.skip(' ', () => {
-          //
+        it('should use a bottom error slot', () => {
+          const model = ref(selectOptions[ 0 ])
+          const bottomSlot = 'Hello there'
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              bottomSlotSlots: true,
+              error: true
+            },
+            slots: {
+              error: () => bottomSlot
+            }
+          })
+
+          getHostElement().find('.q-field__bottom')
+            .should('contain.text', bottomSlot)
+        })
+
+        it('should use a bottom hint slot', () => {
+          const model = ref(selectOptions[ 0 ])
+          const bottomSlot = 'Hello there'
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              bottomSlots: true
+            },
+            slots: {
+              hint: () => bottomSlot
+            }
+          })
+
+          getHostElement().find('.q-field__bottom').should('contain.text', bottomSlot)
+        })
+
+        it('should use a bottom counter slot', () => {
+          const model = ref(selectOptions[ 0 ])
+          const bottomSlot = 'Hello there'
+
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              bottomSlots: true
+            },
+            slots: {
+              hint: () => bottomSlot
+            }
+          })
+
+          getHostElement().find('.q-field__bottom').should('contain.text', bottomSlot)
         })
       })
 
       describe('(prop): counter', () => {
-        it.skip(' ', () => {
-          //
+        it('should show an automatic counter on bottom right', () => {
+          const model = ref(selectOptions[ 0 ])
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              counter: true
+            }
+          })
+
+          getHostElement().get('.q-field__counter').should('contain', model.value.length)
         })
       })
     })
 
     describe('Category: state', () => {
       describe('(prop): disable', () => {
-        it.skip(' ', () => {
-          //
+        it('should put the component on disable state', () => {
+          mountQFieldWrapper({
+            props: {
+              disable: true
+            }
+          })
+
+          getHostElement().should('have.class', 'q-field--disabled')
         })
       })
 
       describe('(prop): readonly', () => {
-        it.skip(' ', () => {
-          //
+        it('should put the component on readonly state', () => {
+          mountQFieldWrapper({
+            props: {
+              readonly: true
+            }
+          })
+
+          getHostElement().should('have.class', 'q-field--readonly')
         })
       })
     })
 
     describe('Category: style', () => {
       describe('(prop): label-color', () => {
-        it.skip(' ', () => {
-          //
+        it('should display a label color', () => {
+          const label = 'Hello there!'
+          mountQFieldWrapper({
+            props: {
+              label,
+              labelColor: 'red'
+            }
+          })
+
+          getHostElement().get('.q-field__label.text-red').should('contain', label)
         })
       })
 
       describe('(prop): color', () => {
-        it.skip(' ', () => {
-          //
+        it('should set a color on the component', () => {
+          mountQFieldWrapper()
+          getHostElement().get('.q-field__control.text-red').should('not.exist')
+
+          getHostElement().get('input').then(() => {
+            Cypress.vueWrapper.setProps({ color: 'red' })
+
+            getHostElement().get('.q-field__control.text-red').should('exist')
+          })
         })
       })
 
       describe('(prop): bg-color', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
+        it('should display a background color', () => {
+          mountQFieldWrapper({
+            props: {
+              bgColor: 'red'
+            }
+          })
 
-      describe('(prop): dark', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
-
-      describe('(prop): filled', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
-
-      describe('(prop): outlined', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
-
-      describe('(prop): borderless', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
-
-      describe('(prop): standout', () => {
-        it.skip(' ', () => {
-          //
+          getHostElement().get('.q-field__control.bg-red').should('exist')
         })
       })
 
@@ -238,112 +418,134 @@ describe('use-field API', () => {
         })
       })
 
-      describe('(prop): rounded', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
+      const fieldLooks = [ 'item-aligned', 'dark', 'filled', 'outlined', 'borderless', 'standout', 'rounded', 'square', 'dense' ]
+      for (const style of fieldLooks) {
+        describe(`(prop): ${ style }`, () => {
+          it(`should apply ${ style } design style`, () => {
+            mountQFieldWrapper({
+              props: {
+                [ style ]: true
+              }
+            })
 
-      describe('(prop): square', () => {
-        it.skip(' ', () => {
-          //
+            getHostElement().get(`.q-field--${ style }`).should('exist')
+          })
         })
-      })
-
-      describe('(prop): dense', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
-
-      describe('(prop): item-aligned', () => {
-        it.skip(' ', () => {
-          //
-        })
-      })
+      }
     })
   })
 
   describe('Slots', () => {
+    const slots = [ 'prepend', 'append', 'before', 'after', 'label' ]
+
     describe('(slot): default', () => {
-      it.skip(' ', () => {
-        //
+      it('should use the default slot', () => {
+        const model = ref(selectOptions[ 0 ])
+        const labelSlot = 'Hello world'
+
+        mountQFieldWrapper({
+          props: {
+            ...vModelAdapter(model),
+            options: selectOptions,
+            labelSlot: true
+          },
+          slots: {
+            default: () => labelSlot
+          }
+        })
+
+        getHostElement().should('contain.text', labelSlot)
       })
     })
 
-    describe('(slot): prepend', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
+    for (const slot of slots) {
+      describe(`(slot): ${ slot }`, () => {
+        it(`should append a '${ slot }' slot`, () => {
+          const model = ref(selectOptions[ 0 ])
+          const labelSlot = 'Hello world'
 
-    describe('(slot): append', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
+          mountQFieldWrapper({
+            props: {
+              ...vModelAdapter(model),
+              options: selectOptions,
+              labelSlot: true
+            },
+            slots: {
+              [ slot ]: () => labelSlot
+            }
+          })
 
-    describe('(slot): before', () => {
-      it.skip(' ', () => {
-        //
+          getHostElement().get(`.q-field__${ slot }`).should('contain.text', labelSlot)
+        })
       })
-    })
-
-    describe('(slot): after', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
-
-    describe('(slot): label', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
-
-    describe('(slot): error', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
-
-    describe('(slot): hint', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
-
-    describe('(slot): counter', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
-
-    describe('(slot): loading', () => {
-      it.skip(' ', () => {
-        //
-      })
-    })
+    }
   })
 
   describe('Events', () => {
     describe('(event): clear', () => {
-      it.skip(' ', () => {
-        //
+      it('should emit the clear event when the clear button is clicked', () => {
+        const model = ref(selectOptions[ 0 ])
+        const fn = cy.stub()
+
+        mountQFieldWrapper({
+          props: {
+            ...vModelAdapter(model),
+            clearable: true,
+            options: selectOptions,
+            onClear: fn
+          }
+        })
+
+        getHostElement().get('button[type="button"]')
+          .contains(Icons.field.clear).click()
+          .then(() => {
+            expect(fn).to.be.calledWith()
+          })
       })
     })
   })
 
   describe('Methods', () => {
     describe('(method): focus', () => {
-      it.skip(' ', () => {
-        //
+      it('should focus the component', () => {
+        mountQFieldWrapper()
+
+        getHostElement()
+          .get('[tabindex="0"]')
+          .should('not.have.focus')
+        getHostElement()
+          .then(() => {
+            console.log(Cypress.vueWrapper.vm)
+            Cypress.vueWrapper.vm.focusMethod()
+          })
+        getHostElement()
+          .get('[tabindex="0"]')
+          .should('have.focus')
       })
     })
 
     describe('(method): blur', () => {
-      it.skip(' ', () => {
-        //
+      it('should blur the component', () => {
+        mountQFieldWrapper()
+
+        getHostElement()
+          .get('input').focus()
+        getHostElement()
+          .get('.q-field--focused')
+          .as('focused-element')
+          .should('exist')
+
+        cy.get('@focused-element')
+          .get('input')
+          .should('have.focus')
+
+        getHostElement()
+          .then(() => {
+            Cypress.vueWrapper.vm.blur()
+          })
+
+        cy.get('@focused-element').should('not.exist')
+        getHostElement().get('input').should('not.have.focus')
       })
     })
   })

--- a/ui/src/composables/private/__tests__/use-field.cy.js
+++ b/ui/src/composables/private/__tests__/use-field.cy.js
@@ -107,7 +107,7 @@ describe('use-field API', () => {
 
           getHostElement().find('input').should('exist').should('have.value', model.value)
           getHostElement().get('button[type="button"]').contains(Icons.field.clear).click()
-          getHostElement().get('input').should('not.have.value', model.value)
+          getHostElement().get('input').should('have.value', '')
         })
       })
     })
@@ -313,20 +313,16 @@ describe('use-field API', () => {
 
         it('should use a bottom counter slot', () => {
           const model = ref(selectOptions[ 0 ])
-          const bottomSlot = 'Hello there'
 
           mountQFieldWrapper({
             props: {
               ...vModelAdapter(model),
               options: selectOptions,
-              bottomSlots: true
-            },
-            slots: {
-              hint: () => bottomSlot
+              counter: true
             }
           })
 
-          getHostElement().find('.q-field__bottom').should('contain.text', bottomSlot)
+          getHostElement().find('.q-field__bottom').should('contain.text', model.value.length)
         })
       })
 
@@ -511,14 +507,14 @@ describe('use-field API', () => {
         mountQFieldWrapper()
 
         getHostElement()
-          .get('[tabindex="0"]')
+          .get('input')
           .should('not.have.focus')
         getHostElement()
           .then(() => {
             Cypress.vueWrapper.vm.focusMethod()
           })
         getHostElement()
-          .get('[tabindex="0"]')
+          .get('input')
           .should('have.focus')
       })
     })


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: tests

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
