### PR TITLE
fix(QSelect): dialog positioning in select behavior #16097

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -116,6 +116,12 @@ export default createComponent({
       default: 'default'
     },
 
+    dialogPosition: {
+      type: String,
+      validator: v => [ 'standard', 'top', 'bottom', 'right', 'left' ].includes(v),
+      default: 'standard'
+    },
+
     virtualScrollItemSize: {
       type: [ Number, String ],
       default: void 0
@@ -1259,7 +1265,7 @@ export default createComponent({
       return h(QDialog, {
         ref: dialogRef,
         modelValue: dialog.value,
-        position: props.useInput === true ? 'top' : void 0,
+        position: props.dialogPosition,
         transitionShow: transitionShowComputed,
         transitionHide: props.transitionHide,
         transitionDuration: props.transitionDuration,

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -338,6 +338,16 @@
       ],
       "default": "default",
       "category": "behavior"
+    },
+
+    "dialog-position": {
+      "type": "String",
+      "desc": "Overrides the default standard (middle) positioning if dialog is used",
+      "values": [
+        "standard", "top", "bottom", "right", "left"
+      ],
+      "default": "standard",
+      "category": "behavior"
     }
   },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->
Currently the dialog that appears from QSelect's behavior defaults to the middle of the screen (which is the dialog standard). However if use-input was set along with the behavior dialog setting it was hard-coded to the top of the screen. With this change just doing a general control of the dialog and defaulting to the standard (middle) position anyone who has a dialog with use-input will have an unexpected change. Now could code in support for both possibilities of dialog position determined default if use-input or not but seems unnecessary.

The fix though is simple in that adding dialog-position to top in the qselect to put it back.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
