### PR TITLE
fix(ui): correctly apply iOS safe area padding when using q-tabs

### DIFF
--- a/ui/src/components/layout/QLayout.sass
+++ b/ui/src/components/layout/QLayout.sass
@@ -131,14 +131,14 @@
 
 body.q-ios-padding
   .q-layout--standard .q-header > .q-toolbar:nth-child(1),
-  .q-layout--standard .q-header > .q-tabs:nth-child(1) .q-tabs-head,
+  .q-layout--standard .q-header > .q-tabs:nth-child(1) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
     padding-top: $ios-statusbar-height
     min-height: ($toolbar-min-height + $ios-statusbar-height)
     padding-top: env(safe-area-inset-top)
     min-height: calc(env(safe-area-inset-top) + #{$toolbar-min-height})
   .q-layout--standard .q-footer > .q-toolbar:last-child,
-  .q-layout--standard .q-footer > .q-tabs:last-child .q-tabs-head,
+  .q-layout--standard .q-footer > .q-tabs:nth-last-child(2) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
     padding-bottom: env(safe-area-inset-bottom)
     min-height: calc(env(safe-area-inset-bottom) + #{$toolbar-min-height})

--- a/ui/src/components/layout/QLayout.sass
+++ b/ui/src/components/layout/QLayout.sass
@@ -138,7 +138,7 @@ body.q-ios-padding
     padding-top: env(safe-area-inset-top)
     min-height: calc(env(safe-area-inset-top) + #{$toolbar-min-height})
   .q-layout--standard .q-footer > .q-toolbar:last-child,
-  .q-layout--standard .q-footer > .q-tabs:nth-last-child(2) .q-tabs__content,
+  .q-layout--standard .q-footer > .q-tabs:nth-last-child(1 of :not(.q-layout__shadow)) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
     padding-bottom: env(safe-area-inset-bottom)
     min-height: calc(env(safe-area-inset-bottom) + #{$toolbar-min-height})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- Maybe: if the users patched the safe area themselves because the builtin solution wasn't working, this might break their apps depending on the element they applied padding

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
`.q-tabs-head` seems to be left from v0.17, it's now `.q-tabs__content`

`.q-tabs:last-child` doesn't work when using the `elevated` prop of `q-footer`, as the last child of the footer becomes the layout shadow div. So, fortified the selector to work regardless of whether the footer is elevated or not.