### PR TITLE
fix(create-quasar): remove comments from devland tsconfig

### DIFF
--- a/create-quasar/templates/app/quasar-v1/ts/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v1/ts/BASE/_tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@quasar/app/tsconfig-preset",
   "compilerOptions": {
-    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."<% if (sfcStyle === 'class') { %>,
     "experimentalDecorators": true<% } %><% if (preset.ie) { %>,
     "target": "es5"<% } %>

--- a/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/_tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
-    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@quasar/app-vite/tsconfig-preset",
   "compilerOptions": {
-      // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {
-    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_tsconfig.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@quasar/app-webpack/tsconfig-preset",
   "compilerOptions": {
-    // `baseUrl` should be set to the current folder to allow Quasar TypeScript preset to manage paths on your behalf
     "baseUrl": "."
   },
   "exclude": [

--- a/create-quasar/utils/index.js
+++ b/create-quasar/utils/index.js
@@ -90,6 +90,7 @@ function renderTemplate (relativePath, scope) {
       const template = compileTemplate(rawContent, { interpolate: /<%=([\s\S]+?)%>/g })
 
       const newContent = extension === '.json'
+        // This prevents us to add comments into JSONC files, like tsconfig ones
         ? JSON.stringify(JSON.parse(template(scope)), null, 2)
         : template(scope)
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

I noticed that JSON files are treated differently from other files from templates, going through a parse/stringify
I'm not sure why is it the case, as there isn't many info in the code and in the commit description, but I think this has been done to "format" the JSON file or to check its validity

Unfortunately this breaks new projects generation when a comment is present into a JSON file which is actually a JSONC (they cannot be distinguished by file extension), like tsconfig, even if it's a perfectly valid TS config file

Since I'm not sure what is that about, I just reverted the change adding the comments in the scaffolded tsconfigs