### PR TITLE
Better handling of notification timeouts

### DIFF
--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -116,7 +116,7 @@ function addNotification (config, $q, originalApi) {
     notif.timeout = 5000
   }
   else {
-    const t = parseInt(notif.timeout, 10)
+    const t = Number(notif.timeout)
     if (isNaN(t) || t < 0) {
       return logError('wrong timeout', config)
     }

--- a/ui/src/plugins/Notify.js
+++ b/ui/src/plugins/Notify.js
@@ -55,7 +55,7 @@ const notifTypes = {
 
   ongoing: {
     group: false,
-    timeout: 0,
+    timeout: Infinity,
     spinner: true,
     color: 'grey-8'
   }
@@ -112,7 +112,7 @@ function addNotification (config, $q, originalApi) {
     notif.position = 'bottom'
   }
 
-  if (notif.timeout === void 0) {
+  if (notif.timeout === void 0 || notif.timeout === '') {
     notif.timeout = 5000
   }
   else {
@@ -123,7 +123,8 @@ function addNotification (config, $q, originalApi) {
     notif.timeout = t
   }
 
-  if (notif.timeout === 0) {
+  if (notif.timeout === 0 || notif.timeout > (1 << 31)) {
+    notif.timeout = Infinity
     notif.progress = false
   }
   else if (notif.progress === true) {
@@ -295,7 +296,7 @@ function addNotification (config, $q, originalApi) {
     Api = void 0
   }
 
-  if (notif.timeout > 0) {
+  if (Number.isFinite(notif.timeout)) {
     notif.meta.timer = setTimeout(() => {
       notif.meta.timer = void 0
       dismiss()

--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -363,7 +363,7 @@
 
             "progress": {
               "type": "Boolean",
-              "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is 0)"
+              "desc": "Show progress bar to detail when notification will disappear automatically (unless timeout is Infinity)"
             },
             "progressClass": {
               "type": [ "String", "Array", "Object" ],
@@ -392,7 +392,7 @@
 
             "timeout": {
               "type": "Number",
-              "desc": "Amount of time to display (in milliseconds)",
+              "desc": "Amount of time to display (in milliseconds). If Infinity, the notification will never dismiss itself. 0 will be treated as Infinity.",
               "default": 5000,
               "examples": [ 2500 ]
             },


### PR DESCRIPTION
parseInt is not good for coercion.
* Infinity gets implicitly converted to NaN.
* Large numbers e.g. `5e+30`, get truncated (to 5).

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
