### PR TITLE
fix(ui): QInput shadow-text is showing when input is out of focus but hasError (#17155)

### DIFF
--- a/ui/src/components/field/QField.sass
+++ b/ui/src/components/field/QField.sass
@@ -209,6 +209,8 @@ $field-transition-label-right-up: .324s cubic-bezier(.4,0,.2,1)
   &--highlighted
     .q-field__label
       color: currentColor
+
+  &--focused:not(.q-field--error)
     .q-field__shadow
       opacity: .5
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

Since errors were treated the same as focus for the highlighted class in use-field.js
```
+ (hasError.value === true || state.focused.value === true ? ' q-field--highlighted' : '')
```
made a simple change for the shadow-text/focused situation by splitting off for focused and checking if there's an error. If not, shadow-text acts normally.
