### PR TITLE
feat(ui): add specific types for colors

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -53,7 +53,7 @@ const objectTypes = {
   },
 
   String: {
-    props: [ 'tsInjectionPoint', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'transformAssetUrls', 'internal' ],
+    props: [ 'tsInjectionPoint', 'tsType', 'desc', 'required', 'reactive', 'sync', 'syncable', 'link', 'values', 'default', 'examples', 'category', 'addedIn', 'transformAssetUrls', 'internal' ],
     required: [ 'desc' ],
     isBoolean: [ 'tsInjectionPoint', 'required', 'reactive', 'sync', 'syncable', 'transformAssetUrls', 'internal' ],
     isArray: [ 'examples', 'values' ]

--- a/ui/src/api.extends.json
+++ b/ui/src/api.extends.json
@@ -14,15 +14,17 @@
 
     "color": {
       "type": "String",
+      "tsType": "NamedColor",
       "desc": "Color name for component from the Quasar Color Palette",
-      "examples": [ "primary", "teal-10" ],
+      "examples": [ "primary", "teal", "teal-10" ],
       "category": "style"
     },
 
     "text-color": {
       "type": "String",
+      "tsType": "NamedColor",
       "desc": "Overrides text color (if needed); Color name from the Quasar Color Palette",
-      "examples": [ "primary", "teal-10" ],
+      "examples": [ "primary", "teal", "teal-10" ],
       "category": "style"
     },
 

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -20,7 +20,7 @@
       },
 
       "textColor": {
-        "extends": "color"
+        "extends": "text-color"
       },
 
       "message": {
@@ -205,7 +205,7 @@
             },
 
             "textColor": {
-              "extends": "color"
+              "extends": "text-color"
             },
 
             "message": {

--- a/ui/types/api.d.ts
+++ b/ui/types/api.d.ts
@@ -1,4 +1,5 @@
 export * from "./api/vue-prop-types";
+export * from "./api/color";
 export * from "./api/cookies";
 export * from "./api/dialog";
 export * from "./api/qfile";

--- a/ui/types/api/color.d.ts
+++ b/ui/types/api/color.d.ts
@@ -1,0 +1,51 @@
+import type { LiteralUnion } from "quasar";
+
+/**
+ * Augment this interface to add custom colors.
+ *
+ * @example
+ * ```ts
+ * declare module "quasar" {
+ *   interface CustomColors {
+ *     custom: string;
+ *   }
+ * }
+ * ```
+ */
+export interface CustomColors {}
+
+export type BrandColor =
+  | "primary"
+  | "secondary"
+  | "accent"
+  | "dark"
+  | "positive"
+  | "negative"
+  | "info"
+  | "warning";
+type Color =
+  | "red"
+  | "pink"
+  | "purple"
+  | "deep-purple"
+  | "indigo"
+  | "blue"
+  | "light-blue"
+  | "cyan"
+  | "teal"
+  | "green"
+  | "light-green"
+  | "lime"
+  | "yellow"
+  | "amber"
+  | "orange"
+  | "deep-orange"
+  | "brown"
+  | "grey"
+  | "blue-grey";
+type ColorShade = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
+type DetailedColor = `${Color}-${ColorShade}`;
+
+export type NamedColor = LiteralUnion<
+  BrandColor | Color | DetailedColor | keyof CustomColors
+>;

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -1,4 +1,4 @@
-import { QUploader } from "quasar";
+import { QUploader, LiteralUnion } from "quasar";
 import {
   ComponentOptionsMixin,
   ComponentPropsOptions,
@@ -20,6 +20,7 @@ export * from "./utils/scroll";
 export * from "./utils/is";
 export * from "./utils/run-sequential-promises";
 
+import { BrandColor } from "./api/color";
 import { VueStyleObjectProp } from "./api/vue-prop-types";
 
 interface ExportFileOpts {
@@ -95,10 +96,10 @@ interface MorphOptions {
 
 export function morph(options: MorphOptions): (abort?: boolean) => boolean;
 
-export function getCssVar(varName: string, element?: Element): string | null;
+export function getCssVar(varName: LiteralUnion<BrandColor>, element?: Element): string | null;
 
 export function setCssVar(
-  varName: string,
+  varName: LiteralUnion<BrandColor>,
   value: string,
   element?: Element
 ): void;

--- a/ui/types/utils.d.ts
+++ b/ui/types/utils.d.ts
@@ -96,7 +96,10 @@ interface MorphOptions {
 
 export function morph(options: MorphOptions): (abort?: boolean) => boolean;
 
-export function getCssVar(varName: LiteralUnion<BrandColor>, element?: Element): string | null;
+export function getCssVar(
+  varName: LiteralUnion<BrandColor>,
+  element?: Element
+): string | null;
 
 export function setCssVar(
   varName: LiteralUnion<BrandColor>,

--- a/ui/types/utils/colors.d.ts
+++ b/ui/types/utils/colors.d.ts
@@ -1,3 +1,5 @@
+import { NamedColor } from "../api/color";
+
 export interface colorsRgba {
   r: number;
   g: number;
@@ -23,9 +25,9 @@ export namespace colors {
   function luminosity(color: string | colorsRgba): number;
   function brightness(color: string | colorsRgba): number;
   function blend(
-    fgColor: string | colorsRgba,
-    bColor: string | colorsRgba
+    foregroundColor: string | colorsRgba,
+    backgroundColor: string | colorsRgba
   ): string;
   function changeAlpha(color: string, offset: number): string;
-  function getPaletteColor(colorName: string): string;
+  function getPaletteColor(colorName: NamedColor): string;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

It offers auto-completion for known colors in related props and utils. It still accepts any string value, so custom colors won't produce errors.

It's possible to add custom colors into auto-completion as well.
```ts
declare module "quasar" {
  interface CustomColors {
    tertiary: string;
    'my-color': string;
  }
}
```

It doesn't work with `class` completion(_e.g.`text-primary`_) as it works quite differently under the hood.

![image](https://github.com/quasarframework/quasar/assets/6266078/19c91967-3573-4eb4-a7b4-6e303261bdf8)
![image](https://github.com/quasarframework/quasar/assets/6266078/12066b60-80f8-45cf-b2f1-80d3a047eecd)
![image](https://github.com/quasarframework/quasar/assets/6266078/2b4e610c-5bdb-4b20-bc84-705c9eff7375)
![image](https://github.com/quasarframework/quasar/assets/6266078/fe57715f-a5ba-449a-843d-bedeb61dd643)

Thanks `@angelhdzmultimedia` from our Discord server for the idea.