### PR TITLE
fix(ui): define both UI and quasar.config file compatible types in quasarConfOptions (fix: #16046)

### DIFF
--- a/ui/build/build.api.js
+++ b/ui/build/build.api.js
@@ -176,6 +176,7 @@ function isClassStyleType (type) {
   return hits === 3
 }
 
+// See https://github.com/quasarframework/quasar/issues/16046#issuecomment-1666395268 for more info
 const serializableTypes = [ 'Any', 'Boolean', 'Number', 'String', 'Array', 'Object' ]
 function isSerializable (value) {
   const types = Array.isArray(value.type) ? value.type : [ value.type ]
@@ -236,6 +237,11 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory, verif
     for (const prop in obj) {
       // These props are always valid and doesn't need to be specified in 'props' of 'objectTypes' entries
       if ([ 'type', '__exemption' ].includes(prop)) {
+        continue
+      }
+
+      // 'configFileType' is always valid in any level of 'quasarConfOptions' and nothing else
+      if (prop === 'configFileType' && banner.includes('"quasarConfOptions"')) {
         continue
       }
 
@@ -350,8 +356,8 @@ function parseObject ({ banner, api, itemName, masterType, verifyCategory, verif
       }
     }
 
-    if (verifySerializable && isSerializable(obj) === false) {
-      logError(`${ banner } object's type is non-serializable but props in "quasarConfOptions" can only consist of ${ serializableTypes.join('/') }:`)
+    if (verifySerializable && obj.configFileType === undefined && isSerializable(obj) === false) {
+      logError(`${ banner } object's type is non-serializable but props in "quasarConfOptions" can only consist of ${ serializableTypes.join('/') } to be used in quasar.config file. Use "configFileType" prop to specify a serializable type for quasar.config file, or set to null if there is no suitable type:`)
       console.error(obj)
       console.log()
       process.exit(1)

--- a/ui/src/plugins/Loading.json
+++ b/ui/src/plugins/Loading.json
@@ -52,7 +52,8 @@
         "desc": "Color name for background from the Quasar Color Palette"
       },
       "spinner": {
-        "type": "String",
+        "type": "Component",
+        "configFileType": "String",
         "desc": "One of the QSpinners",
         "examples": [ "QSpinnerAudio" ]
       },

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -174,18 +174,39 @@
         "tsType": "QNotifyAction",
         "desc": "Notification actions (buttons); Unless 'noDismiss' is true, clicking/tapping on the button will close the notification; Also check 'closeBtn' convenience prop",
         "definition": {
+          "handler": {
+            "type": "Function",
+            "configFileType": null,
+            "desc": "Function to be executed when the button is clicked/tapped",
+            "params": null,
+            "returns": null,
+            "examples": [
+              "() => { console.log('button clicked') }"
+            ]
+          },
           "noDismiss": {
             "type": "Boolean",
             "desc": "Do not dismiss the notification when the button is clicked/tapped"
           },
           "...": {
             "type": "Any",
-            "desc": "Any other QBtn prop expect 'onClick' (use 'handler' instead)",
+            "desc": "Any other QBtn prop expect 'onClick' (use 'handler' instead, only possible with UI config)",
             "examples": [ "label: 'Learn more'", "color: 'primary'" ]
           }
         },
         "examples": [
           "[ { label: 'Show', handler: () => {}, 'aria-label': 'Button label' }, { icon: 'map', handler: () => {}, color: 'yellow' }, { label: 'Learn more', noDismiss: true, handler: () => {} } ]"
+        ]
+      },
+
+      "onDismiss": {
+        "type": "Function",
+        "configFileType": null,
+        "desc": "Function to call when notification gets dismissed",
+        "params": null,
+        "returns": null,
+        "examples": [
+          "() => { console.log('Dismissed') }"
         ]
       },
 
@@ -455,7 +476,7 @@
           "type": "Object",
           "tsType": "QNotifyOptions",
           "required": true,
-          "desc": "Notification options (See 'opts' param of 'create()' for object properties)",
+          "desc": "Notification options except 'ignoreDefaults' (See 'opts' param of 'create()' for object properties)",
           "__exemption": [ "definition" ]
         }
       }
@@ -475,7 +496,7 @@
           "type": "Object",
           "tsType": "QNotifyOptions",
           "required": true,
-          "desc": "Notification options (See 'opts' param of 'create()' for object properties)",
+          "desc": "Notification options except 'ignoreDefaults' (See 'opts' param of 'create()' for object properties)",
           "__exemption": [ "definition" ]
         }
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Documentation

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #16046

(_improved search will come in a separate PR, searching through quasarConfOptions like in the screenshot doesn't work in the current docs_)
![image](https://github.com/quasarframework/quasar/assets/6266078/4a976d3d-783e-4fe2-a7ed-ce21a9656f64)
![image](https://github.com/quasarframework/quasar/assets/6266078/f099d8e3-7c99-41b9-8db4-e3f2a7d48f26)
![image](https://github.com/quasarframework/quasar/assets/6266078/a659b69e-54ba-4fa8-aff0-56a5d43d1275)
