### PR TITLE
fix(create-quasar): correctly configure typescript-eslint/consistent-type-imports rule

### DIFF
--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
@@ -54,7 +54,7 @@ export default [
     // Supports all the configurations in
     // https://typescript-eslint.io/users/configs#recommended-configurations
     extends: [
-      // By default, only the 'recommendedTypeChecked' rules are enabled on typescript projects.
+      // By default, only the 'recommendedTypeChecked' rules are enabled.
       'recommendedTypeChecked'
       // You can also manually enable the stylistic rules.
       // "stylistic",

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
@@ -35,18 +35,14 @@ export default [
    */
   ...pluginVue.configs[ 'flat/essential' ],
 
-  // this rule needs to be above the vueTsEslintConfig to avoid error: 'You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file.'
-  { 
+  {
+    files: ['**/*.ts', '**/*.vue'],
     rules: {
-        'prefer-promise-reject-errors': 'off',
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          { prefer: 'type-imports' }
-        ],
-  
-        // allow debugger during development only
-        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
-      }
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports' }
+      ],
+    }
   },
   // https://github.com/vuejs/eslint-config-typescript
   ...vueTsEslintConfig({

--- a/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
+++ b/create-quasar/templates/app/quasar-v2/ts-vite-2/eslint/_eslint.config.js
@@ -35,14 +35,27 @@ export default [
    */
   ...pluginVue.configs[ 'flat/essential' ],
 
+  // this rule needs to be above the vueTsEslintConfig to avoid error: 'You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file.'
+  { 
+    rules: {
+        'prefer-promise-reject-errors': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          { prefer: 'type-imports' }
+        ],
+  
+        // allow debugger during development only
+        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+      }
+  },
   // https://github.com/vuejs/eslint-config-typescript
   ...vueTsEslintConfig({
     // Optional: extend additional configurations from typescript-eslint'.
     // Supports all the configurations in
     // https://typescript-eslint.io/users/configs#recommended-configurations
     extends: [
-      // By default, only the recommended rules are enabled.
-      'recommended'
+      // By default, only the 'recommendedTypeChecked' rules are enabled on typescript projects.
+      'recommendedTypeChecked'
       // You can also manually enable the stylistic rules.
       // "stylistic",
 
@@ -71,10 +84,6 @@ export default [
     // add your custom rules here
     rules: {
       'prefer-promise-reject-errors': 'off',
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        { prefer: 'type-imports' }
-      ],
 
       // allow debugger during development only
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/eslint/_eslint.config.js
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/eslint/_eslint.config.js
@@ -36,17 +36,14 @@ export default [
   ...pluginVue.configs[ 'flat/essential' ],
 
   // this rule needs to be above the vueTsEslintConfig to avoid error: 'You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file.'
-  { 
+ {
+    files: ['**/*.ts', '**/*.vue'],
     rules: {
-        'prefer-promise-reject-errors': 'off',
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          { prefer: 'type-imports' }
-        ],
-  
-        // allow debugger during development only
-        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
-      }
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports' }
+      ],
+    }
   },
   // https://github.com/vuejs/eslint-config-typescript
   ...vueTsEslintConfig({

--- a/create-quasar/templates/app/quasar-v2/ts-webpack-4/eslint/_eslint.config.js
+++ b/create-quasar/templates/app/quasar-v2/ts-webpack-4/eslint/_eslint.config.js
@@ -35,14 +35,27 @@ export default [
    */
   ...pluginVue.configs[ 'flat/essential' ],
 
+  // this rule needs to be above the vueTsEslintConfig to avoid error: 'You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file.'
+  { 
+    rules: {
+        'prefer-promise-reject-errors': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          { prefer: 'type-imports' }
+        ],
+  
+        // allow debugger during development only
+        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+      }
+  },
   // https://github.com/vuejs/eslint-config-typescript
   ...vueTsEslintConfig({
     // Optional: extend additional configurations from typescript-eslint'.
     // Supports all the configurations in
     // https://typescript-eslint.io/users/configs#recommended-configurations
     extends: [
-      // By default, only the recommended rules are enabled.
-      'recommended'
+       // By default, only the 'recommendedTypeChecked' rules are enabled.
+      'recommendedTypeChecked'
       // You can also manually enable the stylistic rules.
       // "stylistic",
 
@@ -71,10 +84,6 @@ export default [
     // add your custom rules here
     rules: {
       'prefer-promise-reject-errors': 'off',
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        { prefer: 'type-imports' }
-      ],
 
       // allow debugger during development only
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Adding this for documentation purposes:
After creating a new project with the latest app-vite, I was getting this error when running the dev command:
```
node:internal/event_target:1100
  process.nextTick(() => { throw err; });
                           ^
Error: Error while loading rule '@typescript-eslint/consistent-type-imports': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file. See https://typescript-eslint.io/getting-started/typed-linting for enabling linting with type information.
Parser: vue-eslint-parser
Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.
```

@yusufkandemir gave me the solution and asked to create this PR. 