### PR TITLE
feat(app-vite&app-webpack): support configuring default spinner component for Notify

### DIFF
--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -641,11 +641,23 @@ export class QuasarConfigFile {
     }
 
     // special case where a component can be designated for a framework > config prop
-    if (cfg.framework.config && cfg.framework.config.loading) {
-      const component = cfg.framework.config.loading.spinner
+    if (cfg.framework.config) {
+      const config = cfg.framework.config
       // Is a component and is a QComponent
-      if (component !== void 0 && /^(Q[A-Z]|q-)/.test(component) === true) {
-        cfg.framework.components.push(component)
+      const isComponent = (component) => component !== void 0 && /^(Q[A-Z]|q-)/.test(component) === true
+
+      if (config.loading) {
+        const component = config.loading.spinner
+        if (isComponent(component)) {
+          cfg.framework.components.push(component)
+        }
+      }
+
+      if (config.notify) {
+        const component = config.notify.spinner
+        if (isComponent(component)) {
+          cfg.framework.components.push(component)
+        }
       }
     }
 

--- a/app-webpack/lib/quasar-config-file.js
+++ b/app-webpack/lib/quasar-config-file.js
@@ -653,11 +653,23 @@ module.exports.QuasarConfigFile = class QuasarConfigFile {
     }
 
     // special case where a component can be designated for a framework > config prop
-    if (cfg.framework.config && cfg.framework.config.loading) {
-      const component = cfg.framework.config.loading.spinner
+    if (cfg.framework.config) {
+      const config = cfg.framework.config
       // Is a component and is a QComponent
-      if (component !== void 0 && /^(Q[A-Z]|q-)/.test(component) === true) {
-        cfg.framework.components.push(component)
+      const isComponent = (component) => component !== void 0 && /^(Q[A-Z]|q-)/.test(component) === true
+
+      if (config.loading) {
+        const component = config.loading.spinner
+        if (isComponent(component)) {
+          cfg.framework.components.push(component)
+        }
+      }
+
+      if (config.notify) {
+        const component = config.notify.spinner
+        if (isComponent(component)) {
+          cfg.framework.components.push(component)
+        }
       }
     }
 

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -65,7 +65,8 @@
       },
 
       "spinner": {
-        "type": "Boolean",
+        "type": [ "Boolean", "Component" ],
+        "configFileType": "Boolean",
         "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
         "examples": [ true, "QSpinnerBars" ]
       },

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -66,7 +66,7 @@
 
       "spinner": {
         "type": [ "Boolean", "Component" ],
-        "configFileType": "Boolean",
+        "configFileType": [ "Boolean", "String" ],
         "desc": "Useful for notifications that are updated; Displays a Quasar spinner instead of an avatar or icon; If value is Boolean 'true' then the default QSpinner is shown",
         "examples": [ true, "QSpinnerBars" ]
       },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Took the logic for supporting spinner component configuration for Loading and updated it to support Notify as well.