### PR TITLE
feat(ui): no-(re)focus properties passed to the QMenu of QBtnDropdown

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.js
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.js
@@ -43,6 +43,8 @@ export default createComponent({
     persistent: Boolean,
     noRouteDismiss: Boolean,
     autoClose: Boolean,
+    noRefocus: Boolean,
+    noFocus: Boolean,
 
     menuAnchor: {
       type: String,
@@ -177,6 +179,8 @@ export default createComponent({
           persistent: props.persistent,
           noRouteDismiss: props.noRouteDismiss,
           autoClose: props.autoClose,
+          noFocus: props.noFocus,
+          noRefocus: props.noRefocus,
           anchor: props.menuAnchor,
           self: props.menuSelf,
           offset: props.menuOffset,

--- a/ui/src/components/btn-dropdown/QBtnDropdown.json
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.json
@@ -85,6 +85,18 @@
       "category": "behavior"
     },
 
+    "no-refocus": {
+      "type": "Boolean",
+      "desc": "(Accessibility) When the dropdown gets hidden, do not refocus on the DOM element that previously had focus",
+      "category": "behavior"
+    },
+
+    "no-focus": {
+      "type": "Boolean",
+      "desc": "(Accessibility) When the dropdown gets shown, do not switch focus on it",
+      "category": "behavior"
+    },
+
     "menu-anchor": {
       "type": "String",
       "desc": "Two values setting the starting position or anchor point of the menu relative to its target",

--- a/ui/src/components/btn-dropdown/QBtnDropdown.json
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.json
@@ -88,13 +88,15 @@
     "no-refocus": {
       "type": "Boolean",
       "desc": "(Accessibility) When the dropdown gets hidden, do not refocus on the DOM element that previously had focus",
-      "category": "behavior"
+      "category": "behavior",
+      "addedIn": "v2.18"
     },
 
     "no-focus": {
       "type": "Boolean",
       "desc": "(Accessibility) When the dropdown gets shown, do not switch focus on it",
-      "category": "behavior"
+      "category": "behavior",
+      "addedIn": "v2.18"
     },
 
     "menu-anchor": {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
=> ui test fail on a fresh install so I'll count on the tests of the CI
![image](https://github.com/user-attachments/assets/798d22f6-228f-45b8-bc51-0b077511c157)

- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)


This is required to avoid loosing the focus/selection of a contenteditable while clicking inside the dropdown like here:
![image](https://github.com/user-attachments/assets/948e191f-29bc-4483-bd9e-df460a77a598)

**Other information:**
Should this be retested as it is already by QMenu? 