### PR TITLE
Convert file: URL to path correctly

### DIFF
--- a/cli/lib/app-paths.js
+++ b/cli/lib/app-paths.js
@@ -1,6 +1,7 @@
 
 import { existsSync } from 'node:fs'
 import { normalize, join, sep } from 'node:path'
+import { fileURLToPath } from 'node:url';
 
 const quasarConfigFilenameList = [
   'quasar.config.js',
@@ -29,7 +30,7 @@ function getAppInfo () {
 
 const { appDir, quasarConfigFilename } = getAppInfo()
 
-const cliDir = new URL('..', import.meta.url).pathname
+const cliDir = fileURLToPath(new URL('..', import.meta.url))
 
 export default {
   cliDir,

--- a/cli/lib/app-paths.js
+++ b/cli/lib/app-paths.js
@@ -1,7 +1,7 @@
 
 import { existsSync } from 'node:fs'
 import { normalize, join, sep } from 'node:path'
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from 'node:url'
 
 const quasarConfigFilenameList = [
   'quasar.config.js',

--- a/icongenie/lib/utils/parse-argv.js
+++ b/icongenie/lib/utils/parse-argv.js
@@ -1,6 +1,7 @@
 
 import { existsSync, lstatSync } from 'node:fs'
 import { resolve, normalize, isAbsolute } from 'node:path'
+import { fileURLToPath } from 'node:url';
 import untildify from 'untildify'
 
 import { getPngSize } from './get-png-size.js'
@@ -148,8 +149,8 @@ function parseIconPath (value) {
 function icon (value, argv) {
   if (!value) {
     warn(`No source icon file specified, so using the sample one`)
-    argv.icon = normalize(
-      new URL('../../samples/icongenie-icon.png', import.meta.url).pathname
+    argv.icon = normalize(fileURLToPath(
+      new URL('../../samples/icongenie-icon.png', import.meta.url))
     )
     return
   }

--- a/icongenie/lib/utils/parse-argv.js
+++ b/icongenie/lib/utils/parse-argv.js
@@ -1,7 +1,7 @@
 
 import { existsSync, lstatSync } from 'node:fs'
 import { resolve, normalize, isAbsolute } from 'node:path'
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from 'node:url'
 import untildify from 'untildify'
 
 import { getPngSize } from './get-png-size.js'

--- a/utils/render-ssr-error/build/index.js
+++ b/utils/render-ssr-error/build/index.js
@@ -3,18 +3,18 @@ import { readFileSync, writeFileSync } from 'node:fs'
 
 const TARGET_STRING = '"<!-- inject:data -->"'
 const [ pre, post ] = readFileSync(
-  new URL('../src-ui/dist/index.html', import.meta.url).pathname,
+  new URL('../src-ui/dist/index.html', import.meta.url),
   'utf8'
 ).split(TARGET_STRING)
 
 writeFileSync(
-  new URL('../compiled-assets/before-injection', import.meta.url).pathname,
+  new URL('../compiled-assets/before-injection', import.meta.url),
   pre,
   'utf8'
 )
 
 writeFileSync(
-  new URL('../compiled-assets/after-injection', import.meta.url).pathname,
+  new URL('../compiled-assets/after-injection', import.meta.url),
   post,
   'utf8'
 )


### PR DESCRIPTION
This fixes various path issues on Windows. Most notably a crash when loading quasar.config:
> ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'

The node function [url.fileURLToPath](https://nodejs.org/api/url.html#urlfileurltopathurl) correctly performs this translation.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
