### PR TITLE
fix(ui): fix generic usage of QTreeNode type (fix: #15351)

### DIFF
--- a/ui/types/api/qtree.d.ts
+++ b/ui/types/api/qtree.d.ts
@@ -1,7 +1,7 @@
 /**
  * @template TExtra Object type to add extra properties for the node, overrides the existing ones as well
  */
-export type QTreeNode<TExtra = { [index: string]: any }> = Omit<
+export type QTreeNode<TExtra = unknown> = Omit<
   {
     label?: string;
     icon?: string;
@@ -20,9 +20,9 @@ export type QTreeNode<TExtra = { [index: string]: any }> = Omit<
     header?: string;
     body?: string;
   },
-  keyof TExtra
+  unknown extends TExtra ? "" : keyof TExtra
 > &
-  TExtra;
+  (unknown extends TExtra ? Record<string, any> : TExtra);
 
 export interface QTreeLazyLoadParams<
   Node extends QTreeNode = QTreeNode,

--- a/ui/types/api/qtree.d.ts
+++ b/ui/types/api/qtree.d.ts
@@ -1,5 +1,95 @@
 /**
+ * Node type to be used with QTree's `nodes` prop
+ *
+ * @see https://v2.quasar.dev/vue-components/tree#qtree-api
+ *
  * @template TExtra Object type to add extra properties for the node, overrides the existing ones as well
+ *
+ * @example
+ * Basic usage
+ * ```ts
+ * const nodes: QTreeNode[] = [
+ *   // ...
+ * ];
+ * // <q-tree :nodes="nodes" />
+ * ```
+ *
+ * @example
+ * Making some properties required
+ * ```ts
+ * // make label and icon required, the rest will stay optional
+ * const nodes: QTreeNode<{ label: string; icon: string }>[] = [
+ *   // ...
+ * ];
+ * ```
+ *
+ * @example
+ * Adding extra properties
+ * ```ts
+ * // on top of the existing properties, add a foo property
+ * const nodes: QTreeNode<{ foo: number }>[] = [
+ *   // ...
+ * ];
+ * ```
+ *
+ * @example
+ * Using different label/children properties
+ * ```ts
+ * type Node = QTreeNode<{ name: string; subNodes: Node[] }>;
+ * const nodes: Node[] = [
+ *   // ...
+ * ];
+ * // <q-tree :nodes="nodes" label-key="name" children-key="subNodes" />
+ * ```
+ *
+ * @example
+ * Using a different child node type
+ * ```ts
+ * type ChildNode = QTreeNode<{ foo: number }>;
+ * type ParentNode = QTreeNode<{ bar: string; children?: ChildNode[] }>;
+ *
+ * const nodes: ParentNode[] = [
+ *   // ...
+ * ];
+ * ```
+ *
+ * @example
+ * A very basic file system tree
+ * ```ts
+ * interface FileInfo {
+ *   path: string;
+ *   size: number;
+ *   lastModified: number;
+ * }
+ * type FileNode = QTreeNode<FileInfo & { type: "file", children?: never }>;
+ * type DirectoryNode = QTreeNode<FileInfo & { type: "directory", children?: (FileNode | DirectoryNode)[] }>;
+ *
+ * const nodes: DirectoryNode[] = [
+ *   {
+ *     type: "directory",
+ *     path: "/",
+ *     size: 0,
+ *     lastModified: 0,
+ *     // allows both file and directory as children
+ *     children: [
+ *       {
+ *         type: "file",
+ *         path: "/foo.txt",
+ *         size: 100,
+ *         lastModified: 1000,
+ *         // does not allow children
+ *       },
+ *       {
+ *         type: "directory",
+ *         path: "/bar",
+ *         size: 0,
+ *         lastModified: 0,
+ *         // empty folder - doesn't have children
+ *       }
+ *     ]
+ *   }
+ * ]
+ * ```
  */
 export type QTreeNode<TExtra = unknown> = Omit<
   {

--- a/ui/types/api/qtree.d.ts
+++ b/ui/types/api/qtree.d.ts
@@ -1,24 +1,28 @@
-// We can't set QTreeNode as default assignment for the generics param,
-// we use unknown and use conditional types to set it
-export interface QTreeNode<Node = unknown> {
-  label?: string;
-  icon?: string;
-  iconColor?: string;
-  img?: string;
-  avatar?: string;
-  children?: (Node extends unknown ? QTreeNode : Node)[];
-  disabled?: boolean;
-  expandable?: boolean;
-  selectable?: boolean;
-  handler?: (node: Node extends unknown ? QTreeNode : Node) => void;
-  tickable?: boolean;
-  noTick?: boolean;
-  tickStrategy?: "leaf" | "leaf-filtered" | "string" | "none";
-  lazy?: boolean;
-  header?: string;
-  body?: string;
-  [index: string]: any;
-}
+/**
+ * @template TExtra Object type to add extra properties for the node, overrides the existing ones as well
+ */
+export type QTreeNode<TExtra = { [index: string]: any }> = Omit<
+  {
+    label?: string;
+    icon?: string;
+    iconColor?: string;
+    img?: string;
+    avatar?: string;
+    children?: QTreeNode<TExtra>[];
+    disabled?: boolean;
+    expandable?: boolean;
+    selectable?: boolean;
+    handler?: (node: QTreeNode<TExtra>) => void;
+    tickable?: boolean;
+    noTick?: boolean;
+    tickStrategy?: "leaf" | "leaf-filtered" | "string" | "none";
+    lazy?: boolean;
+    header?: string;
+    body?: string;
+  },
+  keyof TExtra
+> &
+  TExtra;
 
 export interface QTreeLazyLoadParams<
   Node extends QTreeNode = QTreeNode,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- Yes (type-only)

**! This breaks the previous usage, so the users should migrate to the new usage. See below for more information !**

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Resolves #15351.

Example use case: Add `{ key: string }` to the node type.

Previous usage to achieve expected behavior (isn't an obvious solution):
```ts
type TreeNode = { key: string } & QTreeNode<TreeNode>;
const nodes: TreeNode[] = [
  {
    key: 'foo',
    label: 'bar',
    children: []
  }
];
```
New usage:
```ts
const nodes: QTreeNode<{ key: string }>[] = [
  {
    key: 'foo',
    label: 'bar',
    children: []
  }
];
```