### PR TITLE
Feat/teleport shadow root

### DIFF
--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -88,6 +88,10 @@ export default [
       {
         name: 'Transitions',
         path: 'transitions'
+      },
+      {
+        name: 'Config Root Element',
+        path: 'root-element'
       }
     ]
   },

--- a/docs/src/pages/options/root-element.md
+++ b/docs/src/pages/options/root-element.md
@@ -1,0 +1,61 @@
+---
+title: Config Root Element
+desc: Configuring the root element for Quasar Teleported components.
+related:
+  - /quasar-cli-vite/quasar-config-file
+  - /quasar-cli-webpack/quasar-config-file
+---
+
+Quasar defaults to appending teleported components (such as `QDialog`, `QMenu`, `QSelect`, and `QTooltip`) to `document.body`. This behavior can be changed using the `config.root` property.
+
+## Changing the Root Element
+
+You can customize the root element by modifying your `/quasar.config` file. The `root` property accepts either a DOM Element or a function that returns a DOM Element.
+
+```js [highlight=4-6] /quasar.config.js
+module.exports = function (ctx) {
+  return {
+    framework: {
+      config: {
+        root: () => document.getElementById('my-app')
+      }
+    }
+  }
+}
+```
+
+## Micro Front-ends (Web Components)
+
+A special use case for `config.root` is when building Micro Front-ends using Web Components with Shadow DOM. When a Quasar app is encapsulated inside a Shadow Root, appending globally to `document.body` breaks CSS encapsulation. Teleported elements end up rendered outside the Shadow DOM and therefore miss the applied Quasar styles and CSS variables.
+
+The simplest approach is to pass the `shadowRoot` of your Web Component using a basic DOM selector.
+
+### Example
+
+If you are bootstrapping Quasar inside a Web Component (using `defineCustomElement` in Vue 3), you can configure the App instance to point to your custom element's `shadowRoot`:
+
+```ts [highlight=9] /src/main.ts
+import { defineCustomElement } from 'vue'
+import { Quasar } from 'quasar'
+import RootComponent from './App.ce.vue'
+
+const MyCE = defineCustomElement(RootComponent, {
+  configureApp(app) {
+    app.use(Quasar, {
+      config: {
+        root: () =>
+          document.querySelector('my-web-component')?.shadowRoot ||
+          document.body
+      }
+    })
+  }
+})
+
+customElements.define('my-web-component', MyCE)
+```
+
+::: warning Side Effect with Multiple Instances
+Because the `root` function is evaluated in user-land using `document.querySelector`, it will naturally return the **first** `<my-web-component>` instance found on the page if multiple are present. Consequently, Quasar will append all teleported components (like `QDialog`, `QMenu`, `QSelect`, etc.) to that first instance's Shadow DOM.
+
+However, if your Micro Front-ends share the same CSS (Quasar styling is present on all instances), this behavior works smoothly and the overlays will still render correctly inside the first Web Component.
+:::

--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -7,7 +7,6 @@ import {
   Transition,
   getCurrentInstance
 } from 'vue'
-import { getRootElement } from '../../utils/private.dom/root.js'
 
 import useHistory from '../../composables/private.use-history/use-history.js'
 import useTimeout from '../../composables/use-timeout/use-timeout.js'
