### PR TITLE
fix(ui): allow number[] in QSlider markerLabels type (fix: #17450)

### DIFF
--- a/ui/types/api/slider.d.ts
+++ b/ui/types/api/slider.d.ts
@@ -26,7 +26,8 @@ interface SliderMarkerLabelObjectDefinition {
 
 export type SliderMarkerLabels =
   | boolean
-  | Array<SliderMarkerLabelDefinitionRequiredValue>
+  // using a number is shorthand for { value: number }
+  | (SliderMarkerLabelDefinitionRequiredValue | number)[]
   | SliderMarkerLabelObjectDefinition
   | ((value: number) => string | SliderMarkerLabelDefinition);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?** <!-- Check one -->

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #17450