### PR TITLE
feat(ui): generate types for vue directives

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -353,10 +353,21 @@ function getIndexDts (apis) {
       const valueType = getTypeVal(content.value)
 
       const directiveValueType = `${ typeName }Value`
+      const comments = [
+        '/**',
+        ` * ${ content.value.desc }`,
+        ' *',
+        ` * @see ${ content.meta.docsUrl }`,
+        ' */'
+      ].join('\n')
+
+      write(contents, comments + '\n')
       writeLine(contents, `export type ${ directiveValueType } = ${ valueType }`)
+      write(contents, comments + '\n')
       writeLine(contents, `export type ${ typeName } = Directive<any, ${ directiveValueType }>`)
 
-      write(directives, propTypeDef)
+      write(directives, comments)
+      writeLine(directives, `v${ typeName }: ${ typeValue }`)
 
       // Nothing else to do for directives
       return
@@ -572,11 +583,9 @@ function getIndexDts (apis) {
   // See: https://github.com/vuejs/language-tools/issues/465#issuecomment-1229166260
   // See: https://github.com/vuejs/core/pull/3399
   writeLine(contents)
-  writeLine(contents, '// Directives')
-  directives.forEach(directive => {
-    // Example: `ClosePopup?: ClosePopup` -> `vClosePopup: ClosePopup`
-    writeLine(contents, `v${ directive.replace('?', '') }`, 2)
-  })
+  writeLine(contents, '// Directives', 2)
+  writeLine(contents)
+  writeLines(contents, directives.join('\n'), 2)
 
   writeLine(contents, '}', 1)
   writeLine(contents, '}')

--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -353,16 +353,43 @@ function getIndexDts (apis) {
       const valueType = getTypeVal(content.value)
 
       const directiveValueType = `${ typeName }Value`
-      const comments = [
+      const argComments = content.arg ? [
+        ' * Directive argument:',
+        ' *  - type: ' + getTypeVal(content.arg),
+        ...(content.arg.default ? [ ' *  - default: ' + content.arg.default ] : []),
+        ' *  - description: ' + content.arg.desc,
+        ' *  - examples:',
+        ...content.arg.examples.map(example => ' *    - ' + example),
+        ' *'
+      ] : []
+      const modifiersComments = content.modifiers ? [
+        ' * Modifiers:',
+        ...Object.entries(content.modifiers).map(([ name, modifier ]) => [
+          ' *  - ' + name + ':',
+          ' *    - type: ' + getTypeVal(modifier),
+          ' *    - description: ' + modifier.desc,
+          ...(modifier.examples && modifier.examples.length > 0 ? [
+            ' *    - examples:',
+            ...modifier.examples.map(example => ' *      - ' + example)
+          ] : [])
+        ].join('\n')),
+        ' *'
+      ] : []
+      const getComments = (withExtra) => [
         '/**',
         ` * ${ content.value.desc }`,
         ' *',
+        ...(withExtra ? [ ...argComments, ...modifiersComments ] : []),
         ` * @see ${ content.meta.docsUrl }`,
         ' */'
       ].join('\n')
 
-      write(contents, comments + '\n')
+      // We don't need the comments for args and modifiers in the value type
+      write(contents, getComments(false) + '\n')
       writeLine(contents, `export type ${ directiveValueType } = ${ valueType }`)
+
+      const comments = getComments(true)
+
       write(contents, comments + '\n')
       writeLine(contents, `export type ${ typeName } = Directive<any, ${ directiveValueType }>`)
 

--- a/ui/src/directives/Morph.json
+++ b/ui/src/directives/Morph.json
@@ -101,7 +101,7 @@
       },
 
       "waitFor": {
-        "type": [ "Number", "String", "Promise" ],
+        "type": [ "Number", "String", "Promise<void>" ],
         "desc": "Delay animation start for that number of milliseconds, or until a 'transitionend' event is emitted by the destination element, or until the promise is resolved (if the promise is rejected the morphing will abort, but the `toggle function` was already called)",
         "default": "0",
         "examples": [ "300", "transitionend" ]

--- a/ui/src/directives/Scroll.json
+++ b/ui/src/directives/Scroll.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Function to call when scrolling occurs (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Function to call when scrolling occurs (use undefined to disable)",
     "params": {
       "verticalScrollPosition": {
         "type": "Number",
@@ -17,6 +17,6 @@
       }
     },
     "returns": null,
-    "examples": [ "v-scroll=\"fnToCall\"", "v-scroll=\"void 0\"" ]
+    "examples": [ "v-scroll=\"fnToCall\"", "v-scroll=\"undefined\"" ]
   }
 }

--- a/ui/src/directives/ScrollFire.json
+++ b/ui/src/directives/ScrollFire.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Function to call when scrolling and element comes into the viewport (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Function to call when scrolling and element comes into the viewport (use undefined to disable)",
     "params": {
       "el": {
         "type": "Element",
@@ -13,6 +13,6 @@
       }
     },
     "returns": null,
-    "examples": [ "v-scroll-fire=\"fnToCall\"", "v-scroll-fire=\"void 0\"" ]
+    "examples": [ "v-scroll-fire=\"fnToCall\"", "v-scroll-fire=\"undefined\"" ]
   }
 }

--- a/ui/src/directives/TouchHold.json
+++ b/ui/src/directives/TouchHold.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Function to call after user has hold touch/click for the specified amount of time (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Function to call after user has hold touch/click for the specified amount of time (use undefined to disable)",
     "params": {
       "details": {
         "type": "Object",
@@ -45,7 +45,7 @@
       }
     },
     "returns": null,
-    "examples": [ "v-touch-hold=\"fnToCall\"", "v-touch-hold=\"void 0\"" ]
+    "examples": [ "v-touch-hold=\"fnToCall\"", "v-touch-hold=\"undefined\"" ]
   },
 
   "arg": {

--- a/ui/src/directives/TouchPan.json
+++ b/ui/src/directives/TouchPan.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Handler for panning (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Handler for panning (use undefined to disable)",
     "params": {
       "details": {
         "type": "Object",
@@ -102,7 +102,7 @@
       }
     },
     "returns": null,
-    "examples": [ "v-touch-pan=\"fnToCall\"", "v-touch-pan=\"void 0\"" ]
+    "examples": [ "v-touch-pan=\"fnToCall\"", "v-touch-pan=\"undefined\"" ]
   },
 
   "modifiers": {

--- a/ui/src/directives/TouchRepeat.json
+++ b/ui/src/directives/TouchRepeat.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Handler for touch-repeat (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Handler for touch-repeat (use undefined to disable)",
     "params": {
       "details": {
         "type": "Object",
@@ -61,7 +61,7 @@
       }
     },
     "returns": null,
-    "examples": [ "v-touch-repeat=\"fnToCall\"", "v-touch-repeat=\"void 0\"" ]
+    "examples": [ "v-touch-repeat=\"fnToCall\"", "v-touch-repeat=\"undefined\"" ]
   },
 
   "arg": {

--- a/ui/src/directives/TouchSwipe.json
+++ b/ui/src/directives/TouchSwipe.json
@@ -4,8 +4,8 @@
   },
 
   "value": {
-    "type": "Function",
-    "desc": "Handler for swipe (use a non-function to disable)",
+    "type": ["Function", "undefined"],
+    "desc": "Handler for swipe (use undefined to disable)",
     "params": {
       "details": {
         "type": "Object",
@@ -50,7 +50,7 @@
       }
     },
     "returns": null,
-    "examples": [ "v-touch-swipe=\"fnToCall\"", "v-touch-swipe=\"void 0\"" ]
+    "examples": [ "v-touch-swipe=\"fnToCall\"", "v-touch-swipe=\"undefined\"" ]
   },
 
   "arg": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Resolves #15798. This was already planned way before the discussion thread, but linking it anyway.

The types we are generating for directives will no longer be empty interfaces. They will now use the `Directive<Target, Value>` type.

Volar, unfortunately, doesn't provide auto-completion for directives when doing `v-`. I am not sure if this is a known issue. But, it recognizes them and does type-checking. It's not possible to strongly type arg and modifiers, so they are documented as comments. It will be possible with https://github.com/vuejs/core/pull/3399, but without the ability to add an extra explanation for individual things from the way it is structured, it seems. So, the comments will be useful in any case.

We are now generating new types for each directive with the `Value` suffix(e.g. `TouchPanValue`) which holds the type of the value the directive expects. This type can be used to create variables to feed to the directive. Here is an example:
```html
<template>
  <div v-touch-pan.mouse="touchPanHandler">
    Touch Here
  </div>
</template>

<script setup lang="ts">
import { TouchPanValue } from 'quasar';

const touchPanHandler: TouchPanValue = (event) => {
  console.log(event);
};
</script>
```
![image](https://github.com/quasarframework/quasar/assets/6266078/f292c9ed-0b64-4de5-879e-629117dbff70)

Extra screenshots:

![image](https://github.com/quasarframework/quasar/assets/6266078/b4e9fb41-5315-4f76-ae66-322923990d81)
![image](https://github.com/quasarframework/quasar/assets/6266078/7be03000-77f1-43b5-9911-484824a5518c)
![image](https://github.com/quasarframework/quasar/assets/6266078/b1c0fb02-7594-4967-90f3-2e3568266dbd)
![image](https://github.com/quasarframework/quasar/assets/6266078/627b6ecd-6f06-424b-b969-51f214610667)
