### PR TITLE
fix(QExpansionItem): switch-toggle-side colors are now correct

### DIFF
--- a/ui/src/components/expansion-item/QExpansionItem.sass
+++ b/ui/src/components/expansion-item/QExpansionItem.sass
@@ -1,5 +1,14 @@
 .q-expansion-item
 
+  .q-item__section--avatar:has(> &__toggle-icon)
+    color: $grey-7
+
+  .q-item--dark .q-item__section--avatar:has(> &__toggle-icon)
+    color: rgba(255,255,255,.7)
+
+  .q-item__section--side:has(> .q-icon):not(:has(> &__toggle-icon))
+    color: inherit !important
+
   &__border
     opacity: 0
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

When using `switch-toggle-side` on `QExpansionItem` with an `:icon` prop, the icon turns grey and the expand arrow turns black — the opposite of expected.

The `side`/`avatar` props on the icon's `QItemSection` were inverted in `getHeaderChild()`:

```diff
// ui/src/components/expansion-item/QExpansionItem.js
- side: props.switchToggleSide === true,
- avatar: props.switchToggleSide !== true
+ side: props.switchToggleSide !== true,
+ avatar: props.switchToggleSide === true
```

This restores the correct colours: icon stays full-colour (`avatar`), expand arrow stays secondary/grey (`side`), regardless of which side they're on.

closes #18008