### PR TITLE
Bump fontawesome version to fix PDF icon displaying PNG label

### DIFF
--- a/extras/package.json
+++ b/extras/package.json
@@ -152,7 +152,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "6.5.0",
+    "@fortawesome/fontawesome-free": "6.5.1",
     "@mdi/font": "7.3.67",
     "@mdi/svg": "7.3.67",
     "@xmldom/xmldom": "0.8.10",


### PR DESCRIPTION
Fixes error https://github.com/FortAwesome/Font-Awesome/issues/20017

**What kind of change does this PR introduce?**
- [x] Bugfix
- [x] Build-related changes

**Does this PR introduce a breaking change?** 
- [ ] Yes
- [x] No, see https://fontawesome.com/changelog

**The PR fulfills these requirements:**
- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
