### PR TITLE
fix(ui): set disable prop default to false quasarframework#17945

### DIFF
--- a/ui/src/components/chip/QChip.js
+++ b/ui/src/components/chip/QChip.js
@@ -54,7 +54,10 @@ export default createComponent({
     removeAriaLabel: String,
 
     tabindex: [ String, Number ],
-    disable: Boolean,
+    disable: {
+      type: Boolean,
+      default: false
+    },
 
     ripple: {
       type: [ Boolean, Object ],

--- a/ui/src/components/chip/QChip.json
+++ b/ui/src/components/chip/QChip.json
@@ -107,7 +107,8 @@
     },
 
     "disable": {
-      "extends": "disable"
+      "extends": "disable",
+      "default": "false"
     }
   },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
This PR aims to solve the bug described in issue #17945, setting a false default for disable prop.
As per Vue docs, all props are optional by default and an absent prop other than Boolean will have undefined value. In this scenario, a Boolean prop willl be cast to false, unless an undefined value is explicitly passed.
Setting a default to false prevents hybrid behaviours described in the linked issue because false value (our default) will be used if the resolved value is undefined, including both when the prop is missing or explicit undefined is passed 

Further reference can be found in the aforementioned doc: https://vuejs.org/guide/components/props.html#prop-validation 