### PR TITLE
fix: corect the css name of ui dev tabs-router

### DIFF
--- a/ui/dev/src/pages/components/tabs-router.vue
+++ b/ui/dev/src/pages/components/tabs-router.vue
@@ -94,7 +94,7 @@ export default {
   color: black
   padding: 12px
   border: 1px solid black
-  minwidth: 50px
+  min-width: 50px
 
   &--active
     background-color: #ee9


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

fix this warning:

```
warnings when minifying css:
▲ [WARNING] "minwidth" is not a known CSS property [unsupported-css-property]

    <stdin>:7:2:
      7 │   minwidth: 50px;
        │   ~~~~~~~~
        ╵   min-width

  Did you mean "min-width" instead?
```
