### PR TITLE
DOCS ref.optionIndex does not exist in the current version of Quasar

### DIFF
--- a/docs/src/examples/QSelect/InputFilterAfter.vue
+++ b/docs/src/examples/QSelect/InputFilterAfter.vue
@@ -115,7 +115,7 @@ export default {
             ref => {
               if (val !== '' && ref.options.length > 0 && ref.getOptionIndex() === -1) {
                 ref.moveOptionSelection(1, true) // focus the first selectable option and do not update the input-value
-                ref.toggleOption(ref.options[ ref.optionIndex ], true) // toggle the focused option
+                ref.toggleOption(ref.options[ ref.getOptionIndex() ], true) // toggle the focused option
               }
             }
           )


### PR DESCRIPTION
ref.optionIndex does not exist in the current version of Quasar, updating QSelect Docs to leverage getter instead in autoselect example.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch (or `v[X]` branch)
- [x ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x] It's been tested on a Cordova (iOS, Android) app
- [x ] It's been tested on an Electron app
- [x ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
