### PR TITLE
fix: remove regex double-escape in custom service worker denylist

### DIFF
--- a/app-vite/templates/pwa/default/custom-service-worker.js
+++ b/app-vite/templates/pwa/default/custom-service-worker.js
@@ -24,7 +24,7 @@ if (process.env.MODE !== 'ssr' || process.env.PROD) {
   registerRoute(
     new NavigationRoute(
       createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
-      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
+      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
     )
   )
 }

--- a/app-vite/templates/pwa/ts/custom-service-worker.ts
+++ b/app-vite/templates/pwa/ts/custom-service-worker.ts
@@ -29,7 +29,7 @@ if (process.env.MODE !== 'ssr' || process.env.PROD) {
   registerRoute(
     new NavigationRoute(
       createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
-      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
+      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
     )
   );
 }

--- a/app-webpack/templates/pwa/default/custom-service-worker.js
+++ b/app-webpack/templates/pwa/default/custom-service-worker.js
@@ -24,7 +24,7 @@ if (process.env.MODE !== 'ssr' || process.env.PROD) {
   registerRoute(
     new NavigationRoute(
       createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
-      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
+      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
     )
   )
 }

--- a/app-webpack/templates/pwa/ts/custom-service-worker.ts
+++ b/app-webpack/templates/pwa/ts/custom-service-worker.ts
@@ -29,7 +29,7 @@ if (process.env.MODE !== 'ssr' || process.env.PROD) {
   registerRoute(
     new NavigationRoute(
       createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
-      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
+      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
     )
   );
 }

--- a/docs/src/pages/quasar-cli-vite/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/upgrade-guide.md
@@ -157,7 +157,7 @@ if (process.env.MODE !== 'ssr' || process.env.PROD) {
     new NavigationRoute(
       createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
 -     { denylist: [/sw\.js$/, /workbox-(.)*\.js$/] }
-+     { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
++     { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
     )
   )
 }

--- a/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
@@ -264,7 +264,7 @@ Editing your `/src-pwa/custom-service-worker.js` file:
 +  registerRoute(
 +    new NavigationRoute(
 +      createHandlerBoundToURL(process.env.PWA_FALLBACK_HTML),
-+      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\\.js$/] }
++      { denylist: [new RegExp(process.env.PWA_SERVICE_WORKER_REGEX), /workbox-(.)*\.js$/] }
 +    )
 +  )
 + }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [X] Bugfix

Current regex has a backslash erroneously escaped: `/workbox-(.)*\\.js$/`, while it should actually be `/workbox-(.)*\.js$/`. The current version would match a pathname such as `/workbox-bar\.js` and even `/foo/workbox-bar/hello\ajs`, but not `/workbox-foo.js`. 

**Does this PR introduce a breaking change?**

- [X] Yes

I've never personally seen any `workbox-*.js` files being emitted, but if they were then they are currently being served by Service Worker and with this change they will start to get loaded from the server instead.

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Other information:**

It is also entirely possible that this regex is no longer relevant if Workbox is no longer emitting files with those names.

On the other hand, if we know these files are being emitted, then a more appropriate regex is `/workbox-[^/]+\.js$/`.
