### PR TITLE
feat(app-vite): use sass-embedded

### DIFF
--- a/app-vite/lib/config-tools.js
+++ b/app-vite/lib/config-tools.js
@@ -121,6 +121,9 @@ export async function createViteConfig (quasarConf, { compileId }) {
     build.viteVuePluginOptions
   )
 
+  /**
+   * @type {import('vite').UserConfig}
+   */
   const viteConf = {
     configFile: false,
     root: appPaths.appDir,
@@ -140,6 +143,18 @@ export async function createViteConfig (quasarConf, { compileId }) {
 
     resolve: {
       alias: build.alias
+    },
+
+    css: {
+      preprocessorOptions: {
+        // Vite defaults to 'legacy' which produce warnings
+        sass: {
+          api: 'modern'
+        },
+        scss: {
+          api: 'modern'
+        }
+      }
     },
 
     build: {

--- a/app-vite/lib/config-tools.js
+++ b/app-vite/lib/config-tools.js
@@ -147,12 +147,12 @@ export async function createViteConfig (quasarConf, { compileId }) {
 
     css: {
       preprocessorOptions: {
-        // Vite defaults to 'legacy' which produce warnings
+        // Use sass-embedded for better stability and performance
         sass: {
-          api: 'modern'
+          api: 'modern-compiler'
         },
         scss: {
-          api: 'modern'
+          api: 'modern-compiler'
         }
       }
     },

--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -77,7 +77,7 @@
     "minimist": "^1.2.8",
     "open": "^10.1.0",
     "rollup-plugin-visualizer": "^5.12.0",
-    "sass": "^1.78.0",
+    "sass-embedded": "^1.79.1",
     "semver": "^7.6.3",
     "serialize-javascript": "^6.0.2",
     "ts-essentials": "^9.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^5.12.0
         version: 5.12.0(rollup@2.79.1)
-      sass:
-        specifier: ^1.78.0
+      sass-embedded:
+        specifier: ^1.79.1
         version: 1.79.1
       semver:
         specifier: ^7.6.3


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- Maybe: if the system doesn't use Dart. There shouldn't be many systems out there that don't support Dart. See the system requirements [here](https://dart.dev/get-dart).

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Vite was defaulting to the `legacy` API which now produces warnings, see #17518. We decided to skip `modern` and directly go to `modern-compiler` which uses `sass-embedded`. It should have better performance.