### PR TITLE
fix(app-vite&app-webpack): improve pnpm monorepo support for capacitor

### DIFF
--- a/app-vite/lib/cache/create-cache-proxy.js
+++ b/app-vite/lib/cache/create-cache-proxy.js
@@ -1,3 +1,8 @@
+/**
+ * @param {import('../../types/configuration/context').InternalQuasarContext} ctx
+ *
+ * @returns {import('../../types/configuration/context').CacheProxy}
+ */
 export function createCacheProxy (ctx) {
   const runtimeCache = {}
   const moduleCache = {}

--- a/app-vite/lib/modes/bex/bex-installation.js
+++ b/app-vite/lib/modes/bex/bex-installation.js
@@ -3,6 +3,12 @@ import fse from 'fs-extra'
 import { log, warn } from '../../utils/logger.js'
 import { isModeInstalled } from '../modes-utils.js'
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -26,6 +32,11 @@ export async function addMode ({
   log('Browser Extension support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-vite/lib/modes/capacitor/capacitor-installation.js
+++ b/app-vite/lib/modes/capacitor/capacitor-installation.js
@@ -60,6 +60,10 @@ export async function addMode ({
   globSync([ '**/*' ], {
     cwd: appPaths.resolve.cli('templates/capacitor')
   }).forEach(filePath => {
+    if (filePath.endsWith('pnpm-workspace.yaml') && nodePackager.name !== 'pnpm') {
+      return
+    }
+
     const dest = appPaths.resolve.capacitor(filePath)
     const content = fse.readFileSync(appPaths.resolve.cli('templates/capacitor/' + filePath))
     fse.ensureFileSync(dest)

--- a/app-vite/lib/modes/capacitor/capacitor-installation.js
+++ b/app-vite/lib/modes/capacitor/capacitor-installation.js
@@ -9,6 +9,13 @@ import { spawnSync } from '../../utils/spawn.js'
 import { ensureDeps, ensureConsistency } from './ensure-consistency.js'
 import { isModeInstalled } from '../modes-utils.js'
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean,
+ *   target: 'android' | 'ios' | undefined
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, cacheProxy, pkg: { appPkg } },
   silent,
@@ -98,6 +105,11 @@ export async function addMode ({
   await addPlatform(target, appPaths, cacheProxy)
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-vite/lib/modes/capacitor/ensure-consistency.js
+++ b/app-vite/lib/modes/capacitor/ensure-consistency.js
@@ -21,6 +21,9 @@ export async function ensureDeps ({ appPaths, cacheProxy }) {
   nodePackager.install({
     cwd: appPaths.capacitorDir,
     // See https://github.com/orgs/pnpm/discussions/4735
+    // We also started creating an empty pnpm-workspace.yaml file in src-capacitor as of app-vite v2.4.1
+    // which addresses all cases without requiring explicit ignore-workspace flag all the time.
+    // However, we are keeping this for backward compatibility of the scaffolded projects and just in case.
     params: nodePackager.name === 'pnpm' ? [ 'i', '--ignore-workspace' ] : undefined,
     displayName: 'Capacitor'
   })

--- a/app-vite/lib/modes/cordova/cordova-installation.js
+++ b/app-vite/lib/modes/cordova/cordova-installation.js
@@ -6,6 +6,13 @@ import { spawnSync } from '../../utils/spawn.js'
 import { ensureWWW, ensureConsistency } from './ensure-consistency.js'
 import { isModeInstalled } from '../modes-utils.js'
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean,
+ *   target: 'android' | 'ios' | undefined
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, pkg: { appPkg } },
   silent,
@@ -76,6 +83,11 @@ export async function addMode ({
   addPlatform(appPaths, target)
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-vite/lib/modes/electron/electron-installation.js
+++ b/app-vite/lib/modes/electron/electron-installation.js
@@ -7,6 +7,12 @@ const electronDeps = {
   electron: 'latest'
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -41,6 +47,11 @@ export async function addMode ({
   log('Electron support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export async function removeMode ({
   ctx: { appPaths, cacheProxy }
 }) {

--- a/app-vite/lib/modes/pwa/pwa-installation.js
+++ b/app-vite/lib/modes/pwa/pwa-installation.js
@@ -19,6 +19,12 @@ const pwaDeps = {
   'register-service-worker': '^1.7.2'
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -63,6 +69,11 @@ export async function addMode ({
   log('PWA support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export async function removeMode ({
   ctx: { appPaths, cacheProxy }
 }) {

--- a/app-vite/lib/modes/ssr/ssr-installation.js
+++ b/app-vite/lib/modes/ssr/ssr-installation.js
@@ -3,6 +3,12 @@ import fse from 'fs-extra'
 import { log, warn } from '../../utils/logger.js'
 import { isModeInstalled } from '../modes-utils.js'
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 export async function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -25,6 +31,11 @@ export async function addMode ({
   log('SSR support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 export function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-vite/lib/utils/get-ctx.js
+++ b/app-vite/lib/utils/get-ctx.js
@@ -13,7 +13,7 @@ function defineHiddenProp (target, propName, value) {
 }
 
 /**
- * @returns {import('../../types/configuration/context').QuasarContext}
+ * @returns {import('../../types/configuration/context').InternalQuasarContext}
  */
 export function getCtx (opts = {}) {
   const ctx = {

--- a/app-vite/lib/utils/get-pkg.js
+++ b/app-vite/lib/utils/get-pkg.js
@@ -4,6 +4,11 @@ import { parseJSON } from 'confbox'
 import { warning } from './logger.js'
 import { getPackageJson } from '../utils/get-package-json.js'
 
+/**
+ * @param {import('../../types/app-paths').QuasarAppPaths} appPaths
+ *
+ * @returns {import('../../types/configuration/context').InternalQuasarContext['pkg']}
+ */
 export function getPkg (appPaths) {
   const { appDir, cliDir } = appPaths
   const appPkgPath = appPaths.resolve.app('package.json')

--- a/app-vite/templates/capacitor/pnpm-workspace.yaml
+++ b/app-vite/templates/capacitor/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+# This file exists to avoid pnpm only installing in the root and not in src-capacitor
+# https://github.com/pnpm/pnpm/issues/9348#issuecomment-2771925480

--- a/app-vite/types/configuration/context.d.ts
+++ b/app-vite/types/configuration/context.d.ts
@@ -161,3 +161,33 @@ export type QuasarContext =
   | CordovaQuasarContext
   | ElectronQuasarContext
   | BexQuasarContext;
+
+type CacheProxyModuleKey =
+  | "animations"
+  | "capCli"
+  | "cssVariables"
+  | "electron"
+  | "eslint"
+  | "hasTypescript"
+  | "nodePackager"
+  | "storeProvider"
+  | "workboxBuild";
+interface CacheProxy {
+  getRuntime: (key: string, getInitialValue: () => any) => any;
+  setRuntime: (key: string, value: any) => void;
+  getModule: (key: CacheProxyModuleKey) => Promise<any>;
+}
+
+/**
+ * @internal
+ */
+export type InternalQuasarContext = QuasarContext & {
+  pkg: {
+    appPkg: Record<string, any>;
+    quasarPkg: Record<string, any>;
+    vitePkg: Record<string, any>;
+  };
+  cacheProxy: CacheProxy;
+  // TODO: add proper type
+  appExt: any;
+};

--- a/app-webpack/lib/cache/create-cache-proxy.js
+++ b/app-webpack/lib/cache/create-cache-proxy.js
@@ -1,3 +1,8 @@
+/**
+ * @param {import('../../types/configuration/context').InternalQuasarContext} ctx
+ *
+ * @returns {import('../../types/configuration/context').CacheProxy}
+ */
 module.exports.createCacheProxy = function createCacheProxy (ctx) {
   const runtimeCache = {}
   const moduleCache = {}

--- a/app-webpack/lib/modes/bex/bex-installation.js
+++ b/app-webpack/lib/modes/bex/bex-installation.js
@@ -3,6 +3,12 @@ const fse = require('fs-extra')
 const { log, warn } = require('../../utils/logger.js')
 const { isModeInstalled } = require('../modes-utils.js')
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 module.exports.addMode = async function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -26,6 +32,11 @@ module.exports.addMode = async function addMode ({
   log('Browser Extension support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-webpack/lib/modes/capacitor/capacitor-installation.js
+++ b/app-webpack/lib/modes/capacitor/capacitor-installation.js
@@ -9,6 +9,13 @@ const { spawnSync } = require('../../utils/spawn.js')
 const { ensureDeps, ensureConsistency } = require('./ensure-consistency.js')
 const { isModeInstalled } = require('../modes-utils.js')
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean,
+ *   target: "android" | 'ios' | undefined
+ * }} options
+ */
 module.exports.addMode = async function addMode ({
   ctx: { appPaths, cacheProxy, pkg: { appPkg } },
   silent,
@@ -100,6 +107,11 @@ module.exports.addMode = async function addMode ({
   addPlatform(target, appPaths, cacheProxy)
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-webpack/lib/modes/capacitor/capacitor-installation.js
+++ b/app-webpack/lib/modes/capacitor/capacitor-installation.js
@@ -62,6 +62,10 @@ module.exports.addMode = async function addMode ({
   globSync([ '**/*' ], {
     cwd: appPaths.resolve.cli('templates/capacitor')
   }).forEach(filePath => {
+    if (filePath.endsWith('pnpm-workspace.yaml') && nodePackager.name !== 'pnpm') {
+      return
+    }
+
     const dest = appPaths.resolve.capacitor(filePath)
     const content = fs.readFileSync(appPaths.resolve.cli('templates/capacitor/' + filePath))
     fse.ensureFileSync(dest)

--- a/app-webpack/lib/modes/capacitor/ensure-consistency.js
+++ b/app-webpack/lib/modes/capacitor/ensure-consistency.js
@@ -22,6 +22,9 @@ function ensureDeps ({ appPaths, cacheProxy }) {
   nodePackager.install({
     cwd: appPaths.capacitorDir,
     // See https://github.com/orgs/pnpm/discussions/4735
+    // We also started creating an empty pnpm-workspace.yaml file in src-capacitor as of v4.3.2
+    // which addresses all cases without requiring explicit ignore-workspace flag all the time.
+    // However, we are keeping this for backward compatibility of the scaffolded projects and just in case.
     params: nodePackager.name === 'pnpm' ? [ 'i', '--ignore-workspace' ] : undefined,
     displayName: 'Capacitor'
   })

--- a/app-webpack/lib/modes/cordova/cordova-installation.js
+++ b/app-webpack/lib/modes/cordova/cordova-installation.js
@@ -6,6 +6,13 @@ const { spawnSync } = require('../../utils/spawn.js')
 const { ensureWWW, ensureConsistency } = require('./ensure-consistency.js')
 const { isModeInstalled } = require('../modes-utils.js')
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean,
+ *   target: 'android' | 'ios' | undefined
+ * }} options
+ */
 module.exports.addMode = async function addMode ({
   ctx: { appPaths, pkg: { appPkg } },
   silent,
@@ -77,6 +84,11 @@ module.exports.addMode = async function addMode ({
   addPlatform(appPaths, target)
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-webpack/lib/modes/electron/electron-installation.js
+++ b/app-webpack/lib/modes/electron/electron-installation.js
@@ -7,6 +7,12 @@ const electronDeps = {
   electron: 'latest'
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 module.exports.addMode = function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -41,6 +47,11 @@ module.exports.addMode = function addMode ({
   log('Electron support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths, cacheProxy }
 }) {

--- a/app-webpack/lib/modes/pwa/pwa-installation.js
+++ b/app-webpack/lib/modes/pwa/pwa-installation.js
@@ -11,6 +11,12 @@ const pwaDeps = {
   'register-service-worker': '^1.7.2'
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 module.exports.addMode = function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -55,6 +61,11 @@ module.exports.addMode = function addMode ({
   log('PWA support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths, cacheProxy }
 }) {

--- a/app-webpack/lib/modes/ssr/ssr-installation.js
+++ b/app-webpack/lib/modes/ssr/ssr-installation.js
@@ -3,6 +3,12 @@ const fse = require('fs-extra')
 const { log, warn } = require('../../utils/logger.js')
 const { isModeInstalled } = require('../modes-utils.js')
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ *   silent: boolean
+ * }} options
+ */
 module.exports.addMode = function addMode ({
   ctx: { appPaths, cacheProxy },
   silent
@@ -25,6 +31,11 @@ module.exports.addMode = function addMode ({
   log('SSR support was added')
 }
 
+/**
+ * @param {{
+ *   ctx: import('../../../types/configuration/context').InternalQuasarContext,
+ * }} options
+ */
 module.exports.removeMode = function removeMode ({
   ctx: { appPaths }
 }) {

--- a/app-webpack/lib/utils/get-ctx.js
+++ b/app-webpack/lib/utils/get-ctx.js
@@ -12,6 +12,9 @@ function defineHiddenProp (target, propName, value) {
   })
 }
 
+/**
+ * @returns {import('../../types/configuration/context').InternalQuasarContext}
+ */
 module.exports.getCtx = function getCtx (opts = {}) {
   const ctx = {
     dev: opts.dev || false,

--- a/app-webpack/lib/utils/get-pkg.js
+++ b/app-webpack/lib/utils/get-pkg.js
@@ -4,6 +4,11 @@ const { parseJSON } = require('confbox')
 const { warning } = require('./logger.js')
 const { getPackageJson } = require('../utils/get-package-json.js')
 
+/**
+ * @param {import('../../types/app-paths').QuasarAppPaths} appPaths
+ *
+ * @returns {import('../../types/configuration/context').InternalQuasarContext['pkg']}
+ */
 module.exports.getPkg = function getPkg (appPaths) {
   const { appDir, cliDir } = appPaths
   const appPkgPath = appPaths.resolve.app('package.json')

--- a/app-webpack/templates/capacitor/pnpm-workspace.yaml
+++ b/app-webpack/templates/capacitor/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+# This file exists to avoid pnpm only installing in the root and not in src-capacitor
+# https://github.com/pnpm/pnpm/issues/9348#issuecomment-2771925480

--- a/app-webpack/types/configuration/context.d.ts
+++ b/app-webpack/types/configuration/context.d.ts
@@ -161,3 +161,34 @@ export type QuasarContext =
   | CordovaQuasarContext
   | ElectronQuasarContext
   | BexQuasarContext;
+
+type CacheProxyModuleKey =
+  | "animations"
+  | "capCli"
+  | "cssVariables"
+  | "electron"
+  | "eslint"
+  | "extrasPath"
+  | "hasTypescript"
+  | "nodePackager"
+  | "storeProvider"
+  | "workboxWebpackPlugin";
+interface CacheProxy {
+  getRuntime: (key: string, getInitialValue: () => any) => any;
+  setRuntime: (key: string, value: any) => void;
+  getModule: (key: CacheProxyModuleKey) => Promise<any>;
+}
+
+/**
+ * @internal
+ */
+export type InternalQuasarContext = QuasarContext & {
+  pkg: {
+    appPkg: Record<string, any>;
+    quasarPkg: Record<string, any>;
+    webpackPkg: Record<string, any>;
+  };
+  cacheProxy: CacheProxy;
+  // TODO: add proper type
+  appExt: any;
+};

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,6 @@ catalog:
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - core-js
+  - electron-winstaller
   - esbuild
   - unrs-resolver


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix
- Refactor

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- It's been tested on a Capacitor (iOS, Android) app

**Other information:**
It fixes/improves handling for two cases:
- When the Quasar app is in a monorepo, e.g. `packages/client`
- When using `pnpm-workspace.yaml`(new recommended way) instead of `.npmrc`, which is introduced in pnpm v10