### PR TITLE
fix(lang): correct Japanese (ja) mistranslations in editor/tree labels

### DIFF
--- a/ui/lang/ja.js
+++ b/ui/lang/ja.js
@@ -15,7 +15,7 @@ export default {
     search: '検索', // 'Search',
     filter: 'フィルタ', // 'Filter',
     refresh: '再読込', // 'Refresh'
-    expand: label => (label ? `「${label}」を展開します。` : '拡大'),
+    expand: label => (label ? `「${label}」を展開します。` : '展開'),
     collapse: label => (label ? `「${label}」を折りたたむ` : '折りたたむ')
   },
   date: {

--- a/ui/lang/ja.js
+++ b/ui/lang/ja.js
@@ -16,7 +16,7 @@ export default {
     filter: 'フィルタ', // 'Filter',
     refresh: '再読込', // 'Refresh'
     expand: label => (label ? `「${label}」を展開します。` : '拡大'),
-    collapse: label => (label ? `「${label}」を折りたたむ` : '崩壊')
+    collapse: label => (label ? `「${label}」を折りたたむ` : '折りたたむ')
   },
   date: {
     days: '日曜日_月曜日_火曜日_水曜日_木曜日_金曜日_土曜日'.split('_'), // 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
@@ -82,15 +82,15 @@ export default {
     formatting: '書式', // 'Formatting',
     fontSize: 'フォントサイズ', // 'Font Size',
     align: '揃え', // 'Align',
-    hr: '横線を投入', // 'Insert Horizontal Rule',
+    hr: '横線を挿入', // 'Insert Horizontal Rule',
     undo: '元に戻す', // 'Undo',
     redo: 'やり直し', // 'Redo',
-    heading1: 'ヘッダー 1', // 'Heading 1',
-    heading2: 'ヘッダー 2', // 'Heading 2',
-    heading3: 'ヘッダー 3', // 'Heading 3',
-    heading4: 'ヘッダー 4', // 'Heading 4',
-    heading5: 'ヘッダー 5', // 'Heading 5',
-    heading6: 'ヘッダー 6', // 'Heading 6',
+    heading1: '見出し 1', // 'Heading 1',
+    heading2: '見出し 2', // 'Heading 2',
+    heading3: '見出し 3', // 'Heading 3',
+    heading4: '見出し 4', // 'Heading 4',
+    heading5: '見出し 5', // 'Heading 5',
+    heading6: '見出し 6', // 'Heading 6',
     paragraph: '段落', // 'Paragraph',
     code: 'コード', // 'Code',
     size1: '小さい', // 'Very small',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated or explained in the PR's description.

**Other information:**

I'm a native Japanese speaker and noticed a few labels in `ui/lang/ja.js` that are mistranslated. They don't match what the other locales mean, and one of them doesn't even match the editor's own wording. Only string values changed, no keys touched.

`editor.heading1`–`heading6`: `ヘッダー` → `見出し`
`ヘッダー` means "header" (a page/section header). A `<h1>`–`<h6>` heading level is 見出し in Japanese, which is the term Word and Google Docs both use. `zh-CN` uses 标题 and `ko-KR` uses 제목 (both "heading/title"), so ja was the odd one out here.

`label.collapse` (the no-label fallback): `崩壊` → `折りたたむ`
`崩壊` means a structural collapse, like a building caving in, not collapsing a tree node or panel. The labelled branch of the same entry already uses 折りたたむ, so this just makes the two consistent.

`editor.hr`: `横線を投入` → `横線を挿入`
`投入` is to throw/put something in (resources, coins); you don't 投入 a horizontal rule. The action is "insert" = 挿入, matching `zh-CN` 插入水平线 and `ko-KR` 가로줄 넣기.

I left `editor.orderedList` (`段落番号`) as-is on purpose. It looks odd next to "Ordered List" in English, but it's the standard Japanese label for a numbered list and pairs with `箇条書き` (the same wording Word uses).
