### PR TITLE
Add backgroundSize property to uploader

### DIFF
--- a/ui/src/components/uploader/QUploader.json
+++ b/ui/src/components/uploader/QUploader.json
@@ -55,6 +55,14 @@
       "category": "behavior"
     },
 
+    "background-size": {
+      "type": "String",
+      "desc": "How the thumbnail image will fit into the container; Equivalent of the background-size prop;",
+      "default": "'cover'",
+      "examples": [ "'cover'", "'contain'", "'auto'", "'50%'" ],
+      "category": "style"
+    },
+
     "disable": {
       "extends": "disable"
     },

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -34,7 +34,10 @@ export const coreProps = {
   noThumbnails: Boolean,
   autoUpload: Boolean,
   hideUploadBtn: Boolean,
-
+  backgroundSize: {
+    type: String,
+    default: 'cover'
+  },
   disable: Boolean,
   readonly: Boolean
 }
@@ -389,7 +392,7 @@ export function getRenderer (getPlugin, expose) {
             : (file.__status === 'uploaded' ? ' q-uploader__file--uploaded' : '')
         ),
       style: props.noThumbnails !== true && file.__img !== void 0
-        ? { backgroundImage: 'url("' + file.__img.src + '")' }
+        ? { backgroundImage: 'url("' + file.__img.src + '")', backgroundSize: props.backgroundSize }
         : null
     }, [
       h('div', {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
The current uploader thumbnails only show the images in "cover" mode.  This shows a fraction of the image preview.  This PR adds the ability to set a custom CSS background size for the thumbnail images, while defaulting to the current behavior.