### PR TITLE
fix(a11y): add aria-label to QTable records-per-page QSelect (#18170)

### DIFF
--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -838,6 +838,7 @@ export default createComponent({
             dense: true,
             optionsDense: true,
             optionsCover: true,
+            'aria-label': props.rowsPerPageLabel || $q.lang.table.recordsPerPage,
             'onUpdate:modelValue': onPagSelection
           })
         ])


### PR DESCRIPTION
This PR fixes issue **#18170**, which reported that the QTable pagination "Records per page" dropdown lacked an accessibility label.

The `QSelect` used for selecting the number of rows per page was missing an `aria-label`, causing screen readers to announce it incorrectly and failing WCAG accessibility requirements.

### **What was changed**

Added the following property to the QSelect inside `getPaginationDiv()` in `ui/src/components/table/QTable.js`:

```js
'aria-label': props.rowsPerPageLabel || $q.lang.table.recordsPerPage
```

This ensures:

* If the user provides `rowsPerPageLabel`, it becomes the aria-label.
* Otherwise it falls back to the default language string (`$q.lang.table.recordsPerPage`).

### **Impact**

* Improves accessibility for screen-reader users.
* Fixes the missing label reported in #18170.
* Fully backward-compatible.
* No behavioral or visual changes to QTable.

### **Testing**

Tested locally in the Quasar dev environment and confirmed that the rendered HTML now includes:

```html
<select aria-label="Records per page">
```

This resolves the accessibility issue.
