### PR TITLE
Fix broken links to Chrome DevTools Remote Debugging in Cordova/Capacitor troubleshooting and tips pages

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/troubleshooting-and-tips.md
@@ -10,7 +10,7 @@ While you are developing a Mobile App with Capacitor Mode, you can access `$q.ca
 
 ### Android remote debugging
 
-If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developers.google.com/web/tools/chrome-devtools/debug/remote-debugging/remote-debugging?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
+If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
 
 This way you have Chrome Dev Tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
@@ -9,7 +9,7 @@ While you are developing a Mobile App with Cordova Mode, you can access `$q.cord
 ## Android Tips
 
 ### Android remote debugging
-If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developers.google.com/web/tools/chrome-devtools/debug/remote-debugging/remote-debugging?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
+If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
 
 This way you have Chrome Dev Tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
 

--- a/docs/src/pages/quasar-cli-webpack/developing-capacitor-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-capacitor-apps/troubleshooting-and-tips.md
@@ -10,7 +10,7 @@ While you are developing a Mobile App with Capacitor Mode, you can access `$q.ca
 
 ### Android remote debugging
 
-If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developers.google.com/web/tools/chrome-devtools/debug/remote-debugging/remote-debugging?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
+If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
 
 This way you have Chrome Dev Tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
 

--- a/docs/src/pages/quasar-cli-webpack/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-cordova-apps/troubleshooting-and-tips.md
@@ -9,7 +9,7 @@ While you are developing a Mobile App with Cordova Mode, you can access `$q.cord
 ## Android Tips
 
 ### Android remote debugging
-If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developers.google.com/web/tools/chrome-devtools/debug/remote-debugging/remote-debugging?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
+If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
 
 This way you have Chrome Dev Tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
This PR only fixes a broken link to Chrome DevTools Remove Debugging docs in the documentation on the following pages:
- Quasar CLI (with Vite) > Developing Mobile Apps > Capacitor mode
- Quasar CLI (with Vite) > Developing Mobile Apps > Cordova mode
- Quasar CLI (with Webpack) > Developing Mobile Apps > Capacitor mode
- Quasar CLI (with Webpack) > Developing Mobile Apps > Cordova mode