### PR TITLE
Remove '.native' modifier as it's deprecated

### DIFF
--- a/docs/src/pages/vue-components/editor.md
+++ b/docs/src/pages/vue-components/editor.md
@@ -142,8 +142,8 @@ Pasting from the buffer and drag & dropping images into the editor is unfortunat
 ```html
 <q-editor
   v-model="editor"
-  @paste.native="evt => pasteCapture(evt)"
-  @drop.native="evt => dropCapture(evt)"
+  @paste="evt => pasteCapture(evt)"
+  @drop="evt => dropCapture(evt)"
  />
 ```
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**Other information:**

Vue 3 improved event handling and the `.native` modifier is no longer required. Instead, we can directly bind these events.
