### PR TITLE
feat(ui): add pure CSS icons support

### DIFF
--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -20,7 +20,8 @@ const libMap = {
   'ion-logo': ionFn,
   'iconfont ': sameFn,
   'ti-': i => `themify-icon ${ i }`,
-  'bi-': i => `bootstrap-icons ${ i }`
+  'bi-': i => `bootstrap-icons ${ i }`,
+  'i-': i => `${ i }`
 }
 
 const matMap = {

--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -21,7 +21,7 @@ const libMap = {
   'iconfont ': sameFn,
   'ti-': i => `themify-icon ${ i }`,
   'bi-': i => `bootstrap-icons ${ i }`,
-  'i-': i => `${ i }`
+  'i-': sameFn
 }
 
 const matMap = {

--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -21,7 +21,7 @@ const libMap = {
   'iconfont ': sameFn,
   'ti-': i => `themify-icon ${ i }`,
   'bi-': i => `bootstrap-icons ${ i }`,
-  'i-': sameFn
+  'i-': sameFn // UnoCSS pure icons
 }
 
 const matMap = {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

This PR adds support for using pure CSS icons in QIcon with help of [UnoCSS Icons preset](https://unocss.dev/presets/icons).
With icons preset installed you can now do this:
```vue
QIcon Pure CSS
<q-icon size="lg" name="i-mdi-alarm"> </q-icon>
<q-icon size="lg" name="i-openmoji-party-popper" />
```
![Screenshot From 2025-01-16 11-28-29](https://github.com/user-attachments/assets/3f4f891d-3e4a-41dd-98fe-ba1f4a6d2802)

A prefix different than `i-` can be used but it will also have to be changed in the icons preset settings. You can't use a map similar to other icon sets in this case as UnoCSS tries to match `<prefix><collection>-<icon>` or `<prefix><collection>:<icon>`.