### PR TITLE
fix(app-vite): audit Cordova mode and guide

### DIFF
--- a/app-vite/lib/modes/cordova/cordova-builder.js
+++ b/app-vite/lib/modes/cordova/cordova-builder.js
@@ -80,7 +80,9 @@ export class QuasarModeBuilder extends AppBuilder {
     const outputTargetList =
       ensureArray(
         this.quasarConf.cordova.getCordovaBuildOutputFolder?.(cordovaContext)
-      ) || cordovaOutputFolders[target]
+      ) ||
+      cordovaOutputFolders[target] ||
+      []
 
     // Remove old build output
     outputTargetList.forEach(outputFile => {

--- a/app-vite/types/configuration/cordova-conf.d.ts
+++ b/app-vite/types/configuration/cordova-conf.d.ts
@@ -3,6 +3,7 @@ export type QuasarCordovaTargets =
   | "ios"
   | "blackberry10"
   | "browser"
+  | "electron"
   | "osx"
   | "ubuntu"
   | "webos"
@@ -20,15 +21,15 @@ export interface QuasarCordovaConfiguration {
    * will be executed after the UI has compiled.
    *
    * @param context.debug - True if in debug mode
-   * @param context.target - The target platform (ios/android)
+   * @param context.target - The target platform
    * @returns Array of strings (command parameters)
    *
    * @default: [ 'build', '--debug'/'--release', '--device', 'ios'/'android' ]
-   * @example: ({ isDebug, target }) => [ 'build', `--${isDebug ? 'debug' : 'release'}`, '--device', 'target' ]
+   * @example: ({ debug, target }) => [ 'build', `--${debug ? 'debug' : 'release'}`, '--device', target ]
    */
   getCordovaBuildParams?: (context: {
     readonly debug: boolean;
-    readonly target: "ios" | "android";
+    readonly target: QuasarCordovaTargets;
   }) => string[];
 
   /**
@@ -38,24 +39,24 @@ export interface QuasarCordovaConfiguration {
    * to the /dist folder.
    *
    * @param context.debug - True if in debug mode
-   * @param context.target - The target platform (ios/android)
+   * @param context.target - The target platform
    * @returns string | string[] | undefined - (relative path(s) from /src-cordova)
    *
    * @default ios: platforms/ios/build/... and android: platforms/android/app/build/outputs
    * @example:
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       return target === 'ios'
-   *          ? `platforms/ios/build/${isDebug ? 'Debug' : 'Release'}-iphoneos
+   *          ? `platforms/ios/build/${debug ? 'Debug' : 'Release'}-iphoneos`
    *          : 'platforms/android/app/build/outputs'
    *    }
    * @example: (when interested in only one platform, leaving the other to the default value)
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       if (target === 'ios') {
-   *          return `platforms/ios/build/${isDebug ? 'Debug' : 'Release'}-iphoneos`
+   *          return `platforms/ios/build/${debug ? 'Debug' : 'Release'}-iphoneos`
    *       }
    *    }
    * @example: ()
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       if (target === 'ios') {
    *          // try these two folders
    *          return [ 'platforms/ios/build/device', 'platforms/ios/build/emulator' ]
@@ -64,6 +65,6 @@ export interface QuasarCordovaConfiguration {
    */
   getCordovaBuildOutputFolder?: (context: {
     readonly debug: boolean;
-    readonly target: "ios" | "android";
+    readonly target: QuasarCordovaTargets;
   }) => string | string[] | undefined;
 }

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/app-icons-cordova.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/app-icons-cordova.md
@@ -26,7 +26,7 @@ scope:
           - l: icon.png
             e: 57x57
           - l: icon@2x.png
-            e: 144x144
+            e: 114x114
           - l: icon-20@2x.png
           - l: icon-20@3x.png
           - l: icon-29.png
@@ -95,7 +95,7 @@ scope:
               - l: Default@2x~ipad~anyany.png
 ---
 
-Cordova is one of the most complicated of all of the build targets as far as icons go, because not only do you need to place the icons in specific folders, you also need to register them in the `src-cordova/config.xml` file. Further, if you are using splash screens (which you should), you will also need to install `cordova-plugin-splashscreen` and register it in your config.xml.
+Cordova icons and splash screens are native resources declared in `/src-cordova/config.xml`. The required files and declarations depend on the installed `cordova-android` and `cordova-ios` versions.
 
 If you discover one file that is new or missing, please [open an issue](https://github.com/quasarframework/quasar/issues).
 
@@ -115,13 +115,7 @@ icongenie generate -m cordova -i /path/to/source/icon.png [-b /path/to/backgroun
 
 ## Manual instructions
 
-Unless you are using the Icon Genie CLI, this is what you need to do:
-
-```bash
-cd src-cordova
-cordova plugin add cordova-plugin-splashscreen
-cordova plugin save
-```
+Unless you are using Icon Genie CLI, replace the generated resources and keep their `config.xml` declarations aligned with the requirements of each installed Cordova platform. Current Cordova platforms provide splash-screen handling; install `cordova-plugin-splashscreen` only when an older platform version explicitly requires it.
 
 <DocTree :def="scope.tree" />
 
@@ -182,14 +176,5 @@ And here is part of what your config.xml should look like:
     <icon height="40" src="res/ios/icon-40.png" width="40" />
     <icon height="50" src="res/ios/icon-50.png" width="50" />
     <splash src="res/screen/ios/Default@2x~iphone~comany.png" />
-    <splash src="res/screen/ios/Default-Landscape-2436h.png" />
-    <splash src="res/screen/ios/Default@2x~iphone~anyany" />
-    <splash src="res/screen/ios/Default@2x~iphone~comany" />
-    <splash src="res/screen/ios/Default@2x~iphone~comcom" />
-    <splash src="res/screen/ios/Default@3x~iphone~anyany" />
-    <splash src="res/screen/ios/Default@3x~iphone~anycom" />
-    <splash src="res/screen/ios/Default@3x~iphone~comany" />
-    <splash src="res/screen/ios/Default@2x~ipad~anyany" />
-    <splash src="res/screen/ios/Default@2x~ipad~comany" />
 </platform>
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/app-icons-cordova.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/app-icons-cordova.md
@@ -115,7 +115,7 @@ icongenie generate -m cordova -i /path/to/source/icon.png [-b /path/to/backgroun
 
 ## Manual instructions
 
-Unless you are using Icon Genie CLI, replace the generated resources and keep their `config.xml` declarations aligned with the requirements of each installed Cordova platform. Current Cordova platforms provide splash-screen handling; install `cordova-plugin-splashscreen` only when an older platform version explicitly requires it.
+Unless you are using Icon Genie CLI, replace the generated resources and keep their `config.xml` declarations aligned with the requirements of each installed Cordova platform. Current Cordova platforms provide splash-screen handling; install `cordova-plugin-splashscreen` (in `/src-cordova`) only when an older platform version explicitly requires it.
 
 <DocTree :def="scope.tree" />
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
@@ -1,12 +1,12 @@
 ---
-title: Mobile App Build Commands
+title: Cordova Build Commands
 desc: (@quasar/app-vite) The Quasar CLI list of commands when developing or building a hybrid mobile app with Cordova.
 ---
 
 Before we dive in, make sure you got the Cordova CLI installed.
 
 ```bash
-npm install -g cordova
+pnpm add --global cordova
 ```
 
 ## Developing
@@ -27,7 +27,7 @@ quasar dev -m cordova -T ios '--' some params --and options --here
 It will open the IDE (Android Studio / Xcode) and from there you can manually select the emulator (or multiple ones simultaneously!) and install the dev app on it/them. You can also run the dev app on a real mobile/tablet device.
 
 ::: warning
-In Android Studio, you will be greeted with a message recommending to upgrade the Gradle version. **DO NOT UPGRADE GRADLE** as it will break the Cordova project. Same goes for any other requested upgrades.
+Do not accept Android Studio upgrade suggestions automatically. Confirm that the proposed Java, Gradle, Android Gradle Plugin, and SDK versions are supported by the installed `cordova-android` version.
 
 <img src="https://cdn.quasar.dev/img/gradle-upgrade-notice.png" alt="Gradle upgrade" class="q-my-md rounded-borders" style="max-width: 350px">
 
@@ -42,15 +42,15 @@ In order for you to be able to develop on a device emulator or directly on a pho
 1. Detects your machine's external IP address. If there are multiple such IPs detected, then it asks you to choose one. If you'll be using a mobile phone to develop then choose the IP address of your machine that's pingable from the phone/tablet.
 2. It starts up a development server on your machine.
 3. It temporarily changes the `<content/>` tag in `/src-cordova/config.xml` to point to the IP previously detected. This allows the app to connect to the development server.
-4. It defers to Cordova CLI to build a native app with the temporarily changed config.xml.
-5. Cordova CLI checks if a mobile phone / tablet is connected to your development machine. If it is, it installs the development app on it. If none is found, then it boots up an emulator and runs the development app.
-6. Finally, it reverts the temporary changes made to `/src-cordova/config.xml`.
+4. It runs `cordova prepare` for the selected platform.
+5. It opens Android Studio or Xcode, where you select and run an emulator, simulator, or connected device.
+6. When the Cordova development process stops, Quasar reverts its temporary changes to `/src-cordova/config.xml`.
 
 ::: danger
-If developing on a mobile phone/tablet, it is very important that the external IP address of your build machine is accessible from the phone/tablet, otherwise you'll get a development app with white screen only. Also check your machine's firewall to allow connections to the development chosen port.
+When developing on a physical device, the selected address of the development machine must be reachable from that device. Ensure the firewall permits the development-server port and that the network does not isolate connected clients.
 :::
 
-## Building for Production
+## Building for production
 
 ```bash
 quasar build -m cordova -T [android|ios]
@@ -70,7 +70,7 @@ quasar build -m cordova -T ios -- some params --and options --here
 
 - Built packages will be located in `/dist/cordova` unless configured otherwise.
 
-- If you wish to skip the Cordova CLI packaging step and only fill `/src-cordova/www` folder:
+- If you wish to skip the native Cordova build, generate `/src-cordova/www` and run `cordova prepare` only:
 
 ```bash
 quasar build -m cordova -T [ios|android] --skip-pkg
@@ -83,7 +83,7 @@ quasar build -m cordova -T [ios|android] --ide
 ```
 
 ::: warning
-In Android Studio, you will be greeted with a message recommending to upgrade the Gradle version. **DO NOT UPGRADE GRADLE** as it will break the Cordova project. Same goes for any other requested upgrades.
+Do not accept Android Studio upgrade suggestions automatically. Check the compatibility requirements of the installed Cordova platform before changing the native toolchain.
 
 <img src="https://cdn.quasar.dev/img/gradle-upgrade-notice.png" alt="Gradle upgrade" class="q-my-md rounded-borders" style="max-width: 350px">
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
@@ -5,8 +5,11 @@ desc: (@quasar/app-vite) The Quasar CLI list of commands when developing or buil
 
 Before we dive in, make sure you got the Cordova CLI installed.
 
-```bash
+```tabs
+<<| bash PNPM |>>
 pnpm add --global cordova
+<<| bash NPM |>>
+npm install --global cordova
 ```
 
 ## Developing

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/build-commands.md
@@ -7,9 +7,13 @@ Before we dive in, make sure you got the Cordova CLI installed.
 
 ```tabs
 <<| bash PNPM |>>
-pnpm add --global cordova
+pnpm add -g cordova
+<<| bash Yarn |>>
+yarn global add cordova
 <<| bash NPM |>>
-npm install --global cordova
+npm i -g cordova
+<<| bash Bun |>>
+bun install -g cordova
 ```
 
 ## Developing

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/configuring-cordova.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/configuring-cordova.md
@@ -5,7 +5,7 @@ related:
   - /quasar-cli-vite/quasar-config-file
 ---
 
-We'll be using Quasar CLI (and Cordova CLI) to develop and build a Mobile App. The difference between building a SPA, PWA, SSR, SSG, Electron App or a Mobile App is simply determined by the "mode" parameter in "quasar dev" and "quasar build" commands.
+Quasar CLI selects the Cordova build target through the mode and target arguments passed to `quasar dev` and `quasar build`. Cordova CLI manages the native project under `/src-cordova`.
 
 There are two configuration files of great importance to your mobile apps. We'll go over each one.
 
@@ -17,12 +17,12 @@ Some properties from this file will get overwritten as we'll see in next section
 
 ## quasar.config file
 
-Quasar CLI helps you in setting some properties of the mobile Apps automatically (from config.xml): the Cordova "id", app version, description and android-versionCode. This is for convenience so you'll be able to have a single point where, for example, you change the version of your app, not multiple files that you need to simultaneously touch which is error prone.
+Quasar CLI updates the app version, description, and optional Android version code in `config.xml` before Cordova runs. The widget `id` is set when the Cordova project is created and is not rewritten from the Quasar config.
 
 For determining the values for each of the properties mentioned above, Quasar CLI:
 
 1. Looks in the `/quasar.config` file for a "cordova" Object. Does it have "version", "description" and/or "androidVersionCode"? If yes, it will use them.
-2. If not, then it looks into your `/package.json` for "cordovaId", "version" and "description" fields.
+2. If not, it falls back to `/package.json > version` and `/package.json > description`.
 
 ```ts /quasar.config file > cordova
 cordova: {
@@ -37,13 +37,13 @@ cordova: {
    * will be executed after the UI has compiled.
    *
    * @param context.debug - True if in debug mode
-   * @param context.target - The target platform (ios/android)
+   * @param context.target - The target platform
    * @returns Array of strings (command parameters)
    *
    * @default: [ 'build', '--debug'/'--release', '--device', 'ios'/'android' ]
-   * @example: ({ isDebug, target }) => [ 'build', `--${isDebug ? 'debug' : 'release'}`, '--device', 'target' ]
+   * @example: ({ debug, target }) => [ 'build', `--${debug ? 'debug' : 'release'}`, '--device', target ]
    */
-  getCordovaBuildParams?: (context: { debug: boolean; target: 'ios' | 'android' }) => string[];
+  getCordovaBuildParams?: (context: { debug: boolean; target: string }) => string[];
 
   /**
    * Function to return the Cordova output folder after the "cordova build"
@@ -52,31 +52,31 @@ cordova: {
    * to the /dist folder.
    *
    * @param context.debug - True if in debug mode
-   * @param context.target - The target platform (ios/android)
+   * @param context.target - The target platform
    * @returns string | string[] | undefined - (relative path(s) from /src-cordova)
    *
    * @default ios: platforms/ios/build/... and android: platforms/android/app/build/outputs
    * @example:
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       return target === 'ios'
-   *          ? `platforms/ios/build/${isDebug ? 'Debug' : 'Release'}-iphoneos
+   *          ? `platforms/ios/build/${debug ? 'Debug' : 'Release'}-iphoneos`
    *          : 'platforms/android/app/build/outputs'
    *    }
    * @example: (when interested in only one platform, leaving the other to the default value)
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       if (target === 'ios') {
-   *          return `platforms/ios/build/${isDebug ? 'Debug' : 'Release'}-iphoneos`
+   *          return `platforms/ios/build/${debug ? 'Debug' : 'Release'}-iphoneos`
    *       }
    *    }
    * @example: ()
-   *    ({ isDebug, target }) => {
+   *    ({ debug, target }) => {
    *       if (target === 'ios') {
    *          // try these two folders
    *          return [ 'platforms/ios/build/device', 'platforms/ios/build/emulator' ]
    *       }
    *    }
    */
-  getCordovaBuildOutputFolder?: (context: { debug: boolean; target: 'ios' | 'android' }) => string | string[] | undefined;
+  getCordovaBuildOutputFolder?: (context: { debug: boolean; target: string }) => string | string[] | undefined;
 }
 ```
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/cordova-plugins.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/cordova-plugins.md
@@ -5,7 +5,7 @@ desc: (@quasar/app-vite) How to use the Cordova plugins in a Quasar app.
 
 You can hook into the native device APIs by using [Cordova Plugins](https://cordova.apache.org/docs/en/latest/#plugin-apis).
 
-## Cordova Plugins
+## Cordova plugins
 
 A few examples of such plugins:
 
@@ -22,9 +22,9 @@ A few examples of such plugins:
 - Vibration
 - Statusbar
 
-## Deviceready Event
+## `deviceready` event
 
-You'll notice that some Cordova plugins are usable only after the `deviceready` event has been triggered. We don't need to worry about it too much. Quasar listens to this event and takes care of our root Vue component to be mounted **after** this event has been triggered. But if you need some plugin's own variable and that is initialized after `deviceready` you can follow the example of using the plugin device below
+Some Cordova plugins are usable only after `deviceready`. In Cordova mode, Quasar waits for this event before mounting the root Vue application, so component setup and lifecycle hooks can use initialized plugin APIs.
 
 ### Caveat
 
@@ -51,7 +51,7 @@ Let's take a vue file for example:
 </script>
 ```
 
-The reason is simple. Quasar listens for the event then mounts the root Vue component. But before this, the Vue files are imported into the `/src/router/routes.js` file, so the code outside of the default export gets executed.
+Module-level code can still execute while Vue files are imported, before the application mounts. Avoid accessing Cordova plugin globals at module scope. If module-level initialization is unavoidable, listen for `deviceready` explicitly as shown above.
 
 ## Using a Cordova Plugin
 
@@ -71,9 +71,6 @@ cordova plugin add cordova-plugin-battery-status
 Now let's put this plugin to some good use. In one of your Quasar project's pages/layouts/components Vue file, we write:
 
 ```html // some Vue file
-// remember this is simply an example // only look at how we use the API
-described in the plugin's page // the rest of things here are of no importance
-
 <template>
   <div> Battery status is: <strong>{{ batteryStatus }}</strong> </div>
 </template>
@@ -114,10 +111,6 @@ cordova plugin add cordova-plugin-camera
 Now let's put this plugin to some good use. In one of your Quasar project's pages/layouts/components Vue file, we write:
 
 ```html
-// some Vue file // remember this is simply an example; // only look at how we
-use the API described in the plugin's page; // the rest of things here are of no
-importance
-
 <template>
   <div>
     <q-btn color="primary" label="Get Picture" @click="captureImage" />
@@ -167,25 +160,17 @@ cordova plugin add cordova-plugin-device
 Now let's put this plugin to some good use. If you need the information of your device when starting the application, you will have to capture the created event. In one of your Quasar project's pages/layouts/components Vue file, we write:
 
 ```html
-// some Vue file // remember this is simply an example; // only look at how we
-use the API described in the plugin's page; // the rest of things here are of no
-importance
-
 <template>
   <div>
-    <q-page class="flex flex-center">
-      <div>IMEI: {{ imei }}</div>
-    </q-page>
+    <div>Model: {{ model }}</div>
+    <div>Manufacturer: {{ manufacturer }}</div>
   </div>
 </template>
 
 <script setup>
   import { ref } from 'vue'
 
-  const imei = ref(
-    window.device === void 0
-      ? 'Run this on a mobile/tablet device'
-      : window.device
-  )
+  const model = ref(window.device?.model ?? 'Unavailable')
+  const manufacturer = ref(window.device?.manufacturer ?? 'Unavailable')
 </script>
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/managing-google-analytics.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/managing-google-analytics.md
@@ -1,81 +1,45 @@
 ---
 title: Managing Google Analytics
-desc: (@quasar/app-vite) How to use analytics in a Quasar hybrid mobile app with Cordova.
+desc: (@quasar/app-vite) How to plan analytics integration in a Quasar Cordova app.
 ---
 
-Getting to know your users and measuring user behavior is an important step in App Development. Unfortunately, it takes a bit of non-standard work to get Google Analytics to work after wrapping your mobile app with Cordova. Setting up Google Analytics in a pure web application is quite easy, but Cordova somehow prevents pageviews and events from being sent to Google Analytics.
+The former Analytics.js integration is no longer appropriate for new applications. Google Analytics 4 replaced the Universal Analytics APIs that older Cordova examples used, and Google does not maintain an official Cordova analytics plugin.
 
-Follow this guide to implement Google Analytics into your Cordova powered Quasar App.
-
-You may also want to read this tutorial: [Google Analytics Setup for a Cordova App](https://jannerantala.com/tutorials/quasar-framework-google-analytics-setup-for-cordova-app/).
+Choose a maintained Cordova plugin or analytics provider that supports your target platform versions. Follow that provider's native Android and iOS setup, install the plugin from `/src-cordova`, and keep its platform configuration files out of `/src-cordova/www`.
 
 ::: warning
-You'll need to include a `<script>` tag provided by Google in `/index.html`, which will make your App depend on an Internet connection!
+Analytics may require user consent, privacy disclosures, data-safety declarations, and platform-specific configuration. Review the current Google Play, App Store, analytics-provider, and applicable legal requirements before collecting data.
 :::
 
-## Prerequisites
+## Application integration
 
-- Make sure all your routes have a name and path parameter specified. Otherwise, they cannot be posted to the `ga.logPage` function. Please refer to [Page Routing with Vue Router](/quasar-cli-vite/page-routing-with-vue-router) for more info on routing.
-- Have Basic knowledge of Google Analytics
+Wrap the selected plugin behind a small application service rather than calling a plugin global throughout the UI. This gives the app one place to:
 
-## Preparation
+- wait for Cordova's `deviceready` event
+- disable collection until consent is available
+- normalize screen names and event parameters
+- handle unsupported browser or development environments
+- replace the provider later
 
-Before we can start implementing Google Analytics into your application, you'll need an account for [Google Analytics](https://analytics.google.com) and [Google Tagmanager](https://tagmanager.google.com/). So let's do that first. When you have these accounts, it's time to configure Tag manager. Follow the steps in this [Multiminds article](https://www.multiminds.eu/blog/2016/12/google-analytics-and-tag-manager-with-ionic-and-cordova-apps/) to do so.
+To report route changes, create a Quasar boot file with `defineBoot`, then call the service from `router.afterEach`:
 
-## Implementing this into application
+```js /src/boot/analytics.js
+import { defineBoot } from '#q-app'
+import analytics from 'src/services/analytics'
 
-> For this guide, we'll assume you have a fixed sessionId that you send to Google Analytics. Google Analytics uses a sessionId to distinguish different users from each other. If you want to create an anonymous sessionId, see [Analytics Documentation on user id](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id).
-
-Place the Tag Manager snippet into head of your `index.html` file (if you've followed the [Multiminds article](http://www.multiminds.eu/2016/12/06/google-analytics-tag-manager-ionic-cordova/), you already have this.) Create a new file in your codebase called `analytics.js` with the following contents:
-
-```js
-export default {
-  logEvent(category, action, label, sessionId = null) {
-    window.dataLayer.push({
-      appEventCategory: category,
-      appEventAction: action,
-      appEventLabel: label,
-      sessionId: sessionId
-    })
-    window.dataLayer.push({ event: 'appEvent' })
-  },
-
-  logPage(path, name, sessionId = null) {
-    window.dataLayer.push({
-      screenPath: path,
-      screenName: name,
-      sessionId: sessionId
-    })
-    window.dataLayer.push({ event: 'appScreenView' })
-  }
-}
-```
-
-To make sure all the pages in your application are automatically posted to Google Analytics, we create an app boot file:
-
-```bash
-quasar new boot google-analytics [--format ts]
-```
-
-Then we edit the newly created file: `/src/boot/google-analytics.js`:
-
-```js
-import { defineRouter } from '#q-app'
-import ga from 'analytics.js'
-
-export default defineRouter(({ router }) => {
-  router.afterEach((to, from) => {
-    ga.logPage(to.path, to.name, sessionId)
+export default defineBoot(({ router }) => {
+  router.afterEach(to => {
+    analytics.setCurrentScreen(String(to.name ?? to.path))
   })
 })
 ```
 
-Finally we register the app boot file in the `/quasar.config` file. We can do so only for Cordova wrapped apps if we want:
+Register it only in Cordova mode:
 
-```js
-boot: [ctx.mode.cordova ? 'google-analytics' : '']
+```js /quasar.config file
+export default defineConfig(ctx => ({
+  boot: [...(ctx.mode.cordova ? ['analytics'] : [])]
+}))
 ```
 
-More information about events can be found in the [Analytics documentation on events](https://developers.google.com/analytics/devguides/collection/analyticsjs/events).
-
-You'll see the events and pageviews coming in when you run your app. It usually takes around 5 to 10 seconds for a pageview to be registered in the realtime view.
+The exact service implementation depends on the plugin you select. Verify that the plugin is actively maintained, supports GA4 if Google Analytics is required, and documents the necessary consent and native configuration steps.

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
@@ -7,8 +7,11 @@ desc: (@quasar/app-vite) What you need before developing a Quasar hybrid mobile 
 
 Quasar invokes the `cordova` executable directly, so install Cordova CLI globally using your selected Node package manager:
 
-```bash
+```tabs
+<<| bash PNPM |>>
 pnpm add --global cordova
+<<| bash NPM |>>
+npm install --global cordova
 ```
 
 Verify the installation:

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
@@ -1,180 +1,73 @@
 ---
 title: Preparation for Cordova App
-desc: (@quasar/app-vite) What you need to do before developing a Quasar hybrid mobile app with Cordova.
+desc: (@quasar/app-vite) What you need before developing a Quasar hybrid mobile app with Cordova.
 ---
 
-Before we dive into the actual development, we need to do some preparation work.
+## Install Cordova CLI
 
-## Step 1: Installation
-
-The first step is to make sure you got the Cordova CLI installed and the necessary SDKs.
+Quasar invokes the `cordova` executable directly, so install Cordova CLI globally using your selected Node package manager:
 
 ```bash
-npm install -g cordova
+pnpm add --global cordova
 ```
 
-::: warning
-Depending on your version of Android Studio, you might need to re-enable the "Android SDK Tools". You can do this by going
-to "Tools > SDK Manager > SDK Tools" then un-ticking "Hide Obsolete Packages" and ticking "Android SDK Tools (Obsolete)".
-**The instructions below assume this has been done.**
-:::
+Verify the installation:
 
-::: warning
-The environmental variable `ANDROID_HOME` has been deprecated and replaced with `ANDROID_SDK_ROOT`. Depending on your version of Android Studio you may need one or the other. It doesn't hurt to have both set.
-:::
+```bash
+cordova --version
+```
 
-### Android Setup
+## Android setup
 
-- After this step you will need to install the Android platform SDK on your machine. You can [download the Android Studio here](https://developer.android.com/studio) and follow these [installation steps](https://developer.android.com/studio/install) afterward.
+Install [Android Studio](https://developer.android.com/studio) and the Android SDK components required by the version of `cordova-android` in your project. Cordova's [Android platform guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/) lists the compatible Java, Gradle, Android Gradle Plugin, SDK, and build-tools versions.
 
-- Make sure that after you install the Android SDK you then accept its licenses. Open the terminal and go to the folder where the SDK was installed, in tools/bin, and call `sdkmanager --licenses`.
-
-- Add Android installation to your path:
-
-#### Unix (macOS, Linux)
+Set `ANDROID_HOME` to the Android SDK location and add the current command-line tools and platform tools to `PATH`:
 
 ```bash
 export ANDROID_HOME="$HOME/Android/Sdk"
-export ANDROID_SDK_ROOT="$HOME/Android/Sdk"
-export PATH=$PATH:$ANDROID_SDK_ROOT/tools; PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
+export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools"
 ```
 
-> Please note that sometimes the `/Android/Sdk` folder is added inside `/Library/` inside your user folder. Check your user folder and if the `/Android/` folder is only inside `/Library/` do: `export ANDROID_SDK_ROOT="$HOME/Library/Android/Sdk"` or `export ANDROID_HOME="$HOME/Library/Android/Sdk"` instead.
+On macOS, the SDK is usually under `$HOME/Library/Android/sdk`. On Windows, it is commonly under `%LOCALAPPDATA%\Android\Sdk`.
 
-#### Windows
+::: tip
+`ANDROID_SDK_ROOT` is deprecated. If an older tool still requires it, set it to the same location as `ANDROID_HOME`.
+:::
 
-After installing Android Studio, you need to install two more pieces of software:
-
-- JDK from Oracle. It can be found [here](https://www.oracle.com/java/technologies/downloads/#java8)
-- Gradle. It used to be usable from Android Studio but now you have to install it separately. There is a particular version that Cordova requires. You can download it [here](https://gradle.org/next-steps/?version=4.10.3&format=all)
-
-Then you will have to set environment variables. You will need to set the following variables. Cordova has a good guide for it already. It can be found [here](https://cordova.apache.org/docs/en/latest/guide/platforms/android/#setting-environment-variables). You need to:
-
-- add `ANDROID_SDK_ROOT`. It can safely be set to: "%USERPROFILE%\AppData\Local\Android\Sdk"
-- add two `ANDROID_SDK_ROOT` directories to your path: %ANDROID_SDK_ROOT%\tools;%ANDROID_SDK_ROOT%\platform-tools
-- add Gradle to your path. Note that Gradle does not have an installer. You just put the binary files where you want them, then add the bin directory to your path.
-- add `JAVA_HOME`. Its value depends on where you installed it. You can [download the JDK here](https://www.oracle.com/java/technologies/downloads/)
-
-> You can check the value of an environment variable by typing in console `echo %ENVIRONMENT_VARIABLE%`.
-
-If you have an init script for your command prompt or powershell, you can try this:
+Accept the installed SDK licenses and verify the toolchain:
 
 ```bash
-setx ANDROID_HOME "%USERPROFILE%\AppData\Local\Android\Sdk"
-setx ANDROID_SDK_ROOT "%USERPROFILE%\AppData\Local\Android\Sdk"
-setx path "%path%;%ANDROID_SDK_ROOT%\tools;%ANDROID_SDK_ROOT%\platform-tools;<gradle_path>\bin;"
+sdkmanager --licenses
+cordova requirements android
 ```
 
-After the tools are installed, set up Android Studio with the correct SDK and create a virtual machine.
+## iOS setup
 
-- Start Android Studio (check the executable in the folder that you installed it in). The next step is to install the individual SDKs:
+iOS development requires macOS and a compatible [Xcode](https://developer.apple.com/xcode/) installation. Open Xcode once to finish installing components and accept its license. Check the [Cordova iOS platform guide](https://cordova.apache.org/docs/en/latest/guide/platforms/ios/) for the requirements of the installed `cordova-ios` version.
 
-- Open the "Configure" menu at the bottom of the window:
+## Add Cordova mode
 
-  ![SDK manager](https://cdn.quasar.dev/img/Android-Studio-SDK-Menu.png 'SDK manager')
-
-- Select the desired SDKs. As of December 2019, Cordova requires android-28 (Android 9.0 - Pie) so be sure to include it. Click on "Apply" to install the SDKs.
-
-  ![SDK selection](https://cdn.quasar.dev/img/Android-Studio-SDK-selection.png 'SDK selection')
-
-### iOS Setup
-
-You will need a macOS with [Xcode](https://developer.apple.com/xcode/) installed. After you've installed it, open Xcode in order to get the license prompt. Accept the license, then you can close it.
-
-## Step 2: Add Cordova Quasar Mode
-
-In order to develop/build a Mobile app, we need to add the Cordova mode to our Quasar project. What this does is that it uses Cordova CLI to generate a Cordova project in the `/src-cordova` folder. The `/src-cordova/www` folder will be overwritten each time you build.
+Add the Cordova project under `/src-cordova`:
 
 ```bash
 quasar mode add cordova
 ```
 
-## Step 3: Add Platform
-
-To switch to the Cordova project, type:
+Quasar installs Android or iOS on demand when you first develop or build that target. To add one manually:
 
 ```bash
 cd src-cordova
-```
-
-Target platforms get installed on demand by Quasar CLI. However, if you want to add a platform manually, type:
-
-```bash
 cordova platform add [android|ios]
 ```
 
-To verify that everything is in order, type:
+Treat `/src-cordova` as a native Cordova project and commit any intended configuration, plugin, resource, or native changes. The `/src-cordova/www` directory is generated and overwritten by Quasar builds.
 
-```bash
-cordova requirements
-```
-
-> On some newer Debian-based operating systems you might face a very persistent problem when running `cordova requirements`. Please see the ["Android SDK not found" after installation](/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips#Android-SDK-not-found-after-installation-of-the-SDK) section for assistance.
-
-### Switching to iOS WkWebView
-
-Switching to WKWebView is highly recommended (but optional!) as UIWebView has been deprecated in iOS 12.0 as described in this Cordova blog post: [https://cordova.apache.org/news/2018/08/01/future-cordova-ios-webview.html](https://cordova.apache.org/news/2018/08/01/future-cordova-ios-webview.html).
-
-**However, choose wisely if you want to replace the default Web View. Each comes with its own caveats.** Make sure that you visit the link above.
-
-#### Option 1: Ionic Webview Plugin
-
-1. Install Ionic Webview Plugin
-
-```bash
-# from /src-cordova
-cordova plugin add cordova-plugin-ionic-webview
-```
-
-2. Add `ScrollEnabled` preference to `Config.xml`
-
-```xml
-<platform name="ios">
-  <preference name="ScrollEnabled" value="true" />
-</platform>
-```
-
-3. Consult Ionic Docs for caveats on WkWebViewPlugin
-
-- [https://ionicframework.com/docs/core-concepts/webview](https://ionicframework.com/docs/core-concepts/webview)
-- [https://github.com/ionic-team/cordova-plugin-ionic-webview](https://github.com/ionic-team/cordova-plugin-ionic-webview)
-
-#### Option 2: Cordova WkWebviewEngine Plugin
-
-1. Install Cordova WkWebviewEngine Plugin
-
-```bash
-# from /src-cordova
-cordova plugin add cordova-plugin-wkwebview-engine
-```
-
-2. For caveats and more info, visit: [https://github.com/apache/cordova-plugin-wkwebview-engine](https://github.com/apache/cordova-plugin-wkwebview-engine)
-
-## Step 4: Start Developing
-
-You can start the development server with the command below:
+## Start developing
 
 ```bash
 quasar dev -m cordova -T [android|ios]
-
-# passing extra parameters and/or options to
-# underlying "cordova" executable:
-quasar dev -m ios -- some params --and options --here
-# when on Windows and using PowerShell:
-quasar dev -m ios '--' some params --and options --here
 ```
 
-This will also add Cordova mode and install the related Cordova platform automatically if it is missing.
+Quasar starts the development server, prepares the native project, and opens Android Studio or Xcode. Select an emulator, simulator, or connected device from the IDE.
 
-You will be able to run the app on your mobile device if you have one, or through the emulator. See [Mobile App Build Commands > Developing](/quasar-cli-vite/developing-cordova-apps/build-commands#developing) for more information.
-
-::: warning
-In Android Studio, you will be greeted with a message recommending to upgrade the Gradle version. **DO NOT UPGRADE GRADLE** as it will break the Cordova project. The same goes for any other requested upgrades.
-
-<img src="https://cdn.quasar.dev/img/gradle-upgrade-notice.png" alt="Gradle upgrade" class="q-my-md rounded-borders" style="max-width: 350px">
-
-If you encounter any IDE errors then click on File > Invalidate caches and restart.
-
-<img src="https://cdn.quasar.dev/img/gradle-invalidate-cache.png" alt="Gradle upgrade" class="q-mt-md rounded-borders" style="max-width: 350px">
-
-:::
+Do not accept native toolchain upgrade suggestions automatically. First confirm that the proposed Java, Gradle, Android, or Xcode versions are supported by the installed Cordova platform version.

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/preparation.md
@@ -9,9 +9,13 @@ Quasar invokes the `cordova` executable directly, so install Cordova CLI globall
 
 ```tabs
 <<| bash PNPM |>>
-pnpm add --global cordova
+pnpm add -g cordova
+<<| bash Yarn |>>
+yarn global add cordova
 <<| bash NPM |>>
-npm install --global cordova
+npm i -g cordova
+<<| bash Bun |>>
+bun install -g cordova
 ```
 
 Verify the installation:

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/publishing-to-store.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/publishing-to-store.md
@@ -1,168 +1,58 @@
 ---
-title: Publishing to Store
-desc: (@quasar/app-vite) How to publish a Quasar hybrid mobile app with Cordova to Google Play Store and to Apple App Store.
+title: Publishing to Stores
+desc: (@quasar/app-vite) How to publish a Quasar Cordova app to Google Play and the Apple App Store.
 ---
 
-So, you've finished working on your Mobile App. Now it's time to deploy it. Let's learn how.
+Quasar builds the web application and prepares the Cordova project. Android Studio, Xcode, Cordova's platform tooling, and the store portals handle signing and submission.
 
-## Android Publishing
-
-To generate a release build for Android, we can use the following Quasar CLI command:
-
-```bash
-quasar build -m cordova -T android
-# or the short form:
-quasar build -m android
-```
-
-This will generate a release build based on the settings in your `/src-cordova/config.xml`.
-
-Next, we can find our unsigned APK file in "/src-cordova/platforms/android/app/build/outputs/apk/release" or equivalent path (written in the output of terminal). Filename usually ends with "-release-unsigned.apk". Now, we need to sign the unsigned APK and run an alignment utility on it to optimize it and prepare it for the app store. If you already have a signing key, skip these steps and use that one instead.
-
-Let’s generate our private key using the keytool command that comes with the JDK. If this tool isn’t found, refer to the installation guide:
-
-```bash
-keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg RSA -keysize 2048 -validity 20000
-```
-
-You’ll first be prompted to create a password for the keystore. Then, answer the rest of the nice tool’s questions and when it’s all done, you should have a file called my-release-key.keystore created in the current directory.
-
-::: danger
-Make sure to save this file somewhere safe, if you lose it you won’t be able to submit updates to your app!
+::: warning
+Store policies, target SDK requirements, signing workflows, and developer-program details change regularly. Treat the platform documentation linked below as authoritative.
 :::
 
-Next, we need to _zip align_ and to sign the APK. For this we use a couple of applications that can be found in the Android SDK `build-tools` folder, something like `/path/to/Android/Sdk/build-tools/VERSION/`. For example, on OS X with Android Studio installed, `zipalign` is in `~/Library/Android/Sdk/build-tools/VERSION/`.
+Before creating a release:
 
-To zip align the APK:
+- commit or back up native changes under `/src-cordova`
+- remove development-only endpoints, logging, and permissions
+- set the release version and platform-specific build number
+- verify icons, splash screens, privacy disclosures, plugins, permissions, and production services
+- test a release build on physical devices
 
-```bash
-zipalign -v 4 <path-to-same-apk-file> HelloWorld.apk
-```
+## Google Play
 
-To sign the APK:
-
-```bash
-apksigner sign --ks my-release-key.keystore --ks-key-alias alias_name <path-to-unsigned-apk-file>
-```
-
-Now we have our final release binary called HelloWorld.apk and we can release this on the Google Play Store for all the world to enjoy!
-
-(There are a few other ways to sign APKs. Refer to the official Android App Signing documentation for more information.)
-
-### Google Play Store
-
-Now that we have our release APK ready for the Google Play Store, we can create a Play Store listing and upload our APK.
-
-To start, you’ll need to visit the [Google Play Store Developer Console](https://play.google.com/apps/publish) and create a new developer account. Unfortunately, this is not free. However, the cost is only $25 compared to Apple’s $99.
-
-Once you have a developer account, you can go ahead and click “Publish an Android App on Google Play”.
-
-Then, you can go ahead and click the button to edit the store listing (We will upload an APK later). You’ll want to fill out the description for the app.
-
-When you are ready, upload the APK for the release build and publish the listing. Be patient and your hard work should be live in the wild!
-
-### Updating your App
-
-As you develop your app, you’ll want to update it periodically.
-
-In order for the Google Play Store to accept updated APKs, you’ll need to bump the app version (from `/package.json` or from `/quasar.config file > cordova > version`, then rebuild the app for release.
-
-## iOS Publishing
-
-First, you need to enroll in [Apple Developer Program](https://developer.apple.com/programs/). As with Google, if you have a personal account with Apple, you can create an additional one for your applications.
-
-### Connecting Xcode with your developer account
-
-After you receive your developer status, open Xcode on your Mac and go to Preferences > Accounts. Add your account to Xcode by clicking the `+` button on the lower left-hand side and follow the instructions.
-
-### Signing
-
-Now that you linked Xcode with your developer account, go to Preferences > Accounts, select your Apple Id on the left-hand side and then click the View Details button shown on the previous image.
-
-Click the Create button next to the iOS Distribution option.
-
-You can learn more about maintaining your signing identities and certificates from the official documentation.
-
-### Setting up the app identifier
-
-Next, through the Apple Developer Member Center we’ll set up the app ID identifier details. Identifiers are used to allow an app to have access to certain app services like for example Apple Pay. You can login to Apple Developer Member Center with your Apple ID and password.
-
-Once you’re logged in you should choose Certificates, Identifiers, and Profiles option. Also select the Identifiers option under the iOS Apps. Then select the `+` button in order to add a new iOS App ID.
-
-Then you’ll have to set the name of your app, use the Explicit App ID option and set the Bundle ID to the value of the id in your Cordova config.xml tag.
-
-Additionally, you’ll have to choose any of the services that need to be enabled. For example, if you use Apple Pay or Wallet in your app, you need to choose those option.
-
-You can learn more about registering app identifiers from the [official documentation](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/MaintainingProfiles/MaintainingProfiles.html).
-
-### Creating the app listing
-
-Apple uses iTunes Connect to manage app submissions. After your login, you should select the My Apps button, and on the next screen select the `+` button, just below the iTunes Connect My Apps header.
-
-This will show three options in a dropdown, and you should select the New App. After this the popup appears where you have to choose the name of the application, platform, primary language, bundle ID and SKU.
-
-Once you’re done, click on the Create button and you’ll be presented with a screen where you’ll have to set some basic options like Privacy Policy URL, category and sub category.
-
-Now, before we fill out everything in the listing, we’ll build our app and get it uploaded with Xcode. Then you’ll come back to finish the listing.
-
-You can learn more about managing your app in iTunes Connect from the [official documentation](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/UsingiTunesConnect/UsingiTunesConnect.html).
-
-### Building the app for production
+Prepare the Cordova project and open Android Studio:
 
 ```bash
-quasar build -m cordova -T ios
-# or the short form:
-quasar build -m ios
-
-# passing extra parameters and/or options to
-# underlying "cordova" executable:
-quasar build -m ios -- some params --and options --here
+quasar build -m cordova -T android --ide
 ```
 
-If everything went well you’ll see the `BUILD SUCCEEDED` output in the console.
+In Android Studio, use **Build > Generate Signed Bundle / APK**. Google Play normally expects an Android App Bundle (`.aab`). Configure a release signing key and keep both the key and its credentials backed up securely.
 
-### Opening the project in Xcode
+Set the shared app version through `/quasar.config > cordova > version` or `/package.json > version`. Set `cordova.androidVersionCode` when you need to control Android's monotonically increasing version code.
 
-Now, open the `/src-cordova/platforms/ios/<name>.xcodeproj` file in Xcode. You may need to instead use `<name>.xcworkspace` if the next step doesn't work.
+Create or update the app in [Google Play Console](https://play.google.com/console/), complete its policy and store-listing requirements, upload the signed bundle to a testing track, and promote it after testing.
 
-Once the Xcode opens up the project, you should see the details about your app in the general view.
+Refer to Android's current guides for [signing an app](https://developer.android.com/studio/publish/app-signing), [preparing a release](https://developer.android.com/studio/publish/preparing), and [publishing on Google Play](https://developer.android.com/studio/publish/upload-bundle). Also check the release documentation for the installed `cordova-android` version.
 
-You should just check that the bundle identifier is set up correctly, so that it’s the same as the value you specified earlier in the app ID. Also, make sure that the version and build numbers are correct. Team option should be set to your Apple developer account. Under the deployment target you can choose which devices your application will support.
+## Apple App Store
 
-### Creating an archive of the application
+Apple releases require macOS, Xcode, and membership in the Apple Developer Program. Prepare the Cordova project and open Xcode:
 
-In Xcode, select Product > Scheme > Edit Scheme to open the scheme editor. Next, select the Archive from the list on the left-hand side. Make sure that the Build configuration is set to Release.
+```bash
+quasar build -m cordova -T ios --ide
+```
 
-To create an archive, choose a Generic iOS Device, or your device if it’s connected to your Mac (you can’t create an archive if simulator is selected), from the Scheme toolbar menu in the project editor.
+Open the generated workspace when the project uses CocoaPods. In Xcode:
 
-Next, select Product > Archive, and the Archive organizer appears and displays the new archive. (If it produces an error instead, go back to the last step and open `<name>.xcworkspace`.)
+1. Select the app target and configure **Signing & Capabilities** with the correct team and bundle identifier.
+2. Set the user-visible version and build number. Each uploaded build needs a unique build number.
+3. Select a generic or connected iOS device as the destination.
+4. Choose **Product > Archive**.
+5. In the Organizer, validate and distribute the archive to App Store Connect.
 
-At this point you can click the `Upload to App Store...` button, and if everything goes fine you’ll have an uploaded app, and the only thing that’s left to do is to complete the iTunes Connect listing and submit it for review!
+Create the app record in [App Store Connect](https://appstoreconnect.apple.com/), select the uploaded build, complete the privacy and store metadata, test with TestFlight, and submit the release for review.
 
-At this point you should get an email from iTunes Connect shortly after you uploaded the archive with the content.
+Refer to Apple's current documentation for [distributing an app through the App Store](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases), [uploading builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds-overview), and [submitting for review](https://developer.apple.com/help/app-store-connect/manage-submissions-to-app-review/submit-an-app-for-review). Also check the release documentation for the installed `cordova-ios` version.
 
-### Finishing the app list process
+## Command-line builds
 
-Now you should head back to the iTunes Connect portal and login. Next, click on the Pricing and Availability on the left-hand side under APP STORE INFORMATION.
-
-You don’t have to worry about forgetting to insert any crucial and required information about your application, since you’ll be notified about what’s missing and what needs to be added/changed if you try to submit the app for review before all details are filled in.
-
-Next, click on the 1.0 Prepare for Submission button on the left-hand side, as shown on the image below. When we uploaded our archive, iTunes Connect automatically determined which device sizes are supported. You’ll need to upload at least one screenshot image for each of the various app sizes that were detected by iTunes Connect.
-
-Next, you’ll have to insert Description, Keywords, Support URL and Marketing URL (optionally).
-
-In the Build section you have to click on the `+` button and select the build that was uploaded through Xcode in the previous steps.
-
-Next, you’ll have to upload the icon, edit the rating, and set some additional info like copyright and your information. Note that the size of the icon that you’ll have to upload here will have to be 1024 by 1024 pixels. Thankfully, you can use the splash.png from the second tutorial. If you’re the sole developer then the data in the App Review Information should be your own. Finally, as the last option, you can leave the default checked option that once your app is approved that it is automatically released to the App Store.
-
-Now that we’re finished with adding all of the details to the app listing, we can press Save and then Submit for Review. Finally, you’ll be presented with the last form that you’ll have to fill out.
-
-After you submit your app for review you’ll see the status of it in the My Apps as Waiting for review, as shown on the image below. Also, shortly after you submit your app for review you’ll get a confirmation email from iTunes Connect that your app is in review.
-
-Apple prides itself with a manual review process, which basically means it can take several days for your app to be reviewed. You’ll be notified of any issues or updates to your app status.
-
-### Updating the app
-
-Since you’ll probably want to update your app at some point you’ll first need to bump the app version (from `/package.json` or from `/quasar.config file > cordova > version`, then rebuild the app for release. Finally, you'll have to open it up from the Xcode and follow the same steps all over again.
-
-Once you submit for the review, you’ll have to wait for the review process again.
+Without `--ide`, Quasar invokes `cordova build` and copies recognized native output under `/dist/cordova/<target>`. Customize `cordova.getCordovaBuildParams` for signing arguments or nonstandard build commands, and `cordova.getCordovaBuildOutputFolder` when a platform writes artifacts somewhere else.

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
@@ -21,9 +21,34 @@ Check that:
 
 Inspect the WebView console for the exact network or certificate error. Quasar restores the original `config.xml` content URL when the Cordova process stops.
 
+If the process was forcibly terminated and a later build still tries to load the development server, check `/src-cordova/config.xml`. Restore `<content src="index.html" />` and remove the `allow-navigation` entry for the old development URL.
+
+## Inspect the Cordova project state
+
+Run Cordova commands from `/src-cordova`. These commands provide a useful snapshot when a build starts failing after a platform or plugin change:
+
+```bash
+cordova platform ls
+cordova plugin ls
+cordova requirements [android|ios]
+cordova info
+```
+
+Compare the installed platform and plugin versions with those recorded in `/src-cordova/package.json`. Include the output of `cordova info` when reporting a reproducible Cordova issue, after checking it for sensitive environment details.
+
+After changing `config.xml`, plugins, or platform resources, prepare the native project again:
+
+```bash
+cordova prepare [android|ios]
+```
+
+For stale build artifacts, try `cordova clean [android|ios]` before removing and re-adding a platform. Treat `/src-cordova/platforms` as generated output; make durable configuration changes through `config.xml`, Cordova plugins, hooks, or platform-specific source files managed by your project.
+
 ## Android
 
 Use Chrome's [WebView remote debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews) to inspect an Android device or emulator. Open `chrome://inspect` after enabling USB debugging and connecting the device.
+
+For native failures, use Android Studio's [Logcat window](https://developer.android.com/studio/debug/logcat) or stream device logs from a terminal with `adb logcat`. Filter by your application ID or process to reduce unrelated system output.
 
 Accept SDK licenses with `sdkmanager --licenses`. Set `ANDROID_HOME` and the current `cmdline-tools/latest/bin` and `platform-tools` paths as described on the [Preparation](/quasar-cli-vite/developing-cordova-apps/preparation) page. Run these commands to inspect the installed toolchain and device connection:
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
@@ -82,11 +82,11 @@ Do not edit `/src-cordova/www` directly; Quasar overwrites it. Fix application c
 Quasar components such as QHeader, QFooter, and Notify account for common safe-area cases. Test multiple devices and orientations. Custom layout elements can use the standard CSS environment variables:
 
 ```css
-body.cordova .app-header {
+body.cordova .top-element {
   padding-top: env(safe-area-inset-top, 0px);
 }
 
-body.cordova .app-footer {
+body.cordova .bottom-element {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
@@ -1,227 +1,74 @@
 ---
 title: Cordova Troubleshooting and Tips
-desc: (@quasar/app-vite) Tips and tricks for a Quasar hybrid mobile app with Cordova.
+desc: (@quasar/app-vite) Tips and troubleshooting for a Quasar hybrid mobile app with Cordova.
 ---
 
 ## $q.cordova
 
-While you are developing a Mobile App with Cordova Mode, you can access `$q.cordova` in your Vue files. This is an alias to the global `cordova` Object.
+In Cordova mode, `$q.cordova` provides the global Cordova object in Vue components. Plugin APIs may expose additional globals after the `deviceready` event.
 
-## Android Tips
+## Development app shows a blank screen
 
-### Android remote debugging
+During `quasar dev -m cordova`, Quasar temporarily points `/src-cordova/config.xml > content` at the development server. The selected address must be reachable from the emulator or physical device.
 
-If you are debugging Android Apps, you can use Google Chrome [Remote Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews?hl=en) through a USB cable attached to your Android phone/tablet. It can be used for emulator too.
+Check that:
 
-This way you have Chrome Dev Tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
+- the device and development machine can reach each other over the network
+- the selected host belongs to the correct network interface
+- the firewall permits the development-server port
+- a VPN, proxy, guest Wi-Fi, or client-isolation setting is not blocking traffic
+- the development URL opens in the device browser
 
-![Android Remote Debugging](https://cdn.quasar.dev/img/remote-debug.png 'Android Remote Debugging')
-![Android Remote Debugging](https://cdn.quasar.dev/img/remote-debug-2.png 'Android Remote Debugging')
+Inspect the WebView console for the exact network or certificate error. Quasar restores the original `config.xml` content URL when the Cordova process stops.
 
-### Accept Licenses
+## Android
 
-If you are having problems getting Android builds to finish and you see a message like:
+Use Chrome's [WebView remote debugging](https://developer.chrome.com/docs/devtools/remote-debugging/webviews) to inspect an Android device or emulator. Open `chrome://inspect` after enabling USB debugging and connecting the device.
 
-```
-> Failed to install the following Android SDK packages as some licenses have not been accepted.
-```
-
-If this is the case you need to accept ALL the licenses. Thankfully there is a tool for this:
-
-- Linux: `sdkmanager --licenses`
-- macOS: `~/Library/Android/sdk/tools/bin/sdkmanager --licenses`
-- Windows: `%ANDROID_SDK_ROOT%/tools/bin/sdkmanager --licenses`
-
-### Android SDK not found after installation of the SDK
-
-::: warning
-The environmental variable `ANDROID_HOME` has been deprecated and replaced with `ANDROID_SDK_ROOT`. Depending on your version of Android Studio you may need one or the other. It doesn't hurt to have both set.
-:::
-
-Some newer Debian-based OS (e.g. ubuntu, elementary OS) might leave you with a `Android SDK not found.` after you installed and (correctly) configured the environment. The output might look similar to this:
-
-```
-$ cordova requirements
-
-Requirements check results for android:
-Java JDK: installed 1.8.0
-Android SDK: installed true
-Android target: not installed
-Android SDK not found. Make sure that it is installed. If it is not at the default location, set the ANDROID_HOME (or ANDROID_SDK_ROOT) environment variable.
-Gradle: not installed
-Could not find gradle wrapper within Android SDK. Might need to update your Android SDK.
-Looked here: /home/your_user/Android/Sdk/tools/templates/gradle/wrapper
-Error: Some of requirements check failed
-```
-
-This could have two different reasons: Usually the paths aren't configured correctly. The first step is to verify if your paths are set correctly. This can be done by running the following commands:
+Accept SDK licenses with `sdkmanager --licenses`. Set `ANDROID_HOME` and the current `cmdline-tools/latest/bin` and `platform-tools` paths as described on the [Preparation](/quasar-cli-vite/developing-cordova-apps/preparation) page. Run these commands to inspect the installed toolchain and device connection:
 
 ```bash
-echo $ANDROID_HOME
-# or
-echo $ANDROID_SDK_ROOT
+cordova requirements android
+adb devices
 ```
 
-The expected output should be a path similar to this `$HOME/Android/Sdk`. After this run:
+On Linux, follow Android's current [hardware-device setup](https://developer.android.com/studio/run/device#setting-up) instructions rather than applying a generic permissive udev ruleset.
 
-```bash
-ls -la $ANDROID_HOME
-# or
-ls -la $ANDROID_SDK_ROOT
-```
+Do not accept Android Studio upgrades automatically. The compatible Java, Gradle, Android Gradle Plugin, SDK, and build-tools versions depend on the installed `cordova-android` version.
 
-To ensure the folder contains the SDK. The expected output should contain folders like 'tools', 'sources', 'platform-tools', etc.
+## iOS
 
-```bash
-echo $PATH
-```
+Use Safari Web Inspector to inspect an app on an iOS device or simulator. Enable Web Inspector on the device and Safari's Develop menu, then select the app's WebView.
 
-The output should contain each one entry for the Android SDK 'tools'-folder and 'platform-tools'-tools. This could look like this:
+If a simulator requested through additional Cordova arguments no longer exists, list the installed devices with `xcrun simctl list devices` and pass a currently available target using the syntax supported by your `cordova-ios` version.
 
-```bash
-/home/your_user/bin:/home/your_user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/home/your_user/Android/Sdk/tools:/home/your_user/Android/Sdk/platform-tools
-```
+## Debugging a production build
 
-> If you ensured your paths are set correctly and still get the error on `cordova requirements` you can try the following fix: [Replacing the Android Studio 'tools' folder manually](https://github.com/meteor/meteor/issues/8464#issuecomment-288112504)
+If development mode works but a production build does not:
 
-### Android Studio
+1. Build the web assets with `quasar build -m cordova -T [android|ios] --skip-pkg`.
+2. From `/src-cordova`, run or build the prepared native project with Cordova CLI, or open it in the native IDE.
+3. Inspect the Android WebView and Logcat or the iOS WebView and Xcode logs.
 
-In Android Studio (if you open it on `/src-cordova/platforms/android`), you will be greeted with a message recommending to upgrade the Gradle version. **DO NOT UPGRADE GRADLE** as it will break the Cordova project. Same goes for any other requested upgrades.
+Do not edit `/src-cordova/www` directly; Quasar overwrites it. Fix application code under `/src` and rebuild.
 
-<img src="https://cdn.quasar.dev/img/gradle-upgrade-notice.png" alt="Gradle upgrade" class="q-mb-md rounded-borders" style="max-width: 350px">
+## Safe areas
 
-If you encounter any IDE errors then click on File > Invalidate caches and restart.
-
-<img src="https://cdn.quasar.dev/img/gradle-invalidate-cache.png" alt="Gradle upgrade" class="rounded-borders" style="max-width: 350px">
-
-### Setting up device on Linux
-
-You may bump into `?????? no permissions` problem when trying to run your App directly on an Android phone/tablet.
-
-Here's how you fix this:
-
-```bash
-# create the .rules file and insert the content
-# from below this example
-sudo vim /etc/udev/rules.d/51-android.rules
-sudo chmod 644   /etc/udev/rules.d/51-android.rules
-sudo chown root. /etc/udev/rules.d/51-android.rules
-sudo service udev restart
-sudo killall adb
-```
-
-The content for `51-android.rules`:
-
-```
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0e79", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0502", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="413c", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0489", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="091e", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="12d1", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="24e3", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="2116", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0482", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="17ef", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="22b8", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0409", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="2080", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0955", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="2257", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="10a9", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1d4d", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0471", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04da", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="05c6", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1f53", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04e8", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04dd", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fce", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0930", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="19d2", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1bbb", MODE="0666"
-```
-
-Now running `adb devices` should discover your device.
-
-### Post-build debugging
-
-There are intermediate states to help with debugging, between `quasar dev` and distributing a completed app. If your app works fine on `quasar dev` but is not running properly after `quasar build`, you have two options:
-
-- go to your `src-cordova` directory and `cordova run [platform]`.
-  - You will be running the final build, but you can still use Chrome DevTools Remote Debugging with a wired connection (see above), to inspect the internal web internals. You cannot do this while running the .apk file.
-  - For more detail, read the Cordova [platform guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/#using-buildjson) and the [CLI reference](https://cordova.apache.org/docs/en/latest/reference/cordova-cli/index.html)
-- open Android Studio and watch the Logcat
-  - Here you can watch everything related to the app and its interaction with the underlying Android OS. After opening your Cordova project in Android Studio, go to `Run`...`Debug` from the top menu. Android Studio will ask you to confirm the device or emulator, then will deploy the app. In the bottom window, choose `Logcat` You may want to use the filters to reduce the volume of messages. You should see `[your app id].MainActivity.onCreate()` signifying the app launch, then various messages related to your app functionality.
-  - Note: this should be for experienced Android developers only. If your app is not functioning properly, it is much more likely that `quasar dev` or `cordova run` can reveal the issue.
-
-::: danger Important!
-If you find a bug using one of the above methods, do not edit the output files (probably the `www` folder) directly, as they will soon be overwritten. Go back to your quasar source, fix the bug, then re-run `quasar build`.
-:::
-
-## iOS Tips
-
-### Device type not found
-
-If you get this error while running `quasar dev -m cordova -T ios`:
-
-```
-No target specified for emulator. Deploying to undefined simulator
-Device type "com.apple.CoreSimulator.SimDeviceType.undefined" could not be found.
-```
-
-Then it means you need to specify an emulator. Depending on your Cordova CLI version, here are some examples:
-
-```bash
-quasar dev -m cordova -T ios -e iPhone-X,12.2
-# or with older versions of Cordova CLI installed on your machine:
-quasar dev -m cordova -T ios -e iPhone-X,com.apple.CoreSimulator.SimRuntime.iOS-12-2
-```
-
-### iOS remote debugging
-
-If you are debugging iOS Apps, you can use the Safari developer tools to remotely debug through a USB cable attached to your iOS phone/tablet. It can be used for emulator too.
-
-This way you have Safari developer tools directly for your App running on the emulator/phone/table. Inspect elements, check console output, and so on and so forth.
-
-First enable the "developer" menu option in the Settings of Safari. Then if you navigate to the "developer" menu option you will see your emulator or connected device listed near the top. From here you can open the developer tools.
-
-### Status bar and notch safe-areas
-
-Since mobile phones have a status bar and/or notches, your app's styling might need some tweaking when building on Cordova. In order to prevent parts of your app from going behind the status bar, there is a global CSS variable that can be used for creating a "safe-area". This variable can then be applied in your app's top and bottom padding or margin.
-
-Quasar has support for these CSS safe-areas by default in QHeader/QFooter and Notify. However it's important to always check your Cordova build on several models to see if all cases of your app are dealing with the safe areas correctly.
-
-In cases you need to manually tweak your CSS you can do so with:
+Quasar components such as QHeader, QFooter, and Notify account for common safe-area cases. Test multiple devices and orientations. Custom layout elements can use the standard CSS environment variables:
 
 ```css
-/* for your app's header */
-padding-top: constant(safe-area-inset-top); // for iOS 11.0
-padding-top: env(safe-area-inset-top); // for iOS 11.2 +
-/* for your app's footer */
-padding-bottom: constant(safe-area-inset-bottom);
-padding-bottom: env(safe-area-inset-bottom);
-```
+body.cordova .app-header {
+  padding-top: env(safe-area-inset-top, 0px);
+}
 
-Of course you can also use the above example with `margin` instead of `padding` depending on your app.
-
-In order to make sure these are only added when opened on mobile via the Cordova build, you can check for the CSS class `.cordova` which is automatically added to the body by Quasar. Example:
-
-```css
-body.cordova .my-selector {
-  padding-top: constant(safe-area-inset-top);
-  padding-top: env(safe-area-inset-top);
+body.cordova .app-footer {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 ```
 
-### Disabling iOS rubber band effect
+## Disable iOS overscroll
 
-When building an iOS app with Cordova and you want to [disable the rubber band effect](https://www.youtube.com/watch?v=UjuNGpU29Mk), add this to your `/src-cordova/config.xml`:
+To disable the rubber-band overscroll effect, add this preference to `/src-cordova/config.xml`:
 
 ```xml
 <preference name="DisallowOverscroll" value="true" />


### PR DESCRIPTION
## Summary

- audit the Cordova mode implementation, configuration types, and guide against current Quasar and Cordova behavior
- prevent builds for nonstandard Cordova targets from failing when no default output folder is defined
- correct Cordova target types and callback examples
- replace obsolete or unsafe setup and troubleshooting guidance with current diagnostics
- align build, plugin, analytics, publishing, icon, and configuration guidance
- offer both pnpm and npm commands where a global CLI installation is appropriate

## Why

The Cordova guide had accumulated obsolete SDK paths, permissive device rules, old platform-specific instructions, and examples that had drifted from the implementation. The builder also assumed every accepted Cordova target had a predefined output-folder mapping.

## Validation

- repository formatting and lint hooks passed for the committed files
- `git diff --check upstream/dev...HEAD`
