### PR TITLE
docs: Fix example uuid to be valid v4

### DIFF
--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -436,7 +436,7 @@ Generate unique identifiers:
 import { uid } from 'quasar'
 
 let uid = uid()
-// Example: 501e7ae1-7e6f-b923-3e84-4e946bff31a8
+// Example: 84402c0e-7a8c-4784-b0b1-2e471e631645
 ```
 
 ## testPattern


### PR DESCRIPTION
The old value was a (non-standard) version 11 UUID, but the uid tool actually generates standard (random) version 4 UUID.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

The uid function actually generates valid v4 (random) UUIDs, but the example was implying it was completely random by using a non-standard v11 UUID. Replace the example UUID to something that was actually produced as output