### PR TITLE
docs: fix typo in --skip-pkg option

### DIFF
--- a/app-vite/lib/cmd/build.js
+++ b/app-vite/lib/cmd/build.js
@@ -62,8 +62,8 @@ if (argv.help) {
                         electron-builder as bundler
     --debug, -d     Build for debugging purposes
     --skip-pkg, -s  Build only UI (skips creating Cordova/Capacitor/Electron executables)
-                      - Cordova (it only fills in /src/cordova/www folder with the UI code)
-                      - Capacitor (it only fills in /src/capacitor/www folder with the UI code)
+                      - Cordova (it only fills in /src-cordova/www folder with the UI code)
+                      - Capacitor (it only fills in /src-capacitor/www folder with the UI code)
                       - Electron (it only creates the /dist/electron/UnPackaged folder)
     --help, -h      Displays this message
 

--- a/app-webpack/lib/cmd/build.js
+++ b/app-webpack/lib/cmd/build.js
@@ -62,8 +62,8 @@ if (argv.help) {
                         electron-builder as bundler
     --debug, -d     Build for debugging purposes
     --skip-pkg, -s  Build only UI (skips creating Cordova/Capacitor/Electron executables)
-                      - Cordova (it only fills in /src/cordova/www folder with the UI code)
-                      - Capacitor (it only fills in /src/capacitor/www folder with the UI code)
+                      - Cordova (it only fills in /src-cordova/www folder with the UI code)
+                      - Capacitor (it only fills in /src-capacitor/www folder with the UI code)
                       - Electron (it only creates the /dist/electron/UnPackaged folder)
     --help, -h      Displays this message
 

--- a/docs/src/pages/quasar-cli-vite/commands-list.md
+++ b/docs/src/pages/quasar-cli-vite/commands-list.md
@@ -248,8 +248,8 @@ $ quasar build -h
                         electron-builder as bundler
     --debug, -d     Build for debugging purposes
     --skip-pkg, -s  Build only UI (skips creating Cordova/Capacitor/Electron executables)
-                      - Cordova (it only fills in /src/cordova/www folder with the UI code)
-                      - Capacitor (it only fills in /src/capacitor/www folder with the UI code)
+                      - Cordova (it only fills in /src-cordova/www folder with the UI code)
+                      - Capacitor (it only fills in /src-capacitor/www folder with the UI code)
                       - Electron (it only creates the /dist/electron/UnPackaged folder)
     --help, -h      Displays this message
 

--- a/docs/src/pages/quasar-cli-webpack/commands-list.md
+++ b/docs/src/pages/quasar-cli-webpack/commands-list.md
@@ -246,8 +246,8 @@ $ quasar build -h
                         electron-builder as bundler
     --debug, -d     Build for debugging purposes
     --skip-pkg, -s  Build only UI (skips creating Cordova/Capacitor/Electron executables)
-                      - Cordova (it only fills in /src/cordova/www folder with the UI code)
-                      - Capacitor (it only fills in /src/capacitor/www folder with the UI code)
+                      - Cordova (it only fills in /src-cordova/www folder with the UI code)
+                      - Capacitor (it only fills in /src-capacitor/www folder with the UI code)
                       - Electron (it only creates the /dist/electron/UnPackaged folder)
     --help, -h      Displays this message
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The docs for `--skip-pkg` options say that it just copies files to `/src/cordova/www`/`/src/capacitor/www`, but the quasar folders for cordova and capacitor are not put inside src folder, but in a separate `/src-cordova/`/`/src-capacitor/` folder, so replacing the `/` with `-` in app the places where it's used (docs and command description)