### PR TITLE
doc correction for dynamic-import use in lazy loading dependencies

### DIFF
--- a/docs/src/pages/quasar-cli-webpack/lazy-loading.md
+++ b/docs/src/pages/quasar-cli-webpack/lazy-loading.md
@@ -82,7 +82,7 @@ import('./categories.json')
 One advantage of using dynamic imports as opposed to regular imports is that the import path can be determined at runtime:
 
 ```js
-import('pages/' + pageName + '/' + 'id')
+import('pages/' + pageName + '/' + this.id)
 ```
 
 ## Caveat with vendor imports

--- a/docs/src/pages/quasar-cli-webpack/lazy-loading.md
+++ b/docs/src/pages/quasar-cli-webpack/lazy-loading.md
@@ -82,7 +82,7 @@ import('./categories.json')
 One advantage of using dynamic imports as opposed to regular imports is that the import path can be determined at runtime:
 
 ```js
-import('pages/' + pageName + '/' + this.id)
+import('pages/' + pageName + '/' + id)
 ```
 
 ## Caveat with vendor imports


### PR DESCRIPTION
Not sure if this is what was originally intended, but the string-concat makes me think so.

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

Alternatively, I could update to collapse the '/' + 'id' into one string.  Seems good to add a this.* reference in there for example's sake -- the preceding text talks about dynamically constructing paths to import.