### PR TITLE
fix(ui): add role="list" to QList (fix: #17439)

### DIFF
--- a/ui/src/components/item/QList.js
+++ b/ui/src/components/item/QList.js
@@ -34,11 +34,7 @@ export default createComponent({
       + (props.padding === true ? ' q-list--padding' : '')
     )
 
-    const role = computed(() => {
-      if (props.tag === 'ul') return undefined
-      if (props.tag === 'ol') return undefined
-      return 'list'
-    })
+    const role = computed(() => props.tag === 'ul' || props.tag === 'ol' ? undefined : 'list')
 
     return () => h(props.tag, { class: classes.value, role: role.value }, hSlot(slots.default))
   }

--- a/ui/src/components/item/QList.js
+++ b/ui/src/components/item/QList.js
@@ -34,6 +34,12 @@ export default createComponent({
       + (props.padding === true ? ' q-list--padding' : '')
     )
 
-    return () => h(props.tag, { class: classes.value }, hSlot(slots.default))
+    const role = computed(() => {
+      if (props.tag === 'ul') return undefined
+      if (props.tag === 'ol') return undefined
+      return 'list'
+    })
+
+    return () => h(props.tag, { class: classes.value, role: role.value }, hSlot(slots.default))
   }
 })

--- a/ui/src/components/item/QList.test.js
+++ b/ui/src/components/item/QList.test.js
@@ -11,7 +11,6 @@ describe('[QList API]', () => {
 
         const target = wrapper.get('.q-list')
 
-        expect(target.element.getAttribute('role')).toBeDefined()
         expect(target.element.getAttribute('role')).toBe('list')
       })
 

--- a/ui/src/components/item/QList.test.js
+++ b/ui/src/components/item/QList.test.js
@@ -1,0 +1,171 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, test, expect } from 'vitest'
+
+import QList from './QList.js'
+
+describe('[QList API]', () => {
+  describe('[Props]', () => {
+    describe('[default attributes]', () => {
+      test('has a role="list" attribute with a div', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.element.getAttribute('role')).toBeDefined()
+        expect(target.element.getAttribute('role')).toBe('list')
+      })
+
+      test('does not have a role="list" attribute with a ol', async () => {
+        const wrapper = mount(QList, { props: { tag: 'ol' } })
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.element.getAttribute('role')).toBe(null)
+      })
+
+      test('does not have a role="list" attribute with a ul', async () => {
+        const wrapper = mount(QList, { props: { tag: 'ul' } })
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.element.getAttribute('role')).toBe(null)
+      })
+    })
+
+    describe('[(prop)bordered]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.classes()).not.toContain('q-list--bordered')
+
+        await wrapper.setProps({ bordered: true })
+        await flushPromises()
+
+        expect(target.classes()).toContain('q-list--bordered')
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.classes()).not.toContain('q-list--dense')
+
+        await wrapper.setProps({ dense: true })
+        await flushPromises()
+
+        expect(target.classes()).toContain('q-list--dense')
+      })
+    })
+
+    describe('[(prop)separator]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.classes()).not.toContain('q-list--separator')
+
+        await wrapper.setProps({ separator: true })
+        await flushPromises()
+
+        expect(target.classes()).toContain('q-list--separator')
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QList)
+        await wrapper.setProps({ dark: false })
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.classes()).not.toContain('q-list--dark')
+
+        await wrapper.setProps({ dark: true })
+        await flushPromises()
+
+        expect(target.classes()).toContain('q-list--dark')
+
+        await wrapper.setProps({ dark: false })
+        await wrapper.vm.$q.dark.set(true)
+        await flushPromises()
+
+        expect(target.classes()).not.toContain('q-list--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mount(QList)
+        await wrapper.vm.$q.dark.set(false)
+
+        const target = wrapper.get('.q-list')
+        expect(target.classes()).not.toContain('q-list--dark')
+
+        await wrapper.setProps({ dark: null })
+        await flushPromises()
+
+        expect(target.classes()).not.toContain('q-list--dark')
+
+        await wrapper.vm.$q.dark.set(true)
+
+        expect(target.classes()).toContain('q-list--dark')
+      })
+    })
+
+    describe('[(prop)padding]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(target.classes()).not.toContain('q-list--padding')
+
+        await wrapper.setProps({ padding: true })
+        await flushPromises()
+
+        expect(target.classes()).toContain('q-list--padding')
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mount(QList, { props: { tag: 'ol' } })
+
+        const target = wrapper.get('.q-list')
+
+        expect(
+          target.element.tagName.toLowerCase()
+        ).toBe('ol')
+      })
+
+      test('default tag is div', async () => {
+        const wrapper = mount(QList)
+
+        const target = wrapper.get('.q-list')
+
+        expect(
+          target.element.tagName.toLowerCase()
+        ).toBe('div')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QList, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/testing/README.md
+++ b/ui/testing/README.md
@@ -43,6 +43,9 @@ $ pnpm test:specs --target <target_file>
 # withOUT Vitest UI:
 $ pnpm test:watch
 
+# to watch only a specific file pattern
+$ pnpm test:watch "QList"
+
 # with Vitest UI:
 $ pnpm test:watch:ui
 ```


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

I also added some tests for the QList component. The QItem `role="listitem"` should be similarly conditional when using `li` as a tag, because then the listitem role is not necessary. But that could be a next PR.

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
