### PR TITLE
feat(app-vite): preserve JSON config file formatting when updating (fix: #16808)

### DIFF
--- a/app-vite/lib/app-extension/create-app-ext.js
+++ b/app-vite/lib/app-extension/create-app-ext.js
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { merge } from 'webpack-merge'
+import { parseJSON, stringifyJSON } from 'confbox'
 
 import { log, fatal } from '../utils/logger.js'
 import { AppExtensionInstance } from './AppExtensionInstance.js'
@@ -10,7 +11,7 @@ function readJson (file) {
   }
 
   try {
-    return JSON.parse(
+    return parseJSON(
       readFileSync(file, 'utf-8')
     )
   }
@@ -21,10 +22,13 @@ function readJson (file) {
 }
 
 function getAppExtJson ({ file, json, onListUpdate }) {
+  const fileExists = Object.keys(json).length > 0
+
   function save () {
     writeFileSync(
       file,
-      JSON.stringify(json, null, 2),
+      // if file exists, preserve indentation, otherwise use 2 spaces
+      stringifyJSON(json, { indent: fileExists ? undefined : 2 }),
       'utf-8'
     )
   }

--- a/app-vite/lib/modes/capacitor/config-file.js
+++ b/app-vite/lib/modes/capacitor/config-file.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { globSync } from 'tinyglobby'
+import { parseJSON, stringifyJSON } from 'confbox'
 
 import { log, warn } from '../../utils/logger.js'
 import { ensureConsistency } from './ensure-consistency.js'
@@ -74,8 +75,9 @@ export class CapacitorConfigFile {
 
     this.#tamperedFiles = []
 
+    // TODO: support other formats: .js and .ts
     const capJsonPath = appPaths.resolve.capacitor('capacitor.config.json')
-    const capJson = JSON.parse(
+    const capJson = parseJSON(
       fs.readFileSync(capJsonPath, 'utf-8')
     )
 
@@ -85,7 +87,7 @@ export class CapacitorConfigFile {
       path: capJsonPath,
       name: 'capacitor.config.json',
       content: this.#updateCapJson(quasarConf, capJson, capVersion, target),
-      originalContent: JSON.stringify(capJson, null, 2)
+      originalContent: stringifyJSON(capJson)
     })
 
     this.#save()
@@ -137,7 +139,7 @@ export class CapacitorConfigFile {
       }
     }
 
-    return JSON.stringify(capJson, null, 2)
+    return stringifyJSON(capJson)
   }
 
   #updateCapPkg (quasarConf) {
@@ -147,7 +149,7 @@ export class CapacitorConfigFile {
     } = this.#ctx
 
     const capPkgPath = appPaths.resolve.capacitor('package.json')
-    const capPkg = JSON.parse(
+    const capPkg = parseJSON(
       fs.readFileSync(capPkgPath, 'utf-8')
     )
 
@@ -158,7 +160,7 @@ export class CapacitorConfigFile {
       author: appPkg.author
     })
 
-    fs.writeFileSync(capPkgPath, JSON.stringify(capPkg, null, 2), 'utf-8')
+    fs.writeFileSync(capPkgPath, stringifyJSON(capPkg), 'utf-8')
   }
 
   async #updateSSL (quasarConf, target, capVersion) {

--- a/app-vite/lib/modes/ssr/ssr-builder.js
+++ b/app-vite/lib/modes/ssr/ssr-builder.js
@@ -9,6 +9,7 @@ import { getFixedDeps } from '../../utils/get-fixed-deps.js'
 import { getProdSsrTemplateFn, transformProdSsrPwaOfflineHtml } from '../../utils/html-template.js'
 
 import { injectPwaManifest, buildPwaServiceWorker } from '../pwa/utils.js'
+import { stringifyJSON } from 'confbox'
 
 export class QuasarModeBuilder extends AppBuilder {
   async build () {
@@ -122,7 +123,7 @@ export class QuasarModeBuilder extends AppBuilder {
       this.quasarConf.ssr.extendPackageJson(pkg)
     }
 
-    this.writeFile('package.json', JSON.stringify(pkg, null, 2))
+    this.writeFile('package.json', stringifyJSON(pkg, { indent: 2 }))
   }
 
   async #writeRenderTemplate (clientDir) {

--- a/app-vite/lib/utils/get-pkg.js
+++ b/app-vite/lib/utils/get-pkg.js
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from 'node:fs'
 
 import { warning } from './logger.js'
 import { getPackageJson } from '../utils/get-package-json.js'
+import { parseJSON } from 'confbox'
 
 export function getPkg (appPaths) {
   const { appDir, cliDir } = appPaths
@@ -16,7 +17,8 @@ export function getPkg (appPaths) {
     if (mtime !== lastAppPkgModifiedTime) {
       lastAppPkgModifiedTime = mtime
       try {
-        appPkg = JSON.parse(
+        // This may get updated and written, so use parseJSON to preserve formatting
+        appPkg = parseJSON(
           readFileSync(appPkgPath, 'utf-8')
         )
       }

--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -94,6 +94,7 @@
     "chokidar": "^3.6.0",
     "ci-info": "^4.0.0",
     "compression": "^1.7.5",
+    "confbox": "^0.1.8",
     "cross-spawn": "^7.0.6",
     "dot-prop": "9.0.0",
     "dotenv": "^16.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       compression:
         specifier: ^1.7.5
         version: 1.7.5
+      confbox:
+        specifier: ^0.1.8
+        version: 0.1.8
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
@@ -3832,6 +3835,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -7018,6 +7024,7 @@ packages:
   rollup-plugin-visualizer@5.13.1:
     resolution: {integrity: sha512-vMg8i6BprL8aFm9DKvL2c8AwS8324EgymYQo9o6E26wgVvwMhsJxS37aNL6ZsU7X9iAcMYwdME7gItLfG5fwJg==}
     engines: {node: '>=18'}
+    deprecated: Contains unintended breaking changes
     hasBin: true
     peerDependencies:
       rolldown: 1.x
@@ -12296,6 +12303,8 @@ snapshots:
       - supports-color
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   config-chain@1.1.13:
     dependencies:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Resolves #16808, but contains other changes as well.

Affecting `package.json`, `quasar.extensions.json`, `src-capacitor/package.json`, `src-capacitor/capacitor.config.json`, and `api.extendJsonFile`

Using [`confbox`](https://github.com/unjs/confbox) package to manage this.

Will be ported to app-webpack if everything is fine.