### PR TITLE
doc: disable and hide "remove row" button conditionally

### DIFF
--- a/docs/src/examples/QTable/CustomTop.vue
+++ b/docs/src/examples/QTable/CustomTop.vue
@@ -12,7 +12,7 @@
 
       <template v-slot:top>
         <q-btn color="primary" :disable="loading" label="Add row" @click="addRow" />
-        <q-btn class="q-ml-sm" color="primary" :disable="loading" label="Remove row" @click="removeRow" />
+        <q-btn class="q-ml-sm" color="primary" :disable="loading || rows.length < 1" v-show="rows.length > 0" label="Remove row" @click="removeRow" />
         <q-space />
         <q-input borderless dense debounce="300" color="primary" v-model="filter">
           <template v-slot:append>

--- a/docs/src/examples/QTable/CustomTop.vue
+++ b/docs/src/examples/QTable/CustomTop.vue
@@ -12,7 +12,7 @@
 
       <template v-slot:top>
         <q-btn color="primary" :disable="loading" label="Add row" @click="addRow" />
-        <q-btn class="q-ml-sm" color="primary" :disable="loading || rows.length < 1" v-show="rows.length > 0" label="Remove row" @click="removeRow" />
+        <q-btn v-if="rows.length !== 0" class="q-ml-sm" color="primary" :disable="loading" label="Remove row" @click="removeRow" />
         <q-space />
         <q-input borderless dense debounce="300" color="primary" v-model="filter">
           <template v-slot:append>


### PR DESCRIPTION
Custom top QTable example: disable and hide "remove row"  button when there is no row to remove. Good usability.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Minor usability improvement to a docs example