### PR TITLE
fix(ui): add ref property to QTable virtual-scroll event type (fix: #16246)

### DIFF
--- a/ui/src/components/table/QTable.json
+++ b/ui/src/components/table/QTable.json
@@ -2026,6 +2026,11 @@
               "required": true,
               "desc": "Direction of change",
               "values": [ "increase", "decrease" ]
+            },
+            "ref": {
+              "type": "Component",
+              "required": true,
+              "desc": "Vue reference to the underlying QVirtualScroll instance"
             }
           }
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Documentation


**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #16246