### PR TITLE
fix: update vue-router to version 5.0.0 across multiple packages

### DIFF
--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -129,7 +129,7 @@
     "quasar": "workspace:^",
     "typescript": "^5.6.3",
     "vue": "3.5.20",
-    "vue-router": "^4.4.5",
+    "vue-router": "^5.0.0",
     "workbox-build": "^7.3.0"
   },
   "peerDependencies": {
@@ -139,7 +139,7 @@
     "quasar": "^2.16.0",
     "typescript": ">= 5.4",
     "vue": "^3.2.29",
-    "vue-router": "^4.0.12",
+    "vue-router": "^4.0.12 || ^5.0.0",
     "workbox-build": ">= 6"
   },
   "peerDependenciesMeta": {

--- a/app-webpack/package.json
+++ b/app-webpack/package.json
@@ -159,7 +159,7 @@
     "ts-loader": "^9.5.1",
     "typescript": "^5.6.2",
     "vue": "3.5.20",
-    "vue-router": "^4.4.5"
+    "vue-router": "^5.0.0"
   },
   "peerDependencies": {
     "@electron/packager": ">= 18",
@@ -169,7 +169,7 @@
     "quasar": "^2.16.0",
     "typescript": ">= 5.4",
     "vue": "^3.2.29",
-    "vue-router": "^4.0.12",
+    "vue-router": "^4.0.12 || ^5.0.0",
     "workbox-webpack-plugin": ">= 6"
   },
   "peerDependenciesMeta": {

--- a/create-quasar/templates/ui-kit/quasar-v2/BASE/ui/_package.json
+++ b/create-quasar/templates/ui-kit/quasar-v2/BASE/ui/_package.json
@@ -38,7 +38,7 @@
     "@rollup/plugin-replace": "^2.4.2",
     "uglify-js": "^3.13.3",
     "vue": "^3.0.0",
-    "vue-router": "^4.0.0",
+    "vue-router": "^5.0.0",
     "zlib": "^1.0.5"
   },
   "browserslist": [

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "quasar": "^2",
     "register-service-worker": "^1.7.2",
     "vue": "3.4.20",
-    "vue-router": "^4.4.5"
+    "vue-router": "^5.0.0"
   },
   "devDependencies": {
     "@quasar/app-vite": "^2.0.0",

--- a/playground/app-vite-ts/package.json
+++ b/playground/app-vite-ts/package.json
@@ -16,7 +16,7 @@
     "@quasar/extras": "workspace:*",
     "quasar": "workspace:*",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/ui/playground/package.json
+++ b/ui/playground/package.json
@@ -16,7 +16,7 @@
     "@quasar/extras": "workspace:*",
     "quasar": "workspace:^",
     "vue": "3.5.20",
-    "vue-router": "^4.4.5"
+    "vue-router": "^5.0.0"
   },
   "devDependencies": {
     "@quasar/app-vite": "workspace:*",

--- a/utils/render-ssr-error/package.json
+++ b/utils/render-ssr-error/package.json
@@ -49,6 +49,6 @@
     "quasar": "workspace:*",
     "vite": "^7.1.6",
     "vue": "3.5.20",
-    "vue-router": "^4.4.5"
+    "vue-router": "^5.0.0"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Build-related changes
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Summary**
Updates `vue-router` to `^5.0.0` across Quasar packages/templates/playgrounds/docs to align the repo with Vue Router v5.
Also expands peer dependency support to allow both Vue Router v4 and v5 where applicable:
- `peerDependencies.vue-router`: `^4.0.12 || ^5.0.0`

**Changes**
- Bumped `devDependencies.vue-router` to `^5.0.0` in:
  - `app-vite`
  - `app-webpack`
  - `docs`
  - `playground/app-vite-ts`
  - `ui/playground`
  - `utils/render-ssr-error`
  - `create-quasar` ui-kit template
- Updated `peerDependencies.vue-router` to support `^4.0.12 || ^5.0.0` in:
  - `app-vite`
  - `app-webpack`

**Why**
Vue Router v5 is the next stable major iteration for Vue 3 router. This keeps Quasar templates/playgrounds aligned with the latest router while maintaining compatibility via peer dependency ranges.
(Please tick the items you actually ran.)

**Notes**
No functional code changes were made beyond dependency/version updates.
