### PR TITLE
fix(create-quasar): correct title/label mismatch in JS app-vite template (fix: #18349)

### DIFF
--- a/create-quasar/templates/app/vite-3/js/BASE/src/components/EssentialLink.vue
+++ b/create-quasar/templates/app/vite-3/js/BASE/src/components/EssentialLink.vue
@@ -13,7 +13,7 @@
     </q-item-section>
 
     <q-item-section>
-      <q-item-label>{{ props.title }}</q-item-label>
+      <q-item-label>{{ props.label }}</q-item-label>
       <q-item-label caption>{{ props.caption }}</q-item-label>
     </q-item-section>
   </q-item>

--- a/create-quasar/templates/app/vite-3/js/filenameBasedRouting/src/pages/index.vue
+++ b/create-quasar/templates/app/vite-3/js/filenameBasedRouting/src/pages/index.vue
@@ -23,7 +23,7 @@
 
         <EssentialLink
           v-for="link in linksList"
-          :key="link.title"
+          :key="link.label"
           v-bind="link"
         />
       </q-list>

--- a/create-quasar/templates/app/vite-3/js/manualRouting/src/layouts/MainLayout.vue
+++ b/create-quasar/templates/app/vite-3/js/manualRouting/src/layouts/MainLayout.vue
@@ -33,7 +33,7 @@
 
         <EssentialLink
           v-for="link in linksList"
-          :key="link.title"
+          :key="link.label"
           v-bind="link"
         />
       </q-list>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (`fix: #18349`)

**Other information:**

The JS app-vite scaffold still referenced `title` after the prop was renamed to `label`. `EssentialLink.vue` rendered `{{ props.title }}`, an undeclared prop, so the drawer link titles came out blank, and the `v-for` over the links used `:key="link.title"` (undefined) in both the manual-routing `MainLayout.vue` and the file-based-routing `index.vue`. Switched all three to `label`, which is what the TS templates already use.

Fixes #18349
