### PR TITLE
test(QSelect): prefer Quasar test AE 'select' override

### DIFF
--- a/ui/src/components/select/__tests__/QSelect.cy.js
+++ b/ui/src/components/select/__tests__/QSelect.cy.js
@@ -222,12 +222,7 @@ describe('QSelect API', () => {
             }
           })
           getHostElement()
-            .click()
-          cy.get('.q-menu')
-            .contains('Option 1')
-            .should('be.visible')
-            .click()
-          cy.get('.q-menu')
+            .select('Option 1')
             .then(() => {
               expect(fn).to.have.been.calledWith(1)
             })
@@ -243,12 +238,7 @@ describe('QSelect API', () => {
             }
           })
           getHostElement()
-            .click()
-          cy.get('.q-menu')
-            .contains('Option 1')
-            .should('be.visible')
-            .click()
-          cy.get('.q-menu')
+            .select('Option 1')
             .then(() => {
               expect(fn).to.have.been.calledWith(options[ 0 ])
             })
@@ -268,27 +258,17 @@ describe('QSelect API', () => {
             }
           })
 
-          getHostElement().click()
-          cy.withinSelectMenu(() => {
-            cy.contains('Option 1')
-              .should('be.visible')
-              .click()
-            cy.contains('Option 1')
-              .then(() => {
-                expect(model.value).to.equal(options[ 0 ])
-              })
-          })
+          getHostElement()
+            .select('Option 1')
+            .then(() => {
+              expect(model.value).to.equal(options[ 0 ])
+            })
 
-          getHostElement().click()
-          cy.withinSelectMenu(() => {
-            cy.contains('Option 2')
-              .should('be.visible')
-              .click()
-            cy.contains('Option 2')
-              .then(() => {
-                expect(model.value).to.equal(options[ 1 ])
-              })
-          })
+          getHostElement()
+            .select('Option 2')
+            .then(() => {
+              expect(model.value).to.equal(options[ 1 ])
+            })
         })
 
         it('should select multiple options if multiple is true', () => {
@@ -302,27 +282,11 @@ describe('QSelect API', () => {
             }
           })
 
-          getHostElement().click()
-          cy.withinSelectMenu({
-            persistent: true,
-            fn: () => {
-              cy.contains('Option 1')
-                .should('be.visible')
-                .click()
-              cy.contains('Option 1')
-                .then(() => {
-                  expect(model.value).to.eql([ options[ 0 ] ])
-                })
-
-              cy.contains('Option 2')
-                .should('be.visible')
-                .click()
-              cy.contains('Option 2')
-                .then(() => {
-                  expect(model.value).to.eql(options)
-                })
-            }
-          })
+          getHostElement()
+            .select(options)
+            .then(() => {
+              expect(model.value).to.eql(options)
+            })
         })
       })
     })
@@ -359,12 +323,7 @@ describe('QSelect API', () => {
             }
           })
           getHostElement()
-            .click()
-          cy.get('.q-menu')
-            .contains(options[ 0 ].label)
-            .should('be.visible')
-            .click()
-          cy.get('.q-menu')
+            .select(options[ 0 ].label)
             .then(() => {
               expect(model.value).to.equal(options[ 0 ].value)
             })
@@ -382,12 +341,7 @@ describe('QSelect API', () => {
             }
           })
           getHostElement()
-            .click()
-          cy.get('.q-menu')
-            .contains(options[ 0 ].label)
-            .should('be.visible')
-            .click()
-          cy.get('.q-menu')
+            .select(options[ 0 ].label)
             .then(() => {
               expect(model.value).to.equal(options[ 0 ].test)
             })
@@ -405,12 +359,7 @@ describe('QSelect API', () => {
             }
           })
           getHostElement()
-            .click()
-          cy.get('.q-menu')
-            .contains(options[ 0 ].label)
-            .should('be.visible')
-            .click()
-          cy.get('.q-menu')
+            .select(options[ 0 ].label)
             .then(() => {
               expect(model.value).to.equal(options[ 0 ].test)
             })


### PR DESCRIPTION
I'll open this in Draft mode until after the release of a new version for the AE with changes from https://github.com/quasarframework/quasar-testing/pull/369
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
