### PR TITLE
fix(ui): fix QOptionGroup options type (fix: #17710)

### DIFF
--- a/ui/src/components/option-group/QOptionGroup.json
+++ b/ui/src/components/option-group/QOptionGroup.json
@@ -17,22 +17,6 @@
       "desc": "Array of objects with value, label, and disable (optional) props. The binary components will be created according to this array; Props from QToggle, QCheckbox or QRadio can also be added as key/value pairs to control the components singularly",
       "default": "[]",
       "definition": {
-        "label": {
-          "type": "String",
-          "desc": "Label to display along the component",
-          "required": true,
-          "examples": [ "'Option 1'", "'Option 2'", "'Option 3'" ]
-        },
-        "value": {
-          "type": "Any",
-          "desc": "Value of the option that will be used by the component model",
-          "required": true,
-          "examples": [ "'op1'", "'op2'", "'op3'" ]
-        },
-        "disable": {
-          "type": "Boolean",
-          "desc": "If true, the option will be disabled"
-        },
         "...props": {
           "type": "Any",
           "desc": "Any other props from QToggle, QCheckbox, or QRadio",


### PR DESCRIPTION
to respect option-label and option-value props

**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
Fixes #17710 