### PR TITLE
perf(vite-plugin): load import map only when needed

### DIFF
--- a/vite-plugin/src/js-transform.js
+++ b/vite-plugin/src/js-transform.js
@@ -3,17 +3,28 @@ import { join } from 'node:path'
 
 import { quasarPath } from './quasar-path.js'
 
-const importMap = JSON.parse(
-  readFileSync(
-    join(quasarPath, 'dist/transforms/import-map.json'),
-    'utf-8'
-  )
-)
+let quasarImportMap
+export function loadQuasarImportMap() {
+  if (quasarImportMap !== void 0) {
+    return
+  }
+
+  try {
+    quasarImportMap = JSON.parse(
+      readFileSync(
+        join(quasarPath, 'dist/transforms/import-map.json'),
+        'utf-8'
+      )
+    )
+  } catch (error) {
+    throw new Error('Failed to load Quasar import map', { cause: error })
+  }
+}
 
 const importQuasarRegex = /import\s*\{([\w,\s]+)\}\s*from\s*(['"])quasar\2;?/g
 
 export function importTransformation (importName) {
-  const file = importMap[ importName ]
+  const file = quasarImportMap[ importName ]
   if (file === void 0) {
     throw new Error('Unknown import from Quasar: ' + importName)
   }

--- a/vite-plugin/src/plugin.js
+++ b/vite-plugin/src/plugin.js
@@ -4,7 +4,7 @@ import { getViteConfig } from './vite-config.js'
 import { vueTransform } from './vue-transform.js'
 import { createScssTransform } from './scss-transform.js'
 import { parseViteRequest, createExtMatcher } from './query.js'
-import { mapQuasarImports } from './js-transform.js'
+import { loadQuasarImportMap, mapQuasarImports } from './js-transform.js'
 
 const defaultOptions = {
   runMode: 'web-client',
@@ -97,6 +97,8 @@ function getScriptTransformsPlugin (opts) {
     configResolved (resolvedConfig) {
       if (opts.devTreeshaking === false && resolvedConfig.mode !== 'production') {
         useTreeshaking = false
+      } else {
+        loadQuasarImportMap()
       }
     },
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Performance improvement

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**
Also contains improved error handling just in case.
It will also be helpful in Quasar monorepo for running `quasar prepare` in playground apps without having to build the ui package for no reason. There were other ways, but this one improves vite-plugin performance in dev mode (_if not opted into dev tree shaking_), so it's better.