### PR TITLE
perf(QTree): QTree opt-in property to enable virtual scrolling (fix #17941)

### DIFF
--- a/ui/playground/src/pages/components/tree.vue
+++ b/ui/playground/src/pages/components/tree.vue
@@ -46,7 +46,7 @@
       <div class="q-mt-lg q-pa-lg" :class="{'bg-black': dark}">
         <q-tree
           ref="tree"
-          style="height: 300px"
+          style="height: 500px;"
           :nodes="nodes"
           node-key="key"
           children-key="subnodes"
@@ -153,7 +153,7 @@ export default {
     findNode('KEY: Node 1.3 - tap on me!', smallTree).handler = () => this.$q.notify('Tapped on node 1.3')
 
     return {
-      virtualScroll: false,
+      virtualScroll: true,
       noConnectors: false,
       noTransition: false,
       selected: null,

--- a/ui/playground/src/pages/components/tree.vue
+++ b/ui/playground/src/pages/components/tree.vue
@@ -19,6 +19,7 @@
             <q-toggle v-model="selectableNodes" label="Selectable nodes" />
             <q-toggle v-model="noSelectionUnset" label="noSelectionUnset" />
             <q-toggle v-model="noConnectors" label="No connectors" />
+            <q-toggle v-model="virtualScroll" label="Virtual Scroll" />
           </div>
           <div class="col-xs-12 col-md-4">
             <q-input v-model="filter" label="Filter" />
@@ -36,7 +37,7 @@
             <q-btn @click="getNodeByKey" no-caps label="getNodeByKey test" />
             <q-toggle v-model="isBigTree" label="Load Big Tree"/>
             <q-toggle v-model="noTransition" label="noTransition"/>
-            <q-btn @click="expandAll" no-caps label="Expand all" />
+            <q-btn @click="expandAll" no-caps :ripple="false" label="Expand all" />
             <q-btn @click="collapseAll" no-caps label="Collapse all" />
           </div>
         </div>
@@ -45,6 +46,7 @@
       <div class="q-mt-lg q-pa-lg" :class="{'bg-black': dark}">
         <q-tree
           ref="tree"
+          style="height: 300px"
           :nodes="nodes"
           node-key="key"
           children-key="subnodes"
@@ -52,6 +54,7 @@
           :tick-strategy="tickStrategy"
           v-model:ticked="ticked"
           v-model:expanded="expanded"
+          :virtual-scroll="virtualScroll"
           :dark="dark"
           :dense="dense"
           :accordion="accordion"
@@ -150,6 +153,7 @@ export default {
     findNode('KEY: Node 1.3 - tap on me!', smallTree).handler = () => this.$q.notify('Tapped on node 1.3')
 
     return {
+      virtualScroll: false,
       noConnectors: false,
       noTransition: false,
       selected: null,

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -90,8 +90,9 @@ export default createComponent({
     const isDark = useDark(props, $q)
 
     const lazy = ref({})
-    const innerTicked = ref(props.ticked || [])
-    const innerExpanded = ref(props.expanded || [])
+    const innerTicked = ref(new Set(props.ticked || []))
+    const innerExpanded = ref(new Set(props.expanded || []))
+    const innerNodes = ref(new Map(getNodesPairs(props.nodes)))
 
     let blurTargets = {}
 
@@ -139,7 +140,7 @@ export default createComponent({
       const travel = (node, parent) => {
         const tickStrategy = node.tickStrategy || (parent ? parent.tickStrategy : props.tickStrategy)
         const
-          key = node[ props.nodeKey ],
+          key = getNodeKey(node),
           isParent = node[ props.childrenKey ] && Array.isArray(node[ props.childrenKey ]) && node[ props.childrenKey ].length !== 0,
           selectable = node.disabled !== true && hasSelection.value === true && node.selectable !== false,
           expandable = node.disabled !== true && node.expandable !== false,
@@ -174,7 +175,7 @@ export default createComponent({
 
           selected: key === props.selected && selectable === true,
           selectable,
-          expanded: isParent === true ? innerExpanded.value.includes(key) : false,
+          expanded: isParent === true ? innerExpanded.value.has(key) : false,
           expandable,
           noTick: node.noTick === true || (strictTicking !== true && localLazy && localLazy !== 'loaded'),
           tickable,
@@ -184,8 +185,8 @@ export default createComponent({
           leafFilteredTicking,
           leafTicking,
           ticked: strictTicking === true
-            ? innerTicked.value.includes(key)
-            : (isParent === true ? false : innerTicked.value.includes(key))
+            ? innerTicked.value.has(key)
+            : (isParent === true ? false : innerTicked.value.has(key))
         }
 
         meta[ key ] = m
@@ -246,32 +247,39 @@ export default createComponent({
     })
 
     watch(() => props.ticked, val => {
-      innerTicked.value = val
+      innerTicked.value = new Set(val)
     })
 
     watch(() => props.expanded, val => {
-      innerExpanded.value = val
+      innerExpanded.value = new Set(val)
     })
 
-    function getNodeByKey (key) {
-      const reduce = [].reduce
+    watch(() => props.nodes, val => {
+      innerNodes.value = new Map(getNodesPairs(val))
+    })
 
-      const find = (result, node) => {
-        if (result || !node) {
-          return result
+    function getNodesPairs (nodes) {
+      const nodePairs = []
+
+      const travel = (node) => {
+        if (Array.isArray(node[ props.childrenKey ])) {
+          node[ props.childrenKey ].forEach(travel)
         }
-        if (Array.isArray(node) === true) {
-          return reduce.call(Object(node), find, result)
-        }
-        if (node[ props.nodeKey ] === key) {
-          return node
-        }
-        if (node[ props.childrenKey ]) {
-          return find(null, node[ props.childrenKey ])
-        }
+
+        nodePairs.push([ getNodeKey(node), node ])
       }
 
-      return find(null, props.nodes)
+      nodes.forEach(travel)
+
+      return nodePairs
+    }
+
+    function getNodeKey (node) {
+      return node[ props.nodeKey ]
+    }
+
+    function getNodeByKey (key) {
+      return innerNodes.value.get(key) ?? null
     }
 
     function getTickedNodes () {
@@ -293,28 +301,20 @@ export default createComponent({
         emit('update:expanded', [])
       }
       else {
-        innerExpanded.value = []
+        innerExpanded.value = new Set([])
       }
     }
 
     function expandAll () {
-      const expanded = []
-      const travel = node => {
-        if (node[ props.childrenKey ] && node[ props.childrenKey ].length !== 0) {
-          if (node.expandable !== false && node.disabled !== true) {
-            expanded.push(node[ props.nodeKey ])
-            node[ props.childrenKey ].forEach(travel)
-          }
-        }
-      }
+      const expanded = [ ...innerNodes.value.keys() ]
 
-      props.nodes.forEach(travel)
+      const shouldEmit = props.expanded !== void 0
 
-      if (props.expanded !== void 0) {
+      if (shouldEmit) {
         emit('update:expanded', expanded)
       }
       else {
-        innerExpanded.value = expanded
+        innerExpanded.value = new Set(expanded)
       }
     }
 
@@ -353,12 +353,7 @@ export default createComponent({
     }
 
     function localSetExpanded (key, state) {
-      let target = innerExpanded.value
       const shouldEmit = props.expanded !== void 0
-
-      if (shouldEmit === true) {
-        target = target.slice()
-      }
 
       if (state) {
         if (props.accordion) {
@@ -373,30 +368,25 @@ export default createComponent({
             }
             else {
               props.nodes.forEach(node => {
-                const k = node[ props.nodeKey ]
+                const k = getNodeKey(node)
                 if (k !== key) {
                   collapse.push(k)
                 }
               })
             }
             if (collapse.length !== 0) {
-              target = target.filter(k => collapse.includes(k) === false)
+              collapse.forEach(key => innerExpanded.value.delete(key))
             }
           }
         }
-
-        target = target.concat([ key ])
-          .filter((key, index, self) => self.indexOf(key) === index)
+        innerExpanded.value.add(key)
       }
       else {
-        target = target.filter(k => k !== key)
+        innerExpanded.value.delete(key)
       }
 
       if (shouldEmit === true) {
-        emit('update:expanded', target)
-      }
-      else {
-        innerExpanded.value = target
+        emit('update:expanded', [ ...innerExpanded.value ])
       }
     }
 
@@ -407,23 +397,17 @@ export default createComponent({
     }
 
     function setTicked (keys, state) {
-      let target = innerTicked.value
       const shouldEmit = props.ticked !== void 0
 
-      if (shouldEmit === true) {
-        target = target.slice()
-      }
-
       if (state) {
-        target = target.concat(keys)
-          .filter((key, index, self) => self.indexOf(key) === index)
+        keys.forEach(key => innerTicked.value.add(key))
       }
       else {
-        target = target.filter(k => keys.includes(k) === false)
+        keys.forEach(key => innerTicked.value.delete(key))
       }
 
       if (shouldEmit === true) {
-        emit('update:ticked', target)
+        emit('update:ticked', [ ...innerTicked.value ])
       }
     }
 
@@ -482,7 +466,7 @@ export default createComponent({
 
     function getNode (node) {
       const
-        key = node[ props.nodeKey ],
+        key = getNodeKey(node),
         m = meta.value[ key ],
         header = node.header
           ? slots[ `header-${ node.header }` ] || slots[ 'default-header' ]

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -8,7 +8,6 @@ import QIcon from '../icon/QIcon.js'
 import QCheckbox from '../checkbox/QCheckbox.js'
 import QSlideTransition from '../slide-transition/QSlideTransition.js'
 import QSpinner from '../spinner/QSpinner.js'
-import QIntersection from '../intersection/QIntersection.js'
 
 import useDark, { useDarkProps } from '../../composables/private.use-dark/use-dark.js'
 
@@ -93,8 +92,6 @@ export default createComponent({
 
     const isDark = useDark(props, $q)
 
-    const nodesCache = []
-
     const lazy = ref({})
     const innerTicked = ref(new Set(props.ticked || []))
     const innerExpanded = ref(new Set(props.expanded || []))
@@ -137,7 +134,31 @@ export default createComponent({
     ))
         const virtSlots = {
           default: props => {
-            return getNode(props.item)
+            console.log(props)
+            const key = getNodeKey(props.item.node)
+            const m = meta.value[key]
+            
+            const node = getNode(props.item.node, true)
+
+            if (props.item.level > 0) {
+              let level = node;
+              for (let index = 0; index < props.item.level; index++) {
+                level = h('div', {
+                        class: 'q-tree__node-collapsible' + textColorClass.value,
+                        key: `${ key }__q`
+                      }, [
+                        h('div', {
+                          class: 'q-tree__children'
+                            + (m.disabled === true ? ' q-tree__node--disabled' : ''),
+                          role: 'group'
+                        }, [level])
+                      ]);
+              }
+
+              return level;
+            }
+
+            return node
           }
         }
 
@@ -440,15 +461,30 @@ export default createComponent({
     }
 
     function getChildren (nodes) {
-      const children =  (
+    if (props.virtualScroll) {
+      const virtualChildren = []
+
+      const travel = (node, level = 0) => {
+        const key = getNodeKey(node)
+        const m = meta.value[key]
+
+        virtualChildren.push({node, level})
+        
+        if (m.expanded && Array.isArray(node[ props.childrenKey ])) {
+          node[ props.childrenKey ].forEach(child => travel(child, level + 1))
+        }
+      }
+
+      nodes.forEach(node => travel(node, 0))
+
+      return h(QVirtualScroll, {style: attrs.style, separator: true, type: 'list', items: virtualChildren}, virtSlots)
+    }
+
+      return (
         props.filter
           ? nodes.filter(n => meta.value[ n[ props.nodeKey ] ].matchesFilter)
           : nodes
-      ).map((child, index) => getNode(child, index))
-
-      return props.virtualScroll ? h(QVirtualScroll, {style: {
-        height: `300px`
-      }, separator: true, type: 'list', items: nodes}, virtSlots) : children
+      ).map((child) => getNode(child))
     }
 
     function getNodeMedia (node) {
@@ -476,7 +512,7 @@ export default createComponent({
       emit('afterHide')
     }
 
-    function getNode (node, cacheIndex) {
+    function getNode (node, omitChildren) {
       const
         key = getNodeKey(node),
         m = meta.value[ key ],
@@ -484,11 +520,13 @@ export default createComponent({
           ? slots[ `header-${ node.header }` ] || slots[ 'default-header' ]
           : slots[ 'default-header' ]
 
-      const children = m.isParent === true
-        ? getChildren(node[ props.childrenKey ])
+      const childrenMeta = node[props.childrenKey] ?? [];
+
+      const children = m.isParent === true 
+        ? getChildren(childrenMeta)
         : []
 
-      const isParent = children.length !== 0 || (m.lazy && m.lazy !== 'loaded')
+      const isParent = childrenMeta.length !== 0 || (m.lazy && m.lazy !== 'loaded')
 
       let body = node.body
         ? slots[ `body-${ node.body }` ] || slots[ 'default-body' ]
@@ -506,8 +544,7 @@ export default createComponent({
         ])
       }
 
-      return withMemo([key, m.selected, m.disabled, m.ticked, m.expanded], () => 
-        h('div', {
+      return h('div', {
         key,
         class: 'q-tree__node relative-position'
           + ` q-tree__node--${ isParent === true ? 'parent' : 'child' }`
@@ -581,7 +618,7 @@ export default createComponent({
           ])
         ]),
 
-        isParent === true
+        isParent === true && !omitChildren
           ? (
               props.noTransition === true
                 ? (
@@ -620,7 +657,7 @@ export default createComponent({
                 ))
             )
           : body
-      ]), nodesCache, cacheIndex)
+      ])
     }
 
     function blur (key) {
@@ -702,7 +739,7 @@ export default createComponent({
     })
 
     return () => {
-      const children = getChildren(props.nodes)
+      const children = getChildren(props.nodes);
 
       return h(
         'div', {

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -1,12 +1,14 @@
 import {
   h, ref, computed, watch,
-  withDirectives, vShow, nextTick, getCurrentInstance, onBeforeUpdate
+  withDirectives, vShow, nextTick, getCurrentInstance, onBeforeUpdate,
+  withMemo
 } from 'vue'
 
 import QIcon from '../icon/QIcon.js'
 import QCheckbox from '../checkbox/QCheckbox.js'
 import QSlideTransition from '../slide-transition/QSlideTransition.js'
 import QSpinner from '../spinner/QSpinner.js'
+import QIntersection from '../intersection/QIntersection.js'
 
 import useDark, { useDarkProps } from '../../composables/private.use-dark/use-dark.js'
 
@@ -14,6 +16,7 @@ import { createComponent } from '../../utils/private.create/create.js'
 import { stopAndPrevent } from '../../utils/event/event.js'
 import { shouldIgnoreKey } from '../../utils/private.keyboard/key-composition.js'
 import { injectProp } from '../../utils/private.inject-obj-prop/inject-obj-prop.js'
+import QVirtualScroll from '../virtual-scroll/QVirtualScroll.js'
 
 const tickStrategyOptions = [ 'none', 'strict', 'leaf', 'leaf-filtered' ]
 
@@ -41,6 +44,7 @@ export default createComponent({
     },
 
     dense: Boolean,
+    virtualScroll: Boolean,
 
     color: String,
     controlColor: String,
@@ -83,22 +87,20 @@ export default createComponent({
     'afterHide'
   ],
 
-  setup (props, { slots, emit }) {
+  setup (props, { slots, emit, attrs }) {
     const { proxy } = getCurrentInstance()
     const { $q } = proxy
 
     const isDark = useDark(props, $q)
+
+    const nodesCache = []
 
     const lazy = ref({})
     const innerTicked = ref(new Set(props.ticked || []))
     const innerExpanded = ref(new Set(props.expanded || []))
     const innerNodes = ref(new Map(getNodesPairs(props.nodes)))
 
-    let blurTargets = {}
-
-    onBeforeUpdate(() => {
-      blurTargets = {}
-    })
+    const blurTargets = {}
 
     const classes = computed(() =>
       `q-tree q-tree--${ props.dense === true ? 'dense' : 'standard' }`
@@ -133,6 +135,11 @@ export default createComponent({
             && node[ props.labelKey ].toLowerCase().indexOf(filt) !== -1
           }
     ))
+        const virtSlots = {
+          default: props => {
+            return getNode(props.item)
+          }
+        }
 
     const meta = computed(() => {
       const meta = {}
@@ -243,6 +250,7 @@ export default createComponent({
       }
 
       props.nodes.forEach(node => travel(node, null))
+
       return meta
     })
 
@@ -432,11 +440,15 @@ export default createComponent({
     }
 
     function getChildren (nodes) {
-      return (
+      const children =  (
         props.filter
           ? nodes.filter(n => meta.value[ n[ props.nodeKey ] ].matchesFilter)
           : nodes
-      ).map(child => getNode(child))
+      ).map((child, index) => getNode(child, index))
+
+      return props.virtualScroll ? h(QVirtualScroll, {style: {
+        height: `300px`
+      }, separator: true, type: 'list', items: nodes}, virtSlots) : children
     }
 
     function getNodeMedia (node) {
@@ -464,7 +476,7 @@ export default createComponent({
       emit('afterHide')
     }
 
-    function getNode (node) {
+    function getNode (node, cacheIndex) {
       const
         key = getNodeKey(node),
         m = meta.value[ key ],
@@ -494,7 +506,8 @@ export default createComponent({
         ])
       }
 
-      return h('div', {
+      return withMemo([key, m.selected, m.disabled, m.ticked, m.expanded], () => 
+        h('div', {
         key,
         class: 'q-tree__node relative-position'
           + ` q-tree__node--${ isParent === true ? 'parent' : 'child' }`
@@ -607,7 +620,7 @@ export default createComponent({
                 ))
             )
           : body
-      ])
+      ]), nodesCache, cacheIndex)
     }
 
     function blur (key) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.


**Other information:**
- This PR will solve the bad performance to find the expanded/ticked node when the big tree is loaded, and solves the rendering overhead  when full expanded.