### PR TITLE
fix(date): return Date instead of number

### DIFF
--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -598,7 +598,7 @@ export function getMaxDate (date /* , ...args */) {
   Array.prototype.slice.call(arguments, 1).forEach(d => {
     t = Math.max(t, new Date(d))
   })
-  return t
+  return new Date(t)
 }
 
 export function getMinDate (date /*, ...args */) {
@@ -606,7 +606,7 @@ export function getMinDate (date /*, ...args */) {
   Array.prototype.slice.call(arguments, 1).forEach(d => {
     t = Math.min(t, new Date(d))
   })
-  return t
+  return new Date(t)
 }
 
 function getDiff (t, sub, interval) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

fixes #18260 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #<issue-number>`)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated

---

### Problem

`getMaxDate` and `getMinDate` currently return a numeric timestamp instead of a `Date` object.

This happens because `Math.max()` / `Math.min()` convert Date objects into timestamps.

Example:

```js
const d1 = new Date('2024-01-01')
const d2 = new Date('2024-06-01')

const result = date.getMaxDate(d1, d2)

console.log(typeof result) // number
console.log(result instanceof Date) // false

result.getFullYear() // TypeError