### PR TITLE
fix(docs): set color theme preference cookie expiration date

### DIFF
--- a/docs/src/layouts/doc-layout/store/index.js
+++ b/docs/src/layouts/doc-layout/store/index.js
@@ -30,7 +30,7 @@ export function provideDocStore () {
 
     toggleDark () {
       const val = store.state.value.dark = store.state.value.dark === false
-      $q.cookies.set('theme', val ? 'dark' : 'light', { path: '/', sameSite: 'Strict' })
+      $q.cookies.set('theme', val ? 'dark' : 'light', { path: '/', sameSite: 'Strict', expires: 400 })
     },
 
     toggleMenuDrawer () {

--- a/docs/src/layouts/doc-layout/store/index.js
+++ b/docs/src/layouts/doc-layout/store/index.js
@@ -30,7 +30,11 @@ export function provideDocStore () {
 
     toggleDark () {
       const val = store.state.value.dark = store.state.value.dark === false
-      $q.cookies.set('theme', val ? 'dark' : 'light', { path: '/', sameSite: 'Strict', expires: 400 })
+      $q.cookies.set(
+        'theme',
+        val ? 'dark' : 'light',
+        { path: '/', sameSite: 'Strict', expires: 400 }
+      )
     },
 
     toggleMenuDrawer () {


### PR DESCRIPTION

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**Other information:**

Currently, when user sets his website color scheme preference to `light` and then relaunches the browser, the color scheme is `dark` again because the theme preference is saved to a session cookie.

This PR adds the `expires` property to a session cookie. The value is `400` because of this https://developer.chrome.com/blog/cookie-max-age-expires