### PR TITLE
fix table pagination label direction

### DIFF
--- a/ui/lang/ar-TN.js
+++ b/ui/lang/ar-TN.js
@@ -52,7 +52,7 @@ export default {
             : 'عدد المُدخَلات المحدّدة ' + rows + '.',
     recordsPerPage: 'عدد المُدخَلات في كل صفحة:',
     allRows: 'الكل',
-    pagination: (start, end, total) => start + '-' + end + ' من ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' من ' + total,
     columns: 'أعمدة'
   },
   pagination: {

--- a/ui/lang/ar.js
+++ b/ui/lang/ar.js
@@ -52,7 +52,7 @@ export default {
             : 'عدد المُدخَلات المحدّدة ' + rows + '.',
     recordsPerPage: 'عدد المُدخَلات في كل صفحة:',
     allRows: 'الكل',
-    pagination: (start, end, total) => start + '-' + end + ' من ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' من ' + total,
     columns: 'أعمدة'
   },
   pagination: {

--- a/ui/lang/az-Latn.js
+++ b/ui/lang/az-Latn.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'No' : rows) + ' seçilmiş məlumat.',
     recordsPerPage: 'Hər səhifədəki məlumat:',
     allRows: 'Bütün',
-    pagination: (start, end, total) => start + '-' + end + ' cəmi ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' cəmi ' + total,
     columns: 'Sütun'
   },
   pagination: {

--- a/ui/lang/bg.js
+++ b/ui/lang/bg.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Няма' : '1') + ' избрани редове.',
     recordsPerPage: 'Редове на страница:',
     allRows: 'Всички',
-    pagination: (start, end, total) => start + '-' + end + ' от ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' от ' + total,
     columns: 'Колони'
   },
   pagination: {

--- a/ui/lang/bn.js
+++ b/ui/lang/bn.js
@@ -50,7 +50,7 @@ export default {
         : (rows === 0 ? '' : rows) + ' রেকর্ড নির্বাচিত',
     recordsPerPage: 'প্রতি পৃষ্ঠায় রেকর্ড:',
     allRows: 'সব',
-    pagination: (start, end, total) => start + '-' + end + ' মধ্যে ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' মধ্যে ' + total,
     columns: 'কলাম'
   },
   pagination: {

--- a/ui/lang/bs-BA.js
+++ b/ui/lang/bs-BA.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Nema' : '1') + ' odabranih redova.',
     recordsPerPage: 'Redova po stranici:',
     allRows: 'Sve',
-    pagination: (start, end, total) => start + '-' + end + ' od ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' od ' + total,
     columns: 'Kolone'
   },
   pagination: {

--- a/ui/lang/ca.js
+++ b/ui/lang/ca.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Sense' : '1') + ' fila seleccionada.',
     recordsPerPage: 'Files per pàgina:',
     allRows: 'Totes',
-    pagination: (start, end, total) => start + '-' + end + ' de ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' de ' + total,
     columns: 'Columnes'
   },
   pagination: {

--- a/ui/lang/cs.js
+++ b/ui/lang/cs.js
@@ -63,7 +63,7 @@ export default {
     },
     recordsPerPage: 'Počet řádků na stránku:',
     allRows: 'Všechny',
-    pagination: (start, end, total) => start + '-' + end + ' z ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' z ' + total,
     columns: 'Sloupce'
   },
   pagination: {

--- a/ui/lang/da.js
+++ b/ui/lang/da.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Ingen' : rows) + ' rækker valgt.',
     recordsPerPage: 'Rækker per side:',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' af ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' af ' + total,
     columns: 'Kolonner'
   },
   pagination: {

--- a/ui/lang/de-CH.js
+++ b/ui/lang/de-CH.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Keine' : '1') + ' ausgewählt.',
     recordsPerPage: 'Zeilen pro Seite',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' von ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' von ' + total,
     columns: 'Spalten'
   },
   pagination: {

--- a/ui/lang/de-DE.js
+++ b/ui/lang/de-DE.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Keine' : '1') + ' ausgewählt.',
     recordsPerPage: 'Zeilen pro Seite',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' von ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' von ' + total,
     columns: 'Spalten'
   },
   pagination: {

--- a/ui/lang/de.js
+++ b/ui/lang/de.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Keine' : '1') + ' ausgewählt.',
     recordsPerPage: 'Zeilen pro Seite',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' von ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' von ' + total,
     columns: 'Spalten'
   },
   pagination: {

--- a/ui/lang/el.js
+++ b/ui/lang/el.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Καμμία' : rows) + ' επιλεγμένες εγγραφές.',
     recordsPerPage: 'Εγγραφές ανα σελίδα:',
     allRows: 'Όλες',
-    pagination: (start, end, total) => start + '-' + end + ' από ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' από ' + total,
     columns: 'Στήλες'
   },
   pagination: {

--- a/ui/lang/en-GB.js
+++ b/ui/lang/en-GB.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'No' : rows) + ' records selected.',
     recordsPerPage: 'Records per page:',
     allRows: 'All',
-    pagination: (start, end, total) => start + '-' + end + ' of ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' of ' + total,
     columns: 'Columns'
   },
   pagination: {

--- a/ui/lang/en-US.js
+++ b/ui/lang/en-US.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'No' : rows) + ' records selected.',
     recordsPerPage: 'Records per page:',
     allRows: 'All',
