### PR TITLE
fix(ui): set viewport meta to satisfy WCAG AA (fix: #17031)

### DIFF
--- a/app-vite/templates/capacitor/www/index.html
+++ b/app-vite/templates/capacitor/www/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Quasar Capacitor App">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, viewport-fit=cover">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width, viewport-fit=cover">
 
     <style>
       .page {

--- a/app-vite/templates/cordova/www/index.html
+++ b/app-vite/templates/cordova/www/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Quasar Capacitor App">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, viewport-fit=cover">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width, viewport-fit=cover">
 
     <style>
       .page {

--- a/app-webpack/templates/capacitor/www/index.html
+++ b/app-webpack/templates/capacitor/www/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Quasar Capacitor App">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, viewport-fit=cover">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width, viewport-fit=cover">
 
     <style>
       .page {

--- a/app-webpack/templates/cordova/www/index.html
+++ b/app-webpack/templates/cordova/www/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Quasar Capacitor App">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, viewport-fit=cover">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width, viewport-fit=cover">
 
     <style>
       .page {

--- a/create-quasar/templates/app-extension/ae-ts/BASE/playground/quasar-cli-vite/index.html
+++ b/create-quasar/templates/app-extension/ae-ts/BASE/playground/quasar-cli-vite/index.html
@@ -9,7 +9,7 @@
     <meta name="msapplication-tap-highlight" content="no" />
     <meta
       name="viewport"
-      content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>"
+      content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>"
     />
 
     <link

--- a/create-quasar/templates/app-extension/ae-ts/BASE/playground/quasar-cli-webpack/index.html
+++ b/create-quasar/templates/app-extension/ae-ts/BASE/playground/quasar-cli-webpack/index.html
@@ -9,7 +9,7 @@
     <meta name="msapplication-tap-highlight" content="no" />
     <meta
       name="viewport"
-      content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>"
+      content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>"
     />
 
     <link

--- a/create-quasar/templates/app/quasar-v1/js/BASE/src/index.template.html
+++ b/create-quasar/templates/app/quasar-v1/js/BASE/src/index.template.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover \<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover \<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v1/ts/BASE/src/index.template.html
+++ b/create-quasar/templates/app/quasar-v1/ts/BASE/src/index.template.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover \<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover \<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/js-vite-1/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/js-vite-1/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/js-vite-2/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/js-vite-2/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/js-webpack-3/BASE/src/index.template.html
+++ b/create-quasar/templates/app/quasar-v2/js-webpack-3/BASE/src/index.template.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/js-webpack-4/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/js-webpack-4/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-1/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/index.html
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/BASE/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= '\<%= productDescription %\>' %>">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, maximum-scale=5, width=device-width<%= '\<% if (ctx.mode.cordova || ctx.mode.capacitor) { %\>, viewport-fit=cover\<% } %\>' %>">
 
     <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
     <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Fix issue related WCAG 2.1 AA guideline 1.4.4

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

The following PR introduce a change to the viewport meta in all the templates used to create the structure of a new Quasar project, according to WCAG 2.1 guidelines.

In particular, guideline 1.4.4 states the following:

> Except for [captions](https://www.w3.org/TR/WCAG21/#dfn-captions) and [images of text](https://www.w3.org/TR/WCAG21/#dfn-images-of-text), [text](https://www.w3.org/TR/WCAG21/#dfn-text) can be resized without [assistive technology](https://www.w3.org/TR/WCAG21/#dfn-assistive-technologies) up to 200 percent without loss of content or functionality.

I set the values of user_scalable and maximum_scale accordingly to [Viewport MDN guide](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics)

Thanks to these changes now the accessibility test related to this feature will pass

Fixes https://github.com/quasarframework/quasar/issues/17031