### PR TITLE
fix(ui): change clearable node from icon to button #18084

### DIFF
--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -2,6 +2,7 @@ import { h, ref, computed, Transition, nextTick, onActivated, onDeactivated, onB
 
 import QIcon from '../../components/icon/QIcon.js'
 import QSpinner from '../../components/spinner/QSpinner.js'
+import QBtn from '../../components/btn/QBtn.js'
 
 import useId from '../use-id/use-id.js'
 import useSplitAttrs from '../use-split-attrs/use-split-attrs.js'
@@ -392,12 +393,14 @@ export default function (state) {
     else if (props.clearable === true && state.hasValue.value === true && state.editable.value === true) {
       node.push(
         getInnerAppendNode('inner-clearable-append', [
-          h(QIcon, {
+          h(QBtn, {
             class: 'q-field__focusable-action',
-            name: props.clearIcon || $q.iconSet.field.clear,
-            tabindex: 0,
-            role: 'button',
-            'aria-hidden': 'false',
+            icon: props.clearIcon || $q.iconSet.field.clear,
+            flat: true,
+            unelevated: true,
+            padding: '0px 0px',
+            round: true,
+            dense: true,
             'aria-label': $q.lang.label.clear,
             onKeyup: onClearableKeyup,
             onClick: clearValue


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This PR replaces the rendering of a QIcon with a QBtn, in order to stick to WCAG rules.
This chage aims to use semantic HTML instead of roles and ARIA to provide accessible components out of the box, without changing icon library or type
Every input component created using use-field composable is affected by this modification

Closes #18084