### PR TITLE
fix(docs): change mouse events for QDrawer mini mode toggle

### DIFF
--- a/docs/src/examples/QDrawer/MiniMouseEvents.vue
+++ b/docs/src/examples/QDrawer/MiniMouseEvents.vue
@@ -13,8 +13,8 @@
         show-if-above
 
         :mini="miniState"
-        @mouseover="miniState = false"
-        @mouseout="miniState = true"
+        @mouseenter="miniState = false"
+        @mouseleave="miniState = true"
 
         :width="200"
         :breakpoint="500"


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

The example currently uses `mousein` and `mouseout` events. The problem is, that these events bubble and therefore toggle the mini-mode when moving the mouse between items in the drawer.

Reopen of #17440