### PR TITLE
Add Total file build size to summary

### DIFF
--- a/app-vite/lib/utils/print-build-summary.js
+++ b/app-vite/lib/utils/print-build-summary.js
@@ -51,13 +51,28 @@ function getGzippedSize (file) {
 }
 
 function getTableLines (assets, showGzipped) {
-  return assets.map(asset => {
+  const totalSize = {
+    js: [
+      colorFn["js"]('Total JS file size: '),
+      0,
+    ],
+    css: [
+      colorFn["css"]('Total CSS file size: '),
+      0,
+    ],
+  };
+
+  const tableLines = assets.map(asset => {
     const dir = dirname(asset.name)
 
     const acc = [
       (dir !== '.' ? gray(dir + '/') : '') + colorFn[ asset.type ](basename(asset.name)),
       getHumanSize(asset.size)
     ]
+
+    if (['js', 'css'].includes(asset.type)) {
+      totalSize[ asset.type ][1] += asset.size
+    }
 
     if (showGzipped === true) {
       acc.push(
@@ -69,6 +84,19 @@ function getTableLines (assets, showGzipped) {
 
     return acc
   })
+
+  totalSize['js'][1] = getHumanSize(totalSize['js'][1]);
+  totalSize['css'][1] = getHumanSize(totalSize['css'][1]);
+
+  if (showGzipped === true) {
+    totalSize['js'][2] = '-';
+    totalSize['css'][2] = '-';
+  }
+
+  tableLines.push(totalSize.js);
+  tableLines.push(totalSize.css);
+
+  return tableLines;
 }
 
 function getTableIndexDelimiters (assets) {
@@ -89,6 +117,8 @@ export function printBuildSummary (distDir, showGzipped) {
   const assets = getAssets(distDir)
   const tableLines = getTableLines(assets, showGzipped)
   const tableIndexDelimiters = getTableIndexDelimiters(assets)
+
+  tableIndexDelimiters.push(tableLines.length + 1);
 
   const header = [
     underline('Asset'),

--- a/app-vite/lib/utils/print-build-summary.js
+++ b/app-vite/lib/utils/print-build-summary.js
@@ -89,12 +89,12 @@ function getTableLines (assets, showGzipped) {
   totalSize['css'][1] = getHumanSize(totalSize['css'][1]);
 
   if (showGzipped === true) {
-    totalSize['js'][2] = '-';
-    totalSize['css'][2] = '-';
+    totalSize['js'][2] = '-'
+    totalSize['css'][2] = '-'
   }
 
-  tableLines.push(totalSize.js);
-  tableLines.push(totalSize.css);
+  tableLines.push(totalSize.js)
+  tableLines.push(totalSize.css)
 
   return tableLines;
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

It's just add the total file size for JS and CSS files generated by "quasar build" command. 
This is usefully (in my opinion).


![image](https://github.com/user-attachments/assets/c4a74cff-41fa-4220-98f6-882f5e4e9d47)
