### PR TITLE
fix(capacitor): Remove old npmClient config option

### DIFF
--- a/app-vite/templates/capacitor/capacitor.config.json
+++ b/app-vite/templates/capacitor/capacitor.config.json
@@ -1,6 +1,5 @@
 {
   "appId": "<%= appId %>",
   "appName": "<%= appName %>",
-  "npmClient": "<%= nodePackager %>",
   "webDir": "www"
 }

--- a/app-webpack/templates/capacitor/capacitor.config.json
+++ b/app-webpack/templates/capacitor/capacitor.config.json
@@ -1,6 +1,5 @@
 {
   "appId": "<%= appId %>",
   "appName": "<%= appName %>",
-  "npmClient": "<%= nodePackager %>",
   "webDir": "www"
 }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

`npmClient` was removed in Capacitor 3, both Capacitor 1, 2 and 3 are out of support now, so I think it can be removed safely 
but if you think you should still support capacitor 1 and 2 for some reason, I can do as you did in the `bundledWebRuntime` PR and programmatically add `npmClient` if capacitor version is < 3
