### PR TITLE
fix(QTabPanels): tab-panels 'transition' emit fires before transition ends (fix #17479).

### DIFF
--- a/ui/src/composables/private.use-panel/use-panel.js
+++ b/ui/src/composables/private.use-panel/use-panel.js
@@ -117,9 +117,11 @@ export default function () {
     if (panelIndex.value !== index) {
       panelIndex.value = index
       emit('beforeTransition', newVal, oldVal)
-      nextTick(() => {
-        emit('transition', newVal, oldVal)
-      })
+      setTimeout(() => {
+        nextTick(() => {
+          emit('transition', newVal, oldVal)
+        })
+      }, props.transitionDuration);
     }
   })
 


### PR DESCRIPTION
Resolves #17479 
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The docs in `QTabPanels` state for the `@transition`:
"Emitted after component transitioned to a new panel"

The source code has a `nextTick` before emitting this, but this does not wait for the transition to finish.
My proposed fix is adding a simple `setTimeout` *before* the `nextTick`, with a duration equal to the `transitionDuration`.

I have given this some thought as to how it could be more robust(maybe with a composable, alongside other transition functionalities), but ultimately i think just using a timeout here is the most straightforward way.

If the team decides that this is not a good way to approach this and has something else in mind, i would be willing to help to close this PR.