### PR TITLE
feat(QScrollArea): add scroll viewport to create overscrolling effect

### DIFF
--- a/ui/dev/src/pages/components/scroll-area.vue
+++ b/ui/dev/src/pages/components/scroll-area.vue
@@ -96,7 +96,38 @@
     <pre class="inline-block" dir="ltr">{{ scrollDetails }}</pre>
     <q-separator spaced />
 
-    <div style="height: 250px" />
+    <div style="height: 100px" />
+
+    <div class="row q-gutter-md">
+      <q-scroll-area
+        class="bg-yellow"
+        style="width: 800px; height: 300px;"
+        :visible="alwaysVisible"
+        :bar-style="customBarStyle"
+        :vertical-bar-style="customVBarStyle"
+        :horizontal-bar-style="customHBarStyle"
+        :thumbStyle="customThumbStyle"
+        :vertical-thumb-style="customVThumbStyle"
+        :horizontal-thumb-style="customHThumbStyle"
+        :horizontal-offset="[topOffset, bottomOffset]"
+      >
+        <div v-if="topOffset" :style="`width: ${topOffset}px`" class="flex flex-center text-center text-white fixed-left" style="backdrop-filter: blur(8px);background: #0008;z-index: 1;">User-Defined Panel</div>
+
+        <div class="flex no-wrap" :style="{
+          'padding-left': topOffset ? ` ${topOffset}px` : void 0,
+          'padding-right': bottomOffset ? ` ${bottomOffset}px` : void 0,
+        }">
+          <div style="margin: 12px; width: 300px" v-for="n in number" :key="n">
+            {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            <q-btn label="Click" color="primary" />
+          </div>
+        </div>
+
+        <div v-if="bottomOffset" :style="`width: ${bottomOffset}px`" class="flex flex-center text-center text-white fixed-right" style="backdrop-filter: blur(8px);background: #0008;z-index: 1;">User-Defined Panel</div>
+      </q-scroll-area>
+    </div>
+
+    <div style="height: 100px" />
 
     <div class="row q-gutter-md">
       <q-scroll-area
@@ -161,7 +192,7 @@ export default {
   data () {
     return {
       darkVariant: false,
-      number: 3,
+      number: 5,
       horizontal: false,
       alwaysVisible: true,
       customStyle: false,

--- a/ui/dev/src/pages/components/scroll-area.vue
+++ b/ui/dev/src/pages/components/scroll-area.vue
@@ -28,7 +28,9 @@
           <div style="margin-top: 150px" />
           <div style="margin-bottom: 25px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
             {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            <q-btn label="Click" color="primary" />
+            <q-btn label="Click" color="primary">
+              {{ logRender() }}
+            </q-btn>
           </div>
         </div>
       </q-scroll-area>
@@ -47,7 +49,9 @@
           <div style="margin-top: 150px" />
           <div style="margin-bottom: 25px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
             {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            <q-btn label="Click" color="primary" />
+            <q-btn label="Click" color="primary">
+              {{ logRender() }}
+            </q-btn>
           </div>
         </div>
       </q-scroll-area>
@@ -223,6 +227,9 @@ export default {
       console.log('getScroll()', this.$refs.scroll.getScroll())
       console.log('getScrollPosition()', this.$refs.scroll.getScrollPosition())
       console.log('getScrollPercentage()', this.$refs.scroll.getScrollPercentage())
+    },
+    logRender () {
+      console.log('button render call')
     }
   }
 }

--- a/ui/dev/src/pages/components/scroll-area.vue
+++ b/ui/dev/src/pages/components/scroll-area.vue
@@ -28,9 +28,7 @@
           <div style="margin-top: 150px" />
           <div style="margin-bottom: 25px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
             {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            <q-btn label="Click" color="primary">
-              {{ logRender() }}
-            </q-btn>
+            <q-btn label="Click" color="primary" />
           </div>
         </div>
       </q-scroll-area>
@@ -49,9 +47,7 @@
           <div style="margin-top: 150px" />
           <div style="margin-bottom: 25px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
             {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            <q-btn label="Click" color="primary">
-              {{ logRender() }}
-            </q-btn>
+            <q-btn label="Click" color="primary" />
           </div>
         </div>
       </q-scroll-area>
@@ -227,9 +223,6 @@ export default {
       console.log('getScroll()', this.$refs.scroll.getScroll())
       console.log('getScrollPosition()', this.$refs.scroll.getScrollPosition())
       console.log('getScrollPercentage()', this.$refs.scroll.getScrollPercentage())
-    },
-    logRender () {
-      console.log('button render call')
     }
   }
 }

--- a/ui/dev/src/pages/components/scroll-area.vue
+++ b/ui/dev/src/pages/components/scroll-area.vue
@@ -5,9 +5,20 @@
     <q-toggle v-model="alwaysVisible" toggle-indeterminate label="Always visible" />
     <q-toggle v-model="darkVariant" toggle-indeterminate label="Dark variant" />
     <q-toggle v-model="focusable" label="Focusable" />
-    <q-slider v-model="topOffset" :min="0" :max="100"/>
 
-    <div style="height: 100px;" />
+    <div class="row items-center">
+      <div class="q-mr-md">
+        <div>Top offset</div>
+        <q-slider v-model="topOffset" :min="0" :max="100" label-always switch-label-side style="width: 200px"/>
+      </div>
+
+      <div>
+        <div>Bottom offset</div>
+        <q-slider v-model="bottomOffset" :min="0" :max="100" label-always switch-label-side style="width: 200px"/>
+      </div>
+    </div>
+
+    <div style="height: 50px;" />
 
     <keep-alive>
       <q-scroll-area
@@ -16,7 +27,7 @@
         ref="scroll"
         style="width: 400px; height: 500px;"
         class="bg-yellow"
-        :vertical-offset="[topOffset, 100]"
+        :vertical-offset="[topOffset, bottomOffset]"
         :visible="alwaysVisible"
         :bar-style="customBarStyle"
         :vertical-bar-style="customVBarStyle"
@@ -26,13 +37,19 @@
         :horizontal-thumb-style="customHThumbStyle"
         :tabindex="focusable === true ? 0 : void 0"
       >
-        <div :class="{ 'flex no-wrap' : horizontal }">
-          <div style="margin-top: 150px" />
-          <div style="margin-bottom: 25px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
+        <div v-if="topOffset" :style="`height: ${topOffset}px`" class="flex flex-center text-white fixed-top" style="backdrop-filter: blur(8px);background: #0008;z-index: 1;">User-Defined Header</div>
+
+        <div :class="{ 'flex no-wrap' : horizontal }" :style="{
+          'padding-top': topOffset ? ` ${topOffset}px` : void 0,
+          'padding-bottom': bottomOffset ? ` ${bottomOffset}px` : void 0,
+        }">
+          <div style="margin-block: 12px" :style="horizontal ? 'width: 160px' : ''" v-for="n in number" :key="n">
             {{ n }} Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             <q-btn label="Click" color="primary" />
           </div>
         </div>
+
+        <div v-if="bottomOffset" :style="`height: ${bottomOffset}px`" class="flex flex-center text-white fixed-bottom" style="backdrop-filter: blur(8px);background: #0008;z-index: 1;">User-Defined Footer</div>
       </q-scroll-area>
 
       <q-scroll-area
@@ -144,13 +161,14 @@ export default {
   data () {
     return {
       darkVariant: false,
-      number: 10,
+      number: 3,
       horizontal: false,
       alwaysVisible: true,
       customStyle: false,
       focusable: true,
       scrollDetails: null,
-      topOffset: 50
+      topOffset: 100,
+      bottomOffset: 100
     }
   },
 

--- a/ui/dev/src/pages/components/scroll-area.vue
+++ b/ui/dev/src/pages/components/scroll-area.vue
@@ -5,6 +5,7 @@
     <q-toggle v-model="alwaysVisible" toggle-indeterminate label="Always visible" />
     <q-toggle v-model="darkVariant" toggle-indeterminate label="Dark variant" />
     <q-toggle v-model="focusable" label="Focusable" />
+    <q-slider v-model="topOffset" :min="0" :max="100"/>
 
     <div style="height: 100px;" />
 
@@ -15,6 +16,7 @@
         ref="scroll"
         style="width: 400px; height: 500px;"
         class="bg-yellow"
+        :vertical-offset="[topOffset, 100]"
         :visible="alwaysVisible"
         :bar-style="customBarStyle"
         :vertical-bar-style="customVBarStyle"
@@ -147,7 +149,8 @@ export default {
       alwaysVisible: true,
       customStyle: false,
       focusable: true,
-      scrollDetails: null
+      scrollDetails: null,
+      topOffset: 50
     }
   },
 

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -1,22 +1,19 @@
 import { h, ref, computed, watch, onActivated, onDeactivated, onBeforeUnmount, getCurrentInstance } from 'vue'
 
 import useDark, { useDarkProps } from '../../composables/private/use-dark.js'
+import { dirProps } from './use-scroll-area.js'
 
 import QResizeObserver from '../resize-observer/QResizeObserver.js'
 import QScrollObserver from '../scroll-observer/QScrollObserver.js'
+import QScrollAreaControls from './QScrollAreaControls.js'
 
 import { createComponent } from '../../utils/private/create.js'
 import { between } from '../../utils/format.js'
 import { setVerticalScrollPosition, setHorizontalScrollPosition } from '../../utils/scroll.js'
 import { hMergeSlot } from '../../utils/private/render.js'
 import debounce from '../../utils/debounce.js'
-import QScrollAreaControls from './QScrollAreaControls.js'
 
 const axisList = [ 'vertical', 'horizontal' ]
-const dirProps = {
-  vertical: { offset: 'offsetY', scroll: 'scrollTop', dir: 'down', dist: 'y' },
-  horizontal: { offset: 'offsetX', scroll: 'scrollLeft', dir: 'right', dist: 'x' }
-}
 const getMinThumbSize = size => (size >= 250 ? 50 : Math.ceil(size / 5))
 
 export default createComponent({

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -410,6 +410,9 @@ export default createComponent({
           verticalBarStyle: props.verticalBarStyle,
           horizontalBarStyle: props.horizontalBarStyle,
 
+          verticalOffset: props.verticalOffset,
+          horizontalOffset: props.horizontalOffset,
+
           visible: props.visible,
 
           scroll,

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -175,7 +175,9 @@ export default createComponent({
     )
 
     const mainStyle = computed(() => (
-      scroll.vertical.thumbHidden.value === true && scroll.horizontal.thumbHidden.value === true
+      (props.contentStyle || props.contentActiveStyle)
+      && scroll.vertical.thumbHidden.value === true
+      && scroll.horizontal.thumbHidden.value === true
         ? props.contentStyle
         : props.contentActiveStyle
     ))

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -401,7 +401,7 @@ export default createComponent({
           scroll,
           container,
 
-          onScroll: setScroll
+          onSetScroll: setScroll
         })
       ])
     }

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -132,7 +132,8 @@ export default createComponent({
         ...props.thumbStyle,
         ...props.verticalThumbStyle,
         top: `${ scroll.vertical.thumbStart.value }px`,
-        height: `${ scroll.vertical.thumbSize.value }px`
+        height: `${ scroll.vertical.thumbSize.value }px`,
+        right: `${ props.horizontalOffset[ 1 ] }px`
       }
     })
     scroll.vertical.thumbClass = computed(() =>
@@ -157,9 +158,9 @@ export default createComponent({
         && panning.value === false
       ) || scroll.horizontal.size.value <= container.horizontal.value + 1
     )
-    scroll.horizontal.thumbStart = computed(() =>
-      scroll.horizontal.percentage.value * (container.horizontalNet.value - scroll.horizontal.thumbSize.value)
-    )
+    scroll.horizontal.thumbStart = computed(() => {
+      return props.horizontalOffset[ 0 ] + scroll.horizontal.percentage.value * (container.horizontalNet.value - scroll.horizontal.thumbSize.value)
+    })
     scroll.horizontal.thumbSize = computed(() =>
       Math.round(
         between(
@@ -174,7 +175,8 @@ export default createComponent({
         ...props.thumbStyle,
         ...props.horizontalThumbStyle,
         [ proxy.$q.lang.rtl === true ? 'right' : 'left' ]: `${ scroll.horizontal.thumbStart.value }px`,
-        width: `${ scroll.horizontal.thumbSize.value }px`
+        width: `${ scroll.horizontal.thumbSize.value }px`,
+        bottom: `${ props.verticalOffset[ 1 ] }px`
       }
     })
     scroll.horizontal.thumbClass = computed(() =>

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -30,6 +30,15 @@ export default createComponent({
     verticalBarStyle: [ Array, String, Object ],
     horizontalBarStyle: [ Array, String, Object ],
 
+    verticalOffset: {
+      type: Array,
+      default: [ 0, 0 ]
+    },
+    horizontalOffset: {
+      type: Array,
+      default: [ 0, 0 ]
+    },
+
     contentStyle: [ Array, String, Object ],
     contentActiveStyle: [ Array, String, Object ],
 
@@ -57,7 +66,13 @@ export default createComponent({
     // other...
     const container = {
       vertical: ref(0),
-      horizontal: ref(0)
+      verticalNet: computed(() =>
+        container.vertical.value - props.verticalOffset[ 0 ] - props.verticalOffset[ 1 ]
+      ),
+      horizontal: ref(0),
+      horizontalNet: computed(() =>
+        container.horizontal.value - props.horizontalOffset[ 0 ] - props.horizontalOffset[ 1 ]
+      )
     }
 
     const scroll = {
@@ -100,15 +115,15 @@ export default createComponent({
         && panning.value === false
       ) || scroll.vertical.size.value <= container.vertical.value + 1
     )
-    scroll.vertical.thumbStart = computed(() =>
-      scroll.vertical.percentage.value * (container.vertical.value - scroll.vertical.thumbSize.value)
-    )
+    scroll.vertical.thumbStart = computed(() => {
+      return props.verticalOffset[ 0 ] + scroll.vertical.percentage.value * (container.verticalNet.value - scroll.vertical.thumbSize.value)
+    })
     scroll.vertical.thumbSize = computed(() =>
       Math.round(
         between(
-          container.vertical.value * container.vertical.value / scroll.vertical.size.value,
-          getMinThumbSize(container.vertical.value),
-          container.vertical.value
+          container.verticalNet.value * container.verticalNet.value / scroll.vertical.size.value,
+          getMinThumbSize(container.verticalNet.value),
+          container.verticalNet.value
         )
       )
     )
@@ -143,14 +158,14 @@ export default createComponent({
       ) || scroll.horizontal.size.value <= container.horizontal.value + 1
     )
     scroll.horizontal.thumbStart = computed(() =>
-      scroll.horizontal.percentage.value * (container.horizontal.value - scroll.horizontal.thumbSize.value)
+      scroll.horizontal.percentage.value * (container.horizontalNet.value - scroll.horizontal.thumbSize.value)
     )
     scroll.horizontal.thumbSize = computed(() =>
       Math.round(
         between(
-          container.horizontal.value * container.horizontal.value / scroll.horizontal.size.value,
-          getMinThumbSize(container.horizontal.value),
-          container.horizontal.value
+          container.horizontalNet.value * container.horizontalNet.value / scroll.horizontal.size.value,
+          getMinThumbSize(container.horizontalNet.value),
+          container.horizontalNet.value
         )
       )
     )

--- a/ui/src/components/scroll-area/QScrollArea.json
+++ b/ui/src/components/scroll-area/QScrollArea.json
@@ -86,6 +86,20 @@
       "category": "behavior"
     },
 
+    "vertical-offset": {
+      "type": "Array",
+      "desc": "Adds [top, bottom] offset to vertical thumb",
+      "default": [0, 0],
+      "category": "style"
+    },
+
+    "horizontal-offset": {
+      "type": "Array",
+      "desc": "Adds [top, bottom] offset to horizontal thumb",
+      "default": [0, 0],
+      "category": "style"
+    },
+
     "tabindex": {
       "extends": "tabindex"
     }

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -1,4 +1,4 @@
-import { h, ref, withDirectives } from 'vue'
+import { h, ref, computed, withDirectives } from 'vue'
 
 import { dirProps } from './use-scroll-area.js'
 
@@ -64,6 +64,22 @@ export default createComponent({
       void 0,
       { horizontal: true, ...panOpts }
     ] ]
+
+    const verticalBarStyle = computed(() => {
+      return {
+        top: `${ props.verticalOffset[ 0 ] }px`,
+        bottom: `${ props.verticalOffset[ 1 ] }px`,
+        right: `${ props.horizontalOffset[ 1 ] }px`
+      }
+    })
+
+    const horizontalBarStyle = computed(() => {
+      return {
+        left: `${ props.horizontalOffset[ 0 ] }px`,
+        right: `${ props.horizontalOffset[ 1 ] }px`,
+        bottom: `${ props.verticalOffset[ 1 ] }px`
+      }
+    })
 
     function onPanThumb (e, axis) {
       const data = props.scroll[ axis ]
@@ -132,14 +148,14 @@ export default createComponent({
     return () => [
       h('div', {
         class: props.scroll.vertical.barClass.value,
-        style: [ props.barStyle, props.verticalBarStyle ],
+        style: [ verticalBarStyle.value, props.barStyle, props.verticalBarStyle ],
         'aria-hidden': 'true',
         onMousedown: onVerticalMousedown
       }),
 
       h('div', {
         class: props.scroll.horizontal.barClass.value,
-        style: [ props.barStyle, props.horizontalBarStyle ],
+        style: [ horizontalBarStyle.value, props.barStyle, props.horizontalBarStyle ],
         'aria-hidden': 'true',
         onMousedown: onHorizontalMousedown
       }),

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -17,6 +17,8 @@ const panOpts = {
 export default createComponent({
   name: 'QScrollAreaControls',
 
+  emits: ['scroll'],
+
   props: {
     thumbStyle: Object,
     verticalThumbStyle: Object,

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -1,0 +1,152 @@
+import { h, ref, withDirectives } from 'vue'
+
+import TouchPan from '../../directives/touch-pan/TouchPan.js'
+
+import { createComponent } from '../../utils/private/create.js'
+
+const dirProps = {
+  vertical: { offset: 'offsetY', scroll: 'scrollTop', dir: 'down', dist: 'y' },
+  horizontal: { offset: 'offsetX', scroll: 'scrollLeft', dir: 'right', dist: 'x' }
+}
+const panOpts = {
+  prevent: true,
+  mouse: true,
+  mouseAllDir: true
+}
+
+export default createComponent({
+  name: 'QScrollAreaControls',
+
+  props: {
+    thumbStyle: Object,
+    verticalThumbStyle: Object,
+    horizontalThumbStyle: Object,
+
+    barStyle: [ Array, String, Object ],
+    verticalBarStyle: [ Array, String, Object ],
+    horizontalBarStyle: [ Array, String, Object ],
+
+    visible: {
+      type: Boolean,
+      default: null
+    },
+
+    container: Object,
+    scroll: Object
+  },
+
+  setup (props, { emit }) {
+    // state management
+    const panning = ref(false)
+
+    let panRefPos
+
+    const thumbVertDir = [ [
+      TouchPan,
+      e => { onPanThumb(e, 'vertical') },
+      void 0,
+      { vertical: true, ...panOpts }
+    ] ]
+
+    const thumbHorizDir = [ [
+      TouchPan,
+      e => { onPanThumb(e, 'horizontal') },
+      void 0,
+      { horizontal: true, ...panOpts }
+    ] ]
+
+    function onPanThumb (e, axis) {
+      const data = props.scroll[ axis ]
+
+      if (e.isFirst === true) {
+        if (data.thumbHidden.value === true) {
+          return
+        }
+
+        panRefPos = data.position.value
+        panning.value = true
+      }
+      else if (panning.value !== true) {
+        return
+      }
+
+      if (e.isFinal === true) {
+        panning.value = false
+      }
+
+      const dProp = dirProps[ axis ]
+      const containerSize = props.container[ axis ].value
+
+      const multiplier = (data.size.value - containerSize) / (containerSize - data.thumbSize.value)
+      const distance = e.distance[ dProp.dist ]
+      const pos = panRefPos + (e.direction === dProp.dir ? 1 : -1) * distance * multiplier
+
+      setScroll(pos, axis)
+    }
+
+    function onMousedown (evt, axis) {
+      const data = props.scroll[ axis ]
+
+      if (data.thumbHidden.value !== true) {
+        const offset = evt[ dirProps[ axis ].offset ]
+        if (offset < data.thumbStart.value || offset > data.thumbStart.value + data.thumbSize.value) {
+          const pos = offset - data.thumbSize.value / 2
+          setScroll(pos / props.container[ axis ].value * data.size.value, axis)
+        }
+
+        // activate thumb pan
+        if (data.ref.value !== null) {
+          data.ref.value.dispatchEvent(new MouseEvent(evt.type, evt))
+        }
+      }
+    }
+
+    function onVerticalMousedown (evt) {
+      onMousedown(evt, 'vertical')
+    }
+
+    function onHorizontalMousedown (evt) {
+      onMousedown(evt, 'horizontal')
+    }
+
+    function setScroll (offset, axis) {
+      emit('scroll', offset, axis)
+    }
+
+    return () => [
+      h('div', {
+        class: props.scroll.vertical.barClass.value,
+        style: [ props.barStyle, props.verticalBarStyle ],
+        'aria-hidden': 'true',
+        onMousedown: onVerticalMousedown
+      }),
+
+      h('div', {
+        class: props.scroll.horizontal.barClass.value,
+        style: [ props.barStyle, props.horizontalBarStyle ],
+        'aria-hidden': 'true',
+        onMousedown: onHorizontalMousedown
+      }),
+
+      withDirectives(
+        h('div', {
+          ref: props.scroll.vertical.ref,
+          class: props.scroll.vertical.thumbClass.value,
+          style: props.scroll.vertical.style.value,
+          'aria-hidden': 'true'
+        }),
+        thumbVertDir
+      ),
+
+      withDirectives(
+        h('div', {
+          ref: props.scroll.horizontal.ref,
+          class: props.scroll.horizontal.thumbClass.value,
+          style: props.scroll.horizontal.style.value,
+          'aria-hidden': 'true'
+        }),
+        thumbHorizDir
+      )
+    ]
+  }
+})

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -17,7 +17,7 @@ const panOpts = {
 export default createComponent({
   name: 'QScrollAreaControls',
 
-  emits: ['set-scroll'],
+  emits: [ 'set-scroll' ],
 
   props: {
     thumbStyle: Object,

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -1,13 +1,11 @@
 import { h, ref, withDirectives } from 'vue'
 
+import { dirProps } from './use-scroll-area.js'
+
 import TouchPan from '../../directives/touch-pan/TouchPan.js'
 
 import { createComponent } from '../../utils/private/create.js'
 
-const dirProps = {
-  vertical: { offset: 'offsetY', scroll: 'scrollTop', dir: 'down', dist: 'y' },
-  horizontal: { offset: 'offsetX', scroll: 'scrollLeft', dir: 'right', dist: 'x' }
-}
 const panOpts = {
   prevent: true,
   mouse: true,

--- a/ui/src/components/scroll-area/QScrollAreaControls.js
+++ b/ui/src/components/scroll-area/QScrollAreaControls.js
@@ -17,7 +17,7 @@ const panOpts = {
 export default createComponent({
   name: 'QScrollAreaControls',
 
-  emits: ['scroll'],
+  emits: ['set-scroll'],
 
   props: {
     thumbStyle: Object,
@@ -112,7 +112,7 @@ export default createComponent({
     }
 
     function setScroll (offset, axis) {
-      emit('scroll', offset, axis)
+      emit('set-scroll', offset, axis)
     }
 
     return () => [

--- a/ui/src/components/scroll-area/use-scroll-area.js
+++ b/ui/src/components/scroll-area/use-scroll-area.js
@@ -1,0 +1,4 @@
+export const dirProps = {
+  vertical: { offset: 'offsetY', scroll: 'scrollTop', dir: 'down', dist: 'y' },
+  horizontal: { offset: 'offsetX', scroll: 'scrollLeft', dir: 'right', dist: 'x' }
+}


### PR DESCRIPTION
When designing pages (lists, galleries, horizontal scrollers) that have overlays (headers, footers, navigation panels on the sides) using QScrollArea results in either the scroll bar overlapping the content of the overlays (Figure 1) or scroll thumb/bar being hidden (and made inaccessible) by the overlays (Figure 2). In both cases, it leads to confusing experience for users.

If we add offsets to bottom/top of each (vertical and horizontal) scroll tracks, then it will effectively create a scrollable viewport within the <q-scroll-area> container. The scroll behavior remains consistent and predictable to users, while developers get the freedom of creating overlays and adding acrylic/glass effects to their lists. See Figures 3-4.

**What kind of change does this PR introduce?**

- [X] Feature

**Does this PR introduce a breaking change?**

- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature.

Figure 1.
![chrome_NS7urur5no](https://github.com/quasarframework/quasar/assets/2260539/8647b8c9-ad8a-4623-9357-c646667b7048)

Figure 2.
![chrome_TSSRZD0sYO](https://github.com/quasarframework/quasar/assets/2260539/1e07ca2a-9e31-423a-9def-7459eafb2b68)

Figure 3.
![chrome_aysY4ILKJK](https://github.com/quasarframework/quasar/assets/2260539/bab7d3d8-5980-4139-a7d4-cc7c88ab7f8f)

Figure 4.
![chrome_lFTDUCw31L](https://github.com/quasarframework/quasar/assets/2260539/a17355b2-3d92-446f-80ee-ccb577aed231)

**Other information:**

Note 1: there is no documentation in PR yet, until the feature is approved and parameter names are "locked in".

Note 2: this includes code from #17041 and #17207 - once those are merged I will rebased this against the (updated) dev branch.
