### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/app-vite/templates/store/vuex/ts/index.ts
+++ b/app-vite/templates/store/vuex/ts/index.ts
@@ -27,7 +27,7 @@ export interface StateInterface {
 }
 
 // provide typings for `this.$store`
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $store: VuexStore<StateInterface>
   }

--- a/app-webpack/templates/store/vuex/ts/index.ts
+++ b/app-webpack/templates/store/vuex/ts/index.ts
@@ -27,7 +27,7 @@ export interface StateInterface {
 }
 
 // provide typings for `this.$store`
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $store: VuexStore<StateInterface>
   }

--- a/create-quasar/templates/app/quasar-v2/ts-vite-1/axios/src/boot/axios.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-1/axios/src/boot/axios.ts
@@ -1,7 +1,7 @@
 import { boot } from 'quasar/wrappers';
 import axios, { AxiosInstance } from 'axios';
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $axios: AxiosInstance;
     $api: AxiosInstance;

--- a/create-quasar/templates/app/quasar-v2/ts-vite-1/vuex/src/store/index.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-1/vuex/src/store/index.ts
@@ -27,7 +27,7 @@ export interface StateInterface {
 }
 
 // provide typings for `this.$store`
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $store: VuexStore<StateInterface>
   }

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/axios/src/boot/axios.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/axios/src/boot/axios.ts
@@ -1,7 +1,7 @@
 import { boot } from 'quasar/wrappers';
 import axios, { AxiosInstance } from 'axios';
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $axios: AxiosInstance;
     $api: AxiosInstance;

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-3/axios/src/boot/axios.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-3/axios/src/boot/axios.ts
@@ -1,7 +1,7 @@
 import { boot } from 'quasar/wrappers';
 import axios, { AxiosInstance } from 'axios';
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $axios: AxiosInstance;
     $api: AxiosInstance;

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-3/vuex/src/store/index.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-3/vuex/src/store/index.ts
@@ -27,7 +27,7 @@ export interface StateInterface {
 }
 
 // provide typings for `this.$store`
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $store: VuexStore<StateInterface>
   }

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/axios/src/boot/axios.ts
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/axios/src/boot/axios.ts
@@ -1,7 +1,7 @@
 import { boot } from 'quasar/wrappers';
 import axios, { AxiosInstance } from 'axios';
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $axios: AxiosInstance;
     $api: AxiosInstance;

--- a/docs/src/pages/quasar-cli-vite/supporting-ts.md
+++ b/docs/src/pages/quasar-cli-vite/supporting-ts.md
@@ -253,7 +253,7 @@ export interface StateInterface {
 }
 
 // provide typings for `this.$store`
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $store: VuexStore<StateInterface>
   }

--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -465,7 +465,7 @@ interface MyUploaderProps extends QUploaderProps {
   onFreeze: boolean;
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface GlobalComponents {
     MyUploader: GlobalComponentConstructor<MyUploaderProps, QUploaderSlots>;
   }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

For a while, in the Vue ecosystem we've been augmenting `@vue/runtime-core` to add custom properties and more to `vue`. However, this inadvertently breaks the types for projects that augment `vue` - which is (now?) the officially recommended in the docs way to augment these interfaces (for example, [ComponentCustomProperties](https://vuejs.org/api/utility-types.html#componentcustomproperties), [GlobalComponents](https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript) and [so on](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)).

This means _all_ libraries must update their code (or it will break the types of the libraries that augment `vue` instead).

[Here's an example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQQTGOAXzgDMoIQ4ByANwFc0qAoJ5CAOwGd4N84BeFOiy58ACgSEAlCwD0suAAEYnALRoAHmDTIY6qOShwARhiOcAFhDoAbACYm0cGAE9tDjJ2owoDZmy54AH0MAC44djoQYzQjQV4wADoAkmAAc0S0mwhTGwAFcm1YYDRORNMoOQVlNU1tXX1DUggIOEtre0dnNzQPLyofP1YObjgg43DI6NiBOATkjlSMrJyMfMLYmBKykhaWOx0bMycQCDtbJ1o-RCY4OGB2bCgSDGQnAGEKSHY0R-e6bgUAoQIpbUo3O53XYQcKDNC3IhMQj7Q7HOCnc42S6KehoWS+R6gNCqNjoKgQ+6PWIvN5wT7gDi-GD-QEgYGg7YUu4VWG+eF3ZGEIA) of how the augmented types end up broken.

This PR is a small effort to ensure the ecosystem is consistent. For context, you can see that `vue-router` has [moved to do this](https://github.com/vuejs/router/pull/2295), as well as [Nuxt](https://github.com/nuxt/nuxt/pull/28542).
