### PR TITLE
Border property for Chat Messages

### DIFF
--- a/ui/dev/src/pages/components/chat.vue
+++ b/ui/dev/src/pages/components/chat.vue
@@ -178,7 +178,8 @@ export default {
         name: 'Vladimir',
         text: [ 'How are you?' ],
         avatar: 'https://cdn.quasar.dev/img/boy-avatar.png',
-        stamp: 'Yesterday 13:34'
+        stamp: 'Yesterday 13:34',
+        bordered: true
       },
       {
         name: 'Jane',
@@ -192,7 +193,8 @@ export default {
         text: [ 'And you?' ],
         sent: true,
         avatar: 'https://cdn.quasar.dev/img/linux-avatar.png',
-        stamp: 'Yesterday at 13:51'
+        stamp: 'Yesterday at 13:51',
+        bordered: true
       },
       {
         label: 'Sunday, 19th'

--- a/ui/src/components/chat/QChatMessage.js
+++ b/ui/src/components/chat/QChatMessage.js
@@ -19,7 +19,8 @@ export default createComponent({
     labelHtml: Boolean,
     nameHtml: Boolean,
     textHtml: Boolean,
-    stampHtml: Boolean
+    stampHtml: Boolean,
+    bordered: Boolean
   },
 
   setup (props, { slots }) {
@@ -33,6 +34,7 @@ export default createComponent({
     const messageClass = computed(() =>
       `q-message-text q-message-text--${ op.value }`
       + (props.bgColor !== void 0 ? ` text-${ props.bgColor }` : '')
+      + (props.bordered === true ? ' q-message-bordered' : '')
     )
 
     const containerClass = computed(() =>

--- a/ui/src/components/chat/QChatMessage.json
+++ b/ui/src/components/chat/QChatMessage.json
@@ -88,6 +88,12 @@
     "stamp-html": {
       "extends": "html",
       "desc": "Render the stamp as HTML; This can lead to XSS attacks so make sure that you sanitize the message first"
+    },
+    
+    "bordered": {
+      "type": "Boolean",
+      "desc": "Render the chat bubble with border",
+      "category": "style"
     }
   },
 

--- a/ui/src/components/chat/QChatMessage.sass
+++ b/ui/src/components/chat/QChatMessage.sass
@@ -32,6 +32,7 @@
     border-right: 0 solid transparent
     border-left: 8px solid transparent
     border-bottom: 8px solid currentColor
+
 .q-message-text-content--received
   color: $chat-message-received-color
 
@@ -73,3 +74,9 @@
       bottom: 0
       width: 0
       height: 0
+
+.q-message-bordered
+  border: 3px solid red 
+  &:last-child:before
+    border-bottom: 10px solid red !important
+    margin-bottom: -3px


### PR DESCRIPTION
This is a feature to allow for a red border on chat messages. The red border can be used to signify an urgent message or similar semantics. If this is approved, then it can be expanded to include more options for color and size of border.

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
