### PR TITLE
fix: restore QDrawer swipe-to-open guard inverted in v2.20.0 (fix #18331)

### DIFF
--- a/ui/src/components/drawer/QDrawer.js
+++ b/ui/src/components/drawer/QDrawer.js
@@ -519,9 +519,11 @@ export default createComponent({
     }
 
     function onOpenPan(evt) {
-      // some browsers might capture and trigger this
-      // even if Drawer has just been opened (but animation is still pending)
-      if (!showing.value) return
+      if (showing.value !== false) {
+        // some browsers might capture and trigger this
+        // even if Drawer has just been opened (but animation is still pending)
+        return
+      }
 
       const width = size.value,
         position = between(evt.distance.x, 0, width)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description. <!-- No docs change needed: internal guard-condition fix only, no public API change. -->

**Other information:**

### Fixes #18331

`onOpenPan()`'s early-return guard in `QDrawer.js` was inverted between v2.19.3 and v2.20.0, breaking the edge-swipe-to-open gesture whenever the drawer is closed (exactly the case it's meant to handle).

**v2.19.3 (correct):**
```js
function onOpenPan(evt) {
  if (showing.value !== false) {
    // some browsers might capture and trigger this
    // even if Drawer has just been opened (but animation is still pending)
    return
  }
  ...
```

**v2.20.0 / v2.20.1 / dev (broken, before this PR):**
```js
function onOpenPan(evt) {
  // some browsers might capture and trigger this
  // even if Drawer has just been opened (but animation is still pending)
  if (!showing.value) return
  ...
```

`showing.value !== false` (skip only when *already showing*) was changed to `!showing.value` (skip when *not showing*) — the exact logical opposite, so the swipe-to-open gesture became a no-op while the drawer was closed.

This PR reverts the guard back to the v2.19.3 behaviour, with no other functional change.

### Reproduction

Live reproduction (broken on current `quasar@2`, confirmed fixed when pinned to `2.19.3`): https://jsfiddle.net/ytma3qLn/

Steps:
1. Open the reproduction link (a `q-drawer` forced into mobile/swipe mode via `breakpoint="9999"`, starting closed).
2. Drag with the mouse starting at the very left edge (x < 15px) towards the right.
3. Without this fix: nothing happens. With this fix (or quasar@2.19.3): the drawer opens.
