### PR TITLE
fix: Color Picker slider triggers "Uncaught RangeError: Maximum call stack size exceeded" in onHueChange (fix #16999)

### DIFF
--- a/ui/src/components/color/QColor.js
+++ b/ui/src/components/color/QColor.js
@@ -304,7 +304,7 @@ export default createComponent({
     }
 
     function onHueChange (val) {
-      onHueChange(val, true)
+      onHue(val, true)
     }
 
     function onNumericChange (value, formatModel, max, evt, change) {


### PR DESCRIPTION
While interacting with a color picker component using a slider, an unhandled "Uncaught RangeError: Maximum call stack size exceeded" error occurs within the onHueChange event handler, indicating the presence of a straightforward infinite loop.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
