### PR TITLE
doc(QBtnDropdown): description for 'cover' property

### DIFF
--- a/ui/src/components/btn-dropdown/QBtnDropdown.json
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.json
@@ -63,7 +63,7 @@
 
     "cover": {
       "type": "Boolean",
-      "desc": "Allows the menu to cover the button. When used, the 'menu-self' and 'menu-fit' props are no longer effective",
+      "desc": "Allows the menu to cover the button. When used, the 'menu-self' props are no longer effective",
       "category": "position"
     },
 

--- a/ui/src/components/btn-dropdown/QBtnDropdown.json
+++ b/ui/src/components/btn-dropdown/QBtnDropdown.json
@@ -63,7 +63,7 @@
 
     "cover": {
       "type": "Boolean",
-      "desc": "Allows the menu to cover the button. When used, the 'menu-self' props are no longer effective",
+      "desc": "Allows the menu to cover the button. When used, the 'menu-self' prop is no longer effective",
       "category": "position"
     },
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**


There is no `menu-fit` attribute on QBtnDropdown. I don't know if the text should also contain that `menu-anchor` will be used for `selfOrigin`, if `cover` is set to `true`. See code. 

```js
// https://github.com/quasarframework/quasar/blob/dev/ui/src/components/menu/QMenu.js#L135
    const anchorOrigin = computed(() =>
      parsePosition(
        props.anchor || (
          props.cover === true ? 'center middle' : 'bottom start'
        ),
        $q.lang.rtl
      )
    )

    const selfOrigin = computed(() => (
      props.cover === true
        ? anchorOrigin.value
        : parsePosition(props.self || 'top start', $q.lang.rtl)
    ))
```