### PR TITLE
fix(QInput): prevent v-model.trim from trimming input while typing

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -187,6 +187,14 @@ export default createComponent({
 
           updateMaskValue(v)
         } else if (innerValue.value !== v) {
+          if (
+            inputRef.value !== null &&
+            inputRef.value === document.activeElement &&
+            typeof innerValue.value === 'string' &&
+            innerValue.value.trim() === v
+          ) {
+            return
+          }
           innerValue.value = v
 
           if (props.type === 'number' && Object.hasOwn(temp, 'value')) {


### PR DESCRIPTION
## Problem

When using `QInput` with `v-model.trim` **and** `@update:model-value`, typing a space immediately trims the input value. The space is removed from the displayed input as soon as it's typed.

However, this works correctly (space is preserved) when:
- Using `v-model.trim` alone (without `@update:model-value`)
- Using native `<input v-model.trim>`

Fixes #18294

## Root Cause

In `QInput.js`, the `watch(() => props.modelValue, ...)` watcher updates `innerValue.value` whenever the model value changes. When `v-model.trim` is used:

1. User types a space → input value becomes `"hello "`
2. `emitValue("hello ")` emits `update:modelValue` with the raw value
3. Vue's `v-model.trim` directive trims to `"hello"` and sets `props.modelValue = "hello"`
4. The watcher fires with `v = "hello"` (trimmed)
5. The `emitCachedValue` check fails because it stores `"hello "` (raw) vs `"hello"` (trimmed)
6. `innerValue.value` is set to `"hello"` (trimmed)
7. The input DOM value is overwritten, removing the space

When `@update:model-value` is also used and the handler updates reactive state, Vue forces a re-render that syncs the input DOM with the trimmed model value.

## Fix

Skip updating `innerValue.value` in the watcher when:
1. The input currently has focus (user is actively typing)
2. The current input value, after trimming, matches the new model value

This preserves the user's typed characters (including spaces) while the input has focus, while still keeping the model value trimmed. When the input loses focus, the model value (trimmed) will be synced back.

```javascript
// Before
} else if (innerValue.value !== v) {
  innerValue.value = v

// After
} else if (innerValue.value !== v) {
  if (
    inputRef.value !== null &&
    inputRef.value === document.activeElement &&
    typeof innerValue.value === 'string' &&
    innerValue.value.trim() === v
  ) {
    return
  }
  innerValue.value = v
```
