### PR TITLE
docs(Tooltip,Menu): clarify offset interaction with screen-edge clamping

### DIFF
--- a/docs/src/pages/vue-components/menu/menu.md
+++ b/docs/src/pages/vue-components/menu/menu.md
@@ -77,6 +77,10 @@ The final position of QMenu popup is calculated so that it will be displayed on 
 
 For horizontal positioning you can use `start` and `end` when you want to automatically take into account if on RTL or non-RTL. `start` and `end` mean "left" for non-RTL and "right" for RTL.
 
+::: tip
+The `offset` prop is applied to the **anchor element's bounding box**, and only then is the final position clamped to the available screen real estate. As a result, a large offset — or anchoring QMenu to a full-width / screen-edge element — can push the popup against a viewport edge, where it gets clamped and the offset appears to have no effect (the clamped position then becomes independent of the offset value). If an `offset` seems to be ignored on one axis, make sure the chosen `anchor`/`self` lets the popup expand into free space on that axis — for example, attach QMenu to an inline / `inline-block` trigger rather than to a full-width block element.
+:::
+
 <script doc>
 import MenuPositioning from './MenuPositioning.vue'
 </script>

--- a/docs/src/pages/vue-components/tooltip/tooltip.md
+++ b/docs/src/pages/vue-components/tooltip/tooltip.md
@@ -50,6 +50,10 @@ The final position of QTooltip popup is calculated so that it will be displayed 
 
 For horizontal positioning you can use `start` and `end` when you want to automatically take into account if on RTL or non-RTL. `start` and `end` mean "left" for non-RTL and "right" for RTL.
 
+::: tip
+The `offset` prop is applied to the **anchor element's bounding box**, and only then is the final position clamped to the available screen real estate. As a result, a large offset — or anchoring QTooltip to a full-width / screen-edge element — can push the popup against a viewport edge, where it gets clamped and the offset appears to have no effect (the clamped position then becomes independent of the offset value). If an `offset` seems to be ignored on one axis, make sure the chosen `anchor`/`self` lets the popup expand into free space on that axis — for example, attach QTooltip to an inline / `inline-block` trigger rather than to a full-width block element.
+:::
+
 <script doc>
 import TooltipPositioning from './TooltipPositioning.vue'
 </script>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated, or explained in the PR's description

**Other information:**

Follow-up to #18212 (working-as-intended, not an offset bug).

The horizontal/vertical `offset` on QTooltip/QMenu can appear to have no effect.
It isn't an offset bug: `offset` is applied to the anchor element's bounding box
and the result is then clamped to the viewport, so anchoring to a full-width /
screen-edge element (or pointing `anchor`/`self` toward an edge with no room)
masks the offset on that axis.

This adds a tip to the Positioning section of both the Tooltip and Menu docs
explaining the behaviour and how to avoid it.
