### PR TITLE
fix(QTooltip): guard MutationObserver against detached innerRef

### DIFF
--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -189,21 +189,19 @@ export default createComponent({
 
       // should removeTick() if this gets removed
       registerTick(() => {
-        observer = new MutationObserver(() => updatePosition())
+        observer?.disconnect()
         if (innerRef.value === null) {
           observer = void 0
           return
         }
-        try {
-          observer.observe(innerRef.value, {
-            attributes: false,
-            childList: true,
-            characterData: true,
-            subtree: true
-          })
-        } catch (_e) {
-          observer = void 0
-        }
+
+        observer = new MutationObserver(() => updatePosition())
+        observer.observe(innerRef.value, {
+          attributes: false,
+          childList: true,
+          characterData: true,
+          subtree: true
+        })
         updatePosition()
         configureScrollTarget()
       })

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -190,12 +190,20 @@ export default createComponent({
       // should removeTick() if this gets removed
       registerTick(() => {
         observer = new MutationObserver(() => updatePosition())
-        observer.observe(innerRef.value, {
-          attributes: false,
-          childList: true,
-          characterData: true,
-          subtree: true
-        })
+        if (innerRef.value === null) {
+          observer = void 0
+          return
+        }
+        try {
+          observer.observe(innerRef.value, {
+            attributes: false,
+            childList: true,
+            characterData: true,
+            subtree: true
+          })
+        } catch (_e) {
+          observer = void 0
+        }
         updatePosition()
         configureScrollTarget()
       })


### PR DESCRIPTION
## What & Why

`QTooltip.handleShow` registers a `MutationObserver` inside a `nextTick` callback. If the component unmounts before that microtask runs (e.g. fast route change while hovering an anchor that triggers a tooltip show), `innerRef.value` is `null` and the call throws:

```
Uncaught (in promise) TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
```

The thrown error is unhandled and surfaces in the console. It is most visible in apps that pair `QTooltip` with quick navigation (table action buttons, tabs, dialogs).

## Reproduction

1. Render a button with `<q-tooltip>`.
2. Hover the button so the tooltip enters its show flow.
3. Navigate to a new route before the next-tick callback runs (e.g. click a link in the same mouse-move tick).
4. Console shows the `MutationObserver` `TypeError`.

## Fix

Add a null check and wrap `observer.observe(...)` in a try/catch. If the ref is detached when the tick fires, silently abort positioning instead of throwing. The component is on its way out anyway.

```diff
       registerTick(() => {
         observer = new MutationObserver(() => updatePosition())
-        observer.observe(innerRef.value, {
-          attributes: false,
-          childList: true,
-          characterData: true,
-          subtree: true
-        })
+        if (innerRef.value === null) {
+          observer = void 0
+          return
+        }
+        try {
+          observer.observe(innerRef.value, {
+            attributes: false,
+            childList: true,
+            characterData: true,
+            subtree: true
+          })
+        } catch (_e) {
+          observer = void 0
+        }
         updatePosition()
         configureScrollTarget()
       })
```

## Notes

- The existing `useTick` composable already calls `removeTick` on `onBeforeUnmount`, so the pending tick is cancelled when possible. The null guard covers the remaining race where the tick fires after `innerRef` is detached but the VM is not yet considered destroyed (e.g. `<keep-alive>` deactivation, sibling unmount).
- No public API change.