### PR TITLE
fix(QTooltip): show on keyboard focus & dismiss with ESC (fix #18241)

### DIFF
--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -26,6 +26,10 @@ import useTimeout from '../../composables/use-timeout/use-timeout.js'
 import { createComponent } from '../../utils/private.create/create.js'
 import { getScrollTarget, scrollTargetProp } from '../../utils/scroll/scroll.js'
 import { addEvt, cleanEvt, stopAndPrevent } from '../../utils/event/event.js'
+import {
+  addEscapeKey,
+  removeEscapeKey
+} from '../../utils/private.keyboard/escape-key.js'
 import { clearSelection } from '../../utils/private.selection/selection.js'
 import { hSlot } from '../../utils/private.render/render.js'
 import {
@@ -137,7 +141,7 @@ export default createComponent({
       processOnMount: true
     })
 
-    Object.assign(anchorEvents, { delayShow, delayHide })
+    Object.assign(anchorEvents, { delayShow, delayHide, focusShow })
 
     const { showPortal, hidePortal, renderPortal } = usePortal(
       vm,
@@ -183,6 +187,17 @@ export default createComponent({
         removeClickOutside(clickOutsideProps)
       })
     }
+
+    // dismiss with the ESC key (WCAG 1.4.13) without moving focus;
+    // uses the shared escape stack so only the top-most popup reacts
+    const handlesEscape = computed(
+      () => showing.value === true && props.persistent !== true
+    )
+
+    watch(handlesEscape, val => {
+      const fn = val === true ? addEscapeKey : removeEscapeKey
+      fn(onEscapeKey)
+    })
 
     function handleShow(evt) {
       showPortal()
@@ -248,6 +263,7 @@ export default createComponent({
       }
 
       unconfigureScrollTarget()
+      removeEscapeKey(onEscapeKey)
       cleanEvt(anchorEvents, 'tooltipTemp')
     }
 
@@ -297,6 +313,25 @@ export default createComponent({
       }, props.hideDelay)
     }
 
+    function focusShow(evt) {
+      const el = anchorEl.value
+
+      if (el === null) return
+
+      // only react to keyboard focus, not to focus coming from a pointer,
+      // so the tooltip doesn't pop up when the target is clicked;
+      // guard the call for engines that don't support :focus-visible
+      try {
+        if (el.matches(':focus-visible') === false) return
+      } catch {}
+
+      delayShow(evt)
+    }
+
+    function onEscapeKey(evt) {
+      hide(evt)
+    }
+
     function configureAnchorEl() {
       if (props.noParentEvent || anchorEl.value === null) return
 
@@ -304,7 +339,9 @@ export default createComponent({
         ? [[anchorEl.value, 'touchstart', 'delayShow', 'passive']]
         : [
             [anchorEl.value, 'mouseenter', 'delayShow', 'passive'],
-            [anchorEl.value, 'mouseleave', 'delayHide', 'passive']
+            [anchorEl.value, 'mouseleave', 'delayHide', 'passive'],
+            [anchorEl.value, 'focus', 'focusShow', 'passive'],
+            [anchorEl.value, 'blur', 'delayHide', 'passive']
           ]
 
       addEvt(anchorEvents, 'anchor', evts)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (`fix #18241`)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated, or explained in the PR's description

**Other information:**

Fixes #18241.

### Problem
QTooltip only showed on mouse hover (and touch), so keyboard-only users never saw it when tabbing to the target — a violation of WCAG 1.4.13 (Content on Hover or Focus).

### Change
In the tooltip's anchor wiring (desktop):
- **Show on keyboard focus** of the target, gated by `:focus-visible` so the tooltip does *not* appear on plain pointer clicks (mouse users keep hover).
- **Hide on `blur`.**
- **Dismiss with `ESC`** while shown, via Quasar's shared escape-key stack (same mechanism as QMenu/QDialog) — only the top-most popup reacts and focus is not moved (WCAG "dismissible").

No new props/events; respects the existing `noParentEvent` and `persistent`.
The touch/mobile path is unchanged.

### Scope / note
A focusable trigger is required (QBtn, links, inputs…). A tooltip on a non-focusable element (a bare `<div>` without `tabindex`) still can't receive focus — that remains the app's responsibility.

### Verification
Built from source and exercised in headless Chromium (Playwright):
- idle: no tooltip
- Tab focuses target → shown
- ESC → hidden, focus stays on target
- blur (Tab away) → hidden
- mouse hover → shown / mouse leave → hidden
- mouse click (focus without `:focus-visible`) → not shown

Cordova/Electron not separately tested — the change uses standard DOM `focus`/`blur` + `:focus-visible` and the existing escape-key stack, with no platform-specific code. No unit test added: QTooltip currently has no test file and the spec harness requires full-API coverage for any existing test file; the `:focus-visible` gating also can't be exercised under jsdom.
Happy to follow up with full QTooltip test coverage separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips can now be dismissed with the **Escape** key.
  * Tooltips appear when keyboard users focus an eligible anchor and hide when focus leaves.
* **Accessibility**
  * Improved keyboard navigation and focus-visible behavior for tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->