### PR TITLE
fix(QInput): change q-input about type text clearValue() default null to empty string(#14032)

### DIFF
--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -263,6 +263,13 @@ export default function (state) {
     return acc
   })
 
+  const isTextarea = computed(() => props.type === 'textarea')
+
+  const isTypeText = computed(() =>
+    isTextarea.value === true
+    || [ 'text', 'search', 'url', 'tel', 'password' ].includes(props.type)
+  )
+
   function focusHandler () {
     const el = document.activeElement
     let target = state.targetRef?.value
@@ -341,8 +348,13 @@ export default function (state) {
       state.inputRef.value.value = null
     }
 
-    emit('update:modelValue', null)
-    state.changeEvent === true && emit('change', null)
+    if (isTypeText.value) {
+      emit('update:modelValue', '')
+      state.changeEvent === true && emit('change', '')
+    } else {
+      emit('update:modelValue', null)
+      state.changeEvent === true && emit('change', null)
+    }
     emit('clear', props.modelValue)
 
     nextTick(() => {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

close: https://github.com/quasarframework/quasar/issues/14032

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [x] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->
QInput clearable func is changed its default null to empty string when input type is 'text', 'search', 'url', 'tel', 'password', or textarea.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
