### PR TITLE
fix: ios always undefined

### DIFF
--- a/ui/src/plugins/platform/Platform.js
+++ b/ui/src/plugins/platform/Platform.js
@@ -124,8 +124,9 @@ function getPlatform (UA) {
     browser.firefox = true
     matched.browser = 'firefox'
   }
+
   // Set iOS if on iPod, iPad or iPhone
-  else if (browser.ipod || browser.ipad || browser.iphone) {
+  if (browser.ipod || browser.ipad || browser.iphone) {
     browser.ios = true
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix

This reverts an `else` that was added two months ago, perhaps by mistake? With the else, it is impossible to detect 'iOS' when using either chrome, edge or firefox on an iOS device.

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
This came from feedback in Discord.

<img width="764" alt="Screenshot 2024-04-22 at 21 39 29" src="https://github.com/quasarframework/quasar/assets/43420049/a168d552-3a7e-479b-9890-989d3fc99f79">
