### PR TITLE
fix(lang): correct Norwegian (nb-NO) table.selectedRecords + minor fixes

### DIFF
--- a/ui/lang/nb-NO.js
+++ b/ui/lang/nb-NO.js
@@ -41,11 +41,10 @@ export default {
     noData: 'Ingen data tilgjengelig',
     noResults: 'Ingen treff i data funnet',
     loading: 'Laster...',
-    row: 'rad',
     selectedRecords: rows =>
-      rows > 0
-        ? rows + ' row' + (rows === 1 ? '' : 's') + ' valgt.'
-        : 'Ingen valgte rader.',
+      rows === 1
+        ? '1 rad valgt.'
+        : (rows === 0 ? 'Ingen' : rows) + ' rader valgt.',
     recordsPerPage: 'Rader pr side:',
     allRows: 'Alle',
     pagination: (start, end, total) => start + ' - ' + end + ' av ' + total,
@@ -75,7 +74,7 @@ export default {
     right: 'Høyrestill',
     justify: 'Tilpasset bredde',
     print: 'Skriv ut',
-    outdent: 'Midre innrykk',
+    outdent: 'Mindre innrykk',
     indent: 'Større innrykk',
     removeFormat: 'Fjern formatering',
     formatting: 'Formatering',
@@ -98,7 +97,7 @@ export default {
     size4: 'Medium-stor',
     size5: 'Stor',
     size6: 'Veldig stor',
-    size7: 'Maximum',
+    size7: 'Maksimal',
     defaultFont: 'Normal font',
     viewSource: 'Se kilde'
   },


### PR DESCRIPTION
### What it fixes

The Norwegian (`nb-NO`) language pack had a bug in `table.selectedRecords`: it printed the English word "row"/"rows" inside Norwegian text, e.g. `3 rows valgt.` This rewrites it to proper Norwegian and follows the same singular/plural/zero logic as `en-US`:

- 1 → `1 rad valgt.`
- 0 → `Ingen rader valgt.`
- n → `n rader valgt.`

Also in this PR:
- Removed the stale `table.row` key (no longer present in `en-US`).
- `editor.outdent`: typo `Midre` → `Mindre` ("Decrease indentation").
- `editor.size7`: untranslated `Maximum` → `Maksimal`.

No other strings changed; key set now matches `en-US`.

### Disclosure

Prepared with AI assistance and reviewed by me as a native Norwegian (Bokmål) speaker.