### PR TITLE
Docs: Clarification that Dialog componentProps may include built-in Dialog props

### DIFF
--- a/docs/src/pages/quasar-plugins/dialog.md
+++ b/docs/src/pages/quasar-plugins/dialog.md
@@ -112,6 +112,7 @@ setup () {
     // props forwarded to your custom component
     componentProps: {
       text: 'something',
+      persistent: true,
       // ...more..props...
     }
   }).onOk(() => {

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -277,7 +277,7 @@
 
             "componentProps": {
               "type": "Object",
-              "desc": "User defined props which will be forwarded to underlying custom component if 'component' prop is used.  May also include any built-in dialog option such as 'persistent' or 'seamless'"
+              "desc": "User defined props which will be forwarded to underlying custom component if 'component' prop is used; May also include any built-in QDialog option such as 'persistent' or 'seamless'"
             }
           }
         }

--- a/ui/src/plugins/Dialog.json
+++ b/ui/src/plugins/Dialog.json
@@ -277,7 +277,7 @@
 
             "componentProps": {
               "type": "Object",
-              "desc": "User defined props which will be forwarded to underlying custom component if 'component' prop is used"
+              "desc": "User defined props which will be forwarded to underlying custom component if 'component' prop is used.  May also include any built-in dialog option such as 'persistent' or 'seamless'"
             }
           }
         }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Adding clarification that Dialog `componentProps` may include built-in dialog options such as `seamless`.  Both in docs and an example.
Related to issue [#13671](https://github.com/quasarframework/quasar/issues/13671)