### PR TITLE
fix(ui): QLayout containerized on iOS, only force fixed when reveal

### DIFF
--- a/ui/src/components/footer/QFooter.js
+++ b/ui/src/components/footer/QFooter.js
@@ -48,7 +48,7 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('F') > -1
-      || ($q.platform.is.ios && $layout.isContainer.value === true)
+      || ($q.platform.is.ios && props.reveal === true && $layout.isContainer.value === true)
     )
 
     const containerHeight = computed(() => (

--- a/ui/src/components/header/QHeader.js
+++ b/ui/src/components/header/QHeader.js
@@ -45,7 +45,7 @@ export default createComponent({
     const fixed = computed(() =>
       props.reveal === true
       || $layout.view.value.indexOf('H') > -1
-      || ($q.platform.is.ios && $layout.isContainer.value === true)
+      || ($q.platform.is.ios && props.reveal === true && $layout.isContainer.value === true)
     )
 
     const offset = computed(() => {


### PR DESCRIPTION
Adds a check to QFooter and QHeader that only forces a fixed footer/header when reveal is true.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
