### PR TITLE
fix(app-vite): iOS --ide opens .xcworkspace not .xcodeproj (fix: #18324)

### DIFF
--- a/app-vite/lib/utils/open-ide.js
+++ b/app-vite/lib/utils/open-ide.js
@@ -6,15 +6,17 @@ import open from 'open'
 import { fatal, warn } from './logger.js'
 
 function findXcodeWorkspace(folder) {
-  const root = fs.readdirSync(folder)
+  const items = fs.readdirSync(folder)
 
-  for (const item of root) {
-    const __path = path.join(folder, item)
+  // Prefer the .xcworkspace: it's the CocoaPods-integrated container that
+  // links the Pods providing the Capacitor module. readdirSync() can list
+  // the bare .xcodeproj first, and opening that builds without the Pods,
+  // failing with "No such module 'Capacitor'".
+  const target =
+    items.find(item => item.endsWith('.xcworkspace'))
+    || items.find(item => item.endsWith('.xcodeproj'))
 
-    if (item.endsWith('.xcworkspace') || item.endsWith('.xcodeproj')) {
-      return __path
-    }
-  }
+  return target !== undefined ? path.join(folder, target) : undefined
 }
 
 function runMacOS(mode, target, appPaths) {

--- a/app-vite/lib/utils/open-ide.js
+++ b/app-vite/lib/utils/open-ide.js
@@ -16,7 +16,9 @@ function findXcodeWorkspace(folder) {
     items.find(item => item.endsWith('.xcworkspace'))
     || items.find(item => item.endsWith('.xcodeproj'))
 
-  return target !== undefined ? path.join(folder, target) : undefined
+  if (target) {
+    return path.join(folder, target)
+  }
 }
 
 function runMacOS(mode, target, appPaths) {


### PR DESCRIPTION
Closes #18324.

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

### Problem

`quasar build -m capacitor -T ios --ide` opened **App.xcodeproj**, and Xcode builds from there failed with `No such module 'Capacitor'` — the Pods are only linked into **App.xcworkspace**.

`findXcodeWorkspace()` returned whichever of the two `readdirSync` listed first, and `App.xcodeproj` sorts before `App.xcworkspace`, so the workspace was never opened. The non-`--ide` build was unaffected because `capacitor-builder.js` passes `-workspace App.xcworkspace` explicitly.

### Fix

Prefer the `.xcworkspace`, fall back to `.xcodeproj` only when no workspace exists. This matches what `npx cap open ios` and the headless build already do. Behaviour is unchanged for Cordova/older layouts that ship a single target.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (`fix: #18324`)

### Testing

Verified on a Capacitor 8 iOS app on macOS: before the change `--ide` opened `App.xcodeproj` (build → `No such module 'Capacitor'`); after it, `App.xcworkspace` opens and builds cleanly. Cordova shares the same code path; Electron is unaffected.
