### PR TITLE
fix(QInput): useMask wrongly consumes character (fix #17980)

### DIFF
--- a/ui/src/components/input/use-mask.js
+++ b/ui/src/components/input/use-mask.js
@@ -499,7 +499,6 @@ export default function (props, emit, emitValue, inputRef) {
 
       if (typeof maskDef === 'string') {
         output += maskDef
-        valChar === maskDef && valIndex++
       }
       else if (valChar !== void 0 && maskDef.regex.test(valChar)) {
         output += maskDef.transform !== void 0
@@ -529,7 +528,6 @@ export default function (props, emit, emitValue, inputRef) {
 
       if (typeof maskDef === 'string') {
         output = maskDef + output
-        valChar === maskDef && valIndex--
       }
       else if (valChar !== void 0 && maskDef.regex.test(valChar)) {
         do {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->
This PR fixes a behavior in masked QInput where you have a mask, like '#:0:0:###' and you cannot freely enter '0'(Reported in #17980). 
Essentially the buggy behavior is that you cannot freely enter a character that is a literal inside your mask. 

The lines I removed made an extra comparison between the value that was typed and the value of the mask. If matched it incremented the index of the loop(or decremented in the reverseMask function) making it impossible to type a character that already exists as a string literal inside your mask.
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**