### PR TITLE
fix(app-vite): handle SSG filename routes safely

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -16,7 +16,7 @@ const multiSlashRE = /\/{2,}/g
 const ssrManifestIdQueryRE = /vue\?vue/
 const ssrManifestIdQueryReplaceRE = /vue\?vue.*$/
 
-function getParseVueRouterRoutesFn(quasarConf) {
+export function getParseVueRouterRoutesFn(quasarConf) {
   const { clientSideRenderingRoutes } = quasarConf.ssg
   const isCSRMatch =
     clientSideRenderingRoutes.length !== 0
@@ -56,17 +56,6 @@ function getParseVueRouterRoutesFn(quasarConf) {
         continue
       }
 
-      if (route.redirect) {
-        if (verbose) {
-          warn(
-            `Ignored route (redirects): ${fullPath}`,
-            'parseVueRouterRoutes()'
-          )
-        }
-
-        continue
-      }
-
       if (route.children) {
         acc.push(
           ...parseVueRouterRoutes({
@@ -75,6 +64,13 @@ function getParseVueRouterRoutesFn(quasarConf) {
             verbose
           })
         )
+      } else if (route.redirect) {
+        if (verbose) {
+          warn(
+            `Ignored route (redirects): ${fullPath}`,
+            'parseVueRouterRoutes()'
+          )
+        }
       } else {
         acc.push({ route: fullPath })
       }
@@ -84,6 +80,17 @@ function getParseVueRouterRoutesFn(quasarConf) {
   }
 
   return parseVueRouterRoutes
+}
+
+export async function loadFilenameBasedRoutes(viteServerConfig, createServer) {
+  const vite = await createServer(viteServerConfig)
+
+  try {
+    const { routes } = await vite.ssrLoadModule('vue-router/auto-routes')
+    return routes
+  } finally {
+    await vite.close()
+  }
 }
 
 export class QuasarModeBuilder extends AppBuilder {
@@ -382,13 +389,8 @@ export class QuasarModeBuilder extends AppBuilder {
     }
 
     const { createServer } = await import('vite')
-    const vite = await createServer(this.#viteServerConfig)
-
     try {
-      const { routes } = await vite.ssrLoadModule('vue-router/auto-routes')
-      await vite.close()
-
-      return routes
+      return await loadFilenameBasedRoutes(this.#viteServerConfig, createServer)
     } catch (err) {
       console.log()
       console.error(err)

--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -99,7 +99,8 @@
     "dev": "pnpm --filter app-vite-playground-js dev",
     "dev:ts": "pnpm --filter app-vite-playground-ts dev",
     "build": "pnpm --filter app-vite-playground-js build",
-    "build:ts": "pnpm --filter app-vite-playground-ts build"
+    "build:ts": "pnpm --filter app-vite-playground-ts build",
+    "test:unit": "node --test test/**/*.test.js"
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",

--- a/app-vite/test/ssg-router-utils.test.js
+++ b/app-vite/test/ssg-router-utils.test.js
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  getParseVueRouterRoutesFn,
+  loadFilenameBasedRoutes
+} from '../lib/modes/ssg/ssg-builder.js'
+
+function createQuasarConf(clientSideRenderingRoutes = []) {
+  return {
+    ssg: { clientSideRenderingRoutes }
+  }
+}
+
+test('parseVueRouterRoutes traverses children of a redirected parent', () => {
+  const parseVueRouterRoutes = getParseVueRouterRoutesFn(createQuasarConf())
+
+  const pages = parseVueRouterRoutes({
+    routes: [
+      {
+        path: '/account',
+        redirect: '/account/profile',
+        children: [{ path: 'profile' }, { path: 'settings' }]
+      }
+    ]
+  })
+
+  assert.deepEqual(pages, [
+    { route: '/account/profile' },
+    { route: '/account/settings' }
+  ])
+})
+
+test('parseVueRouterRoutes ignores redirect leaf records', () => {
+  const parseVueRouterRoutes = getParseVueRouterRoutesFn(createQuasarConf())
+
+  const pages = parseVueRouterRoutes({
+    routes: [{ path: '/', redirect: '/home' }, { path: '/home' }]
+  })
+
+  assert.deepEqual(pages, [{ route: '/home' }])
+})
+
+test('loadFilenameBasedRoutes closes the Vite server after success', async () => {
+  let closeCalled = false
+  const routes = [{ path: '/' }]
+
+  const result = await loadFilenameBasedRoutes({}, () => ({
+    ssrLoadModule: () => ({ routes }),
+    close: () => {
+      closeCalled = true
+    }
+  }))
+
+  assert.equal(result, routes)
+  assert.equal(closeCalled, true)
+})
+
+test('loadFilenameBasedRoutes closes the Vite server after failure', async () => {
+  let closeCalled = false
+  const failure = new Error('failed to load routes')
+
+  await assert.rejects(
+    loadFilenameBasedRoutes({}, () => ({
+      ssrLoadModule: () => {
+        throw failure
+      },
+      close: () => {
+        closeCalled = true
+      }
+    })),
+    failure
+  )
+
+  assert.equal(closeCalled, true)
+})

--- a/app-vite/types/ssg/index.d.ts
+++ b/app-vite/types/ssg/index.d.ts
@@ -58,7 +58,7 @@ export interface SsgGetPagesParams {
    *
    * @param {Object} options - The configuration object.
    * @param {RouteRecordRaw[]} options.routes - Vue Router routes definition to parse. {@link RouteRecordRaw}
-   * @param {string} [options.parentPath=''] - Optional parent path to use for these routes.
+   * @param {string} [options.parentPath='/'] - Optional parent path to use for these routes.
    * @param {boolean} [options.verbose=false] - Optional flag to enable verbose logging. If true, it logs ignored routes with dynamic parameters.
    * @returns {SsgPage[]} Array of SSG pages. {@link SsgPage}
    */
@@ -73,7 +73,7 @@ export interface SsgGetPagesParams {
     routes: RouteRecordRaw[];
     /**
      * Optional parent path to use for these routes.
-     * @default ''
+     * @default '/'
      */
     parentPath?: string;
     /**


### PR DESCRIPTION
## Summary

- preserve static child routes when an SSG route record redirects its parent path
- always close the temporary Vite server used to load filename-based routes
- align the documented `parentPath` default with the runtime value
- add focused tests for redirect traversal and Vite cleanup

## Why

Vue Router applies a parent redirect when the parent path itself is visited, but its child paths remain independently routable. For example, `/account` can redirect to `/account/profile` while `/account/settings` still resolves normally. The SSG parser previously skipped the entire parent record before traversing its children, so those valid static child pages were omitted.

The filename-route loader also closed its temporary Vite server only after a successful module load. Moving cleanup into `finally` ensures it closes after both success and failure.

## Verification

- `pnpm --filter @quasar/app-vite test:unit`
- `pnpm --filter @quasar/app-vite build`
- `pnpm --filter @quasar/app-vite build:ts`
- formatting and lint through the pre-commit hook
- direct Vue Router verification of exact-parent redirect and child-route resolution