### PR TITLE
feat(app-vite&app-webpack): upgrade tsconfig preset

### DIFF
--- a/app-vite/stricter-tsconfig-preset.json
+++ b/app-vite/stricter-tsconfig-preset.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig-preset.json",
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true
   }

--- a/app-vite/stricter-tsconfig-preset.json
+++ b/app-vite/stricter-tsconfig-preset.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-preset.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true
+  }
+}

--- a/app-vite/tsconfig-preset.json
+++ b/app-vite/tsconfig-preset.json
@@ -1,23 +1,20 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     // `baseUrl` must be placed on the extending configuration in devland, or paths won't be recognized
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     // Needed to address https://github.com/quasarframework/app-extension-typescript/issues/36
     "noEmit": true,
     "resolveJsonModule": true,
-    // Avoid cross-os errors due to inconsistent file casing
-    "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,
     "target": "esnext",
-    "isolatedModules": true,
-    "useDefineForClassFields": true,
-    // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
-    "jsx": "preserve",
     "lib": ["esnext", "dom"],
+    "isolatedModules": true,
+
     "paths": {
       "src/*": ["src/*"],
       "app/*": ["*"],
@@ -27,6 +24,18 @@
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"],
       "stores/*": ["src/stores/*"]
-    }
+    },
+
+    // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
+    "jsx": "preserve",
+
+    // Rules preventing code smells and enforcing best practices, partially overlapping with linting
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    // Avoid cross-os errors due to inconsistent file casing
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/app-vite/tsconfig-preset.json
+++ b/app-vite/tsconfig-preset.json
@@ -33,7 +33,6 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noImplicitOverride": true,
-    "noImplicitReturns": true,
     "noUnusedLocals": true,
     // Avoid cross-os errors due to inconsistent file casing
     "forceConsistentCasingInFileNames": true,

--- a/app-vite/tsconfig-preset.json
+++ b/app-vite/tsconfig-preset.json
@@ -2,7 +2,13 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    // `baseUrl` must be placed on the extending configuration in devland, or paths won't be recognized
+
+    // `"baseUrl": "."` option should be defined in the tsconfig file in devland which extends this preset
+    // That way, the `paths` we defined in this preset are resolved starting from the devland project root
+    // instead of this TS preset file's location
+    // This allows Quasar to centralize the management of default paths in the preset,
+    // instead of asking the dev to keep them in sync when something changes
+
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/app-webpack/stricter-tsconfig-preset.json
+++ b/app-webpack/stricter-tsconfig-preset.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig-preset.json",
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true
   }

--- a/app-webpack/stricter-tsconfig-preset.json
+++ b/app-webpack/stricter-tsconfig-preset.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-preset.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true
+  }
+}

--- a/app-webpack/tsconfig-preset.json
+++ b/app-webpack/tsconfig-preset.json
@@ -1,21 +1,19 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     // `baseUrl` must be placed on the extending configuration in devland, or paths won't be recognized
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     // Needed to address https://github.com/quasarframework/app-extension-typescript/issues/36
     "noEmit": true,
     "resolveJsonModule": true,
-    // Avoid cross-os errors due to inconsistent file casing
-    "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,
     "target": "es6",
-    // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
-    "jsx": "preserve",
     "lib": ["esnext", "dom"],
+
     "paths": {
       "src/*": ["src/*"],
       "app/*": ["*"],
@@ -25,6 +23,18 @@
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"],
       "stores/*": ["src/stores/*"]
-    }
+    },
+
+    // Fix Volar issue https://github.com/johnsoncodehk/volar/issues/1153
+    "jsx": "preserve",
+
+    // Rules preventing code smells and enforcing best practices, partially overlapping with linting
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    // Avoid cross-os errors due to inconsistent file casing
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/app-webpack/tsconfig-preset.json
+++ b/app-webpack/tsconfig-preset.json
@@ -2,7 +2,13 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    // `baseUrl` must be placed on the extending configuration in devland, or paths won't be recognized
+
+    // `"baseUrl": "."` option should be defined in the tsconfig file in devland which extends this preset
+    // That way, the `paths` we defined in this preset are resolved starting from the devland project root
+    // instead of this TS preset file's location
+    // This allows Quasar to centralize the management of default paths in the preset,
+    // instead of asking the dev to keep them in sync when something changes
+
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/app-webpack/tsconfig-preset.json
+++ b/app-webpack/tsconfig-preset.json
@@ -32,7 +32,6 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noImplicitOverride": true,
-    "noImplicitReturns": true,
     "noUnusedLocals": true,
     // Avoid cross-os errors due to inconsistent file casing
     "forceConsistentCasingInFileNames": true,

