### PR TITLE
fix(ui): fix File-based types for q-upload and q-file (fix: #17605)

### DIFF
--- a/ui/build/build.types.js
+++ b/ui/build/build.types.js
@@ -220,7 +220,8 @@ function copyPredefinedTypes (dir, parentDir) {
 
 // Add types that should not be imported from ./api, but rather defined globally or generated in the final index.d.ts
 const extraInterfaceExclusions = [
-  'IntersectionObserverEntry'
+  'IntersectionObserverEntry',
+  'File'
 ]
 function addToExtraInterfaces (def) {
   if (def !== void 0 && def !== null && def.tsType !== void 0) {

--- a/ui/src/components/file/QFile.json
+++ b/ui/src/components/file/QFile.json
@@ -125,7 +125,8 @@
       "desc": "Override default selection slot; Suggestion: QChip",
       "scope": {
         "files": {
-          "type": [ "Array", "FileList" ],
+          "type": "Array",
+          "tsType": "File",
           "desc": "Array of File objects"
         },
 

--- a/ui/src/components/uploader/QUploader.json
+++ b/ui/src/components/uploader/QUploader.json
@@ -212,18 +212,6 @@
         }
       },
       "returns": null
-    },
-
-    "addFiles": {
-      "desc": "Manually add files to the queue",
-      "params": {
-        "files": {
-          "type": "Array",
-          "required": true,
-          "desc": "Must be an array of instances of JS File type"
-        }
-      },
-      "returns": null
     }
   },
 

--- a/ui/src/composables/private.use-file/use-file.json
+++ b/ui/src/composables/private.use-file/use-file.json
@@ -44,12 +44,14 @@
       "desc": "Custom filter for added files; Only files that pass this filter will be added to the queue and uploaded; For best performance, reference it from your scope and do not define it inline",
       "params": {
         "files": {
-          "type": [ "Array", "FileList" ],
+          "type": "Array",
+          "tsType": "File",
           "desc": "Candidate files to be added to queue"
         }
       },
       "returns": {
         "type": "Array",
+        "tsType": "File",
         "desc": "Filtered files to be added to queue"
       },
       "examples": [ "files => files.filter(file => file.size === 1024)" ],
@@ -86,7 +88,7 @@
       "params": {
         "files": {
           "type": [ "Array", "FileList" ],
-          "desc": "Array of files (instances of File)",
+          "desc": "Array of files (instances of File) or FileList",
           "required": true
         }
       },

--- a/ui/src/composables/private.use-file/use-file.json
+++ b/ui/src/composables/private.use-file/use-file.json
@@ -88,6 +88,7 @@
       "params": {
         "files": {
           "type": [ "Array", "FileList" ],
+          "tsType": "QUseFileAddInput",
           "desc": "Array of files (instances of File) or FileList",
           "required": true
         }

--- a/ui/types/api/qfile.d.ts
+++ b/ui/types/api/qfile.d.ts
@@ -13,3 +13,5 @@ export type QFileNativeElement = Omit<
   Omit<HTMLInputElement, "files"> & { files: FileList },
   "type"
 > & { type: "file" };
+
+export type QUseFileAddInput = readonly File[] | FileList;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #17605 but contains more fixes on top.
Extra note for some fixes: we accept `FileList` in inputs, but we maintain the state with `File[]` only. So, methods accept file lists, but computed properties, callback params, etc. are only file arrays.