### PR TITLE
fix(docs): update SSR boot file template variable syntax for app-vite v2

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
@@ -236,12 +236,16 @@ When a boot file runs on the server, you will have access to one more parameter 
 export default ({ app, ..., ssrContext }) => {
   // You can add props to the ssrContext then use them in the /index.html.
   // Example - let's say we ssrContext.someProp = 'some value', then in index template we can reference it:
-  // {{ someProp }}
+  // {{ ssrContext.someProp }}
 }
 ```
 
-When you add such references (`someProp` surrounded by brackets in the example above) into your `/index.html`, make sure you tell Quasar it’s only valid for SSR builds:
+When you add such references into your `/index.html`, make sure you tell Quasar it's only valid for SSR builds:
+
+::: tip
+As of `@quasar/app-vite` v2, template variables in `/index.html` must be scoped under the `ssrContext` object. Use `{{ ssrContext.someProp }}` instead of the v1 form `{{ someProp }}`.
+:::
 
 ```html /index.html
-<% if (ctx.mode.ssr) { %>{{ someProp }} <% } %>
+<% if (ctx.mode.ssr) { %>{{ ssrContext.someProp }} <% } %>
 ```


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

Closes #18246

**Other information:**

In `@quasar/app-vite` v2, the SSR render-template is compiled using lodash `_.template` with `{ variable: 'ssrContext' }` ([source](https://github.com/quasarframework/quasar/blob/dev/app-vite/lib/utils/html-template.js#L158)):

```js
return compileTemplate(html, { interpolate: ssrInterpolationsRE, variable: 'ssrContext' })
```

This scopes all `{{ }}` interpolations in `/index.html` under the `ssrContext` object. The previously documented syntax:

```html
<!-- Broken in v2 -->
<% if (ctx.mode.ssr) { %>{{ someProp }}<% } %>
```

no longer works. The correct v2 syntax is:

```html
<!-- Correct in v2 -->
<% if (ctx.mode.ssr) { %>{{ ssrContext.someProp }}<% } %>
```

This is consistent with all built-in SSR interpolations in the codebase (e.g. `{{ ssrContext._meta.headTags }}`). The change was introduced in commit [2e47188](https://github.com/quasarframework/quasar/commit/2e47188) and mentioned in the [@quasar/app-vite v2.0.0-beta.1 release notes](https://github.com/quasarframework/quasar/releases/tag/%40quasar%2Fapp-vite-v2.0.0-beta.1).

**Changes:**
- Updated boot file code comment to use `{{ ssrContext.someProp }}`
- Updated `/index.html` example to use `{{ ssrContext.someProp }}`
- Added a tip callout explaining the v1 → v2 syntax change for upgrading users
