### PR TITLE
feat(ui): audit css surface

### DIFF
--- a/ui/build/script.css-surface-audit.js
+++ b/ui/build/script.css-surface-audit.js
@@ -1,0 +1,145 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
+
+import { green, red } from 'kolorist'
+import { globSync } from 'tinyglobby'
+
+import { resolveToRoot, rootFolder } from './build.utils.js'
+
+const sassImportRE = /^@import\s+['"]([^'"]+)['"]/gm
+const cssVarDefinitionRE = /(?<![\w-])(--q-[\w-]+)\s*:/g
+const cssVarUsageRE = /var\(\s*(--q-[\w-]+)\s*(?:,|\))/g
+const registryExportPathRE = /export\s+\{[^}]+\}\s+from\s+['"]([^'"]+)['"]/g
+
+const errors = []
+
+function label(file) {
+  return relative(rootFolder, file)
+}
+
+function addError(message) {
+  errors.push(message)
+}
+
+function readText(file) {
+  return readFile(file, 'utf8')
+}
+
+function getFiles(pattern) {
+  return globSync(pattern, {
+    cwd: rootFolder,
+    absolute: true
+  }).sort()
+}
+
+function toSassPath(importPath, parentFile) {
+  const target = resolve(dirname(parentFile), importPath)
+  return target.endsWith('.sass') ? target : `${target}.sass`
+}
+
+async function getRegistrySourceDirs(file) {
+  const content = await readText(file)
+  const dirs = new Set()
+  let match
+
+  registryExportPathRE.lastIndex = 0
+
+  while ((match = registryExportPathRE.exec(content)) !== null) {
+    dirs.add(dirname(resolve(dirname(file), match[1])))
+  }
+
+  return dirs
+}
+
+async function auditSassImports() {
+  const indexFile = resolveToRoot('src/css/index.sass')
+  const content = await readText(indexFile)
+  const importedFiles = new Set()
+  let match
+
+  sassImportRE.lastIndex = 0
+
+  while ((match = sassImportRE.exec(content)) !== null) {
+    const target = toSassPath(match[1], indexFile)
+
+    if (existsSync(target) === false) {
+      addError(`${label(indexFile)}: imports missing ${match[1]}`)
+    } else {
+      importedFiles.add(target)
+    }
+  }
+
+  await auditPublicSassCoverage(importedFiles)
+}
+
+async function auditPublicSassCoverage(importedFiles) {
+  const publicDirs = new Set([
+    ...(await getRegistrySourceDirs(resolveToRoot('src/components.js'))),
+    ...(await getRegistrySourceDirs(resolveToRoot('src/directives.js')))
+  ])
+
+  const sassFiles = [
+    ...getFiles('src/components/*/*.sass'),
+    ...getFiles('src/directives/*/*.sass')
+  ]
+
+  sassFiles.forEach(file => {
+    if (publicDirs.has(dirname(file)) === false) return
+
+    if (importedFiles.has(file) === false) {
+      addError(
+        `${label(file)}: public Sass file is not imported by src/css/index.sass`
+      )
+    }
+  })
+}
+
+async function auditCssCustomProperties() {
+  const files = [
+    ...getFiles('src/**/*.sass'),
+    ...getFiles('src/**/*.js')
+  ].filter(file => file.endsWith('.test.js') === false)
+
+  const defined = new Set()
+  const usages = []
+
+  for (const file of files) {
+    const content = await readText(file)
+    let match
+
+    cssVarDefinitionRE.lastIndex = 0
+    while ((match = cssVarDefinitionRE.exec(content)) !== null) {
+      defined.add(match[1])
+    }
+
+    cssVarUsageRE.lastIndex = 0
+    while ((match = cssVarUsageRE.exec(content)) !== null) {
+      const endChar = match[0].trimEnd().at(-1)
+      usages.push({
+        file,
+        name: match[1],
+        hasFallback: endChar === ','
+      })
+    }
+  }
+
+  usages.forEach(({ file, name, hasFallback }) => {
+    if (defined.has(name) === false && hasFallback === false) {
+      addError(`${label(file)}: uses ${name} without a definition or fallback`)
+    }
+  })
+}
+
+await auditSassImports()
+await auditCssCustomProperties()
+
+if (errors.length !== 0) {
+  console.log(red(`\nCSS surface audit errors (${errors.length}):`))
+  errors.forEach(error => {
+    console.log(red(`- ${error}`))
+  })
+  process.exit(1)
+}
+
+console.log(green('CSS surface audit passed.'))

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,6 +67,7 @@
     "dev:build:ssr": "cd ./playground && quasar build -m ssr && cd ..",
     "dev:umd": "node build/script.test-umd.js",
     "dev:quploader": "cd ./playground/upload-server && pnpm i && cd ../.. && node playground/upload-server/server.js",
+    "audit:css-surface": "node build/script.css-surface-audit.js",
     "test": "pnpm --filter quasar-ui-test test",
     "test:watch": "pnpm --filter quasar-ui-test test:watch",
     "test:watch:ui": "pnpm --filter quasar-ui-test test:watch:ui",


### PR DESCRIPTION
## Summary

Adds a UI CSS surface audit.

The audit checks that Sass imports resolve, public component/directive Sass files are included in the main CSS entry, and `var(--q-*)` usages either have a known definition or a local fallback.

## Validation

- `pnpm --dir ui run audit:css-surface`
- `pnpm --dir ui exec oxfmt --check build/script.css-surface-audit.js package.json`
- `pnpm --dir ui exec oxlint --deny-warnings build/script.css-surface-audit.js`
