### PR TITLE
feat(ui): add input event to QInput

### DIFF
--- a/ui/playground/src/pages/form/input.vue
+++ b/ui/playground/src/pages/form/input.vue
@@ -24,6 +24,11 @@
       <q-input class="gigi" v-bind="props" outlined :model-value="text" @change="val => { text = val }" label="Label" label-color="green" />
 
       <div class="text-h6">
+        Always (@input)
+      </div>
+      <q-input class="gigi" v-bind="props" outlined :model-value="text" @input="val => { text = val }" label="Label" label-color="green" />
+
+      <div class="text-h6">
         Standard
       </div>
 

--- a/ui/playground/src/pages/form/select-part-7-text.vue
+++ b/ui/playground/src/pages/form/select-part-7-text.vue
@@ -23,7 +23,7 @@
         fill-input
         hide-selected
         @filter="filterOptions"
-        @update:model-value-value="val => { model = val }"
+        @update:model-value="val => { model = val }"
       >
         <template v-slot:no-option>
           <q-item>

--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -43,7 +43,7 @@ export default createComponent({
 
   emits: [
     ...useFieldEmits,
-    'paste', 'change',
+    'paste', 'change', 'input',
     'keydown', 'click', 'animationend'
   ],
 
@@ -71,7 +71,7 @@ export default createComponent({
 
     const onComposition = useKeyComposition(onInput)
 
-    const state = useFieldState({ changeEvent: true })
+    const state = useFieldState({ changeEvent: true, inputEvent: true })
 
     const isTextarea = computed(() =>
       props.type === 'textarea' || props.autogrow === true
@@ -225,21 +225,22 @@ export default createComponent({
 
       if (props.type === 'file') {
         emit('update:modelValue', e.target.files)
+        emit('input', e.target.files)
         return
       }
 
       const val = e.target.value
 
-      if (e.target.qComposing === true) {
-        temp.value = val
-
-        return
-      }
-
       if (hasMask.value === true) {
         updateMaskValue(val, false, e.inputType)
       }
       else {
+        if (e.target.qComposing === true) {
+          temp.value = val
+          emit('input', val)
+
+          return
+        }
         emitValue(val)
 
         if (isTypeText.value === true && e.target === document.activeElement) {
@@ -266,6 +267,8 @@ export default createComponent({
     }
 
     function emitValue (val, stopWatcher) {
+      emit('input', val)
+
       emitValueFn = () => {
         emitTimer = null
 

--- a/ui/src/components/input/QInput.json
+++ b/ui/src/components/input/QInput.json
@@ -85,6 +85,16 @@
         }
       }
     },
+    "input": {
+      "desc": "Emitted when inputs new value; Also emitted during IME composition process; No debounce",
+      "params": {
+        "value": {
+          "type": [ "String", "null" ],
+          "desc": "New input value",
+          "required": true
+        }
+      }
+    },
 
     "click": { "internal": true },
     "paste": { "internal": true },

--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -71,7 +71,7 @@ export const useFieldProps = {
 
 export const useFieldEmits = [ 'update:modelValue', 'clear', 'focus', 'blur' ]
 
-export function useFieldState ({ requiredForAttr = true, tagProp, changeEvent = false } = {}) {
+export function useFieldState ({ requiredForAttr = true, tagProp, changeEvent = false, inputEvent = false } = {}) {
   const { props, proxy } = getCurrentInstance()
 
   const isDark = useDark(props, proxy.$q)
@@ -83,6 +83,7 @@ export function useFieldState ({ requiredForAttr = true, tagProp, changeEvent = 
   return {
     requiredForAttr,
     changeEvent,
+    inputEvent,
     tag: tagProp === true
       ? computed(() => props.tag)
       : { value: 'label' },
@@ -345,6 +346,7 @@ export default function (state) {
 
     emit('update:modelValue', null)
     state.changeEvent === true && emit('change', null)
+    state.inputEvent === true && emit('input', null)
     emit('clear', props.modelValue)
 
     nextTick(() => {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Due to IME composition detection, `model-value` of QInput does not update during the IME composition process. However, there are times when we want to handle input during the IME composition process. (referring PR #17476 ) Therefore, `input` event has been added:

- Emitted during input, even during IME composition.
- No debounce.

The corresponding event was not added on QSelect because the native input event can be directly listened to on QSelect.

Additionally, a bug in select-part-7-text.vue in the playground has been fixed.
