### PR TITLE
feat(ui) Add new prop 'option-data-id' to QSelect

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -124,7 +124,8 @@ export default createComponent({
     virtualScrollItemSize: useVirtualScrollProps.virtualScrollItemSize.type,
 
     onNewValue: Function,
-    onFilter: Function
+    onFilter: Function,
+    optionDataId: [ String, Function ]
   },
 
   emits: [
@@ -341,6 +342,9 @@ export default createComponent({
           onClick: () => { toggleOption(opt) }
         }
 
+        if (props.optionDataId) {
+          itemProps[ 'data-id' ] = typeof props.optionDataId === 'string' ? `${ props.optionDataId }-${ i }` : props.optionDataId(opt)
+        }
         if (disable !== true) {
           optionIndex.value === index && (itemProps.focused = true)
 

--- a/ui/src/components/select/QSelect.json
+++ b/ui/src/components/select/QSelect.json
@@ -186,6 +186,30 @@
       "category": "options"
     },
 
+    "option-data-id": {
+      "type": [ "String", "Function" ],
+      "desc": "Add a 'data-id'-attribute to the option elements",
+      "params": {
+        "option": {
+          "type": [ "String", "Object" ],
+          "desc": "The current option being processed",
+          "examples": [
+            "'Tesla'",
+            "'iPhone'",
+            "{ label: 'Tesla', value: 'car' }"
+          ]
+        }
+      },
+      "returns": {
+        "type": "String",
+        "desc": "Use for custom data-id values"
+      },
+      "examples": [
+        "opt => (opt.value || opt).toLowerCase()"
+      ],
+      "category": "options"
+    },
+
     "menu-anchor": {
       "type": "String",
       "desc": "Two values setting the starting position or anchor point of the options list relative to the field (only in menu mode)",


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Currently, there is no easy way to find a specific option (e.g. using querySelector / in automated tests).
This PR adds the option to set a custom data-id attribute to the option-elements, making them easy to query.
