### PR TITLE
fix(a11y): remove `aria-readonly` from labels for QField, QCodeol, QDate, QEditor #16705

### DIFF
--- a/ui/src/components/color/QColor.js
+++ b/ui/src/components/color/QColor.js
@@ -176,15 +176,11 @@ export default createComponent({
       + (isDark.value === true ? ' q-color-picker--dark q-dark' : '')
     )
 
-    const attributes = computed(() => {
-      if (props.disable === true) {
-        return { 'aria-disabled': 'true' }
-      }
-      if (props.readonly === true) {
-        return { 'aria-readonly': 'true' }
-      }
-      return {}
-    })
+    const attributes = computed(() => (
+      props.disable === true
+        ? { 'aria-disabled': 'true' }
+        : {}
+    ))
 
     const spectrumDirective = computed(() => {
       // if editable.value === true

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -694,7 +694,7 @@ export default createComponent({
     const attributes = computed(() => (
       props.disable === true
         ? { 'aria-disabled': 'true' }
-        : (props.readonly === true ? { 'aria-readonly': 'true' } : {})
+        : {}
     ))
 
     watch(() => props.modelValue, v => {

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -323,7 +323,7 @@ export default createComponent({
     const attributes = computed(() => (
       props.disable === true
         ? { 'aria-disabled': 'true' }
-        : (props.readonly === true ? { 'aria-readonly': 'true' } : {})
+        : {}
     ))
 
     function onInput () {

--- a/ui/src/composables/private/use-field.js
+++ b/ui/src/composables/private/use-field.js
@@ -259,9 +259,6 @@ export default function (state) {
     if (props.disable === true) {
       acc[ 'aria-disabled' ] = 'true'
     }
-    else if (props.readonly === true) {
-      acc[ 'aria-readonly' ] = 'true'
-    }
 
     return acc
   })


### PR DESCRIPTION
close #16705