### PR TITLE
fix: file not found when dev ui on Windows

### DIFF
--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -1,6 +1,7 @@
 import { join, isAbsolute, basename, dirname } from 'node:path'
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import fse from 'fs-extra'
 import { merge } from 'webpack-merge'
 import debounce from 'lodash/debounce.js'
@@ -269,7 +270,7 @@ export class QuasarConfigFile {
 
     let quasarConfigFn
     try {
-      const fnResult = await import(this.#tempFile)
+      const fnResult = await import(pathToFileURL(this.#tempFile))
       quasarConfigFn = fnResult.default || fnResult
     }
     catch (e) {
@@ -333,7 +334,7 @@ export class QuasarConfigFile {
 
           try {
             const result = appPaths.quasarConfigOutputFormat === 'esm'
-              ? await import(tempFile + '?t=' + Date.now()) // we also need to cache bust it, hence the ?t= param
+              ? await import(pathToFileURL(tempFile) + '?t=' + Date.now()) // we also need to cache bust it, hence the ?t= param
               : this.#require(tempFile)
 
             quasarConfigFn = result.default || result

--- a/ui/dev/script.build.js
+++ b/ui/dev/script.build.js
@@ -6,4 +6,13 @@ moduleAlias.addAlias('quasar', path.join(__dirname, '..'))
 // Ensure cwd is set to ui/dev
 process.chdir(__dirname)
 
+const { createFolder } = require('../build/build.utils')
+const buildJavascript = require('../build/script.build.javascript')
+
+createFolder('dist/transforms')
+buildJavascript('transforms')
+
+createFolder('dist/api')
+buildJavascript('api')
+
 import('@quasar/app-vite/lib/cmd/build.js')

--- a/ui/dev/script.dev.js
+++ b/ui/dev/script.dev.js
@@ -6,4 +6,13 @@ moduleAlias.addAlias('quasar', path.join(__dirname, '..'))
 // Ensure cwd is set to ui/dev
 process.chdir(__dirname)
 
+const { createFolder } = require('../build/build.utils')
+const buildJavascript = require('../build/script.build.javascript')
+
+createFolder('dist/transforms')
+buildJavascript('transforms')
+
+createFolder('dist/api')
+buildJavascript('api')
+
 import('@quasar/app-vite/lib/cmd/dev.js')


### PR DESCRIPTION

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

When cloned Quasar and follow the [contribution docs](https://quasar.dev/how-to-contribute/contribution-guide#development-setup)
```bash
$ cd ui
$ yarn 
$ yarn dev or yarn dev:build
```
It just fails. I got a series of errors:

```
- Error 1:

Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'D:\Codes\github\quasar\node_modules\quasar\dist\transforms\import-transformation.js' imported from D:\Codes\github\quasar\vite-plugin\src\vue-transform.js

- Error 2:

Error: ENOENT: no such file or directory, open 'D:\Codes\github\quasar\ui\dist\transforms\loader-asset-urls.json'

- Error 3:

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at new NodeError (node:internal/errors:399:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1059:11)
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at file:///D:/Codes/github/quasar/app-vite/lib/quasar-config-file.js:336:47 {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```
btw, If you don't encounter this error, clean it up by `yarn clean` and do it again.

I tried to make some changes and luckily it worked.

I thought there might be someone who needed it too, so submit a contribution.
