### PR TITLE
fix(ui): replace ariaLabel with aria-label (fix: #17988)

### DIFF
--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -1136,7 +1136,7 @@ export default createComponent({
           props.todayBtn === true ? h(QBtn, {
             class: 'q-date__header-today self-start',
             icon: $q.iconSet.datetime.today,
-            ariaLabel: $q.lang.date.today,
+            'aria-label': $q.lang.date.today,
             flat: true,
             size: 'sm',
             round: true,
@@ -1158,7 +1158,7 @@ export default createComponent({
             size: 'sm',
             flat: true,
             icon: dateArrow.value[ 0 ],
-            ariaLabel: type === 'Years' ? $q.lang.date.prevYear : $q.lang.date.prevMonth,
+            'aria-label': type === 'Years' ? $q.lang.date.prevYear : $q.lang.date.prevMonth,
             tabindex: tabindex.value,
             disable: boundaries.prev === false,
             ...getCache('go-#' + type, { onClick () { goTo(-1) } })
@@ -1191,7 +1191,7 @@ export default createComponent({
             size: 'sm',
             flat: true,
             icon: dateArrow.value[ 1 ],
-            ariaLabel: type === 'Years' ? $q.lang.date.nextYear : $q.lang.date.nextMonth,
+            'aria-label': type === 'Years' ? $q.lang.date.nextYear : $q.lang.date.nextMonth,
             tabindex: tabindex.value,
             disable: boundaries.next === false,
             ...getCache('go+#' + type, { onClick () { goTo(1) } })
@@ -1362,7 +1362,7 @@ export default createComponent({
               dense: true,
               flat: true,
               icon: dateArrow.value[ 0 ],
-              ariaLabel: $q.lang.date.prevRangeYears(yearsInterval),
+              'aria-label': $q.lang.date.prevRangeYears(yearsInterval),
               tabindex: tabindex.value,
               disable: isDisabled(start),
               ...getCache('y-', { onClick: () => { startYear.value -= yearsInterval } })
@@ -1381,7 +1381,7 @@ export default createComponent({
               dense: true,
               flat: true,
               icon: dateArrow.value[ 1 ],
-              ariaLabel: $q.lang.date.nextRangeYears(yearsInterval),
+              'aria-label': $q.lang.date.nextRangeYears(yearsInterval),
               tabindex: tabindex.value,
               disable: isDisabled(stop),
               ...getCache('y+', { onClick: () => { startYear.value += yearsInterval } })

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -52,7 +52,7 @@ function getBtn (eVm, btn, clickHandler, active = false) {
     color: toggled ? btn.toggleColor || eVm.props.toolbarToggleColor : btn.color || eVm.props.toolbarColor,
     textColor: toggled && !eVm.props.toolbarPush ? null : btn.textColor || eVm.props.toolbarTextColor,
     label: btn.label,
-    ariaLabel: btn.label == null ? btn.tip : void 0,
+    'aria-label': btn.label == null ? btn.tip : void 0,
     disable: btn.disable ? (typeof btn.disable === 'function' ? btn.disable(eVm) : true) : false,
     size: 'sm',
     onClick (e) {

--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -873,7 +873,7 @@ export default createComponent({
               ...btnProps,
               icon: navIcon.value[ 0 ],
               disable: isFirstPage.value,
-              ariaLabel: $q.lang.pagination.first,
+              'aria-label': $q.lang.pagination.first,
               onClick: firstPage
             })
           )
@@ -884,7 +884,7 @@ export default createComponent({
               ...btnProps,
               icon: navIcon.value[ 1 ],
               disable: isFirstPage.value,
-              ariaLabel: $q.lang.pagination.prev,
+              'aria-label': $q.lang.pagination.prev,
               onClick: prevPage
             }),
 
@@ -893,7 +893,7 @@ export default createComponent({
               ...btnProps,
               icon: navIcon.value[ 2 ],
               disable: isLastPage.value,
-              ariaLabel: $q.lang.pagination.next,
+              'aria-label': $q.lang.pagination.next,
               onClick: nextPage
             })
           )
@@ -904,7 +904,7 @@ export default createComponent({
               ...btnProps,
               icon: navIcon.value[ 3 ],
               disable: isLastPage.value,
-              ariaLabel: $q.lang.pagination.last,
+              'aria-label': $q.lang.pagination.last,
               onClick: lastPage
             })
           )


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
As stated in issue #17988, ariaLabel is not rendered as 'aria-label' in certain testing environments, so I replaced it. 
Sorry for the inconvenience, when I first submitted the PR related to this attribute I didn't think about testing libraries emulating the DOM, my bad
