### PR TITLE
Add missing "persistent" prop for QTooltip

### DIFF
--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -72,7 +72,9 @@ export default createComponent({
     hideDelay: {
       type: Number,
       default: 0
-    }
+    },
+
+    persistent: Boolean
   },
 
   emits: [

--- a/ui/src/components/tooltip/QTooltip.json
+++ b/ui/src/components/tooltip/QTooltip.json
@@ -96,6 +96,12 @@
       "desc": "Configure Tooltip to disappear with delay",
       "default": 0,
       "category": "behavior"
+    },
+
+    "persistent": {
+      "type": "Boolean",
+      "desc": "Prevents Tooltip from auto-closing when app's route changes",
+      "category": "behavior"
     }
   },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

**Description**
I discovered that the QTooltip component lacks the declaration of the "persistent" prop, while it is used within the component's code: 

```javascript
/* QTooltip.js */

// line 95:
const hideOnRouteChange = computed(() => props.persistent !== true)

// line 132:
const hasClickOutside = computed(() =>
  // it doesn't has external model
  // (null is the default value)
  props.modelValue === null
  // and it's not persistent
  && props.persistent !== true
  && showing.value === true
)
```

Because of this, there's no way to create a tooltip that wouldn't disappear when changing routes.

I encountered this need during my work. In this PR, I have added the missing prop and its description to the API.