### PR TITLE
fix(ui): tabs move the focus even when click is triggered programmatically

### DIFF
--- a/ui/src/components/tabs/use-tab.js
+++ b/ui/src/components/tabs/use-tab.js
@@ -99,7 +99,7 @@ export default function (props, slots, emit, routeData) {
   ))
 
   function onClick (e, keyboard) {
-    if (keyboard !== true && blurTargetRef.value !== null) {
+    if (keyboard !== true && blurTargetRef.value !== null && e.isTrusted === true) {
       blurTargetRef.value.focus()
     }
 


### PR DESCRIPTION

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No => `I guess not bluring a non focused q-focus-helper is not a breaking change`

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] ~When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)~
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app

This looks cumbersome to test as we need human fingers to get `e.isTrusted === true`

- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)


Like in this PR https://github.com/quasarframework/quasar/pull/17802, without it I can't switch the color picker tabs while keeping the focus / selection on my contenteditable (Considering the fact I prevent / stop the user event and replace it by a `new MouseEvent('click')` )




**Other information:**
