### PR TITLE
feat(ui, plugins): add specific types for QNotifyCreateOptions type of Notify plugin

### DIFF
--- a/ui/src/plugins/Notify.json
+++ b/ui/src/plugins/Notify.json
@@ -11,6 +11,7 @@
     "definition": {
       "type": {
         "type": "String",
+        "tsType": "QNotifyType",
         "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')",
         "examples": [ "negative", "custom-type" ]
       },
@@ -238,6 +239,7 @@
           "definition": {
             "type": {
               "type": "String",
+              "tsType": "QNotifyType",
               "desc": "Optional type (that has been previously registered) or one of the out of the box ones ('positive', 'negative', 'warning', 'info', 'ongoing')",
               "examples": [ "negative", "custom-type" ]
             },

--- a/ui/types/api/qnotify.d.ts
+++ b/ui/types/api/qnotify.d.ts
@@ -1,4 +1,4 @@
-import { QNotifyCreateOptions, QBtnProps } from "quasar";
+import { QNotifyCreateOptions, QBtnProps, LiteralUnion  } from "quasar";
 import { ButtonHTMLAttributes } from "vue";
 
 export type QNotifyUpdateOptions = Omit<
@@ -6,6 +6,18 @@ export type QNotifyUpdateOptions = Omit<
   "group" | "position"
 >;
 export type QNotifyOptions = Omit<QNotifyCreateOptions, "ignoreDefaults">;
+
+export interface NotifyCustomTypes {};
+
+type NotifyTypes =  
+  | 'positive'
+  | 'negative'
+  | 'warning'
+  | 'info'
+  | 'ongoing';
+
+export type NotifyType = LiteralUnion<NotifyTypes | keyof NotifyCustomTypes>;
+
 
 export type QNotifyAction = Omit<QBtnProps, "onClick"> &
   ButtonHTMLAttributes & { noDismiss?: boolean; handler?: () => void };

--- a/ui/types/api/qnotify.d.ts
+++ b/ui/types/api/qnotify.d.ts
@@ -7,7 +7,7 @@ export type QNotifyUpdateOptions = Omit<
 >;
 export type QNotifyOptions = Omit<QNotifyCreateOptions, "ignoreDefaults">;
 
-export interface NotifyCustomTypes {};
+export interface QNotifyCustomTypes {};
 
 type NotifyTypes =  
   | 'positive'
@@ -16,7 +16,7 @@ type NotifyTypes =
   | 'info'
   | 'ongoing';
 
-export type NotifyType = LiteralUnion<NotifyTypes | keyof NotifyCustomTypes>;
+export type QNotifyType = LiteralUnion<NotifyTypes | keyof QNotifyCustomTypes>;
 
 
 export type QNotifyAction = Omit<QBtnProps, "onClick"> &


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

It offers auto-completion for the type property of QNotifyCreateOptions (and by type intersection QNotifyOptions)
of the Notify plugin.

It's possible to add custom types as well.

```ts
declare module "quasar" {
  interface QNotifyCustomTypes {
    campaign: {
      icon: 'Campaign', 
      color: 'yellow'
    }
  }
}
```
which `QNotify.registerType` will benefit from.

Initially was going to name it `QNotifyCreateOptionsType`, but it's too long, so it ended being `QNotifyType`. 
