### PR TITLE
fix(QEditor): add validation for q-editor link (#18289)

### DIFF
--- a/ui/src/components/editor/editor-caret.js
+++ b/ui/src/components/editor/editor-caret.js
@@ -308,7 +308,6 @@ export default class Caret {
 
         this.eVm.editLinkUrl.value = urlRegex.test(url) ? url : 'https://'
         this.save(selection.getRangeAt(0))
-        document.execCommand('createLink', false, this.eVm.editLinkUrl.value)
       } else {
         this.eVm.editLinkUrl.value = link
 

--- a/ui/src/components/editor/editor-utils.js
+++ b/ui/src/components/editor/editor-utils.js
@@ -268,9 +268,15 @@ export function getLinkEditor(eVm) {
     let link = eVm.editLinkUrl.value
     const updateLink = () => {
       eVm.caret.restore()
+      const nextLink = link.trim()
 
-      if (link !== eVm.editLinkUrl.value) {
-        document.execCommand('createLink', false, link === '' ? ' ' : link)
+      if (nextLink === '' || nextLink === 'https://') {
+        eVm.editLinkUrl.value = null
+        return
+      }
+
+      if (nextLink !== eVm.editLinkUrl.value) {
+        document.execCommand('createLink', false, nextLink)
       }
 
       eVm.editLinkUrl.value = null
@@ -290,6 +296,11 @@ export function getLinkEditor(eVm) {
           stop(evt)
           link = evt.target.value
         },
+
+        onBlur: () => {
+          updateLink()
+        },
+
         onKeydown: evt => {
           if (shouldIgnoreKey(evt) === true) return
 


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**
This fixes the link editing behavior highlighted in #18289  in `QEditor` so opening the link toolbar no longer auto-applies link formatting to the current selection before the user confirms a value.

**Changes made**

- Removed eager `createLink` call when entering link edit mode in `ui/src/components/editor/editor-caret.js`.
- Updated link confirmation logic in `ui/src/components/editor/editor-utils.js` to:
  - trim input before applying,
  - treat empty value or unchanged placeholder (`https://`) as a no-op,
  - run `createLink` only when the URL actually changes.

**Behavior after this fix**

- Clicking the link button opens the URL editor without modifying selected text.
- Link is applied only on explicit user action with a valid changed URL.
