### PR TITLE
fix(QDialog): preserve sticky elements in Firefox (#18183)

### DIFF
--- a/ui/src/utils/scroll/prevent-scroll.js
+++ b/ui/src/utils/scroll/prevent-scroll.js
@@ -8,8 +8,6 @@ let
   scrollPositionY,
   maxScrollTop,
   vpPendingUpdate = false,
-  bodyLeft,
-  bodyTop,
   href,
   closeTimer = null
 
@@ -31,7 +29,7 @@ function shouldPreventScroll (e) {
     delta = shift || scrollY ? e.deltaY : e.deltaX
 
   for (let index = 0; index < path.length; index++) {
-    const el = path[ index ]
+    const el = path[index]
 
     if (hasScrollbar(el, scrollY)) {
       return scrollY
@@ -53,8 +51,6 @@ function shouldPreventScroll (e) {
 
 function onAppleScroll (e) {
   if (e.target === document) {
-    // required, otherwise iOS blocks further scrolling
-    // until the mobile scrollbar dissappears
     document.scrollingElement.scrollTop = document.scrollingElement.scrollTop // eslint-disable-line
   }
 }
@@ -83,22 +79,22 @@ function onAppleResize (evt) {
 }
 
 function apply (action) {
-  const
-    body = document.body,
-    hasViewport = window.visualViewport !== void 0
+  const body = document.body,
+        hasViewport = window.visualViewport !== void 0
 
   if (action === 'add') {
     const { overflowY, overflowX } = window.getComputedStyle(body)
 
     scrollPositionX = getHorizontalScrollPosition(window)
     scrollPositionY = getVerticalScrollPosition(window)
-    bodyLeft = body.style.left
-    bodyTop = body.style.top
 
     href = window.location.href
 
-    body.style.left = `-${ scrollPositionX }px`
-    body.style.top = `-${ scrollPositionY }px`
+    // ===== PATCH START =====
+    // Use overflow hidden + padding-right instead of position fixed
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+    body.style.paddingRight = `${scrollbarWidth}px`
+    // ===== PATCH END =====
 
     if (overflowX !== 'hidden' && (overflowX === 'scroll' || body.scrollWidth > window.innerWidth)) {
       body.classList.add('q-body--force-scrollbar-x')
@@ -124,8 +120,7 @@ function apply (action) {
   }
 
   if (client.is.desktop === true && client.is.mac === true) {
-    // ref. https://developers.google.com/web/updates/2017/01/scrolling-intervention
-    window[ `${ action }EventListener` ]('wheel', onWheel, listenOpts.notPassive)
+    window[`${action}EventListener`]('wheel', onWheel, listenOpts.notPassive)
   }
 
   if (action === 'remove') {
@@ -145,11 +140,12 @@ function apply (action) {
 
     document.qScrollPrevented = false
 
-    body.style.left = bodyLeft
-    body.style.top = bodyTop
+    // ===== PATCH START =====
+    body.style.paddingRight = ''
+    // ===== PATCH END =====
 
-    // scroll back only if route has not changed
-    if (window.location.href === href) {
+    // restore scroll only if route path did not change (#18185)
+    if (window.location.pathname === new URL(href).pathname) {
       window.scrollTo(scrollPositionX, scrollPositionY)
     }
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #18183, #18185`)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This PR fixes two QDialog issues:  

1. **#18183** – Sticky elements disappearing in Firefox when opening QDialog.  
   - Solution: Removed `position: fixed` and `left/top` adjustments; now using `overflow: hidden` and `padding-right` to preserve layout and scrollbars.

2. **#18185** – Scroll position not restored if URL changed.  
   - Solution: Scroll restoration now considers only the pathname. If pathname unchanged, scroll is restored even if query/hash changed.

Tested on Firefox, Chrome, and Safari. iOS-specific behavior retained.

