### PR TITLE
fix(render-ssr-error): do not pass null file names as path segments

### DIFF
--- a/utils/render-ssr-error/src/stack.js
+++ b/utils/render-ssr-error/src/stack.js
@@ -4,6 +4,10 @@ import { join } from 'node:path'
 import { parse } from 'stack-trace'
 
 function getFilename (filename) {
+  if (!filename) {
+    return filename;
+  }
+  
   if (existsSync(filename)) {
     return filename
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

When using `path.join` a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) is thrown if any of the path segments is not a string.

```bash
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
    at join (node:path:1175:7)
    at getFilename (file:///home/freddy/webDev/quasar-app/node_modules/.pnpm/@quasar+render-ssr-error@1.0.2/node_modules/@quasar/render-ssr-error/src/stack.js:12:26)
```

The file name is `null` when the location of a stack frame is anonymous.
For example:
```js
[0].map(() => {
  throw new Error('test');
});
```

```bash
Error: test
    at eval (/src/boot/test.js:5:11)
    at Array.map (<anonymous>)
    at __vite_ssr_exports__.default (/src/boot/test.js:4:7)
```