### PR TITLE
fix(ui): IME composition detection not working

### DIFF
--- a/ui/src/composables/private.use-key-composition/use-key-composition.js
+++ b/ui/src/composables/private.use-key-composition/use-key-composition.js
@@ -1,10 +1,3 @@
-import { client } from '../../plugins/platform/Platform.js'
-
-const isJapanese = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]/
-const isChinese = /[\u4e00-\u9fff\u3400-\u4dbf\u{20000}-\u{2a6df}\u{2a700}-\u{2b73f}\u{2b740}-\u{2b81f}\u{2b820}-\u{2ceaf}\uf900-\ufaff\u3300-\u33ff\ufe30-\ufe4f\uf900-\ufaff\u{2f800}-\u{2fa1f}]/u
-const isKorean = /[\u3131-\u314e\u314f-\u3163\uac00-\ud7a3]/
-const isPlainText = /[a-z0-9_ -]$/i
-
 export default function (onInput) {
   return function onComposition (e) {
     if (e.type === 'compositionend' || e.type === 'change') {
@@ -12,18 +5,8 @@ export default function (onInput) {
       e.target.qComposing = false
       onInput(e)
     }
-    else if (
-      e.type === 'compositionupdate'
-      && e.target.qComposing !== true
-      && typeof e.data === 'string'
-    ) {
-      const isComposing = client.is.firefox === true
-        ? isPlainText.test(e.data) === false
-        : isJapanese.test(e.data) === true || isChinese.test(e.data) === true || isKorean.test(e.data) === true
-
-      if (isComposing === true) {
-        e.target.qComposing = true
-      }
+    else if (e.type === 'compositionstart') {
+      e.target.qComposing = true
     }
   }
 }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Fix the issue where QInput & QSelect updates model-value during the IME composition process.

Previously, the code detected `e.data` and set qComposing to true only when a CJK character was detected. This might work in some IMEs, but it at least doesn't work in my environment (Windows' default Microsoft Pinyin IME), as during composition, `e.data` contains the original key characters instead of CJK characters:
![image](https://github.com/user-attachments/assets/cfc1c6ec-10a7-4e6c-a5eb-f573de9b9791)


To fix this, simply use `compositionstart` and `compositionend`, just like the [official Vue v-model implementation](https://github.com/vuejs/core/blob/d298c431cc422b53cf4e9c69bf1daf926c33b6e0/packages/runtime-dom/src/directives/vModel.ts#L28).

After making the modification, I tested it, and it works well.