### PR TITLE
fix(AddressbarColor): unsupported tag 'apple-mobile-web-app-status-bar-style' replaced by supported tag 'theme-color' for iOS/Safari (fix: #17900)

### DIFF
--- a/ui/src/plugins/addressbar/AddressbarColor.js
+++ b/ui/src/plugins/addressbar/AddressbarColor.js
@@ -7,11 +7,7 @@ let metaValue
 function getProp () {
   return client.is.winphone
     ? 'msapplication-navbutton-color'
-    : (
-        client.is.safari
-          ? 'apple-mobile-web-app-status-bar-style'
-          : 'theme-color' // Chrome, Firefox OS, Opera, Vivaldi, ...
-      )
+    : 'theme-color' // Safari, Chrome, ...
 }
 
 function getMetaTag (v) {


### PR DESCRIPTION


<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

### Why this change?
**Fact 1:**
The currently used meta tag `apple-mobile-web-app-status-bar-style` only supports `default`, `black` and `black-translucent`
([see developer.apple.com](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html))

**Fact 2:**
But the quasar adressbar color plugin accepts a parameter `hexColor` ([see quasar docs](https://quasar.dev/quasar-plugins/addressbar-color#addressbarcolor-api))

**Fact 3:**
The meta tag `theme-color` is supported by Safari and Safari for iOS ([see caniuse.com](https://caniuse.com/meta-theme-color))

**Fact 4:**
The meta tag`apple-mobile-web-app-status-bar-style` isn't really documented ([except in this archive](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html)) but `theme-color` is ([mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/theme-color))

**Fact 5:**
`theme-color` just works ([see this issue](https://github.com/quasarframework/quasar/issues/17900))