### PR TITLE
chore(vite-plugin): normalize bugs metadata

### DIFF
--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -10,7 +10,9 @@
     "vuejs"
   ],
   "homepage": "https://quasar.dev",
-  "bugs": "https://github.com/quasarframework/quasar/issues",
+  "bugs": {
+    "url": "https://github.com/quasarframework/quasar/issues"
+  },
   "license": "MIT",
   "author": {
     "name": "Razvan Stoenescu",


### PR DESCRIPTION
## What does this PR do?

Normalizes the `@quasar/vite-plugin` package `bugs` metadata from a string to the standard npm object form with `bugs.url`.

This keeps the same issue tracker URL and does not change runtime code, exports, dependencies, package versioning, or published files.

## Why is it needed?

The current published metadata for `@quasar/vite-plugin@1.12.0` exposes `bugs` as a plain string:

```json
"bugs": "https://github.com/quasarframework/quasar/issues"
```

Using the standard object form improves compatibility with npm metadata consumers that expect `bugs.url`.

## Validation

- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('vite-plugin/package.json','utf8')); if (pkg.name !== '@quasar/vite-plugin') throw new Error('wrong package'); if (!pkg.bugs || pkg.bugs.url !== 'https://github.com/quasarframework/quasar/issues') throw new Error('bugs.url mismatch'); console.log(pkg.name, pkg.version, pkg.bugs.url)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./vite-plugin`