--- a/create-quasar/templates/app/quasar-v1/ts/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v1/ts/BASE/_tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."<% if (sfcStyle === 'class') { %>,
     "experimentalDecorators": true<% } %><% if (preset.ie) { %>,
     "target": "es5"<% } %>

--- a/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/_tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
+      // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/docs/src/pages/quasar-cli-vite/supporting-ts.md
+++ b/docs/src/pages/quasar-cli-vite/supporting-ts.md
@@ -19,6 +19,7 @@ Create `/tsconfig.json` file at the root of you project with this content:
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/docs/src/pages/quasar-cli-webpack/supporting-ts.md
+++ b/docs/src/pages/quasar-cli-webpack/supporting-ts.md
@@ -33,6 +33,7 @@ Then create `/tsconfig.json` file at the root of you project with this content:
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {
+    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -3,9 +3,8 @@
     "jsx": "preserve",
     "allowJs": true,
     "target": "esnext",
-    "module": "esnext",
+    "module": "nodenext",
     "skipLibCheck": true,
-    "moduleResolution": "node",
     "outDir": "./dist"
   },
   "include": ["./src/**/*"]


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

Minumum accepted TS version would be 5, since we'll use `bundler` option for `moduleResolution`

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

I tested Vite new preset on a couple of projects of ours and aside the problems I reported down there, which should be used as base for a migration guide, I didn't have other problems

---

TS reference suggests to avoid using `baseUrl` and rely on relative values for `path` option
This isn't possible in our case, since we ship default "paths" in the presets instead of the devland tsconfig
Using relative paths in the preset would cause the mapping to search types relatively to the preset tsconfig location and not the devland project folder
There doesn't seem to be another way to achieve this feature, and putting the paths back into the devland tsconfig would remove a good chunk of our flexibility to update those paths on the user behalf
Instead, I added comments to explain this where needed
We could remove "baseUrl" from jsconfig or older tsconfig from Qv1 which weren't using a tsconfig preset, but it doesn't really make sense changing something that's not broken

---

Switching to `bundler` option for `moduleResolution` breaks any kind of deep import, since it nows honors `exports` field in `package.json` when defined
Deep imports are still possible, but the dev needs to define an appropriate entry in `paths` option mapping to the deep import location into `node_modules` folder

E.g.

```json
{
  "compilerOptions": {
    "paths": {
      // ... other Quasar paths definition
      "cypress/types/net-stubbing": ["node_modules/cypress/types/net-stubbing"],
      "@vue/apollo-composable/dist/*": ["node_modules/@vue/apollo-composable/dist/*"]
    }
  }
}
```  

Additionally, `bundler` mode won't recognize CJS imports, thus any kind of CJS file, especially `quasar.conf.js` or `quasar.conf.cjs` in our case, isn't correctly interpreted by TS
I haven't tried, but I expect `quasar.conf.ts` or `quasar.conf.mjs` to work with this setup

---

I added a new version of the presets which is even stricter, and thus could not fit everyone

`useDefineForClassFields` in Vite tsconfig preset isn't needed, since it's true by default when `target` is `esnext` as it is.
This is true since [Vite 2.5 apparently](https://vitejs.dev/guide/features#usedefineforclassfields)

Regarding `target` option, it's actually ignored by Vite, so setting it to `esnext` is a good way to force `useDefineForClassFields` to true and accept any kind of new syntax and feature

For webpack, `target` is apparently used to [determine what to transpile](https://webpack.js.org/guides/typescript/#basic-setup), so I guess we should still keep it set to `es6`

From TS documentation:
> Setting this value to the lowest ECMAScript version that you intend to support ensures the emitted code will not use language features introduced in a later version. 