### PR TITLE
feat(app-vite&app-webpack): allow manual creation of ssr dev https server

### DIFF
--- a/app-vite/lib/modes/ssr/ssr-devserver.js
+++ b/app-vite/lib/modes/ssr/ssr-devserver.js
@@ -430,6 +430,14 @@ export class QuasarModeDevserver extends AppDevserver {
         }
 
         return target.instance?.[prop]
+      },
+      set: (target, prop, value) => {
+        if (!target.instance) {
+          target.instance = createInstance()
+        }
+
+        target.instance[prop] = value
+        return true
       }
     })
   }

--- a/app-vite/lib/modes/ssr/ssr-devserver.js
+++ b/app-vite/lib/modes/ssr/ssr-devserver.js
@@ -291,6 +291,7 @@ export class QuasarModeDevserver extends AppDevserver {
 
     const middlewareParams = {
       port: this.#appOptions.port,
+      devHttpsOptions: quasarConf.devServer.https,
       resolve: {
         urlPath: this.#appOptions.resolveUrlPath,
         root: (...args) => join(this.#pathMap.rootFolder, ...args),
@@ -372,8 +373,10 @@ export class QuasarModeDevserver extends AppDevserver {
     })
 
     if (quasarConf.devServer.https) {
-      const https = await import('node:https')
-      middlewareParams.devHttpsApp = https.createServer(quasarConf.devServer.https, app)
+      middlewareParams.devHttpsApp = await this.#createLazyDevHttpsServer(
+        quasarConf.devServer.https,
+        app
+      )
     }
 
     middlewareParams.listenResult = await listen(middlewareParams)
@@ -389,6 +392,41 @@ export class QuasarModeDevserver extends AppDevserver {
 
     this.printBanner(quasarConf)
     this.#viteClient?.ws.send({ type: 'full-reload' })
+  }
+
+  /**
+   * Lazily create the devHttpsApp proxy when it's first accessed.
+   * This allows the user to handle the devHttpsApp manually if they need to.
+   * This is useful when they are using an custom SSR webserver such as Fastify and h3
+   */
+  async #createLazyDevHttpsServer(httpsOptions, app) {
+    const { createServer } = await import('node:https')
+    const createInstance = () => {
+      try {
+        return createServer(httpsOptions, app)
+      } catch (error) {
+        if (error.code === 'ERR_INVALID_ARG_TYPE') {
+          warn(
+            'The SSR app instance is not compatible with automatic HTTPS support. '
+            + 'Please use `devHttpsOptions` property from callback scope in `create` or `listen` to set up HTTPS manually.'
+          )
+        } else {
+          warn(
+            `An error occurred while setting up HTTPS for the SSR app instance, devHttpsApp won't be available. Error: ${ error.message }`
+          )
+        }
+      }
+    }
+
+    return new Proxy({}, {
+      get: (target, prop) => {
+        if (!target.instance) {
+          target.instance = createInstance()
+        }
+
+        return target.instance?.[prop]
+      }
+    })
   }
 
   // also update pwa-devserver.js when changing here

--- a/app-vite/lib/modes/ssr/ssr-devserver.js
+++ b/app-vite/lib/modes/ssr/ssr-devserver.js
@@ -420,6 +420,11 @@ export class QuasarModeDevserver extends AppDevserver {
 
     return new Proxy({}, {
       get: (target, prop) => {
+        // If handling the result of this function as a Promise, we don't want to do anything
+        if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+          return
+        }
+
         if (!target.instance) {
           target.instance = createInstance()
         }

--- a/app-vite/types/ssrmiddleware.d.ts
+++ b/app-vite/types/ssrmiddleware.d.ts
@@ -1,6 +1,6 @@
 import { Express, Application, Request, Response } from "express";
 import { Server } from "http";
-import { Server as HttpsServer } from "https";
+import { Server as HttpsServer, ServerOptions as HttpsServerOptions } from "https";
 import { ServeStaticOptions } from "serve-static";
 
 interface RenderParams {
@@ -47,11 +47,20 @@ interface SsrCreateParams {
    * for the SSR webserver
    */
   port: number;
+  /**
+   * `devHttpsApp` will be automatically made available in `listen`
+   * and middleware callback parameters if you use HTTPS in development.
+   *
+   * But, you can also ignore `devHttpsApp` and use this to configure
+   * the `app` to handle HTTPS requests.
+   */
+  devHttpsOptions: HttpsServerOptions;
   resolve: SsrMiddlewareResolve;
   publicPath: string;
   folders: SsrMiddlewareFolders;
   /**
    * Uses Vue and Vue Router to render the requested URL path.
+   *
    * @returns the rendered HTML string to return to the client
    */
   render: (ssrContext: RenderVueParams) => Promise<string>;

--- a/app-webpack/lib/modes/ssr/ssr-devserver.js
+++ b/app-webpack/lib/modes/ssr/ssr-devserver.js
@@ -424,8 +424,10 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
     })
 
     if (quasarConf.devServer.server.type === 'https') {
-      const https = require('node:https')
-      middlewareParams.devHttpsApp = https.createServer(quasarConf.devServer.server.options, app)
+      middlewareParams.devHttpsApp = await this.#createLazyDevHttpsServer(
+        quasarConf.devServer.server.options,
+        app
+      )
     }
 
     middlewareParams.listenResult = await listen(middlewareParams)
@@ -435,6 +437,41 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
     done('Webserver is ready')
 
     this.printBanner(quasarConf)
+  }
+
+  /**
+   * Lazily create the devHttpsApp proxy when it's first accessed.
+   * This allows the user to handle the devHttpsApp manually if they need to.
+   * This is useful when they are using an custom SSR webserver such as Fastify and h3
+   */
+  async #createLazyDevHttpsServer(httpsOptions, app) {
+    const { createServer } = require('node:https')
+    const createInstance = () => {
+      try {
+        return createServer(httpsOptions, app)
+      } catch (error) {
+        if (error.code === 'ERR_INVALID_ARG_TYPE') {
+          warn(
+            'The SSR app instance is not compatible with automatic HTTPS support. '
+            + 'Please use `devHttpsOptions` property from callback scope in `create` or `listen` to set up HTTPS manually.'
+          )
+        } else {
+          warn(
+            `An error occurred while setting up HTTPS for the SSR app instance, devHttpsApp won't be available. Error: ${ error.message }`
+          )
+        }
+      }
+    }
+
+    return new Proxy({}, {
+      get: (target, prop) => {
+        if (!target.instance) {
+          target.instance = createInstance()
+        }
+
+        return target.instance?.[prop]
+      }
+    })
   }
 
   // also update ssr-devserver.js when changing here

--- a/app-webpack/lib/modes/ssr/ssr-devserver.js
+++ b/app-webpack/lib/modes/ssr/ssr-devserver.js
@@ -352,6 +352,9 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
 
     const middlewareParams = {
       port: this.#appOptions.port,
+      devHttpsOptions: quasarConf.devServer.server.type === 'https'
+        ? quasarConf.devServer.server.options
+        : void 0,
       resolve: {
         urlPath: resolveUrlPath,
         root: (...args) => join(this.#pathMap.rootFolder, ...args),
@@ -424,7 +427,7 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
     })
 
     if (quasarConf.devServer.server.type === 'https') {
-      middlewareParams.devHttpsApp = await this.#createLazyDevHttpsServer(
+      middlewareParams.devHttpsApp = this.#createLazyDevHttpsServer(
         quasarConf.devServer.server.options,
         app
       )
@@ -444,7 +447,7 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
    * This allows the user to handle the devHttpsApp manually if they need to.
    * This is useful when they are using an custom SSR webserver such as Fastify and h3
    */
-  async #createLazyDevHttpsServer(httpsOptions, app) {
+  #createLazyDevHttpsServer(httpsOptions, app) {
     const { createServer } = require('node:https')
     const createInstance = () => {
       try {

--- a/app-webpack/lib/modes/ssr/ssr-devserver.js
+++ b/app-webpack/lib/modes/ssr/ssr-devserver.js
@@ -478,6 +478,14 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
         }
 
         return target.instance?.[prop]
+      },
+      set: (target, prop, value) => {
+        if (!target.instance) {
+          target.instance = createInstance()
+        }
+
+        target.instance[prop] = value
+        return true
       }
     })
   }

