### PR TITLE
fix: prevent `@typescript-eslint/unbound-method` error on newer utilities types

### DIFF
--- a/ui/types/composables.d.ts
+++ b/ui/types/composables.d.ts
@@ -32,8 +32,8 @@ export function useHydration(): {
 };
 
 export function useInterval(): {
-  registerInterval(fn: () => void, interval: string | number): void;
-  removeInterval(): void;
+  registerInterval: (fn: () => void, interval: string | number) => void;
+  removeInterval: () => void;
 };
 
 export function useId(opts?: {
@@ -60,11 +60,11 @@ export function useSplitAttrs(): {
 };
 
 export function useTick(): {
-  registerTick(fn: () => void): void;
-  removeTick(): void;
+  registerTick: (fn: () => void) => void;
+  removeTick: () => void;
 };
 
 export function useTimeout(): {
-  registerTimeout(fn: () => void, delay?: string | number): void;
-  removeTimeout(): void;
+  registerTimeout: (fn: () => void, delay?: string | number) => void;
+  removeTimeout: () => void;
 };


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The types change has been made to prevent the `@typescript-eslint/unbound-method` error on the new utility types (see https://stackoverflow.com/a/62864909).
