### PR TITLE
fix(ui): fix __splitDate function: invalid call function 'pad' for date.year

### DIFF
--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -466,7 +466,7 @@ export function __splitDate (str, mask, dateLocale, calendar, defaultModel) {
     }
   }
 
-  date.dateHash = pad(date.year, 6) + '/' + pad(date.month) + '/' + pad(date.day)
+  date.dateHash = pad(date.year, 4) + '/' + pad(date.month) + '/' + pad(date.day)
   date.timeHash = pad(date.hour) + ':' + pad(date.minute) + ':' + pad(date.second) + tzString
 
   return date


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
There is an animation bug in the calendar component. After rendering, the first call to switch between month or year shows the wrong animation - the slide always flips to the right. This can be seen in any example in the documentation for the `QDate` component, when v -model is defined.

https://github.com/user-attachments/assets/5f66bf5d-21c4-436d-ad4c-8ed559a8564a

After searching, I found that in the `QDate.js` file in the `getViewModel()` function in the returned object, the `dateHash` field comes in the format `002025/18/03`


