### PR TITLE
fix(QMenu): prevent nested menus from closing on unrelated click-outside (#18091)

### DIFF
--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -118,6 +118,11 @@ export default createComponent({
         if (props.persistent !== true && showing.value === true) {
           hide(e)
 
+          // prevent further processing of click-outside handlers
+          if (props.separateClosePopup === true) {
+            e.qSeparateClosePopup = true
+          }
+
           if (
             // always prevent touch event
             e.type === 'touchstart'

--- a/ui/src/utils/private.click-outside/click-outside.js
+++ b/ui/src/utils/private.click-outside/click-outside.js
@@ -63,6 +63,11 @@ function globalHandler (evt) {
       // used to prevent refocus after menu close
       evt.qClickOutside = true
       state.onClickOutside(evt)
+
+      // used to prevent closing all if nested
+      if (evt.qSeparateClosePopup === true) {
+        return
+      }
     }
     else {
       return


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Since click-outside was processing all registered handlers it was closing everything nested on menus. Added a small check to prevent this from happening so only the inner closes and acts more like esc key method. If wanted could make it so the flag only happens if it notices q-dialog but since the menus all close properly depending on where you click, shouldn't be needed.