### PR TITLE
fix(create-quasar, docs): lint command

### DIFF
--- a/create-quasar/templates/app/quasar-v2/js-vite-2/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/js-vite-2/BASE/_package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js './src*/**/*.{js,cjs,mjs,vue}'",<% } %>
+    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",<% } %>
     <% if (prettier) { %>"format": "prettier --write \"**/*.{js,vue<% if (css !== 'sass') { %>,<%= css %><% } %>,html,md,json}\" --ignore-path .gitignore",<% } %>
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",

--- a/create-quasar/templates/app/quasar-v2/js-webpack-4/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/js-webpack-4/BASE/_package.json
@@ -7,7 +7,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js './src*/**/*.{js,cjs,mjs,vue}'",<% } %>
+    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",<% } %>
     <% if (prettier) { %>"format": "prettier --write \"**/*.{js,vue<% if (css !== 'sass') { %>,<%= css %><% } %>,html,md,json}\" --ignore-path .gitignore",<% } %>
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/_package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js './src*/**/*.{ts,js,cjs,mjs,vue}'",<% } %>
+    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\"",<% } %>
     <% if (prettier) { %>"format": "prettier --write \"**/*.{js,ts,vue,<% if (css !== 'sass') { %><%= css %><% } %>,html,md,json}\" --ignore-path .gitignore",<% } %>
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_package.json
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/_package.json
@@ -7,7 +7,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js './src*/**/*.{ts,js,cjs,mjs,vue}'",<% } %>
+    <% if (preset.eslint) { %>"lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\"",<% } %>
     <% if (prettier) { %>"format": "prettier --write \"**/*.{js,ts,vue,<% if (css !== 'sass') { %><%= css %><% } %>,html,md,json}\" --ignore-path .gitignore",<% } %>
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",

--- a/docs/src/pages/quasar-cli-vite/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/upgrade-guide.md
@@ -232,9 +232,9 @@ Preparations:
   -  "lint": "eslint --ext .js,.ts,.vue ./"
 
   // for non-TS projects:
-  +  "lint": "lint": "eslint -c ./eslint.config.js './src*/**/*.{js,cjs,mjs,vue}'"
+  +  "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\""
   // for TS projects:
-  +  "lint": "lint": "eslint -c ./eslint.config.js './src*/**/*.{ts,js,cjs,mjs,vue}'"
+  +  "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\""
   }
   ```
   <br>

--- a/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
@@ -211,9 +211,9 @@ Preparations:
   -  "lint": "eslint --ext .js,.ts,.vue ./"
 
   // for non-TS projects:
-  +  "lint": "lint": "eslint -c ./eslint.config.js './src*/**/*.{js,cjs,mjs,vue}'"
+  +  "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\""
   // for TS projects:
-  +  "lint": "lint": "eslint -c ./eslint.config.js './src*/**/*.{ts,js,cjs,mjs,vue}'"
+  +  "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\""
   }
   ```
   <br>


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

fix: #17688 

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

fix: #17688 

This PR fixes the command that results in an error that occurs on Windows when running `lint` with the new quasar/app-vite >v2.

```
npm run lint

> quasar-project@0.0.1 lint
> eslint -c ./eslint.config.js './src*/**/*.{ts,js,cjs,mjs,vue}'


Oops! Something went wrong! :(

ESLint: 9.16.0

No files matching the pattern "'./src*/**/*.{ts,js,cjs,mjs,vue}'" were found.
Please check for typing mistakes in the pattern.
```

It fixes the template as well as the migration guide in the docs. Runs well in git bash, PowerShell, cmd and WSL.
The fix is just using escaped quotes instead of the apostrophe for the lint command, as is used in the format command.
