### PR TITLE
fix(docs): fix QKnob docs when img is in default slot (fix: #17812)

### DIFF
--- a/docs/src/examples/QKnob/ShowValue.vue
+++ b/docs/src/examples/QKnob/ShowValue.vue
@@ -59,7 +59,7 @@
       track-color="grey-3"
     >
       <q-avatar size="60px">
-        <img src="https://cdn.quasar.dev/logo-v2/svg/logo.svg">
+        <img draggable="false" src="https://cdn.quasar.dev/logo-v2/svg/logo.svg">
       </q-avatar>
     </q-knob>
   </div>

--- a/docs/src/pages/vue-components/knob.md
+++ b/docs/src/pages/vue-components/knob.md
@@ -22,6 +22,7 @@ By default, QKnob inherits current text color (as arc progress color and inner l
 ### Show value
 
 In the example below, `show-value` property also enables the default slot, so you can fill it with custom content, like even a QAvatar or a QTooltip. The `font-size` prop refers to the inner label font size. 
+
 If the default slot contains an image, you have to style it with class `no-pointer-events` or set the `draggable` prop to false. Otherwise browser's default image dragging behaviour overrides QKnob's one
 
 <DocExample title="Show value" file="ShowValue" />

--- a/docs/src/pages/vue-components/knob.md
+++ b/docs/src/pages/vue-components/knob.md
@@ -21,7 +21,8 @@ By default, QKnob inherits current text color (as arc progress color and inner l
 
 ### Show value
 
-In the example below, `show-value` property also enables the default slot, so you can fill it with custom content, like even a QAvatar or a QTooltip. The `font-size` prop refers to the inner label font size.
+In the example below, `show-value` property also enables the default slot, so you can fill it with custom content, like even a QAvatar or a QTooltip. The `font-size` prop refers to the inner label font size. 
+If the default slot contains an image, you have to style it with class `no-pointer-events` or set the `draggable` prop to false. Otherwise browser's default image dragging behaviour overrides QKnob's one
 
 <DocExample title="Show value" file="ShowValue" />
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
In this pull request I tried to improve QKnob documentation when an image is in the default slot, explaining why draggable="false" or class no-pointer-events are necessary
