### PR TITLE
fix(app-webpack): fix TS linting problem due to hoisting in v3

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-3/BASE/_package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     <% if (preset.lint) { %>
-    "@typescript-eslint/eslint-plugin": "^5.10.0",
-    "@typescript-eslint/parser": "^5.10.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.0.0",
     <% if (lintConfig === 'standard') { %>
@@ -44,6 +44,20 @@
     <% } } %>
     "@types/node": "^12.20.21",
     "@quasar/app-webpack": "^3.13.0"
+  },
+  "overridesComments": {
+    "typescript-1": "npm and pnpm hoist newer version of TypeScript, which is incompatible with app-webpack v3 due to fork-ts-checker-webpack-plugin",
+    "typescript-2": "this hoisting of newer version of TypeScript breaks linting performed by @typescript-eslint packages",
+    "typescript-3": "yarn hoists the correct version of TypeScript, so we don't need to add a resolutions field",
+    "typescript-4": "app-webpack v4 doesn't use fork-ts-checker-webpack-plugin and thus supports newer versions of TypeScript"
+  },
+  "overrides": {
+    "typescript": "^4.9.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "typescript": "^4.9.5"
+    }
   },
   "browserslist": [
     "last 10 Chrome versions",


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This bumps some TS linting deps and force hoisting of pre-v5 TS version, which would otherwise cause problems when linting
This partially solve a couple problems with Jest AE reported vulnerabilities and peer dependencies problems