### PR TITLE
feat(docs): add missing info + possibly helpful reference

### DIFF
--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -253,10 +253,15 @@ interface QuasarFrameworkConfiguration {
   cssAddon?: boolean;
 
   /**
-   * Format in which you will write your Vue templates when
-   * using Quasar components.
+   * Format in which you will write your Vue templates when using Quasar components.
+   *
+   * In case you'll be changing this value sometime during you project's lifetime,
+   * you might want to check-out a CLI utility called `xml-tag-caser`
+   * (it'll help you switch between different component casings).
    *
    * @default 'kebab'
+   *
+   * @see https://github.com/staszek998/xml-tag-caser
    */
   autoImportComponentCase?: "kebab" | "pascal" | "combined";
 

--- a/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
@@ -183,7 +183,14 @@ Filling "components" and "directives" is required only if "all" is set to `false
 return {
   // a list with all options (all are optional)
   framework: {
-    // is using "auto" import strategy, you can also configure:
+    // If using "auto" import strategy, you can also configure the format in which you will write
+    // your Vue templates when using Quasar components.
+    //
+    // In case you'll be changing this value sometime during you project's lifetime,
+    // you might want to check-out a CLI utility called `xml-tag-caser`
+    // (it'll help you switch between different component casings).
+    //
+    // @see https://github.com/staszek998/xml-tag-caser
     autoImportComponentCase: 'pascal', // or 'kebab' (default) or 'combined'
 
     // For special cases outside of where auto-import can have an impact


### PR DESCRIPTION
Every time I scaffold a brand new Quasar app, I have to switch from kebab-case to PascalCase (to meet the [Vue Style Guide recommendation](https://v2.vuejs.org/v2/style-guide/?redirect=true#Component-name-casing-in-JS-JSX-strongly-recommended)). After doing this manually for a number of times, I've finally decided to create a CLI tool that'll do this automatically for me, in bulk. Of course, I've made this CLI publicly available, so others can use it too. **In this PR I'm adding [a URL reference to the CLI I've prepared,](https://github.com/staszek998/xml-tag-caser) with a thought that maybe it'll save somebody a few minutes of their time** 🙂 

---

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] [N/A] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] [N/A] It's been tested on a Cordova (iOS, Android) app
- [ ] [N/A] It's been tested on an Electron app
- [ ] [N/A] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)