### PR TITLE
(fix: QSlider): slider value should start from `innerMin` instead of `min` on drag #16614

### DIFF
--- a/ui/src/components/slider/use-slider.js
+++ b/ui/src/components/slider/use-slider.js
@@ -235,7 +235,7 @@ export default function ({ updateValue, updatePosition, getDragging, formAttrs }
 
   function convertRatioToModel (ratio) {
     const { min, max, step } = props
-    let model = innerMin.value + (ratio - innerMinRatio.value) * (max - min)
+    let model = min + ratio * (max - min)
 
     if (step > 0) {
       const modulo = (model - innerMin.value) % step

--- a/ui/src/components/slider/use-slider.js
+++ b/ui/src/components/slider/use-slider.js
@@ -235,7 +235,7 @@ export default function ({ updateValue, updatePosition, getDragging, formAttrs }
 
   function convertRatioToModel (ratio) {
     const { min, max, step } = props
-    let model = innerMin.value + ratio * (max - min)
+    let model = innerMin.value + (ratio - innerMinRatio.value) * (max - min)
 
     if (step > 0) {
       const modulo = (model - innerMin.value) % step

--- a/ui/src/components/slider/use-slider.js
+++ b/ui/src/components/slider/use-slider.js
@@ -235,10 +235,10 @@ export default function ({ updateValue, updatePosition, getDragging, formAttrs }
 
   function convertRatioToModel (ratio) {
     const { min, max, step } = props
-    let model = min + ratio * (max - min)
+    let model = innerMin.value + ratio * (max - min)
 
     if (step > 0) {
-      const modulo = (model - min) % step
+      const modulo = (model - innerMin.value) % step
       model += (Math.abs(modulo) >= step / 2 ? (modulo < 0 ? -1 : 1) * step : 0) - modulo
     }
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app

I unit tested the calculation which produces the desired result but I did not test the actual behavior in a browser, as this method is used in some other places, it should definitely be tested but I'm rather confident it should work

Fixes #16614 