@@ -370,9 +369,7 @@ export default createComponent({
       if (active === true) {
         if (isMaximized !== true) {
           if (maximizedModals < 1) {
-            let target = getRootElement()
-            if (target instanceof ShadowRoot) target = target.host
-            if (target?.classList) target.classList.add('q-body--dialog')
+            document.body.classList.add('q-body--dialog')
           }
           maximizedModals++
 
@@ -380,9 +377,7 @@ export default createComponent({
         }
       } else if (isMaximized === true) {
         if (maximizedModals < 2) {
-          let target = getRootElement()
-          if (target instanceof ShadowRoot) target = target.host
-          if (target?.classList) target.classList.remove('q-body--dialog')
+          document.body.classList.remove('q-body--dialog')
         }
 
         maximizedModals--

--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -7,6 +7,7 @@ import {
   Transition,
   getCurrentInstance
 } from 'vue'
+import { getRootElement } from '../../utils/private.dom/root.js'
 
 import useHistory from '../../composables/private.use-history/use-history.js'
 import useTimeout from '../../composables/use-timeout/use-timeout.js'
@@ -369,7 +370,9 @@ export default createComponent({
       if (active === true) {
         if (isMaximized !== true) {
           if (maximizedModals < 1) {
-            document.body.classList.add('q-body--dialog')
+            let target = getRootElement()
+            if (target instanceof ShadowRoot) target = target.host
+            if (target?.classList) target.classList.add('q-body--dialog')
           }
           maximizedModals++
 
@@ -377,7 +380,9 @@ export default createComponent({
         }
       } else if (isMaximized === true) {
         if (maximizedModals < 2) {
-          document.body.classList.remove('q-body--dialog')
+          let target = getRootElement()
+          if (target instanceof ShadowRoot) target = target.host
+          if (target?.classList) target.classList.remove('q-body--dialog')
         }
 
         maximizedModals--

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -39,7 +39,7 @@ import {
   addFocusout,
   removeFocusout
 } from '../../utils/private.focus/focusout.js'
-import { childHasFocus } from '../../utils/dom/dom.js'
+import { childHasFocus, getActualActiveElement } from '../../utils/dom/dom.js'
 import {
   addClickOutside,
   removeClickOutside
@@ -211,7 +211,7 @@ export default createComponent({
       addFocusFn(() => {
         let node = innerRef.value
 
-        if (node && node.contains(document.activeElement) !== true) {
+        if (node && node.contains(getActualActiveElement()) !== true) {
           node =
             node.querySelector(
               '[autofocus][tabindex], [data-autofocus][tabindex]'
@@ -227,7 +227,8 @@ export default createComponent({
     }
 
     function handleShow(evt) {
-      refocusTarget = props.noRefocus === false ? document.activeElement : null
+      refocusTarget =
+        props.noRefocus === false ? getActualActiveElement() : null
 
       addFocusout(onFocusout)
 
@@ -262,7 +263,7 @@ export default createComponent({
       }
 
       if (props.noFocus !== true) {
-        document.activeElement.blur()
+        getActualActiveElement().blur()
       }
 
       // should removeTick() if this gets removed

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -7,7 +7,7 @@ import {
   Transition,
   getCurrentInstance
 } from 'vue'
-import { getRootElement } from '../../utils/private.dom/root.js'
+import { getRootTarget } from '../../utils/private.dom/root.js'
 
 import useAnchor, {
   useAnchorStaticProps
@@ -267,8 +267,7 @@ export default createComponent({
     function delayShow(evt) {
       if ($q.platform.is.mobile === true) {
         clearSelection()
-        let rootTarget = getRootElement()
-        if (rootTarget instanceof ShadowRoot) rootTarget = rootTarget.host
+        const rootTarget = getRootTarget()
         if (rootTarget?.classList) rootTarget.classList.add('non-selectable')
 
         const target = anchorEl.value
@@ -290,10 +289,10 @@ export default createComponent({
         clearSelection()
         // delay needed otherwise selection still occurs
         setTimeout(() => {
-          let rootTarget = getRootElement()
-          if (rootTarget instanceof ShadowRoot) rootTarget = rootTarget.host
-          if (rootTarget?.classList)
-            {rootTarget.classList.remove('non-selectable')}
+          const rootTarget = getRootTarget()
+          if (rootTarget?.classList) {
+            rootTarget.classList.remove('non-selectable')
+          }
         }, 10)
       }
 

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -7,6 +7,7 @@ import {
   Transition,
   getCurrentInstance
 } from 'vue'
+import { getRootElement } from '../../utils/private.dom/root.js'
 
 import useAnchor, {
   useAnchorStaticProps
@@ -266,7 +267,9 @@ export default createComponent({
     function delayShow(evt) {
       if ($q.platform.is.mobile === true) {
         clearSelection()
-        document.body.classList.add('non-selectable')
+        let rootTarget = getRootElement()
+        if (rootTarget instanceof ShadowRoot) rootTarget = rootTarget.host
+        if (rootTarget?.classList) rootTarget.classList.add('non-selectable')
 
         const target = anchorEl.value
         const evts = ['touchmove', 'touchcancel', 'touchend', 'click'].map(
@@ -287,7 +290,10 @@ export default createComponent({
         clearSelection()
         // delay needed otherwise selection still occurs
         setTimeout(() => {
-          document.body.classList.remove('non-selectable')
+          let rootTarget = getRootElement()
+          if (rootTarget instanceof ShadowRoot) rootTarget = rootTarget.host
+          if (rootTarget?.classList)
+            {rootTarget.classList.remove('non-selectable')}
         }, 10)
       }
 

--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -310,8 +310,13 @@ export default function useField(state) {
     return acc
   })
 
+  function getActiveEl() {
+    const root = state.rootRef?.value?.getRootNode?.()
+    return (root && root.activeElement) || document.activeElement
+  }
+
   function focusHandler() {
-    const el = document.activeElement
+    const el = getActiveEl()
     let target = state.targetRef?.value
 
     if (target && (el === null || el.id !== state.targetUid.value)) {
@@ -331,7 +336,7 @@ export default function useField(state) {
 
   function blur() {
     removeFocusFn(focusHandler)
-    const el = document.activeElement
+    const el = getActiveEl()
     if (el !== null && state.rootRef.value.contains(el)) {
       el.blur()
     }
@@ -359,7 +364,7 @@ export default function useField(state) {
         (state.hasPopupOpen === true ||
           state.controlRef === void 0 ||
           state.controlRef.value === null ||
-          state.controlRef.value.contains(document.activeElement) !== false)
+          state.controlRef.value.contains(getActiveEl()) !== false)
       ) {
         return
       }

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -6,6 +6,7 @@ import {
   onBeforeUnmount,
   getCurrentInstance
 } from 'vue'
+import { getRootElement } from '../../utils/private.dom/root.js'
 
 import History from '../../plugins/private.history/History.js'
 import { vmHasRouter } from '../../utils/private.vm/vm.js'
@@ -65,11 +66,13 @@ export default function useFullscreen() {
     inFullscreen.value = true
     container = proxy.$el.parentNode
     container.replaceChild(fullscreenFillerNode, proxy.$el)
-    document.body.appendChild(proxy.$el)
+    let root = getRootElement()
+    root.appendChild(proxy.$el)
 
     counter++
     if (counter === 1) {
-      document.body.classList.add('q-body--fullscreen-mixin')
+      let target = root instanceof ShadowRoot ? root.host : root
+      if (target?.classList) target.classList.add('q-body--fullscreen-mixin')
     }
 
     historyEntry = {
@@ -92,7 +95,9 @@ export default function useFullscreen() {
     counter = Math.max(0, counter - 1)
 
     if (counter === 0) {
-      document.body.classList.remove('q-body--fullscreen-mixin')
+      let root = getRootElement()
+      let target = root instanceof ShadowRoot ? root.host : root
+      if (target?.classList) target.classList.remove('q-body--fullscreen-mixin')
 
       if (proxy.$el.scrollIntoView !== void 0) {
         setTimeout(() => {

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -6,7 +6,7 @@ import {
   onBeforeUnmount,
   getCurrentInstance
 } from 'vue'
-import { getRootElement } from '../../utils/private.dom/root.js'
+import { getRootElement, getRootTarget } from '../../utils/private.dom/root.js'
 
 import History from '../../plugins/private.history/History.js'
 import { vmHasRouter } from '../../utils/private.vm/vm.js'
@@ -71,7 +71,7 @@ export default function useFullscreen() {
 
     counter++
     if (counter === 1) {
-      let target = root instanceof ShadowRoot ? root.host : root
+      const target = getRootTarget()
       if (target?.classList) target.classList.add('q-body--fullscreen-mixin')
     }
 
@@ -95,8 +95,7 @@ export default function useFullscreen() {
     counter = Math.max(0, counter - 1)
 
     if (counter === 0) {
-      let root = getRootElement()
-      let target = root instanceof ShadowRoot ? root.host : root
+      const target = getRootTarget()
       if (target?.classList) target.classList.remove('q-body--fullscreen-mixin')
 
       if (proxy.$el.scrollIntoView !== void 0) {

--- a/ui/src/css/core/animations.sass
+++ b/ui/src/css/core/animations.sass
@@ -3,7 +3,7 @@
  * Adapted from: https://github.com/animate-css/animate.css/blob/6828621a01e145119db6194dc9b4d37325b48aa5/source/_base.css
  */
 
-\:root
+\:root, :host
   --animate-duration: #{$animate-duration}
   --animate-delay: #{$animate-delay}
   --animate-repeat: #{$animate-repeat}

--- a/ui/src/css/core/colors.sass
+++ b/ui/src/css/core/colors.sass
@@ -1,4 +1,4 @@
-\:root
+\:root, :host
   --q-primary:      #{$primary}
   --q-secondary:    #{$secondary}
   --q-accent:       #{$accent}

--- a/ui/src/css/core/size.sass
+++ b/ui/src/css/core/size.sass
@@ -1,6 +1,6 @@
 @use 'sass:map'
 
-\:root
+\:root, :host
   @each $name, $size in $sizes
     #{"--q-size-"}#{$name}: #{$size}
 

--- a/ui/src/css/core/transitions.sass
+++ b/ui/src/css/core/transitions.sass
@@ -1,5 +1,5 @@
 // should not need this, but it's good as fallback
-\:root
+\:root, :host
   --q-transition-duration: .3s
 
 .q-transition

--- a/ui/src/directives/touch-repeat/TouchRepeat.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.js
@@ -12,7 +12,7 @@ import {
 import { clearSelection } from '../../utils/private.selection/selection.js'
 import { isKeyCode } from '../../utils/private.keyboard/key-composition.js'
 import getSSRProps from '../../utils/private.noop-ssr-directive-transform/noop-ssr-directive-transform.js'
-import { getRootElement } from '../../utils/private.dom/root.js'
+import { getRootTarget } from '../../utils/private.dom/root.js'
 
 const keyCodes = {
     esc: 27,
@@ -129,10 +129,10 @@ export default createDirective(
                 document.documentElement.style.cursor = ''
 
                 const remove = () => {
-                  let target = getRootElement()
-                  if (target instanceof ShadowRoot) target = target.host
-                  if (target?.classList)
-                    {target.classList.remove('non-selectable')}
+                  const target = getRootTarget()
+                  if (target?.classList) {
+                    target.classList.remove('non-selectable')
+                  }
                 }
 
                 if (withDelay === true) {
@@ -144,8 +144,7 @@ export default createDirective(
               }
 
               if (client.is.mobile === true) {
-                let target = getRootElement()
-                if (target instanceof ShadowRoot) target = target.host
+                const target = getRootTarget()
                 if (target?.classList) target.classList.add('non-selectable')
                 clearSelection()
                 ctx.styleCleanup = styleCleanup
@@ -175,10 +174,10 @@ export default createDirective(
 
                   if (client.is.mobile !== true) {
                     document.documentElement.style.cursor = 'pointer'
-                    let target = getRootElement()
-                    if (target instanceof ShadowRoot) target = target.host
-                    if (target?.classList)
-                      {target.classList.add('non-selectable')}
+                    const target = getRootTarget()
+                    if (target?.classList) {
+                      target.classList.add('non-selectable')
+                    }
                     clearSelection()
                     ctx.styleCleanup = styleCleanup
                   }

--- a/ui/src/directives/touch-repeat/TouchRepeat.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.js
@@ -12,6 +12,7 @@ import {
 import { clearSelection } from '../../utils/private.selection/selection.js'
 import { isKeyCode } from '../../utils/private.keyboard/key-composition.js'
 import getSSRProps from '../../utils/private.noop-ssr-directive-transform/noop-ssr-directive-transform.js'
+import { getRootElement } from '../../utils/private.dom/root.js'
 
 const keyCodes = {
     esc: 27,
@@ -128,7 +129,10 @@ export default createDirective(
                 document.documentElement.style.cursor = ''
 
                 const remove = () => {
-                  document.body.classList.remove('non-selectable')
+                  let target = getRootElement()
+                  if (target instanceof ShadowRoot) target = target.host
+                  if (target?.classList)
+                    {target.classList.remove('non-selectable')}
                 }
 
                 if (withDelay === true) {
@@ -140,7 +144,9 @@ export default createDirective(
               }
 
               if (client.is.mobile === true) {
-                document.body.classList.add('non-selectable')
+                let target = getRootElement()
+                if (target instanceof ShadowRoot) target = target.host
+                if (target?.classList) target.classList.add('non-selectable')
                 clearSelection()
                 ctx.styleCleanup = styleCleanup
               }
@@ -169,7 +175,10 @@ export default createDirective(
 
                   if (client.is.mobile !== true) {
                     document.documentElement.style.cursor = 'pointer'
-                    document.body.classList.add('non-selectable')
+                    let target = getRootElement()
+                    if (target instanceof ShadowRoot) target = target.host
+                    if (target?.classList)
+                      {target.classList.add('non-selectable')}
                     clearSelection()
                     ctx.styleCleanup = styleCleanup
                   }

--- a/ui/src/plugins/dark/Dark.js
+++ b/ui/src/plugins/dark/Dark.js
@@ -1,4 +1,5 @@
 import { createReactivePlugin } from '../../utils/private.create/create.js'
+import { getRootElement } from '../../utils/private.dom/root.js'
 
 const Plugin = createReactivePlugin(
   {
@@ -29,8 +30,13 @@ const Plugin = createReactivePlugin(
       }
 
       Plugin.isActive = val === true
-      document.body.classList.remove(`body--${val === true ? 'light' : 'dark'}`)
-      document.body.classList.add(`body--${val === true ? 'dark' : 'light'}`)
+
+      const root = getRootElement()
+      const target = root instanceof ShadowRoot ? root.host : root
+      if (target?.classList) {
+        target.classList.remove(`body--${val === true ? 'light' : 'dark'}`)
+        target.classList.add(`body--${val === true ? 'dark' : 'light'}`)
+      }
     },
 
     toggle() {
@@ -40,8 +46,10 @@ const Plugin = createReactivePlugin(
     },
 
     install({ $q, ssrContext }) {
+      const root = __QUASAR_SSR_CLIENT__ ? getRootElement() : null
+      const target = root instanceof ShadowRoot ? root.host : root
       const dark = __QUASAR_SSR_CLIENT__
-        ? document.body.classList.contains('body--dark')
+        ? target?.classList?.contains('body--dark')
         : $q.config.dark
 
       if (__QUASAR_SSR_SERVER__) {

--- a/ui/src/plugins/dark/Dark.js
+++ b/ui/src/plugins/dark/Dark.js
@@ -1,5 +1,5 @@
 import { createReactivePlugin } from '../../utils/private.create/create.js'
-import { getRootElement } from '../../utils/private.dom/root.js'
+import { getRootTarget } from '../../utils/private.dom/root.js'
 
 const Plugin = createReactivePlugin(
   {
@@ -31,8 +31,7 @@ const Plugin = createReactivePlugin(
 
       Plugin.isActive = val === true
 
-      const root = getRootElement()
-      const target = root instanceof ShadowRoot ? root.host : root
+      const target = getRootTarget()
       if (target?.classList) {
         target.classList.remove(`body--${val === true ? 'light' : 'dark'}`)
         target.classList.add(`body--${val === true ? 'dark' : 'light'}`)
@@ -46,8 +45,7 @@ const Plugin = createReactivePlugin(
     },
 
     install({ $q, ssrContext }) {
-      const root = __QUASAR_SSR_CLIENT__ ? getRootElement() : null
-      const target = root instanceof ShadowRoot ? root.host : root
+      const target = __QUASAR_SSR_CLIENT__ ? getRootTarget() : null
       const dark = __QUASAR_SSR_CLIENT__
         ? target?.classList?.contains('body--dark')
         : $q.config.dark

--- a/ui/src/utils/css-var/get-css-var.js
+++ b/ui/src/utils/css-var/get-css-var.js
@@ -1,9 +1,18 @@
-export default function getCssVar(propName, element = document.body) {
+import { getRootElement } from '../private.dom/root.js'
+
+export default function getCssVar(propName, element) {
   if (typeof propName !== 'string') {
     throw new TypeError('Expected a string as propName')
   }
-  if (!(element instanceof Element)) {
-    throw new TypeError('Expected a DOM element')
+
+  let target = element || getRootElement()
+  if (target instanceof ShadowRoot) target = target.host
+
+  if (!(target instanceof Element)) {
+    // If element was provided and not an Element, or getRootElement() didn't return an Element
+    throw new TypeError(
+      'Expected a DOM element or a valid root element to be found'
+    )
   }
 
   return (

--- a/ui/src/utils/css-var/get-css-var.js
+++ b/ui/src/utils/css-var/get-css-var.js
@@ -1,21 +1,17 @@
-import { getRootElement } from '../private.dom/root.js'
+import { getRootTarget } from '../private.dom/root.js'
 
 export default function getCssVar(propName, element) {
   if (typeof propName !== 'string') {
     throw new TypeError('Expected a string as propName')
   }
 
-  let target = element || getRootElement()
-  if (target instanceof ShadowRoot) target = target.host
+  const target = element || getRootTarget()
 
   if (!(target instanceof Element)) {
-    // If element was provided and not an Element, or getRootElement() didn't return an Element
-    throw new TypeError(
-      'Expected a DOM element or a valid root element to be found'
-    )
+    throw new TypeError('Expected a DOM element')
   }
 
   return (
-    getComputedStyle(element).getPropertyValue(`--q-${propName}`).trim() || null
+    getComputedStyle(target).getPropertyValue(`--q-${propName}`).trim() || null
   )
 }

--- a/ui/src/utils/css-var/set-css-var.js
+++ b/ui/src/utils/css-var/set-css-var.js
@@ -1,13 +1,15 @@
-export default function setCssVar(propName, value, element = document.body) {
+import { getRootElement } from '../private.dom/root.js'
+
+export default function setCssVar(propName, value, element) {
   if (typeof propName !== 'string') {
     throw new TypeError('Expected a string as propName')
   }
   if (typeof value !== 'string') {
     throw new TypeError('Expected a string as value')
   }
-  if (!(element instanceof Element)) {
-    throw new TypeError('Expected a DOM element')
+  let target = element || getRootElement()
+  if (target instanceof ShadowRoot) target = target.host
+  if (target?.style) {
+    target.style.setProperty(`--q-${propName}`, value)
   }
-
-  element.style.setProperty(`--q-${propName}`, value)
 }

--- a/ui/src/utils/css-var/set-css-var.js
+++ b/ui/src/utils/css-var/set-css-var.js
@@ -1,4 +1,4 @@
-import { getRootElement } from '../private.dom/root.js'
+import { getRootTarget } from '../private.dom/root.js'
 
 export default function setCssVar(propName, value, element) {
   if (typeof propName !== 'string') {
@@ -7,9 +7,6 @@ export default function setCssVar(propName, value, element) {
   if (typeof value !== 'string') {
     throw new TypeError('Expected a string as value')
   }
-  let target = element || getRootElement()
-  if (target instanceof ShadowRoot) target = target.host
-  if (target?.style) {
-    target.style.setProperty(`--q-${propName}`, value)
-  }
+  const target = element || getRootTarget()
+  target.style.setProperty(`--q-${propName}`, value)
 }

--- a/ui/src/utils/dom/dom.js
+++ b/ui/src/utils/dom/dom.js
@@ -62,9 +62,40 @@ export function getElement(el) {
   }
 }
 
+export function getActualActiveElement() {
+  let el = document.activeElement
+  while (
+    el !== null &&
+    el.shadowRoot !== null &&
+    el.shadowRoot.activeElement !== null
+  ) {
+    el = el.shadowRoot.activeElement
+  }
+  return el
+}
+
 // internal
 export function childHasFocus(el, focusedEl) {
-  if (el === void 0 || el === null || el.contains(focusedEl) === true) {
+  if (el === void 0 || el === null) {
+    return false
+  }
+
+  if (focusedEl === void 0 || focusedEl === null) {
+    focusedEl = getActualActiveElement()
+  }
+
+  // If focusedEl is the host of the Shadow DOM containing el,
+  // we must get the ACTUAL focused element inside said Shadow DOM.
+  let actualFocused = focusedEl
+  while (
+    actualFocused !== null &&
+    actualFocused.shadowRoot !== null &&
+    actualFocused.shadowRoot.activeElement !== null
+  ) {
+    actualFocused = actualFocused.shadowRoot.activeElement
+  }
+
+  if (el.contains(actualFocused) === true) {
     return true
   }
 
@@ -73,7 +104,7 @@ export function childHasFocus(el, focusedEl) {
     next !== null;
     next = next.nextElementSibling
   ) {
-    if (next.contains(focusedEl)) {
+    if (next.contains(actualFocused)) {
       return true
     }
   }

--- a/ui/src/utils/dom/dom.js
+++ b/ui/src/utils/dom/dom.js
@@ -77,7 +77,7 @@ export function getActualActiveElement() {
 // internal
 export function childHasFocus(el, focusedEl) {
   if (el === void 0 || el === null) {
-    return false
+    return true
   }
 
   if (focusedEl === void 0 || focusedEl === null) {
@@ -110,6 +110,10 @@ export function childHasFocus(el, focusedEl) {
   }
 
   return false
+}
+
+export function isShadowRoot(el) {
+  return typeof ShadowRoot !== 'undefined' && el instanceof ShadowRoot
 }
 
 export default {

--- a/ui/src/utils/private.click-outside/click-outside.js
+++ b/ui/src/utils/private.click-outside/click-outside.js
@@ -48,17 +48,11 @@ function globalHandler(evt) {
     const state = registeredList[i]
     const path = evt.composedPath !== void 0 ? evt.composedPath() : []
 
-    if (
-      (state.anchorEl.value === null ||
-        (path.length > 0
-          ? path.includes(state.anchorEl.value) === false
-          : state.anchorEl.value.contains(target) === false)) &&
-      (target === document.body ||
-        (state.innerRef.value !== null &&
-          (path.length > 0
-            ? path.includes(state.innerRef.value) === false
-            : state.innerRef.value.contains(target) === false)))
-    ) {
+    const isInside =
+      path.includes(state.anchorEl.value) ||
+      (state.innerRef.value !== null && path.includes(state.innerRef.value))
+
+    if (isInside === false) {
       // mark the event as being processed by clickOutside
       // used to prevent refocus after menu close
       evt.qClickOutside = true

--- a/ui/src/utils/private.click-outside/click-outside.js
+++ b/ui/src/utils/private.click-outside/click-outside.js
@@ -46,13 +46,18 @@ function globalHandler(evt) {
 
   for (let i = registeredList.length - 1; i >= 0; i--) {
     const state = registeredList[i]
+    const path = evt.composedPath !== void 0 ? evt.composedPath() : []
 
     if (
       (state.anchorEl.value === null ||
-        state.anchorEl.value.contains(target) === false) &&
+        (path.length > 0
+          ? path.includes(state.anchorEl.value) === false
+          : state.anchorEl.value.contains(target) === false)) &&
       (target === document.body ||
         (state.innerRef.value !== null &&
-          state.innerRef.value.contains(target) === false))
+          (path.length > 0
+            ? path.includes(state.innerRef.value) === false
+            : state.innerRef.value.contains(target) === false)))
     ) {
       // mark the event as being processed by clickOutside
       // used to prevent refocus after menu close

--- a/ui/src/utils/private.config/nodes.js
+++ b/ui/src/utils/private.config/nodes.js
@@ -1,10 +1,11 @@
 import { globalConfig } from '../private.config/instance-config.js'
+import { getRootElement } from '../private.dom/root.js'
 
 const nodesList = []
 const portalTypeList = []
 
 let portalIndex = 1
-let target = __QUASAR_SSR_SERVER__ ? void 0 : document.body
+let target = null
 
 export function createGlobalNode(id, portalType) {
   const el = document.createElement('div')
@@ -19,7 +20,14 @@ export function createGlobalNode(id, portalType) {
     }
   }
 
-  target.appendChild(el)
+  if (target === null && !__QUASAR_SSR_SERVER__) {
+    target = getRootElement()
+  }
+
+  if (target) {
+    target.appendChild(el)
+  }
+
   nodesList.push(el)
   portalTypeList.push(portalType)
 
@@ -36,12 +44,16 @@ export function removeGlobalNode(el) {
 }
 
 export function changeGlobalNodesTarget(newTarget) {
+  if (target === null && !__QUASAR_SSR_SERVER__) {
+    target = getRootElement()
+  }
+
   if (newTarget === target) return
 
   target = newTarget
 
   if (
-    target === document.body ||
+    target === getRootElement() ||
     // or we have less than 2 dialogs:
     portalTypeList.reduce(
       (acc, type) => (type === 'dialog' ? acc + 1 : acc),

--- a/ui/src/utils/private.config/nodes.js
+++ b/ui/src/utils/private.config/nodes.js
@@ -5,7 +5,7 @@ const nodesList = []
 const portalTypeList = []
 
 let portalIndex = 1
-let target = null
+let target = __QUASAR_SSR_SERVER__ ? void 0 : document.body
 
 export function createGlobalNode(id, portalType) {
   const el = document.createElement('div')
@@ -20,14 +20,15 @@ export function createGlobalNode(id, portalType) {
     }
   }
 
-  if (target === null && !__QUASAR_SSR_SERVER__) {
-    target = getRootElement()
-  }
+  if (!__QUASAR_SSR_SERVER__) {
+    const root = getRootElement()
 
-  if (target) {
+    if (root !== target && root !== void 0 && root !== null) {
+      changeGlobalNodesTarget(root)
+    }
+
     target.appendChild(el)
   }
-
   nodesList.push(el)
   portalTypeList.push(portalType)
 
@@ -44,15 +45,12 @@ export function removeGlobalNode(el) {
 }
 
 export function changeGlobalNodesTarget(newTarget) {
-  if (target === null && !__QUASAR_SSR_SERVER__) {
-    target = getRootElement()
-  }
-
   if (newTarget === target) return
 
   target = newTarget
 
   if (
+    target === document.body ||
     target === getRootElement() ||
     // or we have less than 2 dialogs:
     portalTypeList.reduce(

--- a/ui/src/utils/private.dom/root.js
+++ b/ui/src/utils/private.dom/root.js
@@ -1,0 +1,16 @@
+import { globalConfig } from '../private.config/instance-config.js'
+
+export function getRootElement() {
+  if (__QUASAR_SSR_SERVER__) return void 0
+
+  if (globalConfig.root !== void 0) {
+    if (typeof globalConfig.root === 'function') {
+      return globalConfig.root()
+    }
+    if (typeof globalConfig.root === 'string') {
+      return document.querySelector(globalConfig.root) || document.body
+    }
+    return globalConfig.root
+  }
+  return document.body
+}

--- a/ui/src/utils/private.dom/root.js
+++ b/ui/src/utils/private.dom/root.js
@@ -1,3 +1,4 @@
+import { isShadowRoot } from '../dom/dom.js'
 import { globalConfig } from '../private.config/instance-config.js'
 
 export function getRootElement() {
@@ -13,4 +14,9 @@ export function getRootElement() {
     return globalConfig.root
   }
   return document.body
+}
+
+export function getRootTarget() {
+  const root = getRootElement()
+  return isShadowRoot(root) === true ? root.host : root
 }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

### Config Root Element (`config.root`)

This PR introduces the `config.root` property to the Quasar plugin configuration allowing developers to customize the DOM attachment point (defaulting to `document.body`) for Quasar teleported components (`QDialog`, `QMenu`, `QSelect`, `QTooltip`, etc).

### Why is this needed?
The primary driver for this feature is robust support for **Micro Front-ends / Web Components encapsulated in Shadow DOM**. Prior to this change, teleporting overlays to `document.body` aggressively broke component CSS encapsulation since the appended overlay fell outside the Shadow Root, losing access to local CSS Variables and Quasar styles loaded within the custom element instance. 

By passing the custom element's `shadowRoot` via `config.root`, the overlays seamlessly remain inside the boundaries of the Web Component.

### Content of the PR 
- Implementation of the `config.root` attachment logic across Quasar global components and utilities.
- Introduction of the `Root Element` section within the documentation explaining typical and Web Component usages.
- Menu linkage to expose the new article.
