### PR TITLE
feat(cli): detect bun.lock file for the "upgrade" cmd

### DIFF
--- a/app-vite/lib/cache/module.nodePackager.js
+++ b/app-vite/lib/cache/module.nodePackager.js
@@ -40,7 +40,7 @@ class PackageManager {
    * To be declared by subclasses
    */
   name = 'unknown'
-  lockFile = 'unknown'
+  lockFiles = [ 'unknown' ]
 
   getInstallParams (_env) {
     return []
@@ -110,7 +110,7 @@ class PackageManager {
 
 class Npm extends PackageManager {
   name = 'npm'
-  lockFile = 'package-lock.json'
+  lockFiles = [ 'package-lock.json' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -137,7 +137,7 @@ class Npm extends PackageManager {
 
 class Yarn extends PackageManager {
   name = 'yarn'
-  lockFile = 'yarn.lock'
+  lockFiles = [ 'yarn.lock' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -172,7 +172,7 @@ class Yarn extends PackageManager {
 
 class Pnpm extends PackageManager {
   name = 'pnpm'
-  lockFile = 'pnpm-lock.yaml'
+  lockFiles = [ 'pnpm-lock.yaml' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -195,7 +195,7 @@ class Pnpm extends PackageManager {
 
 class Bun extends PackageManager {
   name = 'bun'
-  lockFile = 'bun.lockb'
+  lockFiles = [ 'bun.lock', 'bun.lockb' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -224,7 +224,7 @@ function getProjectPackageManager (packageManagersList, dir) {
   // the dir tree up to the root
   while (dir.length && dir[ dir.length - 1 ] !== sep) {
     for (const pm of packageManagersList) {
-      if (fs.existsSync(join(dir, pm.lockFile))) {
+      if (pm.lockFiles.some(lockFile => fs.existsSync(join(dir, lockFile)))) {
         return pm
       }
     }

--- a/app-webpack/lib/cache/module.nodePackager.js
+++ b/app-webpack/lib/cache/module.nodePackager.js
@@ -40,7 +40,7 @@ class PackageManager {
    * To be declared by subclasses
    */
   name = 'unknown'
-  lockFile = 'unknown'
+  lockFiles = [ 'unknown' ]
 
   getInstallParams (_env) {
     return []
@@ -110,7 +110,7 @@ class PackageManager {
 
 class Npm extends PackageManager {
   name = 'npm'
-  lockFile = 'package-lock.json'
+  lockFiles = [ 'package-lock.json' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -137,7 +137,7 @@ class Npm extends PackageManager {
 
 class Yarn extends PackageManager {
   name = 'yarn'
-  lockFile = 'yarn.lock'
+  lockFiles = [ 'yarn.lock' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -172,7 +172,7 @@ class Yarn extends PackageManager {
 
 class Pnpm extends PackageManager {
   name = 'pnpm'
-  lockFile = 'pnpm-lock.yaml'
+  lockFiles = [ 'pnpm-lock.yaml' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -195,7 +195,7 @@ class Pnpm extends PackageManager {
 
 class Bun extends PackageManager {
   name = 'bun'
-  lockFile = 'bun.lockb'
+  lockFiles = [ 'bun.lock', 'bun.lockb' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -224,7 +224,7 @@ function getProjectPackageManager (packageManagersList, dir) {
   // the dir tree up to the root
   while (dir.length && dir[ dir.length - 1 ] !== sep) {
     for (const pm of packageManagersList) {
-      if (fs.existsSync(join(dir, pm.lockFile))) {
+      if (pm.lockFiles.some(lockFile => fs.existsSync(join(dir, lockFile)))) {
         return pm
       }
     }

--- a/cli/lib/node-packager.js
+++ b/cli/lib/node-packager.js
@@ -87,7 +87,7 @@ class PackageManager {
    * To be declared by subclasses
    */
   name = 'unknown'
-  lockFile = 'unknown'
+  lockFiles = [ 'unknown' ]
 
   getInstallParams (_env) {
     return []
@@ -202,7 +202,7 @@ class PackageManager {
 
 class Npm extends PackageManager {
   name = 'npm'
-  lockFile = 'package-lock.json'
+  lockFiles = [ 'package-lock.json' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -229,7 +229,7 @@ class Npm extends PackageManager {
 
 class Yarn extends PackageManager {
   name = 'yarn'
-  lockFile = 'yarn.lock'
+  lockFiles = [ 'yarn.lock' ]
 
   getInstallParams (env) {
     if (env === 'development') {
@@ -264,7 +264,7 @@ class Yarn extends PackageManager {
 
 class Pnpm extends PackageManager {
   name = 'pnpm'
-  lockFile = 'pnpm-lock.yaml'
+  lockFiles = [ 'pnpm-lock.yaml' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -287,7 +287,7 @@ class Pnpm extends PackageManager {
 
 class Bun extends PackageManager {
   name = 'bun'
-  lockFile = 'bun.lockb'
+  lockFiles = [ 'bun.lock', 'bun.lockb' ]
 
   getInstallParams (env) {
     return env === 'development'
@@ -323,7 +323,7 @@ function getProjectPackageManager (folder) {
   // the folder tree up to the root
   while (folder.length && folder[ folder.length - 1 ] !== sep) {
     for (const pm of packageManagersList) {
-      if (fs.existsSync(join(folder, pm.lockFile))) {
+      if (pm.lockFiles.some(lockFile => fs.existsSync(join(folder, lockFile)))) {
         return pm
       }
     }

--- a/docs/src/pages/start/upgrade-guide/upgrade-guide.md
+++ b/docs/src/pages/start/upgrade-guide/upgrade-guide.md
@@ -250,7 +250,7 @@ Before starting, it is highly suggested to make a copy of your current working p
   $ bun add --dev @quasar/app-webpack@3
   $ bun add quasar@2 vue@3 vue-router@4
   ```
-7) **Remove** `.quasar` and `node_modules` folders, and `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lockb` file, then run `yarn/npm/pnpm/bun install` to regenerate the lock file. This forces the upgrade of the whole dependency graph (deep dependencies included) and avoids troubles with mismatching packages, especially webpack 5 related ones.
+7) **Remove** `.quasar` and `node_modules` folders, and `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock` / `bun.lockb` file, then run `yarn/npm/pnpm/bun install` to regenerate the lock file. This forces the upgrade of the whole dependency graph (deep dependencies included) and avoids troubles with mismatching packages, especially webpack 5 related ones.
 8) If you are using ESLint, then edit `/.eslintrc.cjs` (also rename from `/.eslintrc.js`):
   ```js
   // old way


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

In version `1.1.39` of Bun they have introduced a text-based lockfile format (`bun.lock`) as an alternative to the binary lockfile (`bun.lockb`). It will be the default soon.  
For more info see Bun's [blog post](https://bun.sh/blog/bun-lock-text-lockfile).  

This change will make `quasar upgrade -i` command detect Bun as a package manager if the new lockfile format is used.

I don't know how to test it. Can you help with with that?  
I tried running my modified version in a Quasar project with pending updates using
```sh
bun ~/git/quasar/cli/bin/quasar.js upgrade -i
```
But it doesn't even detect my pending update. Running `quasar upgrade` (without `-i`) shows that there is one. So I don't think that's the right way to test it.

