### PR TITLE
fix: #18321 unescape create-quasar CSP self sources

### DIFF
--- a/create-quasar/templates/ae/js/BASE/playground/index.html
+++ b/create-quasar/templates/ae/js/BASE/playground/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%~ <% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %> ~%>">
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src \'self\' ws://localhost:*; worker-src \'self\' blob:;<% } %> ~%>"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src 'self' ws://localhost:*; worker-src 'self' blob:;<% } %> ~%>"
     />
 
     <link rel="icon" type="image/ico" href="favicon.ico">

--- a/create-quasar/templates/ae/ts/BASE/playground/index.html
+++ b/create-quasar/templates/ae/ts/BASE/playground/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<%~ <% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %> ~%>">
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src \'self\' ws://localhost:*; worker-src \'self\' blob:;<% } %> ~%>"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src 'self' ws://localhost:*; worker-src 'self' blob:;<% } %> ~%>"
     />
 
     <link rel="icon" type="image/ico" href="favicon.ico">

--- a/create-quasar/templates/app/vite-3/js/BASE/index.html
+++ b/create-quasar/templates/app/vite-3/js/BASE/index.html
@@ -11,7 +11,7 @@
 <% if (scope.linter !== 'eslint') { %>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src \'self\' ws://localhost:*; worker-src \'self\' blob:;<% } %> ~%>"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src 'self' ws://localhost:*; worker-src 'self' blob:;<% } %> ~%>"
     />
 <% } %>
 

--- a/create-quasar/templates/app/vite-3/ts/BASE/index.html
+++ b/create-quasar/templates/app/vite-3/ts/BASE/index.html
@@ -11,7 +11,7 @@
 <% if (scope.linter !== 'eslint') { %>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src \'self\' ws://localhost:*; worker-src \'self\' blob:;<% } %> ~%>"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<%~ <% if (ctx.dev) { %> connect-src 'self' ws://localhost:*; worker-src 'self' blob:;<% } %> ~%>"
     />
 <% } %>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Documentation is not required; this fixes generated template output.

**Other information:**

Fixes #18321.

This removes the extra escaping around `connect-src 'self'` and `worker-src 'self'` in the generated dev CSP template output for Vite 3 app templates, plus the matching app-extension playground templates.

Test plan:
- Rendered each touched create-quasar template through the first-stage create-quasar renderer, then through the app-vite HTML renderer with `ctx.dev: true`, and asserted the final CSP contains unescaped `'self'` sources.
- `git diff --check HEAD~1..HEAD`
