### PR TITLE
fix(ui): switch-toggle-side colors are now switched (#18008)

### DIFF
--- a/ui/src/components/expansion-item/QExpansionItem.sass
+++ b/ui/src/components/expansion-item/QExpansionItem.sass
@@ -1,8 +1,16 @@
 .q-expansion-item
 
+  .q-item__section--avatar:has(> &__toggle-icon)
+    color: $grey-7
+
+  .q-item--dark .q-item__section--avatar:has(> &__toggle-icon)
+    color: rgba(255,255,255,.7)
+
+  .q-item__section--side:has(> .q-icon):not(:has(> &__toggle-icon))
+    color: inherit !important
+
   &__border
     opacity: 0
-
 
   &__toggle-icon
     position: relative


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Added some checks to the SASS on if the toggle icon is there or not. Then for when it's not the toggle icon, important(ed) the inherited color so it nicely comes through. Tested the changes in both light and dark mode.