-    pagination: (start, end, total) => start + '-' + end + ' of ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' of ' + total,
     columns: 'Columns'
   },
   pagination: {

--- a/ui/lang/eo.js
+++ b/ui/lang/eo.js
@@ -50,7 +50,7 @@ export default {
         : 'Neniu elektita linio.',
     recordsPerPage: 'Linioj po paĝoj:',
     allRows: 'Ĉiuj',
-    pagination: (start, end, total) => start + '-' + end + ' el ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' el ' + total,
     columns: 'Kolumnoj'
   },
   pagination: {

--- a/ui/lang/es.js
+++ b/ui/lang/es.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Sin' : '1') + ' fila seleccionada.',
     recordsPerPage: 'Filas por página:',
     allRows: 'Todas',
-    pagination: (start, end, total) => start + '-' + end + ' de ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' de ' + total,
     columns: 'Columnas'
   },
   pagination: {

--- a/ui/lang/et.js
+++ b/ui/lang/et.js
@@ -48,7 +48,7 @@ export default {
       rows === 1 ? '1 kirje valitud.' : rows + ' kirjet valitud.',
     recordsPerPage: 'Kirjed lehel:',
     allRows: 'Kõik',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'Veerud'
   },
   pagination: {

--- a/ui/lang/eu.js
+++ b/ui/lang/eu.js
@@ -48,7 +48,7 @@ export default {
     recordsPerPage: 'Errenkadak orrialde bakoitzeko:',
     allRows: 'Denak',
     pagination: (start, end, total) =>
-      start + 'tik -' + end + 'ra, guztira ' + total,
+      start + ' tik - ' + end + 'ra, guztira ' + total,
     columns: 'Zutabeak'
   },
   pagination: {

--- a/ui/lang/fa-IR.js
+++ b/ui/lang/fa-IR.js
@@ -54,7 +54,7 @@ export default {
       rows === 0 ? 'رکوردی انتخاب نشده' : rows + ' رکورد انتخاب شده',
     recordsPerPage: 'رکورد در صفحه:',
     allRows: 'همه',
-    pagination: (start, end, total) => start + '-' + end + ' از ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' از ' + total,
     columns: 'ستون'
   },
   pagination: {

--- a/ui/lang/fa.js
+++ b/ui/lang/fa.js
@@ -54,7 +54,7 @@ export default {
       rows === 0 ? 'رکوردی انتخاب نشده' : rows + ' رکورد انتخاب شده',
     recordsPerPage: 'رکورد در صفحه:',
     allRows: 'همه',
-    pagination: (start, end, total) => start + '-' + end + ' از ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' از ' + total,
     columns: 'ستون'
   },
   pagination: {

--- a/ui/lang/fi.js
+++ b/ui/lang/fi.js
@@ -55,7 +55,7 @@ export default {
       rows === 1 ? '1 rivi valittu.' : rows + ' riviä valittu.',
     recordsPerPage: 'Rivejä sivulla:',
     allRows: 'Kaikki',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'Sarakkeet'
   },
   pagination: {

--- a/ui/lang/fr.js
+++ b/ui/lang/fr.js
@@ -56,7 +56,7 @@ export default {
         : 'Aucune ligne sélectionnée.',
     recordsPerPage: 'Lignes par page :',
     allRows: 'Tous',
-    pagination: (start, end, total) => start + '-' + end + ' sur ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' sur ' + total,
     columns: 'Colonnes'
   },
   pagination: {

--- a/ui/lang/gn.js
+++ b/ui/lang/gn.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Sin' : '1') + ' fila selesionada.',
     recordsPerPage: 'Fila por páhina:',
     allRows: 'Entero',
-    pagination: (start, end, total) => start + '-' + end + ' de ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' de ' + total,
     columns: 'Columnakuéra'
   },
   pagination: {

--- a/ui/lang/he.js
+++ b/ui/lang/he.js
@@ -51,7 +51,7 @@ export default {
         : (rows === 0 ? 'לא' : rows) + ' שורות נבחרו',
     recordsPerPage: 'שורות בעמוד:',
     allRows: 'הכל',
-    pagination: (start, end, total) => start + '-' + end + ' מתוך ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' מתוך ' + total,
     columns: 'עמודות'
   },
   pagination: {

--- a/ui/lang/hi.js
+++ b/ui/lang/hi.js
@@ -45,7 +45,7 @@ export default {
         : (rows === 0 ? 'कोई' : rows) + ' रिकॉर्ड चयनित।',
     recordsPerPage: 'प्रति पृष्ठ रिकॉर्ड:',
     allRows: 'सभी',
-    pagination: (start, end, total) => start + '-' + end + ' कुल ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' कुल ' + total,
     columns: 'कॉलम'
   },
   pagination: {

--- a/ui/lang/hr.js
+++ b/ui/lang/hr.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Nema' : '1') + ' izabranih redova.',
     recordsPerPage: 'Redova po stranici:',
     allRows: 'Sve',
-    pagination: (start, end, total) => start + '-' + end + ' od ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' od ' + total,
     columns: 'Stupci'
   },
   pagination: {

--- a/ui/lang/hu.js
+++ b/ui/lang/hu.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Nincs' : rows) + ' kiválasztott elem.',
     recordsPerPage: 'Elemek száma oldalanként:',
     allRows: 'Összes',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'Oszlopok'
   },
   pagination: {

--- a/ui/lang/id.js
+++ b/ui/lang/id.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'tidak ada' : '1') + ' baris terpilih.',
     recordsPerPage: 'Baris per halaman:',
     allRows: 'Semua',
-    pagination: (start, end, total) => start + '-' + end + ' dari ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' dari ' + total,
     columns: 'Kolom'
   },
   pagination: {

--- a/ui/lang/is.js
+++ b/ui/lang/is.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Engar' : rows) + ' færslur valdar.',
     recordsPerPage: 'Færslur á hverri síðu:',
     allRows: 'Allar',
-    pagination: (start, end, total) => start + '-' + end + ' af ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' af ' + total,
     columns: 'Dálkar'
   },
   pagination: {

--- a/ui/lang/it.js
+++ b/ui/lang/it.js
@@ -50,7 +50,7 @@ export default {
         : 'Nessuna riga selezionata.',
     recordsPerPage: 'Righe per pagina:',
     allRows: 'Tutte',
-    pagination: (start, end, total) => start + '-' + end + ' di ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' di ' + total,
     columns: 'Colonne'
   },
   pagination: {

--- a/ui/lang/ja.js
+++ b/ui/lang/ja.js
@@ -49,7 +49,7 @@ export default {
     selectedRecords: rows => (rows > 0 ? rows + '行を選択中' : '行を選択'),
     recordsPerPage: 'ページあたりの行数', // 'Rows per page:',
     allRows: '全て', // 'All',
-    pagination: (start, end, total) => start + '-' + end + ' ／ ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' ／ ' + total,
     columns: '列' // 'Columns'
   },
   pagination: {

--- a/ui/lang/kk.js
+++ b/ui/lang/kk.js
@@ -60,7 +60,7 @@ export default {
         : 'Ешбір жол таңдалмады.',
     recordsPerPage: 'Беттегі жолдар:',
     allRows: 'Бәрі',
-    pagination: (start, end, total) => start + '-' + end + ' из ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' из ' + total,
     columns: 'Бағандар'
   },
   pagination: {

--- a/ui/lang/km.js
+++ b/ui/lang/km.js
@@ -46,7 +46,7 @@ export default {
         : (rows === 0 ? 'មិនមាន' : rows) + ' ជួរដេកត្រូវបានជ្រើសរើស',
     recordsPerPage: 'ជួរដេកក្នុងមួយទំព័រ:',
     allRows: 'ទាំងអស់',
-    pagination: (start, end, total) => start + '-' + end + ' នៃ ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' នៃ ' + total,
     columns: 'ជួរឈរ'
   },
   pagination: {

--- a/ui/lang/kur-CKB.js
+++ b/ui/lang/kur-CKB.js
@@ -54,7 +54,7 @@ export default {
         : (rows === 0 ? '0' : rows) + 'ڕیکۆرد هەڵبژێرداوە.',
     recordsPerPage: 'ئەنجام بۆهەر پەڕەیەک:',
     allRows: 'هەمووی',
-    pagination: (start, end, total) => start + '-' + end + ' لە ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' لە ' + total,
     columns: 'ڕیز'
   },
   pagination: {

--- a/ui/lang/lt.js
+++ b/ui/lang/lt.js
@@ -64,7 +64,7 @@ export default {
         : 'Nepasirinktas joks įrašas.',
     recordsPerPage: 'Puslapyje:',
     allRows: 'Visi',
-    pagination: (start, end, total) => start + '-' + end + ' iš ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' iš ' + total,
     columns: 'Stulpeliai'
   },
   pagination: {

--- a/ui/lang/lu.js
+++ b/ui/lang/lu.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Keng' : rows) + ' Zeilen ausgewielt.',
     recordsPerPage: 'Zeilen pro Säit:',
     allRows: 'All',
-    pagination: (start, end, total) => start + '-' + end + ' vun ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' vun ' + total,
     columns: 'Kolonnen'
   },
   pagination: {

--- a/ui/lang/lv.js
+++ b/ui/lang/lv.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Nav' : rows) + ' izvēlētas rindas.',
     recordsPerPage: 'Rindas lapā:',
     allRows: 'Visas',
-    pagination: (start, end, total) => start + '-' + end + ' no ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' no ' + total,
     columns: 'Kolonnas'
   },
   pagination: {

--- a/ui/lang/mk.js
+++ b/ui/lang/mk.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Нема' : rows) + ' записи се избрани.',
     recordsPerPage: 'Записи по страница:',
     allRows: 'Сите',
-    pagination: (start, end, total) => start + '-' + end + ' од ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' од ' + total,
     columns: 'Колони'
   },
   pagination: {

--- a/ui/lang/ml.js
+++ b/ui/lang/ml.js
@@ -50,7 +50,7 @@ export default {
     recordsPerPage: 'ഓരോ പേജിലും റെക്കോർഡുകൾ:',
     allRows: 'എല്ലാം',
     pagination: (start, end, total) =>
-      start + '-' + end + ' മൊത്തം ' + total + ' ൽ നിന്നും',
+      start + ' - ' + end + ' മൊത്തം ' + total + ' ൽ നിന്നും',
     columns: 'നിരകൾ'
   },
   pagination: {

--- a/ui/lang/mm.js
+++ b/ui/lang/mm.js
@@ -49,7 +49,7 @@ export default {
     recordsPerPage: 'တစ်မျက်နှာခြင်း အတန်းရေတွက်',
     allRows: 'အားလုံး',
     pagination: (start, end, total) =>
-      start + 'မှ' + end + 'ထိ' + 'အားလုံး' + total + 'ရှိ',
+      start + ' မှ ' + end + 'ထိ' + 'အားလုံး' + total + 'ရှိ',
     columns: 'ကော်လံ'
   },
   pagination: {

--- a/ui/lang/ms-MY.js
+++ b/ui/lang/ms-MY.js
@@ -53,7 +53,7 @@ export default {
         : (rows === 0 ? 'tiada' : '1') + ' rekod terpilih.',
     recordsPerPage: 'Rekod setiap halaman:',
     allRows: 'Semua',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'Senaraikan'
   },
   pagination: {

--- a/ui/lang/ms.js
+++ b/ui/lang/ms.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'tiada' : '1') + ' rekod terpilih.',
     recordsPerPage: 'Rekod per halaman:',
     allRows: 'Semua',
-    pagination: (start, end, total) => start + '-' + end + ' dari ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' dari ' + total,
     columns: 'Kolum'
   },
   pagination: {

--- a/ui/lang/my.js
+++ b/ui/lang/my.js
@@ -51,7 +51,7 @@ export default {
     selectedRecords: rows => 'dipilih' + rows + 'baris',
     recordsPerPage: 'baris setiap muka surat:',
     allRows: 'semua',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'Senaraikan'
   },
   pagination: {

--- a/ui/lang/nb-NO.js
+++ b/ui/lang/nb-NO.js
@@ -48,7 +48,7 @@ export default {
         : 'Ingen valgte rader.',
     recordsPerPage: 'Rader pr side:',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' av ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' av ' + total,
     columns: 'Kolonner'
   },
   pagination: {

--- a/ui/lang/nl.js
+++ b/ui/lang/nl.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Geen' : rows) + ' geselecteerde records.',
     recordsPerPage: 'Records per pagina:',
     allRows: 'Alle',
-    pagination: (start, end, total) => start + '-' + end + ' van ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' van ' + total,
     columns: 'Kolommen'
   },
   pagination: {

--- a/ui/lang/pl.js
+++ b/ui/lang/pl.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Brak' : '1') + ' zaznaczony wiersz.',
     recordsPerPage: 'Wierszy na stronę:',
     allRows: 'Wszystkie',
-    pagination: (start, end, total) => start + '-' + end + ' z ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' z ' + total,
     columns: 'Kolumny'
   },
   pagination: {

--- a/ui/lang/pt-BR.js
+++ b/ui/lang/pt-BR.js
@@ -52,7 +52,7 @@ export default {
         : 'Nenhum registro selecionado.',
     recordsPerPage: 'Registros por página:',
     allRows: 'Todos',
-    pagination: (start, end, total) => start + '-' + end + ' de ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' de ' + total,
     columns: 'Colunas'
   },
   pagination: {

--- a/ui/lang/pt.js
+++ b/ui/lang/pt.js
@@ -52,7 +52,7 @@ export default {
         : 'Nenhuma linha selecionada.',
     recordsPerPage: 'Linhas por página:',
     allRows: 'Todas',
-    pagination: (start, end, total) => start + '-' + end + ' de ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' de ' + total,
     columns: 'Colunas'
   },
   pagination: {

--- a/ui/lang/ro.js
+++ b/ui/lang/ro.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Nici o' : '1') + ' înregistrare selectată.',
     recordsPerPage: 'Înregistrări pe pagină:',
     allRows: 'Toate',
-    pagination: (start, end, total) => start + '-' + end + ' din ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' din ' + total,
     columns: 'Coloane'
   },
   pagination: {

--- a/ui/lang/ru.js
+++ b/ui/lang/ru.js
@@ -62,7 +62,7 @@ export default {
         : 'Ни одна строка не выбрана.',
     recordsPerPage: 'Строк на странице:',
     allRows: 'Все',
-    pagination: (start, end, total) => start + '-' + end + ' из ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' из ' + total,
     columns: 'Колонки'
   },
   pagination: {

--- a/ui/lang/sk.js
+++ b/ui/lang/sk.js
@@ -54,7 +54,7 @@ export default {
         : 'Žiadne vybraté riadky.',
     recordsPerPage: 'Riadkov na stránku:',
     allRows: 'Všetky',
-    pagination: (start, end, total) => start + '-' + end + ' z ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' z ' + total,
     columns: 'Stĺpce'
   },
   pagination: {

--- a/ui/lang/sl.js
+++ b/ui/lang/sl.js
@@ -49,7 +49,7 @@ export default {
           : (rows === 0 ? 'Ni' : rows) + ' izbranih vrstic.',
     recordsPerPage: 'Vrstic na stran:',
     allRows: 'Vse',
-    pagination: (start, end, total) => start + '-' + end + ' od ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' od ' + total,
     columns: 'Stolpci'
   },
   pagination: {

--- a/ui/lang/sm.js
+++ b/ui/lang/sm.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Lēai ni' : rows) + " laina 'ua filifilia.",
     recordsPerPage: "Laina 'i le ītūlau:",
     allRows: "Laina 'uma",
-    pagination: (start, end, total) => start + '-' + end + ' o ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' o ' + total,
     columns: 'Poutū'
   },
   pagination: {

--- a/ui/lang/sq.js
+++ b/ui/lang/sq.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Asnjë' : rows) + ' regjistrime të përzgjedhura.',
     recordsPerPage: 'Regjistrime për faqe:',
     allRows: 'Të gjitha',
-    pagination: (start, end, total) => `${start}-${end} nga ${total}`,
+    pagination: (start, end, total) => `${start} - ${end} nga ${total}`,
     columns: 'Kolonat'
   },
   pagination: {

--- a/ui/lang/sr-CYR.js
+++ b/ui/lang/sr-CYR.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Нема' : '1') + ' изабраних редова.',
     recordsPerPage: 'Редова по страници:',
     allRows: 'Све',
-    pagination: (start, end, total) => start + '-' + end + ' од ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' од ' + total,
     columns: 'Колоне'
   },
   pagination: {

--- a/ui/lang/sr.js
+++ b/ui/lang/sr.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Nema' : '1') + ' izabranih redova.',
     recordsPerPage: 'Redova po stranici:',
     allRows: 'Sve',
-    pagination: (start, end, total) => start + '-' + end + ' od ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' od ' + total,
     columns: 'Kolone'
   },
   pagination: {

--- a/ui/lang/sv.js
+++ b/ui/lang/sv.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Inga' : rows) + ' valda rader.',
     recordsPerPage: 'Rader per sida:',
     allRows: 'Alla',
-    pagination: (start, end, total) => start + '-' + end + ' av ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' av ' + total,
     columns: 'Kolumner'
   },
   pagination: {

--- a/ui/lang/ta.js
+++ b/ui/lang/ta.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? '0' : rows) + ' பதிவு தேர்ந்தெடுக்கப்பட்டது.',
     recordsPerPage: 'ஒரு பக்கத்திற்கு பதிவுகள்:',
     allRows: 'அனைத்தும்',
-    pagination: (start, end, total) => start + '-' + end + ' மொத்தம் ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' மொத்தம் ' + total,
     columns: 'பத்திகள்'
   },
   pagination: {

--- a/ui/lang/th.js
+++ b/ui/lang/th.js
@@ -46,7 +46,7 @@ export default {
       rows > 0 ? 'เลือกทั้งหมด ' + rows + ' แถว' : 'ไม่มีแถวที่ถูกเลือก',
     recordsPerPage: 'แถวต่อหน้า:',
     allRows: 'แถวทั้งหมด',
-    pagination: (start, end, total) => start + '-' + end + ' of ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' of ' + total,
     columns: 'คอลัมน์'
   },
   pagination: {

--- a/ui/lang/tl.js
+++ b/ui/lang/tl.js
@@ -47,7 +47,7 @@ export default {
         : (rows === 0 ? 'Hindi' : rows) + ' mga rekord na napili.',
     recordsPerPage: 'Mga tala sa bawat pahina:',
     allRows: 'Lahat',
-    pagination: (start, end, total) => start + '-' + end + ' ng ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' ng ' + total,
     columns: 'Mga hanay'
   },
   pagination: {

--- a/ui/lang/tr.js
+++ b/ui/lang/tr.js
@@ -44,7 +44,7 @@ export default {
     selectedRecords: rows => rows + ' seçili kayıt.',
     recordsPerPage: 'Sayfa başına kayıt:',
     allRows: 'Tümü',
-    pagination: (start, end, total) => start + '-' + end + ' toplam ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' toplam ' + total,
     columns: 'Sütunlar'
   },
   pagination: {

--- a/ui/lang/ug.js
+++ b/ui/lang/ug.js
@@ -53,7 +53,7 @@ export default {
     selectedRecords: rows => 'جەمئىي ' + rows + ' قۇر تاللاندى',
     recordsPerPage: 'ھەربەتتىكى قۇر سانى:',
     allRows: 'ھەممىسى',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: 'ئىستون'
   },
   editor: {

--- a/ui/lang/uk.js
+++ b/ui/lang/uk.js
@@ -60,7 +60,7 @@ export default {
         : 'Жодного рядку не обрано.',
     recordsPerPage: 'Рядків на сторінці:',
     allRows: 'Усі',
-    pagination: (start, end, total) => start + '-' + end + ' з ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' з ' + total,
     columns: 'Колонки'
   },
   pagination: {

--- a/ui/lang/ur-PK.js
+++ b/ui/lang/ur-PK.js
@@ -59,7 +59,7 @@ export default {
       rows === 0 ? 'کوئی ریکارڈ منتخب نہیں ہوا' : `${rows} ریکارڈ منتخب ہوئے`,
     recordsPerPage: 'ریکارڈز فی صفحہ:',
     allRows: 'سب',
-    pagination: (start, end, total) => `${start}-${end} / ${total}`,
+    pagination: (start, end, total) => `${start} - ${end} / ${total}`,
     columns: 'کالم'
   },
   pagination: {

--- a/ui/lang/uz-Cyrl.js
+++ b/ui/lang/uz-Cyrl.js
@@ -52,7 +52,7 @@ export default {
     },
     recordsPerPage: 'Сахифадаги қаторлар:',
     allRows: 'Барчаси',
-    pagination: (start, end, total) => start + '-' + end + ' жами ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' жами ' + total,
     columns: 'Устунлар'
   },
   pagination: {

--- a/ui/lang/uz-Latn.js
+++ b/ui/lang/uz-Latn.js
@@ -56,7 +56,7 @@ export default {
     },
     recordsPerPage: 'Saxifadagi qatorlar:',
     allRows: 'Barchasi',
-    pagination: (start, end, total) => start + '-' + end + ' jami ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' jami ' + total,
     columns: 'Ustunlar'
   },
   pagination: {

--- a/ui/lang/vi.js
+++ b/ui/lang/vi.js
@@ -49,7 +49,7 @@ export default {
         : (rows === 0 ? 'Không có hàng nào' : rows) + ' hàng đã chọn.',
     recordsPerPage: 'Hàng trên mỗi trang:',
     allRows: 'Tất cả',
-    pagination: (start, end, total) => start + '-' + end + ' của ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' của ' + total,
     columns: 'Cột'
   },
   pagination: {

--- a/ui/lang/zh-CN.js
+++ b/ui/lang/zh-CN.js
@@ -53,7 +53,7 @@ export default {
     selectedRecords: rows => '已选择' + rows + '行',
     recordsPerPage: '每页的行数:',
     allRows: '全部',
-    pagination: (start, end, total) => start + '-' + end + ' / ' + total,
+    pagination: (start, end, total) => start + ' - ' + end + ' / ' + total,
     columns: '列'
   },
   pagination: {

--- a/ui/lang/zh-TW.js
+++ b/ui/lang/zh-TW.js
@@ -54,7 +54,7 @@ export default {
     recordsPerPage: '每頁列數：',
     allRows: '全部',
     pagination: (start, end, total) =>
-      start + '-' + end + ' 列，共 ' + total + ' 列',
+      start + ' - ' + end + ' 列，共 ' + total + ' 列',
     columns: '欄位'
   },
   pagination: {

--- a/ui/src/plugins/lang/Lang.json
+++ b/ui/src/plugins/lang/Lang.json
@@ -266,7 +266,7 @@
                 "examples": ["'5-10 of 50'"]
               },
               "examples": [
-                "(start, end, total) => start + '-' + end + ' of ' + total"
+                "(start, end, total) => start + ' - ' + end + ' of ' + total"
               ]
             },
             "columns": {
@@ -807,7 +807,7 @@
                     "examples": ["'5-10 of 50'"]
                   },
                   "examples": [
-                    "(start, end, total) => start + '-' + end + ' of ' + total"
+                    "(start, end, total) => start + ' - ' + end + ' of ' + total"
                   ]
                 },
                 "columns": {

--- a/ui/src/plugins/lang/Lang.test.js
+++ b/ui/src/plugins/lang/Lang.test.js
@@ -227,7 +227,7 @@ describe('[Lang API]', () => {
               recordsPerPage: 'Records per page:',
               allRows: 'All',
               pagination: (start, end, total) =>
-                start + '-' + end + ' of ' + total,
+                start + ' - ' + end + ' of ' + total,
               columns: 'Columns'
             },
             pagination: {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
Just adding a space after 'start' word and a space before 'end' word in lang files and related docs to fix and enhance table pagination label when changing direction

before:
<img width="77" height="47" alt="11" src="https://github.com/user-attachments/assets/a16cd2f1-e2c3-4bd5-9c5a-c1d5a5f144b2" />
<img width="77" height="47" alt="12" src="https://github.com/user-attachments/assets/a59ab39a-e9c5-41e7-b1df-c2b39bb70ecd" />

after:
<img width="77" height="47" alt="21" src="https://github.com/user-attachments/assets/5fdc88dd-c809-4d3c-a757-0a04e7908cf3" />
<img width="77" height="47" alt="22" src="https://github.com/user-attachments/assets/b043898c-a05a-4fb3-af0e-0d7786833f62" />
