### PR TITLE
(docs) Update upgrade guide with clarifications on vueOptionsAPI

### DIFF
--- a/docs/src/pages/quasar-cli-vite/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/upgrade-guide.md
@@ -465,7 +465,7 @@ build: {
   env: {}, // [!code --]
   defineEnv: {}, // or long form "define" with 'import.meta.env.' prefix in key
 
-  // change to "true" if needed; defaults to "false" now!
+  // change to "true" if needed; defaults to "false" now. It's worth checking whether your other Vue3 packages still use the Options API. If they do, you'll need to set this to true.
   vueOptionsAPI,
 
   // removed; deferring to Vite's default // [!code --]
@@ -664,7 +664,7 @@ Make sure to update your `/quasar.config` file with the newest specs in order to
 
 - All imports from `#q-app/wrappers` need to be replaced with `#q-app`. Do a global search and replace.
 - Switched from `process.env` to the modern `import.meta.env`. [Link](/quasar-cli-vite/handling-import-meta-env)
-- /quasar.config > build > vueOptionsAPI is now `false` by default
+- /quasar.config > build > vueOptionsAPI is now `false` by default. Check other Vue 3 packages and components. If they use the `Options` API, you will need to set this to true.
 - /quasar.config > build > polyfillModulePreload (removed and now defaulting to Vite's own config for this)
 - /index.html -> new [HTML Constant Replacement](/quasar-cli-vite/handling-import-meta-env#html-constant-replacement). `<% if (process.env.X) %>` will no longer work.
 - New [dotenv files support](/quasar-cli-vite/handling-import-meta-end#more-on-dotenv-files), including for the `/quasar.config` file itself. By default, Quasar CLI will only look for `.env` and `.env.local`, but you can add other files as well to support the ones with prod/dev/mode suffixes.

--- a/docs/src/pages/quasar-cli-vite/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/upgrade-guide.md
@@ -465,7 +465,8 @@ build: {
   env: {}, // [!code --]
   defineEnv: {}, // or long form "define" with 'import.meta.env.' prefix in key
 
-  // change to "true" if needed; defaults to "false" now. It's worth checking whether your other Vue3 packages still use the Options API. If they do, you'll need to set this to true.
+  // change to "true" if needed; defaults to "false" now!
+  // check your deps too!
   vueOptionsAPI,
 
   // removed; deferring to Vite's default // [!code --]


### PR DESCRIPTION
The change to default `vueOptionsAPI` to `false` caught me out, despite it not being used directly in my project. Another dependency was still using the options API, and I had to re-enable this to fix. I wanted to update the docs to make others think about their other dependencies and whether they need to re-enable this option. 

Clarified the default value and implications of vueOptionsAPI in the upgrade guide. Updated notable breaking changes to include additional context for vueOptionsAPI and dotenv support.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
