### PR TITLE
Change proxy configuration to array format

### DIFF
--- a/docs/src/pages/quasar-cli-webpack/api-proxying.md
+++ b/docs/src/pages/quasar-cli-webpack/api-proxying.md
@@ -12,16 +12,15 @@ To configure the proxy rules, edit the `/quasar.config` file in `devServer.proxy
 
 ```js /quasar.config file
 devServer: {
-  proxy: {
+  proxy: [
     // proxy all requests starting with /api to jsonplaceholder
-    '/api': {
-      target: 'http://some.api.target.com:7070',
-      changeOrigin: true,
-      pathRewrite: {
-        '^/api': ''
-      }
+    {
+        context: ['/api'],
+        target: 'http://some.api.target.com:7070',
+        pathRewrite: { '^/api': '' },
+        changeOrigin: true
     }
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
this is following new configuration params in webpack, previous example threw an error

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Previous example about proxy in devserver for webpack was incompatible with latest supported version of webpack. This should fix it.
