### PR TITLE
Fix for issue of Duplicate Workspace in yarn berry (fix: #16110)

### DIFF
--- a/app-vite/lib/modes/capacitor/capacitor-installation.js
+++ b/app-vite/lib/modes/capacitor/capacitor-installation.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import fse from 'fs-extra'
+import path from 'path'
 import compileTemplate from 'lodash/template.js'
 import inquirer from 'inquirer'
 import fglob from 'fast-glob'
@@ -59,6 +60,10 @@ export async function addMode ({
     appId: answer.appId,
     pkg: appPkg,
     nodePackager: nodePackager.name
+  }
+
+  if (nodePackager.name === 'yarn' && nodePackager.majorVersion > 1){
+    fse.ensureFileSync(path.resolve(appPaths.capacitorDir,'yarn.lock'))
   }
 
   fglob.sync([ '**/*' ], {


### PR DESCRIPTION
The solution is to create an empty yarn.lock so that src-capacitor is considered to be a separate yarn project and not a workspace of the parent project folder. This is a simple but effective fix to the problem of not being able to add Capacitor mode when using yarn berry.

Proposed fix for https://github.com/quasarframework/quasar/issues/16110

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