--- a/app-webpack/lib/modes/ssr/ssr-devserver.js
+++ b/app-webpack/lib/modes/ssr/ssr-devserver.js
@@ -468,6 +468,11 @@ module.exports.QuasarModeDevserver = class QuasarModeDevserver extends AppDevser
 
     return new Proxy({}, {
       get: (target, prop) => {
+        // If handling the result of this function as a Promise, we don't want to do anything
+        if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+          return
+        }
+
         if (!target.instance) {
           target.instance = createInstance()
         }

--- a/app-webpack/types/ssrmiddleware.d.ts
+++ b/app-webpack/types/ssrmiddleware.d.ts
@@ -2,6 +2,7 @@ import { Express, Application, Request, Response } from "express";
 import { Server } from "http";
 import { Server as HttpsServer } from "https";
 import { ServeStaticOptions } from "serve-static";
+import { ServerConfiguration } from "webpack-dev-server";
 
 interface RenderParams {
   req: Request;
@@ -47,6 +48,14 @@ interface SsrCreateParams {
    * for the SSR webserver
    */
   port: number;
+  /**
+   * `devHttpsApp` will be automatically made available in `listen`
+   * and middleware callback parameters if you use HTTPS in development.
+   *
+   * But, you can also ignore `devHttpsApp` and use this to configure
+   * the `app` to handle HTTPS requests.
+   */
+  devHttpsOptions: ServerConfiguration["options"];
   resolve: SsrMiddlewareResolve;
   publicPath: string;
   folders: SsrMiddlewareFolders;

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-middleware.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-middleware.md
@@ -5,12 +5,12 @@ related:
   - /quasar-cli-vite/quasar-config-file
 ---
 
-The SSR middleware files fulfill one special purpose: they prepare the Nodejs server that runs your SSR app with additional functionality (Expressjs compatible middleware).
+The SSR middleware files fulfill one special purpose: they prepare the Nodejs server that runs your SSR app with additional functionality (Express compatible middleware).
 
 With SSR middleware files, it is possible to split the middleware logic into self-contained, easy to maintain files. It is also trivial to disable any of the SSR middleware files or even contextually determine which of the SSR middleware files get into the build through the `/quasar.config` file configuration.
 
 ::: tip
-For more advanced usage, you will need to get acquainted to the [Expressjs API](https://expressjs.com/en/4x/api.html).
+For more advanced usage, you will need to get acquainted to the [Express API](https://expressjs.com/en/4x/api.html).
 :::
 
 ::: warning
@@ -19,7 +19,7 @@ You will need at least one SSR middleware file which handles the rendering of th
 
 ## Anatomy of a middleware file
 
-A SSR middleware file is a simple JavaScript file which exports a function. Quasar will then call the exported function when it prepares the Nodejs server (Expressjs) app and additionally pass an Object as param (which will be detailed in the next section).
+A SSR middleware file is a simple JavaScript file which exports a function. Quasar will then call the exported function when it prepares the Nodejs server (Express) app and additionally pass an Object as param (which will be detailed in the next section).
 
 ```js
 import { defineSsrMiddleware } from '#q-app/wrappers'
@@ -64,7 +64,7 @@ Detailing the Object:
 
 ```js
 {
-  app, // Expressjs app or whatever is returned from src-ssr/server -> create()
+  app, // Express app or whatever is returned from src-ssr/server -> create()
   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
   resolve: {
     urlPath, // (url) => path string with publicPath ensured to be included,
@@ -302,7 +302,7 @@ Notice the `render` parameter (from the above code sample) that the exported fun
 
 ## Hot Module Reload
 
-While developing, whenever you change anything in the SSR middlewares, Quasar App CLI will automatically trigger a recompilation of client-side resources and apply the middleware changes to the Nodejs server (Expressjs).
+While developing, whenever you change anything in the SSR middlewares, Quasar App CLI will automatically trigger a recompilation of client-side resources and apply the middleware changes to the Nodejs server (Express).
 
 ## Examples of SSR middleware
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-webserver.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-webserver.md
@@ -41,6 +41,7 @@ import {
  *
  * Param: ({
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
+ *   devHttpsOptions, // DEV only, if using HTTPS; if using a custom server, you can use this to handle HTTPS on your own instead of using the devHttpsApp in listen()
  *   resolve: {
  *      urlPath, // (url) => path string with publicPath ensured to be included,
  *      root, // (pathPart1, ...pathPartN) => path string (joins to the root folder),
@@ -84,8 +85,9 @@ export const create = defineSsrCreate((/* { ... } */) => {
  * Can be async: defineSsrListen(async ({ app, devHttpsApp, port }) => { ... })
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
- *   devHttpsApp, // DEV only, if using HTTPS
+ *   app, // Express app or whatever is returned from create()
+ *   devHttpsApp, // DEV only, if using HTTPS; Node HTTPS server instance
+ *   devHttpsOptions, // DEV only, if using HTTPS; if using a custom server, you can use this to handle HTTPS on your own
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
  *      urlPath, // (url) => path string with publicPath ensured to be included,
@@ -124,7 +126,7 @@ export const listen = defineSsrListen(({ app, devHttpsApp, port }) => {
  * Can be async: defineSsrClose(async ({ listenResult }) => { ... })
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
+ *   app, // Express app or whatever is returned from create()
  *   devHttpsApp, // DEV only, if using HTTPS
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
@@ -163,7 +165,7 @@ const maxAge = process.env.DEV
  * Can return an async function: return async ({ urlPath = '/', pathToServe = '.', opts = {} }) => {
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
+ *   app, // Express app or whatever is returned from create()
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
  *      urlPath: (url) => path string with publicPath ensured to be included,

--- a/docs/src/pages/quasar-cli-webpack/developing-ssr/ssr-middleware.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-ssr/ssr-middleware.md
@@ -5,12 +5,12 @@ related:
   - /quasar-cli-webpack/quasar-config-file
 ---
 
-The SSR middleware files fulfill one special purpose: they prepare the Nodejs server that runs your SSR app with additional functionality (Expressjs compatible middleware).
+The SSR middleware files fulfill one special purpose: they prepare the Nodejs server that runs your SSR app with additional functionality (Express compatible middleware).
 
 With SSR middleware files, it is possible to split the middleware logic into self-contained, easy to maintain files. It is also trivial to disable any of the SSR middleware files or even contextually determine which of the SSR middleware files get into the build through the `/quasar.config` file configuration.
 
 ::: tip
-For more advanced usage, you will need to get acquainted to the [Expressjs API](https://expressjs.com/en/4x/api.html).
+For more advanced usage, you will need to get acquainted to the [Express API](https://expressjs.com/en/4x/api.html).
 :::
 
 ::: warning
@@ -19,7 +19,7 @@ You will need at least one SSR middleware file which handles the rendering of th
 
 ## Anatomy of a middleware file
 
-A SSR middleware file is a simple JavaScript file which exports a function. Quasar will then call the exported function when it prepares the Nodejs server (Expressjs) app and additionally pass an Object as param (which will be detailed in the next section).
+A SSR middleware file is a simple JavaScript file which exports a function. Quasar will then call the exported function when it prepares the Nodejs server (Express) app and additionally pass an Object as param (which will be detailed in the next section).
 
 ```js
 import { defineSsrMiddleware } from '#q-app/wrappers'
@@ -64,7 +64,7 @@ Detailing the Object:
 
 ```js
 {
-  app, // Expressjs app or whatever is returned from src-ssr/server -> create()
+  app, // Express app or whatever is returned from src-ssr/server -> create()
   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
   resolve: {
     urlPath, // (url) => path string with publicPath ensured to be included,
@@ -302,7 +302,7 @@ Notice the `render` parameter (from the above code sample) that the exported fun
 
 ## Hot Module Reload
 
-While developing, whenever you change anything in the SSR middlewares, Quasar App CLI will automatically trigger a recompilation of client-side resources and apply the middleware changes to the Nodejs server (Expressjs).
+While developing, whenever you change anything in the SSR middlewares, Quasar App CLI will automatically trigger a recompilation of client-side resources and apply the middleware changes to the Nodejs server (Express).
 
 ## Examples of SSR middleware
 

--- a/docs/src/pages/quasar-cli-webpack/developing-ssr/ssr-webserver.md
+++ b/docs/src/pages/quasar-cli-webpack/developing-ssr/ssr-webserver.md
@@ -41,6 +41,7 @@ import {
  *
  * Param: ({
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
+ *   devHttpsOptions, // DEV only, if using HTTPS; if using a custom server, you can use this to handle HTTPS on your own instead of using the devHttpsApp in listen()
  *   resolve: {
  *      urlPath, // (url) => path string with publicPath ensured to be included,
  *      root, // (pathPart1, ...pathPartN) => path string (joins to the root folder),
@@ -84,8 +85,9 @@ export const create = defineSsrCreate((/* { ... } */) => {
  * Can be async: defineSsrListen(async ({ app, devHttpsApp, port }) => { ... })
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
- *   devHttpsApp, // DEV only, if using HTTPS
+ *   app, // Express app or whatever is returned from create()
+ *   devHttpsApp, // DEV only, if using HTTPS; Node HTTPS server instance
+ *   devHttpsOptions, // DEV only, if using HTTPS; if you are using a custom server, you can use this to handle HTTPS on your own
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
  *      urlPath, // (url) => path string with publicPath ensured to be included,
@@ -124,7 +126,7 @@ export const listen = defineSsrListen(({ app, devHttpsApp, port }) => {
  * Can be async: defineSsrClose(async ({ listenResult }) => { ... })
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
+ *   app, // Express app or whatever is returned from create()
  *   devHttpsApp, // DEV only, if using HTTPS
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
@@ -163,7 +165,7 @@ const maxAge = process.env.DEV
  * Can return an async function: return async ({ urlPath = '/', pathToServe = '.', opts = {} }) => {
  *
  * Param: ({
- *   app, // Expressjs app or whatever is returned from create()
+ *   app, // Express app or whatever is returned from create()
  *   port, // on dev: devServer port; on prod: process.env.PORT or quasar.config > ssr > prodPort
  *   resolve: {
  *      urlPath: (url) => path string with publicPath ensured to be included,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**

`devHttpsApp` is a `node:https` Server that is automatically created on dev if using HTTPS. However, if using a custom webserver which supports HTTPS, such as h3, then it becomes complicated to handle both `devHttpsApp` and `app`, especially if the `app` instance doesn't have a `listen` method or not with the same signature.

We are now providing `devHttpsOptions` so the user can handle dev server HTTPs on their own.
Also, now `devHttpsApp` will only get created lazily on access, e.g. when calling `devHttpsApp.listen()`. So, if handling it manually, it won't get created unnecessarily. Also, I improved the error handling so now it won't broke the dev server completely, but log a warning with an appropiate message instead.