### PR TITLE
fix(useInterval): remove unused argument passed to removeInterval (fixes #18273)

### DIFF
--- a/ui/src/composables/use-interval/use-interval.js
+++ b/ui/src/composables/use-interval/use-interval.js
@@ -26,7 +26,7 @@ export default function useInterval() {
     removeInterval,
 
     registerInterval(fn, delay) {
-      removeInterval(timer)
+      removeInterval()
 
       if (vmIsDestroyed(vm) === false) {
         timer = setInterval(fn, delay)


### PR DESCRIPTION
Fixes #18273

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Description**

In `ui/src/composables/use-interval/use-interval.js`, the `registerInterval`
function calls:

removeInterval(timer)

However, the `removeInterval` function does not accept any parameters and
uses the closure-scoped `timer` variable internally.

Passing `timer` as an argument has no effect and may confuse readers.

This PR removes the unnecessary argument to improve code clarity.

**Before**

`removeInterval(timer)`

**After**

`removeInterval()`

This change does not affect runtime behavior.

---

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated

**Other information:**

This is a small internal cleanup that removes an unused argument and improves
code readability without changing functionality.