### PR TITLE
Fix `browser` target type in `BuildTargetOptions`

### DIFF
--- a/app-vite/types/configuration/build.d.ts
+++ b/app-vite/types/configuration/build.d.ts
@@ -77,7 +77,7 @@ interface BuildTargetOptions {
   /**
    * @default ['es2022', 'firefox115', 'chrome115', 'safari14']
    */
-  browser?: string[];
+  browser?: string | string[];
   /**
    * @example 'node20'
    */

--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -386,7 +386,7 @@ interface BuildTargetOptions {
   /**
    * @default ['es2022', 'firefox115', 'chrome115', 'safari14']
    */
-  browser?: string[];
+  browser?: string | string[];
   /**
    * @example 'node20'
    */

--- a/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-webpack/upgrade-guide.md
@@ -1930,7 +1930,7 @@ interface EsbuildTargetOptions {
   /**
    * @default ['es2022', 'firefox115', 'chrome115', 'safari14']
    */
-  browser?: string[];
+  browser?: string | string[];
   /**
    * @example 'node20'
    */


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Add `string` as valid type for `browser`, to support 'baseline-widely-available' value.
See release notes: [@quasar/app-vite-v2.5.0 ](https://github.com/quasarframework/quasar/releases/tag/%40quasar%2Fapp-vite-v2.5.0)