### PR TITLE
docs: add note for vueRouterMode usage in Capacitor and Electron

### DIFF
--- a/app-vite/types/configuration/build.d.ts
+++ b/app-vite/types/configuration/build.d.ts
@@ -244,6 +244,7 @@ interface QuasarStaticBuildConfiguration {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
+   * For Capacitor and Electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */

--- a/app-webpack/types/configuration/build.d.ts
+++ b/app-webpack/types/configuration/build.d.ts
@@ -187,6 +187,7 @@ interface QuasarStaticBuildConfiguration {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
+   * For Capacitor and Electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */

--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -553,6 +553,7 @@ interface QuasarBuildConfiguration {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
+   * For capacitor and electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */

--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -553,7 +553,7 @@ interface QuasarBuildConfiguration {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
-   * For capacitor and electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
+   * For Capacitor and Electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */

--- a/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
@@ -494,6 +494,7 @@ build: {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
+   * For capacitor and electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */

--- a/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-webpack/quasar-config-file.md
@@ -494,7 +494,7 @@ build: {
   /**
    * Sets [Vue Router mode](https://router.vuejs.org/guide/essentials/history-mode.html).
    * History mode requires configuration on your deployment web server too.
-   * For capacitor and electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
+   * For Capacitor and Electron, it's always 'hash' for [compatibility reasons](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962).
    *
    * @default 'hash'
    */


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

As illustrated in [this issue](https://github.com/quasarframework/quasar/issues/18116#issuecomment-3252711611) and [this issue](https://github.com/quasarframework/quasar/issues/17322#issuecomment-2191987962), the `ROUTER_MODE` is set to `hash` instead of `history` in Capacitor and Electron modes. However, the documentation does not clarify this. It should be stated explicitly to avoid confusion.
