### PR TITLE
fix(ui): ensure html consistency when css is disabled (fix #16855)

### DIFF
--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -440,6 +440,12 @@ export default function (state) {
       )
     }
 
+    hasLabel.value === true && node.push(
+      h('div', {
+        class: labelClass.value
+      }, hSlot(slots.label, props.label))
+    )
+
     if (state.getControl !== void 0) {
       node.push(state.getControl())
     }
@@ -458,12 +464,6 @@ export default function (state) {
         }, slots.control(controlSlotScope.value))
       )
     }
-
-    hasLabel.value === true && node.push(
-      h('div', {
-        class: labelClass.value
-      }, hSlot(slots.label, props.label))
-    )
 
     props.suffix !== void 0 && props.suffix !== null && node.push(
       h('div', {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Moving the label before rendering of the field itself gives consistency to the HTML structure, ensuring a better experience to screen reader users. 

Fix #16855 