### PR TITLE
fix(ui): allow Font Awesome fa-classic in QIcon (fix: #17483)

### DIFF
--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -42,7 +42,7 @@ const mRE = /^[Mm]\s?[-+]?\.?\d/
 const imgRE = /^img:/
 const svgUseRE = /^svguse:/
 const ionRE = /^ion-/
-const faRE = /^(fa-(sharp|solid|regular|light|brands|duotone|thin)|[lf]a[srlbdk]?) /
+const faRE = /^(fa-(classic|sharp|solid|regular|light|brands|duotone|thin)|[lf]a[srlbdk]?) /
 
 export default createComponent({
   name: 'QIcon',


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The valid Font Awesome v6 class 'fa-classic' causes the QIcon component to render incorrectly.

For example:
 `<q-icon name="fa-classic fa-regular fa-calendar-days" size="5rem" />`
Will render:
`<i class="q-icon notranslate material-icons" aria-hidden="true" role="presentation" style="font-size: 5rem;">fa-classic fa-regular fa-calendar-days</i>`

Without the 'fa-classic' class it will render correctly.

For example:
 `<q-icon name="fa-regular fa-calendar-days" size="5rem" />`
Will render:
`<i class="q-icon fa-regular fa-calendar-days" aria-hidden="true" role="presentation" style="font-size: 5rem;"> </i>`

This pull request fixes this issue by adding 'classic' to the Font Awsome regex validation in QIcon.
`const faRE = /^(fa-(classic|sharp|solid|regular|light|brands|duotone|thin)|[lf]a[srlbdk]?) / `


