### PR TITLE
fix(QDialog): restore scroll after close if only hash/query changed #…

### DIFF
--- a/ui/src/utils/scroll/prevent-scroll.js
+++ b/ui/src/utils/scroll/prevent-scroll.js
@@ -149,9 +149,10 @@ function apply (action) {
     body.style.top = bodyTop
 
     // scroll back only if route has not changed
-    if (window.location.href === href) {
-      window.scrollTo(scrollPositionX, scrollPositionY)
-    }
+  if (window.location.pathname === new URL(href).pathname) {
+    window.scrollTo(scrollPositionX, scrollPositionY)
+  }
+
 
     maxScrollTop = void 0
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #18185`)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Description / What problem is solved:**
QDialog does not restore scroll position if the URL hash or query parameters change while the dialog is open. 
Currently, scroll is restored only if `window.location.href === href`, which fails when only hash/query changes.

This change updates the check to compare only the **route path** (`window.location.pathname`) instead of the full URL. 
Scroll is now restored correctly after closing the dialog if the route path has not changed.

**Code change:**

```js
// before:
if (window.location.href === href) {
  window.scrollTo(scrollPositionX, scrollPositionY)
}

// after:
if (window.location.pathname === new URL(href).pathname) {
  window.scrollTo(scrollPositionX, scrollPositionY)
}
`