### PR TITLE
feat(q-dialog):  Add configurable option to not close dialog when clicking button  fix: #17120

### DIFF
--- a/docs/src/examples/Dialog/Async.vue
+++ b/docs/src/examples/Dialog/Async.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="q-pa-md q-gutter-sm">
+    <q-btn label="hide await Async" color="primary" @click="openDialog" />
+  </div>
+</template>
+
+<script>
+import { useQuasar } from 'quasar'
+
+export default {
+  setup () {
+    const $q = useQuasar()
+
+    // Simulate an asynchronous task that takes two seconds to complete
+    function mockAsyncJob () {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve()
+        }, 2000)
+      })
+    }
+
+    function openDialog () {
+      const dialog = $q.dialog({
+        title: 'Confirm',
+        message: 'Would you like to turn on the wifi?',
+        ok: {
+          push: true,
+          loading: false,
+          notHide: true // We don't want to close the dialog immediately after clicking the OK button
+        },
+        cancel: {
+          push: true,
+          color: 'negative'
+          // notHide: true // we can also set not close the dialog immediately after clicking the Cancel button
+        },
+        persistent: true // we want the user to not be able to close it
+      }).onOk(async () => {
+        // console.log('>>>> OK')
+        // We will manually close the dialog after waiting for the asynchronous task to complete
+        dialog.update({
+          ok: {
+            label: 'connecting',
+            loading: true
+          }
+        })
+        await mockAsyncJob()
+        dialog.update({
+          ok: {
+            loading: false
+          }
+        })
+        dialog.hide()
+      }).onCancel(() => {
+        // console.log('>>>> Cancel')
+      }).onDismiss(() => {
+        // console.log('I am triggered on both OK and Cancel')
+      })
+    }
+
+    return { openDialog }
+  }
+}
+</script>

--- a/docs/src/pages/quasar-plugins/dialog.md
+++ b/docs/src/pages/quasar-plugins/dialog.md
@@ -87,6 +87,13 @@ There is a basic validation system that you can use so that the user won't be ab
 
 <DocExample title="Showing progress" file="Progress" />
 
+### Hide await async task <q-badge label="Quasar 2.15.3+" />
+
+Don't to close the dialog immediately after clicking the OK or Cancel button
+
+<DocExample title="Hide await Async task" file="Async" />
+
+
 ### Using HTML
 You can use HTML on title and message if you specify the `html: true` prop. **Please note that this can lead to XSS attacks**, so make sure that you sanitize the message by yourself.
 

--- a/ui/src/plugins/dialog/component/DialogPluginComponent.js
+++ b/ui/src/plugins/dialog/component/DialogPluginComponent.js
@@ -173,11 +173,11 @@ export default createComponent({
 
     function onOk () {
       emit('ok', toRaw(model.value))
-      hide()
+      if(!props.ok?.notHide)  hide()
     }
 
     function onCancel () {
-      hide()
+      if(!props.cancel?.notHide) hide()
     }
 
     function onDialogHide () {


### PR DESCRIPTION
 #17120

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
**Title: Add `notHide` Option to `props.ok` to Control Dialog Closure on Button Click**

**Summary:**
Introduce a new `notHide` option within `props.ok` to allow control over dialog visibility when the OK button is clicked. This feature will be particularly useful for scenarios where the dialog should remain open until an asynchronous task completes.

**Description:**
Currently, the dialog closes immediately when the OK button is clicked. However, for certain operations, like asynchronous tasks, it may be necessary to keep the dialog open until the operation is fully completed. Implementing a `notHide` property will provide developers with the flexibility to prevent the dialog from closing right away.

**Proposed Solution:**
- Add a `notHide` boolean property to `props.ok`.
- When `notHide` is set to `true`, the dialog will not close upon clicking the OK button.
- The dialog closure can be manually triggered later, typically after the completion of an asynchronous operation.

**Example Use Case:**
Consider a form submission within a dialog where data validation and server-side processing are required. With the `notHide` option set to `true`, the dialog remains open, displaying a loading indicator while the submission is processed. Once the server responds, the dialog can be programmatically closed, either on success or after displaying an error message.

![image](https://github.com/quasarframework/quasar/assets/38457491/6850fb47-ea9d-4da9-89a8-b1c981500379)
