### PR TITLE
feat(app-vite): Add --silent option to prepare command

### DIFF
--- a/app-vite/lib/cmd/prepare.js
+++ b/app-vite/lib/cmd/prepare.js
@@ -4,6 +4,7 @@ import { log } from '../utils/logger.js'
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
+    s: 'silent',
     h: 'help'
   },
   boolean: [ 'h' ]
@@ -21,6 +22,7 @@ if (argv.help) {
     $ quasar prepare
 
   Options
+    --silent, -s    Suppress the startup banner
     --help, -h      Displays this message
   `)
   process.exit(0)
@@ -28,12 +30,14 @@ if (argv.help) {
 
 const { readFileSync } = await import('node:fs')
 
-console.log(
-  readFileSync(
-    new URL('../../assets/logo.art', import.meta.url),
-    'utf8'
+if (!argv.silent) {
+  console.log(
+    readFileSync(
+      new URL('../../assets/logo.art', import.meta.url),
+      'utf8'
+    )
   )
-)
+}
 
 const { getCtx } = await import('../utils/get-ctx.js')
 // ctx doesn't matter for this command


### PR DESCRIPTION
Adds a --silent (-s) option to the quasar prepare command to suppress the logo output. This is useful for CI/CD pipelines and build scripts where cleaner output is preferred

```
random_package postinstall$ quasar prepare
[2 lines collapsed]
│ 888     888
│ 888     888 888  888  8888b.  .d8888b   8888b.  888d888
│ 888     888 888  888     "88b 88K          "88b 888P"
│ 888 Y8b 888 888  888 .d888888 "Y8888b. .d888888 888
│ Y88b.Y8b88P Y88b 888 888  888      X88 888  888 888
│  "Y888888"   "Y88888 "Y888888  88888P' "Y888888 888
│        Y8b
│  App • Using quasar.config.ts in "ts" format
│  App • Generated tsconfig.json and types files in .quasar directory
│  App • The app is now prepared for linting, type-checking, IDE integration, etc.
└─ Done in 2s
Done in 4.5s using pnpm v10.22.0
```
_An example of the heavy output inside a pnpm monorepo_

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:** 
 If there's interest, this could be improved in the future to provide a broader quiet mode across CLI commands.
