### PR TITLE
fix(ui): Rows inside columns now correctly take full width of their parent (#18151)

### DIFF
--- a/ui/src/css/core/flex.sass
+++ b/ui/src/css/core/flex.sass
@@ -57,6 +57,8 @@
   flex-direction: column
   &.reverse
     flex-direction: column-reverse
+  >.row
+    width: 100%
 
 .wrap
   flex-wrap: wrap


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**
This is a pretty straight forward fix that seems to more or less match how other frameworks do things.