### PR TITLE
docs: add preparation for ios

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/preparation.md
@@ -51,6 +51,18 @@ setx path "%path%;%ANDROID_SDK_ROOT%\tools;%ANDROID_SDK_ROOT%\platform-tools"
 
 You will need a macOS with [Xcode](https://developer.apple.com/xcode/) installed. After you've installed it, open Xcode in order to get the license prompt. Accept the license, then you can close it.
 
+#### CocoaPods
+If you haven't installed [CocoaPods](https://cocoapods.org/), please install it by using the command: `sudo gem install cocoapods`. Otherwise, you may encounter errors during development or building, such as:
+
+::: warning terminal warning
+[warn] Skipping pod install because CocoaPods is not installed,
+:::
+
+::: danger Xcode Error
+/path-to/your-project/src-capacitor/ios/App/Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig:1:1 unable to open configuration settings file
+::: 
+
+
 ## Step 2: Add Capacitor Quasar Mode
 
 In order to develop/build a Mobile app, we need to add the Capacitor mode to our Quasar project. This will use the Capacitor CLI to generate a Capacitor project in `/src-capacitor` folder.

--- a/docs/src/pages/quasar-cli-webpack/developing-capacitor-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-capacitor-apps/preparation.md
@@ -51,6 +51,17 @@ setx path "%path%;%ANDROID_SDK_ROOT%\tools;%ANDROID_SDK_ROOT%\platform-tools"
 
 You will need a macOS with [Xcode](https://developer.apple.com/xcode/) installed. After you've installed it, open Xcode in order to get the license prompt. Accept the license, then you can close it.
 
+#### CocoaPods
+If you haven't installed [CocoaPods](https://cocoapods.org/), please install it by using the command: `sudo gem install cocoapods`. Otherwise, you may encounter errors during development or building, such as:
+
+::: warning terminal warning
+[warn] Skipping pod install because CocoaPods is not installed,
+:::
+
+::: danger Xcode Error
+/path-to/your-project/src-capacitor/ios/App/Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig:1:1 unable to open configuration settings file
+::: 
+
 ## Step 2: Add Capacitor Quasar Mode
 
 In order to develop/build a Mobile app, we need to add the Capacitor mode to our Quasar project. This will use the Capacitor CLI to generate a Capacitor project in `/src-capacitor` folder.


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No


**Other information:**

When I first build an iOS app following Quasar's instructions, I encounter an error in Xcode:

![image](https://github.com/quasarframework/quasar/assets/38457491/ab65b91c-8347-40d9-bc2c-79d68fad6055)

Because no 'Pods' directory is generated after running the `quasar build -m capacitor -T ios --ide` command.

![image](https://github.com/quasarframework/quasar/assets/38457491/cccb5e1e-2bdd-4515-9fca-65d0505d868f)

I found out that macOS was missing CocoaPods, so the Capacitor CLI didn't generate the 'Pods' directory and files. After installing CocoaPods, it worked. Therefore, I suggest adding this information to the documentation to help more people.

![image](https://github.com/quasarframework/quasar/assets/38457491/59c61a4e-f768-40ae-bf65-3fec149a1c94)

