### PR TITLE
feat(QImg): add `spinner-delay` prop

### DIFF
--- a/ui/src/components/img/QImg.js
+++ b/ui/src/components/img/QImg.js
@@ -60,7 +60,11 @@ export default createComponent({
     noTransition: Boolean,
 
     spinnerColor: String,
-    spinnerSize: String
+    spinnerSize: String,
+    spinnerDelay: {
+      type: Number,
+      default: 0
+    },
   },
 
   emits: [ 'load', 'error' ],
@@ -69,7 +73,7 @@ export default createComponent({
     const naturalRatio = ref(props.initialRatio)
     const ratioStyle = useRatio(props, naturalRatio)
 
-    let loadTimer = null, isDestroyed = false
+    let loadTimer = null, showSpinnerTimer = null, isDestroyed = false
 
     const images = [
       ref(null),
@@ -80,6 +84,7 @@ export default createComponent({
 
     const isLoading = ref(false)
     const hasError = ref(false)
+    const canShowSpinner = ref(false)
 
     const classes = computed(() =>
       `q-img q-img--${ props.noNativeMenu === true ? 'no-' : '' }menu`
@@ -133,6 +138,20 @@ export default createComponent({
       }
       else {
         isLoading.value = true
+
+        if (showSpinnerTimer !== null) {
+          clearTimeout(showSpinnerTimer)
+          showSpinnerTimer = null
+        }
+
+        canShowSpinner.value = props.spinnerDelay === 0
+
+        if (props.spinnerDelay) {
+          showSpinnerTimer = setTimeout(() => {
+            showSpinnerTimer = null
+            canShowSpinner.value = true
+          }, props.spinnerDelay)
+        }
       }
 
       images[ position.value ].value = imgProps
@@ -241,7 +260,7 @@ export default createComponent({
         slots.loading !== void 0
           ? slots.loading()
           : (
-              props.noSpinner === true
+              props.noSpinner === true || canShowSpinner.value === false
                 ? void 0
                 : [
                     h(QSpinner, {

--- a/ui/src/components/img/QImg.json
+++ b/ui/src/components/img/QImg.json
@@ -197,7 +197,7 @@
     },
 
     "spinner-delay": {
-      "type": [ "Number" ],
+      "type": "Number",
       "desc": "Delay showing the spinner when image changes; gives time for the browser to load the image from cache to prevent flashing the spinner unnecesarily",
       "default": 0,
       "examples": [ 500, ":spinner-delay=\"550\"" ],

--- a/ui/src/components/img/QImg.json
+++ b/ui/src/components/img/QImg.json
@@ -196,6 +196,14 @@
       "category": "style"
     },
 
+    "spinner-delay": {
+      "type": [ "Number", "String" ],
+      "desc": "Delay showing the spinner when image changes; gives time for the browser to load the image from cache to prevent flashing the spinner unnecesarily",
+      "default": 0,
+      "examples": [ 500, ":spinner-delay=\"550\"" ],
+      "category": "behavior"
+    },
+
     "no-spinner": {
       "type": "Boolean",
       "desc": "Do not display the default spinner while waiting for the image to be loaded; It is overriden by the 'loading' slot when one is present",

--- a/ui/src/components/img/QImg.json
+++ b/ui/src/components/img/QImg.json
@@ -197,7 +197,7 @@
     },
 
     "spinner-delay": {
-      "type": [ "Number", "String" ],
+      "type": [ "Number" ],
       "desc": "Delay showing the spinner when image changes; gives time for the browser to load the image from cache to prevent flashing the spinner unnecesarily",
       "default": 0,
       "examples": [ 500, ":spinner-delay=\"550\"" ],


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [X] Feature

**Does this PR introduce a breaking change?**

- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature

**Other information:**

We use QImg for displaying user avatars and country flags. We keep the spinner enabled, as it helps display the loading state to the user. After the first visit, the user will likely have some or all images cached, causing the spinner to quickly "flash" over the almost-instantly loaded image.

This pull request adds a `spinner-delay` prop which allows delaying the display of the spinner until after a short (user-defined) period of time has passed since the image begun loading.

The value is customizable, as it is context-dependent and only the developer knows how long it should be. For example, setting the value to 50 (milliseconds) is enough for loading isolated images within a single viewport, however loading dozens or hundreds of images in a tight grid will hog the browser's cache and network modules and would require a much larger delay (e.g., 1000 milliseconds).

The default value is 0 - consistent with current behavior.

We have been using this code for almost 2 years and it is stable.

![chrome_QhRsBy6FCx](https://github.com/quasarframework/quasar/assets/2260539/b2aad47c-800e-4273-990c-f16b5450315a)
