### PR TITLE
fix: migrate ecosystem-ci scripts to pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "lint:root": "eslint .eslintrc.cjs --report-unused-disable-directives --fix",
     "lint": "pnpm lint:root && pnpm --recursive run lint",
     "test": "pnpm vite-ecosystem-ci:build && pnpm vite-ecosystem-ci:test && pnpm vue-ecosystem-ci:test",
-    "vite-ecosystem-ci:build": "pnpm workspace @quasar/vite-plugin build && pnpm workspace quasar test:build",
-    "vite-ecosystem-ci:test": "pnpm workspace @quasar/vite-plugin test",
+    "vite-ecosystem-ci:build": "pnpm --filter @quasar/vite-plugin build && pnpm --filter quasar test:build",
+    "vite-ecosystem-ci:test": "pnpm --filter @quasar/vite-plugin test",
     "vue-ecosystem-ci:build": "pnpm vite-ecosystem-ci:build",
-    "vue-ecosystem-ci:test": "pnpm workspace quasar test:component:run && pnpm workspace @quasar/vite-plugin test:e2e:ci"
+    "vue-ecosystem-ci:test": "pnpm --filter quasar test:component:run && pnpm --filter @quasar/vite-plugin test:e2e:ci"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.7.2",


### PR DESCRIPTION
There's no `pnpm workspace` command. Instead, pnpm uses the `--filter` option to run a command in a specific workspace package.

Note there will always be an "ELIFECYCLE Command failed." message at the end of the vite-plugin test.
But that's from the vite preview server being stopped after a successful test run. It's not a real error and doesn't affect the test result or the exit code.

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
