### PR TITLE
Add tip on `cypress.config.ts` to testing-and-auditing documentation

### DIFF
--- a/docs/src/pages/quasar-cli-vite/testing-and-auditing.md
+++ b/docs/src/pages/quasar-cli-vite/testing-and-auditing.md
@@ -35,6 +35,24 @@ If you ever need to review your installation choices you can take a look at `qua
 
 > Note that we previously suggested to use `@quasar/testing` AE to manage all testing harnesses in a project. This is no longer the case, as [it is now deprecated](https://github.com/quasarframework/quasar-testing/tree/dev/packages/testing/README.md#DEPRECATION-NOTICE). Please use the above commands instead.
 
+> [!TIP]
+> If using both Cypress and Jest/Vitest, you may need to exclude `cypress.config.ts` in your `tsconfig.json`:
+> ```jsonc
+> {
+>   // [...]
+>   "exclude": [
+>     "./dist",
+>     "./.quasar",
+>     "./node_modules",
+>     "./src-capacitor",
+>     "./src-cordova",
+>     "./quasar.config.*.temporary.compiled*",
+>     // https://stackoverflow.com/a/72663546/1424662
+>     "./cypress.config.ts"
+>   ]
+> }
+> ```
+
 ## Further Reading
 
 ### Books


### PR DESCRIPTION
If you use both Cypress and another testing framework that implements `expect` and other common keywords, you may need to exclude `cypress.config.ts` from your `tsconfig.json` to prevent ESLint from getting confused.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
