### PR TITLE
refactor(ui): remove redundant role in q-icon

### DIFF
--- a/ui/src/components/icon/QIcon.js
+++ b/ui/src/components/icon/QIcon.js
@@ -186,7 +186,6 @@ export default createComponent({
         class: classes.value,
         style: sizeStyle.value,
         'aria-hidden': 'true',
-        role: 'presentation'
       }
 
       if (type.value.none === true) {


### PR DESCRIPTION
The `role` attribute is redundant since `aria-hidden="true"` has a stronger effect and completely remove the element from the accessibility tree, making any other role useless.

This PR removes it from `<q-icon>`.

See [_Know your ARIA: 'Hidden' vs 'None'_](https://www.scottohara.me/blog/2018/05/05/hidden-vs-none.html) from @scottaohara for more.

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: remove dead code.

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)
