### PR TITLE
fix(QEditor): save selection range before execCommand('createLink') t…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,9 +922,6 @@ importers:
       rolldown:
         specifier: 1.0.0-rc.9
         version: 1.0.0-rc.9
-      rollup:
-        specifier: ^4.24.2
-        version: 4.52.4
       vite:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.20.6)(yaml@2.8.2)

--- a/ui/src/components/editor/editor-caret.js
+++ b/ui/src/components/editor/editor-caret.js
@@ -305,9 +305,8 @@ export default class Caret {
         ) return
 
         this.eVm.editLinkUrl.value = urlRegex.test(url) ? url : 'https://'
-        document.execCommand('createLink', false, this.eVm.editLinkUrl.value)
-
         this.save(selection.getRangeAt(0))
+        document.execCommand('createLink', false, this.eVm.editLinkUrl.value)
       }
       else {
         this.eVm.editLinkUrl.value = link


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

When selecting text with mixed formatting (e.g., `**bold** plain`) and applying a hyperlink via the Link toolbar button, the hyperlink was not being applied to the full selection.

**Root Cause:**

`document.execCommand('createLink')` mutates the DOM by splitting a mixed-format selection into separate `<a>` elements per formatting context:

```html
<!-- Before createLink -->
<strong>34</strong> text

<!-- After createLink — browser creates two separate anchors -->
<a href="https://"><strong>34</strong></a><a href="https://"> text</a>
```

The selection range was saved **after** this mutation, so `getRangeAt(0)` only captured the first `<a>` element's range. When the user confirmed the URL, `restore()` reselected only that partial content, and the final `createLink` only updated one anchor's `href`.

**Fix:**

Move `this.save(selection.getRangeAt(0))` to **before** `document.execCommand('createLink', ...)` in `ui/src/components/editor/editor-caret.js`, so the full original selection is preserved before the DOM is mutated.

Since `createLink` only re-parents existing text nodes (it doesn't create new ones), the saved range node references remain valid after the mutation. `restore()` then correctly reselects the full original content, and the final `createLink` call updates all anchor `href` values.

fixes #18233
