### PR TITLE
fix(QItem): caption and overline colors now inherit from container

### DIFF
--- a/ui/src/components/item/QItem.sass
+++ b/ui/src/components/item/QItem.sass
@@ -44,10 +44,12 @@
     max-width: 100%
 
     &--overline
-      color: rgba(0,0,0,.7)
+      color: currentColor
+      opacity: .7
 
     &--caption
-      color: rgba(0,0,0,.54)
+      color: currentColor
+      opacity: .54
 
     &--header
       color: $grey-7
@@ -110,7 +112,7 @@
     &--header
       color: rgba(255,255,255,.64)
     &--overline, &--caption
-      color: rgba(255,255,255,.8)
+      opacity: .8
 
 .q-item
   position: relative


### PR DESCRIPTION
…18150)

Changed q-item__label--caption and --overline to use currentColor with opacity instead of fixed rgba colors. This allows caption and overline text to properly inherit the text color from their parent container (e.g., when using active-class="text-white" or other color utilities).

Fixes #18150

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
