### PR TITLE
fix(ui): consistent use of htmlTip in editor buttons #16933

### DIFF
--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -31,15 +31,16 @@ function getBtn (eVm, btn, clickHandler, active = false) {
       : false),
     child = []
 
-  if (btn.tip && eVm.$q.platform.is.desktop) {
+  if (eVm.$q.platform.is.desktop && (btn.tip || btn.htmlTip)) {
     const Key = btn.key
       ? h('div', [
         h('small', `(CTRL + ${ String.fromCharCode(btn.key) })`)
       ])
       : null
+
     child.push(
       h(QTooltip, { delay: 1000 }, () => [
-        h('div', { innerHTML: btn.htmlTip != null ? btn.htmlTip : void 0, textContent: btn.tip != null ? btn.tip : void 0 }),
+        h('div', btn.htmlTip ? { innerHTML: btn.htmlTip } : btn.tip),
         Key
       ])
     )

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -39,7 +39,7 @@ function getBtn (eVm, btn, clickHandler, active = false) {
       : null
     child.push(
       h(QTooltip, { delay: 1000 }, () => [
-        h('div', { innerHTML: btn.tip }),
+        h('div', { innerHTML: btn.htmlTip != null ? btn.htmlTip : void 0, textContent: btn.tip != null ? btn.tip : void 0 }),
         Key
       ])
     )


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Fix use of htmlTip in QEditor buttons, as per issue #16933 
