### PR TITLE
fix(ui): allow dynamic names in QEditorSlots type

### DIFF
--- a/ui/src/components/editor/QEditor.json
+++ b/ui/src/components/editor/QEditor.json
@@ -368,5 +368,11 @@
       "tsType": "QEditorCaret",
       "desc": "The current caret state"
     }
+  },
+
+  "slots": {
+    "[command]": {
+      "desc": "Content for the given command in the toolbar"
+    }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Documentation

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Resolves #16067. This also documents the dynamic slots more clearly as they will now be listed in the API card.