### PR TITLE
Format Date - Support ISO Week Year (GGGG)

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -67,6 +67,7 @@ Available format tokens:
 | Day of Week | <ul><li>**d**: 0 1 ... 5 6</li><li>**do**: 0th 1st ... 5th 6th</li><li>**dd**: Su Mo ... Fr Sa</li><li>**ddd**: Sun Mon ... Fri Sat</li><li>**dddd**: Sunday Monday ... Friday Saturday</li></ul> |
 | Day of Week (ISO) | <ul><li>**E**: 1 2 ... 6 7</li></ul> |
 | Week of Year | <ul><li>**w**: 1 2 ... 52 53</li><li>**wo**: 1st 2nd ... 52nd 53rd</li><li>**ww**: 01 02 ... 52 53</li></ul> |
+| ISO Week Year | <ul><li>**GG**: 70 71 ... 29 30</li><li>**GGGG**: 1970 1971 ... 2029 2030</li></ul> |
 | Hour | <ul><li>**H**: 0 1 ... 22 23</li><li>**HH**: 00 01 ... 22 23</li><li>**h**: 0 ... 11 12</li><li>**hh**: 01 02 ... 11 12</li></ul> |
 | Minute | <ul><li>**m**: 0 1 ... 58 59</li><li>**mm**: 00 01 ... 58 59</li></ul> |
 | Second | <ul><li>**s**: 0 1 ... 58 59</li><li>**ss**: 00 01 ... 58 59</li></ul> |
@@ -305,6 +306,16 @@ import { date } from 'quasar'
 
 const newDate = new Date(2017, 0, 4)
 const week = date.getWeekOfYear(newDate) // `week` is 1
+```
+
+To get the [ISO week year](https://en.wikipedia.org/wiki/ISO_week_date) for a given date object use:
+
+```js
+import { date } from 'quasar'
+
+const newDate = new Date(2022, 0, 1) // End of the last week of 2021
+const year = date.getISOWeekYear(newDate) // `year` is 2021
+const week = date.getWeekOfYear(newDate) // `week` is 52
 ```
 
 To get the day number in year for a given date object use:

--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -509,6 +509,16 @@ export function getWeekOfYear (date) {
   return 1 + Math.floor(weekDiff)
 }
 
+export function getISOWeekYear (date) {
+  // Remove time components of date
+  const thursday = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
+  // Change date to Thursday same week
+  thursday.setDate(thursday.getDate() - ((thursday.getDay() + 6) % 7) + 3)
+
+  return thursday.getFullYear() 
+}
+
 function getDayIdentifier (date) {
   return date.getFullYear() * 10000 + date.getMonth() * 100 + date.getDate()
 }
@@ -762,6 +772,22 @@ const formatter = {
       : date.getFullYear()
   },
 
+  GG (date, dateLocale, forcedYear) {
+    // workaround for < 1900 with new Date()
+    const g = this.GGGG(date, dateLocale, forcedYear) % 100
+    return g >= 0
+      ? pad(g)
+      : '-' + pad(Math.abs(g))
+  },
+
+  // Year: 1900, 1901, ..., 2099
+  GGGG (date, _dateLocale, forcedYear) {
+    // workaround for < 1900 with new Date()
+    return forcedYear !== void 0 && forcedYear !== null
+      ? forcedYear
+      : getISOWeekYear(date)
+  },
+
   // Month: 1, 2, ..., 12
   M (date) {
     return date.getMonth() + 1
@@ -1013,6 +1039,7 @@ export default {
   buildDate,
   getDayOfWeek,
   getWeekOfYear,
+  getISOWeekYear,
   isBetweenDates,
   addToDate,
   subtractFromDate,


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Moment.js, Day.js, and other date libraries support date format tokens for the ISO week year (`GGGG`). This is so you can format dates like `2022-01-01` as `2021-W52` instead of the current `YYYY` token which returns the locale year.

https://momentjs.com/docs/#/parsing/string-format/:~:text=by%20moment.locale()-,gggg,-2014
https://day.js.org/docs/en/plugin/advanced-format
