### PR TITLE
feat(docs): refine SSG guide

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-ssg/app-icons-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/app-icons-ssg.md
@@ -33,23 +33,23 @@ scope:
           - l: apple-icon-152x152.png
           - l: apple-icon-167x167.png
           - l: apple-icon-180x180.png
-          - l: apple-icon-828x1792.png
-          - l: apple-icon-1125x2436.png
-          - l: apple-icon-1242x2688.png
-          - l: apple-icon-750x1334.png
-          - l: apple-icon-1242x2208.png
-          - l: apple-icon-640x1136.png
-          - l: apple-icon-1536x2048.png
-          - l: apple-icon-1668x2224.png
-          - l: apple-icon-1668x2388.png
-          - l: apple-icon-2048x2732.png
+          - l: apple-launch-828x1792.png
+          - l: apple-launch-1125x2436.png
+          - l: apple-launch-1242x2688.png
+          - l: apple-launch-750x1334.png
+          - l: apple-launch-1242x2208.png
+          - l: apple-launch-640x1136.png
+          - l: apple-launch-1536x2048.png
+          - l: apple-launch-1668x2224.png
+          - l: apple-launch-1668x2388.png
+          - l: apple-launch-2048x2732.png
 ---
 
 ::: warning Warning! Beta Stage
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-This build target includes a variety of special icons for individual browsers and operating systems. You need all of them - and if you discover one that is new or missing, please [open an issue](https://github.com/quasarframework/quasar/issues).
+An SSG site uses the same favicon assets as a SPA. When PWA takeover is enabled, it also needs manifest icons and may include Apple touch icons and launch images.
 
 <img src="/img/iconfactory.png" style="float:right;max-width:15%;min-width:240px;padding-top:40px">
 
@@ -59,7 +59,7 @@ This build target includes a variety of special icons for individual browsers an
 We highly recommend using the [Icon Genie CLI](/icongenie/introduction) v6.1+, because it consumes a source icon and automatically clones, scales, minifies and places the icons in the appropriate directories for you. When needed, it also tells you what tags you'll need to add to your /index.html file.
 :::
 
-Quickly bootstrap the necessary images with Icon Genie CLI. For a complete list of options, please visit the [Icon Genie CLI](/icongenie/command-list) command list page.
+Generate the appropriate assets with Icon Genie CLI. For the complete option list, see the [Icon Genie CLI command list](/icongenie/command-list).
 
 ```bash
 # SSG only:
@@ -103,7 +103,7 @@ The required HTML code that goes into `/index.html` to reference the above files
 />
 ```
 
-However, if you are developing with SSG + PWA mode, then you'll also need the PWA assets:
+With SSG + PWA mode, you also need the PWA assets:
 
 <DocTree :def="scope.ssgTree" />
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/build-commands.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/build-commands.md
@@ -16,7 +16,7 @@ quasar dev -m ssg
 quasar dev --mode ssg
 ```
 
-For SSG Mode, the development server is similar to SSR Mode, except that you don't need to configure the webserver too.
+The development server renders normal SSG routes through the SSR pipeline. Routes matched by `ssg.clientSideRenderingRoutes` are rendered on the client. The `/src-ssg/ssg-renderer` file is used only during a production build, so the development server does not write static HTML files.
 
 ## Building for Production
 
@@ -26,6 +26,8 @@ quasar build -m ssg
 # ..or the longer form:
 quasar build --mode ssg
 ```
+
+The default output directory is `dist/ssg`. The build fails if `getSsgPages()` returns no pages or if two page definitions try to write the same file.
 
 If you want a production build with debugging enabled:
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -19,7 +19,26 @@ The Quasar SSG Mode is currently in the "beta" stage. Based on the community fee
 
 ## quasar.config file
 
-This is the place where you can configure some SSG options. Like if you want the client side to takeover as a SPA (Single Page Application -- the default behaviour), or as a PWA (Progressive Web App).
+The `ssg` section controls generated fallback files, client-rendered routes, PWA takeover, store hydration, and advanced build hooks. Page generation itself belongs in `/src-ssg/ssg-renderer`.
+
+A typical configuration needs only a few options:
+
+```js /quasar.config file
+export default defineConfig(() => ({
+  ssg: {
+    // Generate a PWA service worker and offline shell
+    pwa: false,
+
+    // Generate dist/ssg/404.html
+    error404HtmlFilename: '404.html',
+
+    // Exclude these routes from pre-rendering and generate csr.html
+    clientSideRenderingRoutes: ['/account', '/account/**']
+  }
+}))
+```
+
+The complete option reference follows. Most applications should leave the manual hydration and build-extension options at their defaults.
 
 ```ts /quasar.config file
 return {
@@ -74,7 +93,7 @@ return {
      * as it will have the same content. Otherwise, make sure to use a different
      * name otherwise it will clash with the `pwaOfflineHtmlFilename` one!
      *
-     * If not explicitly configured  and `clientSideRenderingRoutes`
+     * If not explicitly configured and `clientSideRenderingRoutes`
      * is not its default value (an empty array), then this option will
      * default to 'csr.html'.
      *
@@ -184,11 +203,11 @@ return {
 }
 ```
 
-> If you decide to go with a PWA client takeover (**which is a killer combo**), the Quasar CLI PWA mode will be installed too. You may want to check out the [Quasar PWA](/quasar-cli-vite/developing-pwa/introduction) guide too. But most importantly, make sure you read [SSG with PWA](/quasar-cli-vite/developing-ssg/ssg-with-pwa) page.
+> If you enable PWA client takeover, Quasar CLI installs PWA mode too. Read [SSG with PWA](/quasar-cli-vite/developing-ssg/ssg-with-pwa) and the [Quasar PWA guide](/quasar-cli-vite/developing-pwa/introduction).
 
 > If you want certain routes of your app to be rendered exclusively on the client side, [Hybrid SSG + partial CSR](/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr) is here for you.
 
-Should you want to tamper with the Vite config for UI in /src:
+To extend the Vite configuration used to build application code under `/src`, use the normal `build.extendViteConf` hook and check for SSG mode:
 
 ```js /quasar.config file
 export default defineConfig(ctx => {
@@ -207,9 +226,9 @@ export default defineConfig(ctx => {
 
 ### Manually triggering store hydration
 
-By default, Quasar CLI takes care of hydrating the Pinia stores (if you use it) on client-side.
+By default, Quasar CLI serializes the Pinia state into the generated HTML and hydrates the store on the client.
 
-However, should you wish to manually hydrate it yourself, you need to set quasar.config file > ssg > manualStoreHydration: true. One good example is doing it from [a boot file](/quasar-cli-vite/boot-files):
+Set `ssg.manualStoreHydration: true` only when you need to replace that client-side hydration step. For example, use a client-only [boot file](/quasar-cli-vite/boot-files):
 
 ```js Some boot file
 // MAKE SURE TO CONFIGURE THIS BOOT FILE
@@ -226,7 +245,7 @@ export default defineBoot(({ store }) => {
 
 By default, Quasar CLI wraps your App component and calls `$q.onSSRHydrated()` on the client-side when this wrapper component gets mounted. This is the moment that the client-side takes over. You don't need to configure anything for this to happen.
 
-However should you wish to override the moment when this happens, you need to set quasar.config file > ssg > manualPostHydrationTrigger: true. For whatever your reason is (very custom use-case), this is an example of manually triggering the post hydration:
+For an advanced integration that must control this timing, set `ssg.manualPostHydrationTrigger: true` and call the hook yourself after mounting:
 
 ```tabs
 <<| js Composition API |>>
@@ -261,11 +280,11 @@ Adding SSG mode to a Quasar project means a new folder will be created: `/src-ss
 
 <DocTree :def="scope.nodeJsTree" />
 
-Notice a few things:
+Important details:
 
-1. If you import anything from node_modules in /src-ssg, then make sure that the package is specified in /src-ssg/package.json > "dependencies" (and install that dependency in /src-ssg folder).
+1. A package imported directly by `/src-ssg/ssg-renderer` must be listed in `/src-ssg/package.json` and installed in that folder.
 
-2. The SSG renderer file (src-ssg/ssg-renderer) is built through a separate Rolldown config. You can extend the Rolldown configuration of this file through the `/quasar.config` file:
+2. The renderer is built with a separate Rolldown configuration. Extend it through `/quasar.config` only when the renderer needs custom build behavior:
 
 ```ts /quasar.config file
 return {
@@ -285,17 +304,17 @@ return {
 }
 ```
 
-4. The `/src-ssg/ssg-renderer.js` file is detailed in [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) page.
+3. See [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) for the renderer API and page examples.
 
 ## Helping SEO
 
-One of the main reasons when you develop a SSR instead of a SPA is for taking care of the SEO. And SEO can be greatly improved by using the [Quasar Meta Plugin](/quasar-plugins/meta) to manage dynamic html markup required by the search engines.
+Use the [Quasar Meta Plugin](/quasar-plugins/meta) to include route-specific titles, descriptions, canonical links, and social metadata in generated HTML. See [SEO for SSG](/quasar-cli-vite/developing-ssg/seo-for-ssg).
 
 ## Boot Files
 
-When running on SSG mode, your application code needs to be isomorphic or "universal", which means that it must run both on a Node.js context and in the browser. This applies to your [Boot Files](/quasar-cli-vite/boot-files) too.
+In SSG mode, application code must be universal: it runs in Node.js during the production build and again in the browser during hydration. This also applies to [Boot Files](/quasar-cli-vite/boot-files).
 
-However, there are cases where you only want some boot files to run only on the server or only on the client-side. You can achieve that by specifying:
+Mark browser-only or build-time-only boot files explicitly:
 
 ```js /quasar.config file
 return {
@@ -308,21 +327,19 @@ return {
 }
 ```
 
-Just make sure that your app is consistent, though.
+Server-only boot files run at build time for every rendered page. They do not run on the production static host.
 
-When a boot file runs on the server-side (at build time), you will have access to one more parameter (called [ssrContext](/quasar-cli-vite/developing-ssr/ssr-context)) on the default exported function:
+When a boot file runs during server-side generation, its callback receives the [ssrContext](/quasar-cli-vite/developing-ssr/ssr-context):
 
 ```js Some boot file
 import { defineBoot } from '#q-app'
 
-export default defineBoot(({ app, ..., ssrContext }) => {
-  // You can add props to the ssrContext then use them in the /index.html.
-  // Example - let's say we ssrContext.someProp = 'some value', then in index template we can reference it:
-  // {{ ssrContext.someProp }}
+export default defineBoot(({ ssrContext }) => {
+  ssrContext.someProp = 'some value'
 })
 ```
 
-When you add such references into your `/index.html`, make sure you tell Quasar it's only valid for SSG builds. And also, that your /src-ssg/ssg-renderer file returns SSG pages with configured ssrContext props that you reference.
+When `/index.html` references a custom value, guard it by mode and ensure every applicable page definition provides that value:
 
 ```html /index.html
 <% if (ctx.mode.ssg) { %>{{ ssrContext.someProp }} <% } %>

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr.md
@@ -7,11 +7,11 @@ desc: (@quasar/app-vite) How to handle a hybrid SSG with partial CSR with Quasar
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-Quasar CLI allows you to build a hybrid SSG with partial CSR (Client-Side Rendering). This is helpful for cases where you want to generate SSG pages only for some of your routes and leave the other be handled on the client-side like a regular SPA.
+Hybrid SSG lets most routes use pre-rendered HTML while selected routes behave like pages in a SPA. It is useful for authenticated dashboards, account settings, or other pages whose initial content is meaningful only in the browser.
 
 ## Configuration
 
-You can instruct the Quasar CLI to generate a specific html page that will be used for your CSR handled pages:
+The following options are generated in the `ssg` section of `/quasar.config`:
 
 ```js /quasar.config file
 ssg: {
@@ -62,12 +62,27 @@ ssg: {
 }
 ```
 
-You will then need to configure your deployment webserver to point to this html file when serving your CSR only routes, instead of the default "index.html".
+For example, this configuration renders account routes on the client and writes the shell to `dist/ssg/app-shell.html`:
+
+```js /quasar.config file
+ssg: {
+  clientSideRenderingRoutes: ['/account', '/account/**'],
+  clientSideRenderingHtmlFilename: 'app-shell.html'
+}
+```
+
+Do not use a filename that can also be produced by an SSG page. Setting `clientSideRenderingHtmlFilename: false` disables shell generation even when route patterns are configured.
 
 ## How It Works
 
-For dev mode, these pages will not go through rendering with the underlying SSR.
+- In development, matching routes bypass server rendering and use the client application shell.
+- During a production build, `parseVueRouterRoutes()` excludes matching routes from the generated-page list.
+- The production build writes one CSR shell file. Your static host must rewrite each matching request to that file without changing the browser URL.
 
-On production, if you have configured ssg.clientSideRenderingHtmlFilename or ssg.clientSideRenderingRoutes, then the Quasar CLI will generate a shell html file that will act similar to a SPA's generated index.html. It will load your app and Vue Router will handle what gets displayed for the respective route(s), along with its resources.
+With the configuration above, requests for `/account/profile` and `/account/security` must both serve `/app-shell.html`. Do not rewrite every missing URL to the CSR shell, because that would turn real not-found requests into client-rendered pages.
 
-It is important that you configure your deployment webserver correctly for the respective route(s).
+See [Deploying SSG](/quasar-cli-vite/developing-ssg/deploying#hybrid-ssg-partial-csr) for nginx and static-host examples.
+
+::: tip SSG + PWA
+The PWA offline shell has the same application-shell content. You may set `clientSideRenderingHtmlFilename` to the value of `pwaOfflineHtmlFilename` so both features use one file. Otherwise, the two filenames must be different.
+:::

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/installing-ssg-dependencies.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/installing-ssg-dependencies.md
@@ -7,7 +7,7 @@ desc: (@quasar/app-vite) How to handle SSG-specific dependencies.
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-Notice the `/src-ssg/package.json` file in your generated `/src-ssg` folder. The purpose of it is for you to be able to install packages used by the SSG mode directly under this folder (and not pollute the common `/src`).
+The generated `/src-ssg/package.json` keeps build-time renderer dependencies separate from your application dependencies. Add a package here when it is imported directly by `/src-ssg/ssg-renderer`.
 
 ```json /src-ssg/package.json
 {
@@ -21,22 +21,22 @@ Notice the `/src-ssg/package.json` file in your generated `/src-ssg` folder. The
 ```
 
 ::: warning
-If you import anything from node_modules in /src-ssg, then be aware that you will need to install those packages directly in /src-ssg. All these dependencies are used when building the SSG html files.
+Packages imported by application code under `/src` still belong in the root `package.json`. Install only renderer-specific packages under `/src-ssg`.
 :::
 
-Installing SSG specific packages:
+For example, to discover Markdown files from the renderer with `tinyglobby`:
 
 ```tabs
 <<| bash PNPM |>>
-# run in /src-ssg:
-pnpm add <deps>
+# run in /src-ssg
+pnpm add tinyglobby
 <<| bash Yarn |>>
-# run in /src-ssg:
-yarn add <deps>
+# run in /src-ssg
+yarn add tinyglobby
 <<| bash NPM |>>
-# run in /src-ssg:
-npm install <deps>
+# run in /src-ssg
+npm install tinyglobby
 <<| bash Bun |>>
-# run in /src-ssg:
-bun add <deps>
+# run in /src-ssg
+bun add tinyglobby
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/introduction.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/introduction.md
@@ -9,24 +9,24 @@ The Quasar SSG Mode is currently in the "beta" stage. Based on the community fee
 
 Quasar and Vue.js are frameworks for building client-side applications. By default, Vue components produce and manipulate DOM in the browser as output. However, it is also possible to pre-render the exact same components into HTML strings at build time, send those static pages directly to the browser, and finally "hydrate" the static markup into a fully interactive app on the client.
 
-A statically site generated (SSG) Quasar app allows you to write your application using the same Vue architecture you are used to, but outputs flat HTML files for each of your routes.
+A statically generated Quasar app uses the same Vue architecture as other Quasar modes, but renders selected routes to HTML files at build time. When a browser loads one of those files, Vue hydrates the existing markup and the app becomes interactive.
 
 ## Why SSG?
 
 Compared to a traditional SPA (Single-Page Application) or an SSR (Server-Side Rendered) application, the advantages of SSG primarily lie in:
 
-- Can improve SEO, as search engine crawlers will directly see the fully rendered page.
-- Fast time-to-content. Because the HTML is pre-rendered at build time, it doesn't require a server to generate the page on the fly. You can serve these static files directly from a global CDN, meaning your users will see a fully-rendered page almost instantly.
-- Cheaper and easier hosting. You do not need to maintain, monitor, or pay for a Node.js server to render your pages. Your entire app can be hosted on any static file hosting service (like Netlify, Vercel, GitHub Pages, or Amazon S3).
-- Reduces server-rendering attack surface. Since there is no database or server-side execution running to generate the page, there are fewer vulnerabilities and attack vectors.
+- Better initial HTML and SEO. Search engines and link preview crawlers receive the rendered page instead of an empty application shell.
+- Fast time-to-content. A CDN or static server can return pre-rendered HTML without waiting for a server to render it for each request.
+- Simpler hosting. Production does not require a Node.js rendering server. You can deploy the generated files to a static host such as Netlify, Vercel, Cloudflare Pages, GitHub Pages, or Amazon S3.
+- A smaller production attack surface. There is no application server involved in rendering each page. Any APIs used by the client remain separate and must still be secured normally.
 
 There are also some trade-offs to consider when using SSG:
 
-- Development constraints. Just like with SSR, browser-specific code (like window or document) can only be used inside certain lifecycle hooks. Some external libraries may need special treatment to run during the build process.
-- Build times. Because every route must be generated when you build the application, large sites with thousands of pages can take a significant amount of time to compile.
-- Dynamic content. Since pages are rendered at build time, content can become stale. If a page relies on data that changes frequently (like a live feed or user-specific dashboard), SSG might not be the best fit, or it will require fetching that dynamic data on the client-side after the static shell loads. Alternatively, you can configure certain routes of your app to be rendered on client-side only ([Hybrid SSG + partial CSR](/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr)).
+- Universal-code constraints. As with SSR, code executed during rendering cannot assume that browser globals such as `window` or `document` exist.
+- Build time. Every generated page must be rendered during each production build. Large or data-heavy sites can therefore take longer to build.
+- Stale content. Build-time HTML does not change until the next deployment. Frequently changing or user-specific data must be refreshed by rebuilding, fetched on the client, or handled through [hybrid SSG + partial CSR](/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr).
 
-Before using SSG for your app, the first question you should ask is how often your data changes and how important SEO and initial load times are. If you are building a blog, documentation site, marketing page, or e-commerce storefront, SSG is often the perfect choice. However, if you are building an internal dashboard or a highly dynamic application tailored to individual logged-in users, a standard SPA or SSR approach might be more appropriate.
+SSG is a good fit for documentation, marketing pages, blogs, catalogs, and other content that can be known at build time. A SPA or SSR app may be a better fit when most pages depend on the current user or on data that must be fresh for every request.
 
 ## SSG Caveats
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/preparation.md
@@ -17,22 +17,24 @@ scope:
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-We'll be using Quasar CLI (and Cordova CLI) to develop and build a Mobile App. The difference between building a SPA, PWA, SSR, SSG, Electron App or a Mobile App is simply determined by the "mode" parameter in "quasar dev" and "quasar build" commands.
+Quasar CLI selects the application target through the `--mode` (`-m`) option of the `quasar dev` and `quasar build` commands.
 
-In order to develop or build a SSG website, we first need to add the SSG mode to our Quasar project:
+Add SSG mode to an existing Quasar project with:
 
 ```bash
 quasar mode add ssg
 ```
 
-If you want to jump right in and start developing, you can skip the "quasar mode" command and issue:
+You can also start the SSG development server directly:
 
 ```bash
 quasar dev -m ssg
 ```
 
-This will add SSG mode automatically, if it is missing.
+If SSG mode is missing, Quasar CLI offers to add it before starting the server.
 
-After answering the question of whether you're using [Filename-Based Routing](/quasar-cli-vite/page-routing-with-vue-router#filename-based-routing), a new folder will appear in your project folder (which is explained in detail on the [Configuring SSG](/quasar-cli-vite/developing-ssg/configuring-ssg) page):
+After you choose whether to use [Filename-Based Routing](/quasar-cli-vite/page-routing-with-vue-router#filename-based-routing), Quasar creates the following folder:
 
 <DocTree :def="scope.nodeJsTree" />
+
+The renderer defines which routes become static pages. See [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) before creating your first production build.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/seo-for-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/seo-for-ssg.md
@@ -7,12 +7,54 @@ desc: (@quasar/app-vite) Managing the search engine optimizations in a Quasar SS
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-The term SEO refers to Search Engine Optimization. And Quasar covers this aspect too through the [Quasar Meta Plugin](/quasar-plugins/meta).
+SSG gives crawlers rendered HTML, but each generated route still needs an accurate title, description, canonical URL, and social-sharing metadata. Use the [Quasar Meta Plugin](/quasar-plugins/meta) from the page component so those values are included during the build.
 
 ## Quasar Meta Plugin
 
-The [Quasar Meta Plugin](/quasar-plugins/meta) can dynamically change page title, manage `<meta>` tags, manage `<html>` and `<body>` DOM element attributes, add/remove/change `<style>` and `<script>` tags in the head of your document (useful for CDN stylesheets or for json-ld markup, for example), or manage `<noscript>` tags.
+The [Quasar Meta Plugin](/quasar-plugins/meta) can change the page title, manage `<meta>` tags, set attributes on the `<html>` and `<body>` elements, add or update `<style>` and `<script>` tags in the document head, and manage `<noscript>` tags. This includes structured data such as JSON-LD.
 
 ::: tip
-This Quasar plugin has the most tight integration with Quasar and so it has the best performance against any other similar solution.
+The Meta Plugin is integrated with Quasar's rendering pipeline, so metadata declared while an SSG page is rendered is included in the generated HTML.
 :::
+
+For example, an article page can provide its title, description, Open Graph fields, and canonical URL:
+
+```vue /src/pages/ArticlePage.vue
+<script setup>
+import { useMeta } from 'quasar'
+
+const article = {
+  title: 'Choosing a rendering mode',
+  description: 'Compare SPA, SSR, and SSG for a Quasar application.',
+  url: 'https://example.com/guides/rendering-modes'
+}
+
+useMeta({
+  title: article.title,
+  meta: {
+    description: {
+      name: 'description',
+      content: article.description
+    },
+    ogTitle: {
+      property: 'og:title',
+      content: article.title
+    },
+    ogDescription: {
+      property: 'og:description',
+      content: article.description
+    }
+  },
+  link: {
+    canonical: {
+      rel: 'canonical',
+      href: article.url
+    }
+  }
+})
+</script>
+```
+
+Data used to create build-time metadata must be available while the page is rendered. If metadata is fetched only after hydration, it will not be present in the generated HTML.
+
+Also generate and deploy a `robots.txt` file and sitemap when the site needs them. These are site-level files and are not generated automatically from the SSG page list.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-404-error-page.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-404-error-page.md
@@ -7,26 +7,38 @@ desc: (@quasar/app-vite) How to render a 404 error page for SSG mode with Quasar
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-By default, a `404.html` file will be generated on production with Quasar CLI. However, you can change the name for it or even instruct Quasar CLI to skip generating it.
+By default, a production SSG build renders the app's Vue Router not-found route and writes it to `dist/ssg/404.html`.
+
+For this to produce the expected page, your router should include a catch-all route:
+
+```js /src/router/routes file
+{
+  path: '/:catchAll(.*)*',
+  component: () => import('pages/ErrorNotFound.vue')
+}
+```
 
 ## Configuration
 
 ```js /quasar.config file
-ssg: {
-  /**
-   * The name of the html file that will be used for the 404 page.
-   * If set to false, no 404 page will be generated.
-   *
-   * You will need to properly configure the webserver to serve this
-   * file for 404 errors.
-   *
-   * Make sure to name it so that the SSG generated html files
-   * don't conflict with it!
-   *
-   * @default '404.html'
-   */
-  error404HtmlFilename?: string | false;
-}
+export default defineConfig(() => ({
+  ssg: {
+    // Default: '404.html'
+    error404HtmlFilename: 'not-found.html'
+  }
+}))
 ```
 
-You will then need to configure your deployment webserver to point to this html file when a 404 error is encountered.
+Set `error404HtmlFilename: false` if the host supplies its own error page or if you generate custom 404 files through `getSsgPages()`.
+
+The filename alone does not configure your host. Static providers such as Netlify, Cloudflare Pages, Vercel, and GitHub Pages automatically recognize a root `404.html`. Other servers may need an explicit rule. For nginx:
+
+```nginx
+location / {
+    try_files $uri $uri/ =404;
+}
+
+error_page 404 /404.html;
+```
+
+Keep the HTTP response status as `404`; serving the correct markup with a `200` response creates a soft 404. See [Deploying SSG](/quasar-cli-vite/developing-ssg/deploying#404-page) for more host-specific guidance.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-code-caveats.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-code-caveats.md
@@ -9,24 +9,24 @@ related:
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-When developing a SSG app, you will need to be very familiar with [SSR Mode](/quasar-cli-vite/developing-ssr/introduction), because a SSG app is essentially a build-time rendered SSR app. Therefore, writing code for SSG is the same as for SSR. All SSR concepts apply for it too, like [writing universal code](/quasar-cli-vite/developing-ssr/writing-universal-code), [handling the ssrContext](/quasar-cli-vite/developing-ssr/ssr-context), [client-side hydration](/quasar-cli-vite/developing-ssr/client-side-hydration), and so on.
+An SSG app uses the SSR rendering pipeline at build time. The same principles apply: [write universal code](/quasar-cli-vite/developing-ssr/writing-universal-code), use the [ssrContext](/quasar-cli-vite/developing-ssr/ssr-context) only while rendering, and keep the first client render compatible with the generated HTML to avoid [hydration errors](/quasar-cli-vite/developing-ssr/client-side-hydration).
 
-Both Static Site Generator (SSG) and [Server-Side Rendering (SSR)](/quasar-cli-vite/developing-ssr/introduction) solve the same fundamental problems of traditional SPAs: they both provide excellent SEO and drastically improve the time-to-content. However, they take fundamentally different approaches to when the HTML is actually rendered.
+Both SSG and [SSR](/quasar-cli-vite/developing-ssr/introduction) send rendered HTML. SSG renders during the build, while SSR renders for each request. An SSG build therefore has no real browser request, cookies, user agent, viewport, or browser storage unless you deliberately simulate values through a page's `ssrContext`.
 
-The core difference lies in the rendering timing: SSG renders at build time, while SSR renders at request time. Therefore, when writing your app, you will need to do it in such a way that your content will NOT rely on client specific ssrContext, otherwise you will end up with [client-side hydration errors](/quasar-cli-vite/developing-ssr/client-side-hydration).
+Do not render user-specific markup on the server and immediately replace it with different browser-specific markup during hydration.
 
 ## Things to avoid
 
-Avoid using the following features **before client-side gets hydrated**:
+Avoid using the following browser-dependent values to choose initial markup **before the client has hydrated**:
 
 - $q.screen ([Screen Plugin](/options/screen-plugin)). Use Quasar [Window-Width related CSS classes](/style/visibility#window-width-related) instead.
 - $q.platform ([Platform Plugin](/options/platform-detection)). Unless you use the [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) to generate a SSG page for each $q.platform prop combination that you use (and fill ssrContext with a specific req.headers['User-Agent']).
-- $q.cookies ([Cookies Plugin](/quasar-plugins/cookies)). Unless you use the [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) to generate a SSG page for each Cookie that you expect (and fill ssrContext with a specific req.headers.cookies).
-- $q.dark ([Dark Plugin](/quasar-plugins/dark)). Unless you use the [SSG Renderer](/quasar-cli-vite/developing-ssg/ssg-renderer) to generates one "light" and one "dark" SSG page for each route (probably use a cookie with ssrContext.req.headers.cookies to handle it).
+- $q.cookies ([Cookies Plugin](/quasar-plugins/cookies)). Unless you generate a page variant with a specific `ssrContext.req.headers.cookie` value.
+- $q.dark ([Dark Plugin](/quasar-plugins/dark)). Unless you generate separate variants and configure the host to serve the matching file.
 - $q.localStorage ([LocalStorage Plugin](/quasar-plugins/web-storage#localstorage-api))
 - $q.sessionStorage ([SessionStorage Plugin](/quasar-plugins/web-storage#sessionstorage-api))
 
-However, you can use all the above should you combine it with Quasar's [useHydration](/vue-composables/use-hydration) Vue Composable:
+You can defer browser-dependent markup with Quasar's [useHydration](/vue-composables/use-hydration) composable:
 
 ```html Some .vue file
 <template>
@@ -53,9 +53,9 @@ However, you can use all the above should you combine it with Quasar's [useHydra
 </script>
 ```
 
-## Study Case: light and dark mode pages
+## Case Study: Light and Dark Pages
 
-Let's take an example on how to handle light vs dark mode by leveraging the [Dark Plugin](/quasar-plugins/dark) and [Cookies Plugin](/quasar-plugins/cookies). We need to be careful not to generate hydration errors. So:
+The following advanced example generates light and dark variants, then uses nginx to select one from a cookie:
 
 - We will be using a cookie named `theme` which can be `light` or `dark`.
 - We will generate two SSG pages for each Vue Router route, one for each theme.
@@ -140,7 +140,7 @@ export const getSsgPages = defineSsgGetPages(
             }
           }
         }
-        // Finally, we add it to our accummulator that we will return:
+        // Finally, add it to the array that we return:
         ssgPages.push(def)
       })
     }
@@ -154,10 +154,10 @@ On our deployment server, we configure our nginx. We look for the `theme` cookie
 
 ```nginx nginx config
 server {
-  // ...
+  # ...
 
   location / {
-    // ...
+    # ...
 
     set $theme "light";
     if ($cookie_theme = "dark") {

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
@@ -7,15 +7,15 @@ desc: (@quasar/app-vite) Configuring the Quasar SSG Renderer.
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-When you develop a Static Site Generator (SSG) application with Quasar, the `/src-ssg/ssg-renderer` file is the heart of your generation process. This file is responsible for telling Quasar which pages to generate and how to preload assets for those generated pages.
+The `/src-ssg/ssg-renderer` file tells Quasar which routes to render during a production build. It can also customize the preload tags added for each page's assets.
 
 ::: warning
-The SSG renderer script is being used for production only ("quasar build -m ssg"). The script will not be invoked in dev mode as it serves no purpose in this case.
+The SSG renderer runs only for `quasar build -m ssg`. Development mode renders requested routes on demand and does not invoke `getSsgPages()`.
 :::
 
 ## Anatomy
 
-This file exports two main functions: `getSsgPages` and `renderPreloadTag`. The following is the default content of /src-ssg/ssg-renderer:
+The file exports `getSsgPages` and can optionally export `renderPreloadTag`. The generated template includes both:
 
 ```tabs /src-ssg/ssg-renderer
 <<| js Manually defined routes |>>
@@ -125,7 +125,7 @@ export const renderPreloadTag = defineSsgRenderPreloadTag(
 
 ## Defining SSG Pages
 
-The `getSsgPages` export uses the `defineSsgGetPages` wrapper. It must return an Array of page objects that tell the SSG engine what html pages to render (based on Vue Router routes). The function passed to `defineSsgGetPages` can be synchronous or asynchronous.
+The `getSsgPages` export uses the `defineSsgGetPages` wrapper. It returns an array of page definitions and may be synchronous or asynchronous. The build stops when the array is empty.
 
 ### The Callback Parameters
 
@@ -143,7 +143,7 @@ Each object in the returned array represents a single HTML page to be generated.
 
 | Property   | Type        | Description                                                                                                                                                                                            |
 | ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| route      | string      | **Required!** The vue-router route to render. It must be a valid route in your Vue Router configuration.                                                                                               |
+| route      | string      | **Required.** The Vue Router route to render. It must start with `/` and resolve through your router.                                                                                                  |
 | label      | string      | An optional label to identify the SSG page in your build logs.                                                                                                                                         |
 | dir        | string      | The directory to place the generated HTML file in. Must be a relative path to the dist folder. If omitted, the route path determines the directory.                                                    |
 | filename   | string      | The name of the generated HTML file. Defaults to "index.html".                                                                                                                                         |
@@ -154,45 +154,31 @@ When defining the `route` prop of a SSG page, do not include the quasar.config >
 :::
 
 ```tabs getSsgPages example
-<<| js Explicit SSG pages |>>
-import { defineSsgGetPages } from "#q-app"
+<<| js Dynamic routes from data |>>
+import { defineSsgGetPages } from '#q-app'
+import products from '@/data/products.json'
 
-export const getSsgPages = defineSsgGetPages(
-  async ({ ctx }) => {
-    return [
-      { route: '/' },
-      { route: '/second-page' },
-      ...(
-        ['light', 'dark'].map(theme => ({
-          route: '/third-page',
-          label: theme,
-          filename: `index-${theme}.html`,
-          ssrContext: {
-            req: {
-              headers: {
-                cookie: `theme=${theme}`
-              }
-            }
-          }
-        }))
-      )
-    ]
-  }
-)
+export const getSsgPages = defineSsgGetPages(() => [
+  { route: '/' },
+  ...products.map(product => ({
+    route: `/products/${product.slug}`,
+    label: product.name
+  }))
+])
 <<| js Manually defined routes |>>
-import { defineSsgGetPages } from "#q-app"
+import { defineSsgGetPages } from '#q-app'
 // Importing the manually defined app routes:
-import routes from "@/router/routes"
+import routes from '@/router/routes'
 
 export const getSsgPages = defineSsgGetPages(
-  async ({ parseVueRouterRoutes, ctx }) => {
+  ({ parseVueRouterRoutes }) => {
     // The parseVueRouterRoutes helper is optional, but highly recommended
     // for standard routing setups.
     return parseVueRouterRoutes({ routes, verbose: true })
   }
 )
 <<| js With filenameBasedRouting |>>
-import { defineSsgGetPages } from "#q-app";
+import { defineSsgGetPages } from '#q-app'
 
 export const getSsgPages = defineSsgGetPages(
   async ({ getFilenameBasedRoutes, parseVueRouterRoutes /*, ctx */ }) => {
@@ -206,23 +192,22 @@ export const getSsgPages = defineSsgGetPages(
 
 ### Warning on 404 errors
 
-When defining the SSG pages to render, please be aware that your app might have a Vue Router route defined as a catch-all which handles this error:
+Your app will commonly have a Vue Router catch-all route:
 
 ```js /src/router/routes file
 // Example of route for catching 404 with Vue Router
 { path: '/:catchAll(.*)*', component: () => import('@/pages/Error404.vue') }
 ```
 
-Therefore, if your `getSsgPages()` returns a SSG page configured with a non-existent Vue Router route, the html page that will be generated will essentially contain such a 404 rendered page and not your probably expected content and no build-time error will be generated.
+If a page definition contains a route that does not otherwise exist, Vue Router resolves it to this catch-all and Quasar writes the rendered 404 markup. This is valid rendering, so the build cannot infer that the route was a mistake.
 
-As a side-note, please read the [SSG 404 Error Page](/quasar-cli-vite/developing-ssg/ssg-404-error-page) too. By default, such a page is generated so you don't need a specific entry in the returned array of your `getSsgPages()` for it.
+Quasar generates the configured [SSG 404 Error Page](/quasar-cli-vite/developing-ssg/ssg-404-error-page) separately, so do not add a page definition for the default `404.html`.
 
 ## Rendering Preload Tags
 
-To ensure boost performance and Lighthouse scores, Quasar allows you to inject `<link rel="preload">` and `<link rel="modulepreload">` tags into the `<head>` of your generated HTML files.
-The `renderPreloadTag` evaluates the assets required by the current page and returns a string with the appropriate HTML output.
+Quasar can inject `<link rel="preload">` and `<link rel="modulepreload">` tags for assets used by each generated page. `renderPreloadTag` receives each asset URL and returns its HTML tag.
 
-Out of the box, Quasar provides a robust default setup using Regex to match file extensions (.js, .css, fonts, and images) and applies the correct rel, as, and type attributes. You can customize this function to support additional file types or custom caching strategies.
+The generated renderer handles JavaScript, CSS, WOFF fonts, and common image formats. Customize it to omit expensive image preloads or support another asset type.
 
 ```js renderPreloadTag example
 import { defineSsgRenderPreloadTag } from '#q-app'

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-pwa.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-pwa.md
@@ -7,7 +7,7 @@ desc: (@quasar/app-vite) How to configure your Quasar SSG app to become a Progre
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-With Quasar CLI you can build your app with the killer combo of SSG + PWA. In order to enable PWA for SSG builds, you need to edit your `/quasar.config` file first:
+SSG can serve pre-rendered HTML on the first visit and then install a service worker for offline support and subsequent navigations. The following options are generated in the `ssg` section of `/quasar.config`:
 
 ```js /quasar.config file
 return {
@@ -62,6 +62,31 @@ return {
 }
 ```
 
-The first request of a **new** client will be statically served from the webserver (as SSG generates it at build time). The PWA gets installed then it takes over on client side. All further requests will be served from cache (unless you have some custom configuration to change that).
+Set `pwa: true` to enable PWA takeover. Adding SSG mode with this option enabled also installs PWA mode when needed. Configure the manifest, icons, Workbox mode, and service worker through the normal [`pwa` configuration](/quasar-cli-vite/developing-pwa/configuring-pwa).
+
+The production build generates the normal SSG pages, the PWA assets, and an application shell at `dist/ssg/offline.html` by default. The service worker uses that shell as its navigation fallback. Do not name it `index.html`, and do not give it the same name as a generated SSG page.
+
+## Customizing Workbox
+
+SSG-specific extension hooks run after their corresponding PWA hooks:
+
+```js /quasar.config file
+ssg: {
+  pwa: true,
+
+  extendSSGGenerateSWOptions (workboxConfig) {
+    workboxConfig.navigateFallbackDenylist.push(
+      /^\/api\//,
+      /^\/admin\//
+    )
+  }
+}
+```
+
+Use `extendSSGGenerateSWOptions` with Workbox `GenerateSW`, or `extendSSGInjectManifestOptions` with `InjectManifest`. The service worker's actual caching behavior depends on those settings; it should not be assumed that every later request is always served from cache.
+
+::: warning
+Deploy the entire output directory, including the service worker, manifest, icons, Workbox files, generated pages, and offline shell. Service workers also require HTTPS in production, except on localhost.
+:::
 
 > For more information on PWA, head on to [PWA Introduction](/quasar-cli-vite/developing-pwa/introduction) and read the whole PWA Guide section.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-typescript.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-typescript.md
@@ -1,12 +1,23 @@
 ---
 title: SSG with TypeScript
-desc: (@quasar/app-vite) How to use TypeScript with SSG in Quasar
+desc: (@quasar/app-vite) How to use TypeScript with SSG in Quasar.
 ---
 
 ::: warning Warning! Beta Stage
 The Quasar SSG Mode is currently in the "beta" stage. Based on the community feedback, the API may change in the future, so check the release notes each time you upgrade "@quasar/app-vite".
 :::
 
-In order to support SSG with TypeScript, you will need to rename all your files in /src-ssg from `.js` to `.ts` and make the necessary TS code changes.
+When SSG mode is added to a TypeScript project, Quasar creates `/src-ssg/ssg-renderer.ts` automatically. In an existing JavaScript setup, rename `ssg-renderer.js` to `ssg-renderer.ts`; Quasar discovers either extension.
 
-Depending on the packages that you use in `/src-ssg/ssg-renderer`, you may also need to additionally [install @types/\* packages](/quasar-cli-vite/developing-ssg/installing-ssg-dependencies) into your /src-ssg folder.
+The wrapper functions infer their callback and return types:
+
+```ts /src-ssg/ssg-renderer.ts
+import { defineSsgGetPages } from '#q-app'
+import routes from '@/router/routes'
+
+export const getSsgPages = defineSsgGetPages(({ parseVueRouterRoutes }) => {
+  return parseVueRouterRoutes({ routes, verbose: true })
+})
+```
+
+Dependencies imported only by the renderer belong in `/src-ssg/package.json`. If a dependency does not include its own declarations, install its `@types/*` package there as a development dependency.


### PR DESCRIPTION
## What changed

- audit and refine the Quasar CLI with Vite SSG documentation as a complete guide
- clarify SSG setup, configuration, build behavior, renderer APIs, hydration constraints, and renderer-specific dependencies
- add practical examples for dynamic routes, hybrid CSR, custom 404 handling, PWA Workbox configuration, SEO metadata, and TypeScript
- correct Apple launch-image filenames and several inaccurate or copied descriptions
- preserve the generated `quasar.config` option references while adding focused examples beneath them

## Why

The initial SSG documentation covered the API surface but several pages were terse, duplicated configuration declarations without practical context, or contained wording and examples copied from other modes. Some details, such as the launch-image filenames and browser-dependent hydration guidance, were also inaccurate or unclear.

## Impact

Developers get a more consistent path from enabling SSG through rendering and deployment, with examples that distinguish build-time rendering, client hydration, partial CSR, and PWA behavior.

## Validation

- `oxfmt --check` on all SSG documentation pages
- `oxlint --deny-warnings` on all SSG documentation pages
- `git diff --check`
- documentation search indexing (2,394 pages)
- full documentation SSG build (637 pages rendered successfully)

The branch is rebased onto the latest `upstream/dev`, including the corrected `clientSideRenderingHtmlFilename` default behavior and documentation wording.
