### PR TITLE
fix(app-vite): audit Electron mode and guide

### DIFF
--- a/app-vite/exports/electron/main-runtime.d.ts
+++ b/app-vite/exports/electron/main-runtime.d.ts
@@ -29,4 +29,4 @@ export declare const publicDir: string;
  * This allows the preload script and renderer process to request
  * resolved asset and public paths synchronously via `ipcRenderer.sendSync`.
  */
-export declare function registerQuasarRuntime(): Promise<void>;
+export declare function registerQuasarRuntime(): void;

--- a/app-vite/lib/cmd/build.js
+++ b/app-vite/lib/cmd/build.js
@@ -29,12 +29,6 @@ if (argv.help) {
     $ quasar build -m ssr
     $ quasar build -m capacitor -T ios
 
-    # passing extra parameters and/or options to
-    # underlying "cordova" executable:
-    $ quasar build -m electron -- some params --and options --here
-    # when on Windows and using Powershell:
-    $ quasar build -m electron '--' some params --and options --here
-
   Options
     --mode, -m      App mode [spa|ssr|ssg|pwa|cordova|capacitor|electron|bex] (default: spa)
     --target, -T    App target

--- a/app-vite/types/configuration/electron-conf.d.ts
+++ b/app-vite/types/configuration/electron-conf.d.ts
@@ -3,6 +3,7 @@ import type * as ElectronBuilder from "electron-builder";
 import type * as ElectronPackager from "@electron/packager";
 import type { LiteralUnion } from "quasar";
 import type { RolldownOptions } from "rolldown";
+import type { QuasarAppPaths } from "../app-paths.d.ts";
 
 export type QuasarElectronBundlers = "builder" | "packager";
 
@@ -11,7 +12,7 @@ type ElectronPackagerOptions = ElectronPackager.Options;
 
 interface QuasarElectronConfiguration {
   /**
-   * The list of content scripts (js/ts) that you want embedded.
+   * The list of preload scripts (js/ts) that you want compiled.
    * Each entry in the list should be a filename (WITHOUT its extension) from /src-electron/
    *
    * @default [ 'electron-preload' ]
@@ -31,7 +32,18 @@ interface QuasarElectronConfiguration {
     | Promise<void | { [index in string]: any }>;
 
   /**
-   * Extend the Rolldown config that is used for the electron-main thread.
+   * Run after the production dependencies have been installed in the
+   * UnPackaged directory and before the selected Electron bundler runs.
+   *
+   * Can be async.
+   */
+  beforePackaging?: (context: {
+    readonly appPaths: QuasarAppPaths;
+    readonly unpackagedDir: string;
+  }) => void | Promise<void>;
+
+  /**
+   * Extend the Rolldown config that is used for the Electron main process.
    *
    * Can be async. Can directly modify the "config" parameter or
    * return a new one that will be merged with the default one.
@@ -43,7 +55,7 @@ interface QuasarElectronConfiguration {
   ) => void | RolldownOptions | Promise<void | RolldownOptions>;
 
   /**
-   * Extend the Rolldown config that is used for the electron-preload thread.
+   * Extend the Rolldown config that is used for Electron preload scripts.
    *
    * Can be async. Can directly modify the "config" parameter or
    * return a new one that will be merged with the default one.
@@ -56,14 +68,9 @@ interface QuasarElectronConfiguration {
 
   /**
    * You have to choose to use either "packager" or "builder".
-   * They are both excellent open-source projects,
-   *  however they serve slightly different needs.
-   * With packager you will be able to build unsigned projects
-   *  for all major platforms from one machine.
-   * Although this is great, if you just want something quick and dirty,
-   *  there is more platform granularity (and general polish) in builder.
-   * Cross-compiling your binaries from one computer doesn’t really work with builder,
-   *  or we haven’t found the recipe yet.
+   * They serve different needs: packager creates an application bundle,
+   * while builder can also create installers, sign, and publish artifacts.
+   * Host-platform restrictions still apply to signing and some targets.
    *
    * Use along with either the `packager` or `builder` property to
    * configure the options for the chosen bundler.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/build-commands.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/build-commands.md
@@ -33,16 +33,17 @@ quasar dev -m electron
 # ..or the longer form:
 quasar dev --mode electron
 
-# passing extra parameters and/or options to
-# underlying "electron" executable:
+# Pass arguments to the Electron executable:
 quasar dev -m electron -- --no-sandbox --disable-setuid-sandbox
-# when on Windows and using Powershell:
+# PowerShell:
 quasar dev -m electron '--' --no-sandbox --disable-setuid-sandbox
 ```
 
-It opens up an Electron window with dev-tools included. You have HMR for the renderer process and changes to main process are also picked up (but the latter restarts the Electron window on each change).
+It opens an Electron window. The default template also opens renderer DevTools. The renderer supports HMR; changing a main or preload source rebuilds it and restarts Electron.
 
-Check how you can tweak Rolldown config Object for the Main Process and the Preload script on the [Configuring Electron](/quasar-cli-vite/developing-electron-apps/configuring-electron) page.
+Arguments after `--` are forwarded to Electron. The sandbox-disabling arguments above illustrate forwarding syntax, but should only be used when a constrained environment requires them and after considering the security impact.
+
+See [Configuring Electron](/quasar-cli-vite/developing-electron-apps/configuring-electron) to extend the Rolldown configurations for the main process and preload scripts.
 
 ### Chrome DevTools
 
@@ -52,9 +53,9 @@ While in dev mode, hit the following combination (while your app window has focu
 - Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
 - Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>
 
-### Vuejs Devtools
+### Vue DevTools
 
-Should you want to also access Vue Devtools for the renderer thread:
+To load Vue DevTools for the renderer process:
 
 ```bash
 quasar dev -m electron --devtools
@@ -69,7 +70,7 @@ quasar build -m electron
 quasar build --mode electron
 ```
 
-It builds your app for production and then uses @electron/packager to pack it into an executable. Check how to configure this on [Configuring Electron](/quasar-cli-vite/developing-electron-apps/configuring-electron) page.
+It builds the application and packages it with the configured bundler. The default is `@electron/packager`; select `electron-builder` when you need its installer, signing, or publishing features. See [Configuring Electron](/quasar-cli-vite/developing-electron-apps/configuring-electron).
 
 If you want a production build with debugging enabled for the UI code:
 
@@ -84,9 +85,9 @@ Here is the folder structure of the outcome:
 
 <DocTree :def="scope.distTree" />
 
-### A note for non-Windows users
+### Cross-platform packaging
 
-If you want to build for Windows with a custom icon using a non-Windows platform, you must have [wine](https://www.winehq.org/) installed. [More Info](https://github.com/electron-userland/electron-packager#building-windows-apps-from-non-windows-platforms).
+Packaging, signing, and native dependencies impose host-platform restrictions. For example, signing a macOS application requires macOS, and packaging Windows resources from another platform may require Wine. Check the selected bundler's platform requirements and build each target on a matching host or CI runner when signing or native modules are involved.
 
 ## Publishing (electron-builder only)
 
@@ -97,11 +98,9 @@ quasar build -m electron -P always
 quasar build --mode electron --publish always
 ```
 
-You can specify using `electron-builder` to build your app either directly on the command line (`--bundler builder`) or by setting it explicitly within the `quasar.config` file at `electron.bundler`. This flag has no effect when using `@electron/packager`.
+Select `electron-builder` on the command line (`--bundler builder`) or in `quasar.config` at `electron.bundler`. The publish option only applies to `electron-builder`.
 
-Currently (June 2019) supported publishing destinations include GitHub, Bintray, S3, Digital Ocean Spaces, or a generic HTTPS server. More information, including how to create valid publishing instructions, can be found [here](https://www.electron.build/configuration/publish).
-
-Valid options for `-P` are "onTag", "onTagOrDraft", "always" and "never" which are explained at the above link. In addition, you must have valid `publish` configuration instructions in your `quasar.config` file at `electron.builder`.
+Valid values for `-P` are `onTag`, `onTagOrDraft`, `always`, and `never`. Configure a supported provider in `quasar.config > electron > builder > publish`; see the current [electron-builder publishing documentation](https://www.electron.build/docs/publish/).
 
 A very basic configuration to publish a Windows EXE setup file to Amazon S3 might look like this:
 
@@ -114,8 +113,9 @@ electron: {
       target: 'nsis'
     },
     publish: {
-      'provider': 's3',
-      'bucket': 'myS3bucket'
+      provider: 's3',
+      bucket: 'myS3bucket'
     }
   }
+}
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/configuring-electron.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/configuring-electron.md
@@ -5,9 +5,7 @@ related:
   - /quasar-cli-vite/quasar-config-file
 ---
 
-We'll be using Quasar CLI (and Cordova CLI) to develop and build a Mobile App. The difference between building a SPA, PWA, SSR, SSG, Electron App or a Mobile App is simply determined by the "mode" parameter in "quasar dev" and "quasar build" commands.
-
-But first, let's learn how we can configure the Electron build.
+Electron mode is selected with the `--mode electron` option for `quasar dev` and `quasar build`. Its main process, preload scripts, packaging, and publishing behavior are configured in `quasar.config`.
 
 ## quasar.config file
 
@@ -22,7 +20,7 @@ sourceFiles: {
 ```ts /quasar.config file > electron
 electron: {
   /**
-   * The list of content scripts (js/ts) that you want embedded.
+   * The list of preload scripts (js/ts) that you want compiled.
    * Each entry in the list should be a filename (WITHOUT its extension) from /src-electron/
    *
    * @default [ 'electron-preload' ]
@@ -42,7 +40,16 @@ electron: {
     | Promise<void | { [index in string]: any }>;
 
   /**
-   * Extend the Rolldown config that is used for the electron-main thread.
+   * Run after production dependencies are installed in UnPackaged and
+   * before the selected Electron bundler runs.
+   */
+  beforePackaging?: (context: {
+    readonly appPaths: QuasarAppPaths;
+    readonly unpackagedDir: string;
+  }) => void | Promise<void>;
+
+  /**
+   * Extend the Rolldown config that is used for the Electron main process.
    *
    * Can be async. Can directly modify the "config" parameter or
    * return a new one that will be merged with the default one.
@@ -52,7 +59,7 @@ electron: {
   ) => void | RolldownOptions | Promise<void | RolldownOptions>;
 
   /**
-   * Extend the Rolldown config that is used for the electron-preload thread.
+   * Extend the Rolldown config that is used for Electron preload scripts.
    *
    * Can be async. Can directly modify the "config" parameter or
    * return a new one that will be merged with the default one.
@@ -62,22 +69,11 @@ electron: {
   ) => void | RolldownOptions | Promise<void | RolldownOptions>;
 
   /**
-   * You have to choose to use either packager or builder.
-   * They are both excellent open-source projects,
-   *  however they serve slightly different needs.
-   * With packager you will be able to build unsigned projects
-   *  for all major platforms from one machine.
-   * Although this is great, if you just want something quick and dirty,
-   *  there is more platform granularity (and general polish) in builder.
-   * Cross-compiling your binaries from one computer doesn’t really work with builder,
-   *  or we haven’t found the recipe yet.
+   * Choose either packager or builder. Packager creates an application
+   * bundle; builder can also create installers, sign, and publish artifacts.
    */
-  // This property definition is here merely to avoid duplicating the TSDoc
-  // It should not be optional, as TS cannot infer the discriminated union based on the absence of a field
-  // Futhermore, making it optional here won't change the exported interface which is the union
-  // of the two derivate interfaces where `bundler` is set without optionality
   bundler?: "packager" | "builder";
-  packager?: ElectronPackager.Options;
+  packager?: Omit<ElectronPackager.Options, "dir" | "out">;
   builder?: ElectronBuilder.Configuration;
 
   /**
@@ -96,11 +92,11 @@ electron: {
 }
 ```
 
-The "packager" prop refers to [@electron/packager options](https://electron.github.io/packager/main/). The `dir` and `out` properties are overwritten by Quasar CLI to ensure the best results.
+The `packager` property accepts [@electron/packager options](https://electron.github.io/packager/main/), except `dir` and `out`, which Quasar controls.
 
-The "builder" prop refers to [electron-builder options](https://www.electron.build/configuration).
+The `builder` property accepts [electron-builder options](https://www.electron.build/configuration).
 
-Should you want to tamper with the "Renderer" thread (UI in /src) Vite config:
+To extend the renderer process (the UI in `/src`) Vite configuration:
 
 ```js /quasar.config file
 export default defineConfig(ctx => {
@@ -117,14 +113,14 @@ export default defineConfig(ctx => {
 })
 ```
 
-## Packager vs. Builder
+## Packager vs Builder
 
-You have to choose to use either packager or builder. They are both excellent open-source projects, however they serve slightly different needs. With packager you will be able to build unsigned projects for all major platforms from one machine (with restrictions). Although this is great, if you just want something quick and dirty, there is more platform granularity (and general polish) in builder. Cross-compiling your binaries from one computer doesn't really work with builder (or we haven't found the recipe yet...)
+`@electron/packager` creates an application bundle and is the Quasar default. `electron-builder` adds installer targets, code-signing integration, and publishing. Both tools have target-specific host restrictions; code signing and native dependencies often require building on the target operating system.
 
 ## Dependencies optimization
 
-By default, all `dependencies` from your root `package.json` file get installed and embedded into the production executable.
+The production package uses the `dependencies` from `/src-electron/package.json`. They are installed in `/dist/electron/UnPackaged` before packaging.
 
-This means that it will also include your UI-only deps, which are already bundled in the UI files (so it will duplicate them). From our CLI perspective, we don't have any generic way of telling whether a dependency is UI only or if it's used by the main/preload scripts, so we cannot reliably auto-remove them.
+Keep renderer-only dependencies in the root package and Electron runtime dependencies in `/src-electron/package.json`. Preload imports are bundled, but a sandboxed preload cannot use arbitrary Node.js APIs or native modules; move privileged work to the main process and expose a narrow IPC API.
 
-However, you can do this by using quasar.conf > electron > extendElectronPackageJson(pkgJson) and overwriting or tampering with the `dependencies` key from your `package.json` file. If you leave only the main & preload threads depdendencies then this will lead to a smaller production executable file.
+Use `electron.extendElectronPackageJson(pkgJson)` only when the generated production manifest needs additional adjustment. Removing a dependency required by externalized main-process code will make the packaged application fail at runtime.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-accessing-files.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-accessing-files.md
@@ -17,13 +17,13 @@ scope:
 
 ## The problem
 
-Since the main thread (with preload scripts) is bundled using Rolldown, the use of `import.meta.env.dirname` and `import.meta.env.filename` (...and so on) will not provide an expected value in dev and in production, especially in regards to the absolute paths.
+The main process and preload scripts are bundled with Rolldown, and their output locations differ between development and production. Paths derived from a source-file location therefore do not reliably identify `/public` or `/src-electron/electron-assets` in both environments.
 
 <DocTree :def="scope.distTree" />
 
 ## The solution
 
-Quasar CLI provides an out of the box solution for referencing files, regardless of the dev or production environment, by leveraging the IPC communication.
+Quasar CLI provides runtime helpers for referencing these directories in both environments.
 
 Notice the following sections:
 
@@ -55,9 +55,9 @@ import { quasarRuntime } from '#q-app/electron/preload'
 contextBridge.exposeInMainWorld('quasarRuntime', quasarRuntime)
 ```
 
-Notice that we are exposing a `quasarRuntime` variable to the redenderer thread, so we can reference `window.quasarRuntime` from there.
+This exposes `quasarRuntime` to the renderer as `window.quasarRuntime`.
 
-Should you wish, you can expose whatever variable name you want. And also, whatever subset of this runtime you desire. Just import from `#q-app/electron/preload` and call contextBridge.exposeInMainWorld().
+You can choose another property name or expose only the helpers your renderer needs.
 
 ### API for electron-main
 
@@ -105,7 +105,7 @@ export declare const publicDir: string;
  * This allows the preload script and renderer process to request
  * resolved asset and public paths synchronously via `ipcRenderer.sendSync`.
  */
-export declare function registerQuasarRuntime(): Promise<void>;
+export declare function registerQuasarRuntime(): void;
 ```
 
 ### API for electron-preload
@@ -160,16 +160,49 @@ export declare const quasarRuntime: {
 };
 ```
 
-### Usage in renderer thread (/src)
+### Usage in the renderer process (`/src`)
 
 ```js
 window.quasarRuntime.resolvePublicPath('my-file')
 ```
 
-## Read & Write Local Files
+## Read and write local files
 
-One great benefit of using Electron is the ability to access the user's file system. This enables you to read and write files on the local system. To help avoid Chromium restrictions and writing to your application's internal files, make sure to make use of electron's APIs, specifically the `app.getPath(name)` function. This helper method can get you file paths to system directories such as the user's desktop, system temporary files, etc.
+Treat packaged application files as read-only. Use Electron's `app.getPath(name)` for writable locations such as the application-specific `userData` directory, and perform filesystem operations in the main process.
 
-We can use the userData directory, which is reserved specifically for our application, so we can have confidence other programs or other user interactions should not tamper with this file space.
+Expose a narrow IPC operation rather than a path or unrestricted filesystem API. For example:
 
-Note that if you care about security, you will need to use the IPC communication to handle this in your preload or renderer thread, just as the Quasar CLI does with its `quasarRuntime`.
+```js /src-electron/electron-main
+import { app, ipcMain } from 'electron'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export function registerPreferencesHandler(mainWindow) {
+  ipcMain.handle('preferences:load', async event => {
+    if (event.senderFrame !== mainWindow.webContents.mainFrame) {
+      throw new Error('Untrusted IPC sender')
+    }
+
+    const filename = path.join(app.getPath('userData'), 'preferences.json')
+
+    try {
+      return JSON.parse(await readFile(filename, 'utf8'))
+    } catch (error) {
+      if (error.code === 'ENOENT') return {}
+      throw error
+    }
+  })
+}
+```
+
+Call `registerPreferencesHandler(mainWindow)` after creating the trusted window. Remove the handler with `ipcMain.removeHandler('preferences:load')` if that window and its handlers are recreated during the same application session.
+
+```js /src-electron/electron-preload
+import { contextBridge, ipcRenderer } from 'electron'
+
+contextBridge.exposeInMainWorld('preferencesAPI', {
+  load: () => ipcRenderer.invoke('preferences:load')
+})
+```
+
+For applications with multiple or remote windows, keep a separate allowlist for each operation or validate `event.senderFrame.url` with the URL parser. Merely checking that a window exists is not sufficient.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-live-updates.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-live-updates.md
@@ -14,15 +14,15 @@ One open-source option is [`@capgo/electron-updater`](https://www.npmjs.com/pack
 The updater is used by the Electron main and preload scripts, so install it from your Electron folder:
 
 ```tabs
+<<| bash PNPM |>>
+cd src-electron
+pnpm add @capgo/electron-updater
 <<| bash Yarn |>>
 cd src-electron
 yarn add @capgo/electron-updater
 <<| bash NPM |>>
 cd src-electron
 npm install @capgo/electron-updater
-<<| bash PNPM |>>
-cd src-electron
-pnpm add @capgo/electron-updater
 <<| bash Bun |>>
 cd src-electron
 bun add @capgo/electron-updater
@@ -41,6 +41,7 @@ import {
   setupEventForwarding,
   setupIPCHandlers
 } from '@capgo/electron-updater' // [!code highlight]
+import { registerQuasarRuntime } from '#q-app/electron/main' // [!code highlight]
 
 const updater = new ElectronUpdater({ // [!code highlight]
   // [!code highlight]
@@ -73,8 +74,9 @@ async function createWindow() {
   }
 }
 
-void app.whenReady().then(() => {
-  createWindow()
+void app.whenReady().then(async () => {
+  await registerQuasarRuntime() // [!code highlight]
+  await createWindow()
 })
 ```
 
@@ -154,7 +156,7 @@ Build the Electron app without packaging it into an installer:
 quasar build -m electron --skip-pkg
 ```
 
-The renderer files are created in `/dist/electron/UnPackaged`. Stage the files that belong to the web bundle, such as `index.html`, `assets/` and any files copied from `/public`, then create a zip with the CLI:
+The renderer files are created in `/dist/electron/UnPackaged`. Copy the files that belong to the web bundle, such as `index.html`, `assets/`, and files originating from `/public`, into a separate staging directory. Do not include `electron-main.js`, preload scripts, `package.json`, `node_modules`, or `electron-assets` in a live-update archive. Then create a zip with the CLI:
 
 ```bash
 npx @capgo/cli@latest bundle zip --path dist/electron/live-update

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-preload-script.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-preload-script.md
@@ -1,15 +1,15 @@
 ---
 title: Electron Preload Script
-desc: (@quasar/app-vite) How to handle Electron Node Integration with an Electron Preload script with Quasar CLI.
+desc: (@quasar/app-vite) How to expose a controlled Electron API to a Quasar renderer.
 ---
 
-For security reasons, the renderer thread (your UI code from `/src`) does not have access to the Node.js stuff. However, you can run Node.js code and bridge it to the renderer thread through an Electron Preload script located at `/src-electron/electron-preload.js`. Use `contextBridge` (from the `electron` package) to expose the stuff that you need for your UI.
+The renderer process (your UI code from `/src`) does not have direct access to Node.js or Electron APIs in Quasar's default secure configuration. Use the preload script at `/src-electron/electron-preload.js` (or `.ts`) and Electron's `contextBridge` to expose only the operations the UI needs.
 
-Since the preload script runs from Node.js, be careful what you do with it and what you expose to the renderer thread!
+The default renderer sandbox gives the preload script a limited API. Perform filesystem access and other privileged work in the main process, then expose purpose-built operations through IPC.
 
 ## How to use it
 
-In `/src-electron/` folder, there is a file named `electron-preload.js`. Fill it with your preload code.
+The generated `/src-electron/electron-preload.js` already exposes Quasar's runtime path helpers. Add your own bridge methods alongside it.
 
 Make sure that your `/src-electron/electron-main.js` has the following (near the "webPreferences" section):
 
@@ -45,7 +45,7 @@ Example of `/src-electron/electron-preload` content:
  * Instead, use IPC to communicate with the main process and access packages and Node.js
  * functionality there.
  *
- * Example on injecting window.myAPI.doAThing() into renderer thread:
+ * Example of exposing window.myAPI.doAThing() to the renderer process:
  *
  *   import { contextBridge } from 'electron'
  *
@@ -61,13 +61,6 @@ import { quasarRuntime } from '#q-app/electron/preload'
 
 contextBridge.exposeInMainWorld('quasarRuntime', quasarRuntime)
 ```
-
-::: warning
-
-1. Be aware that this file runs in a Node.js context.
-2. If you import anything from node_modules, then make sure that the package is specified in /src-electonr/package.json > "dependencies" and NOT in "devDependencies".
-
-:::
 
 ## Security considerations
 
@@ -89,13 +82,13 @@ contextBridge.exposeInMainWorld('myAPI', {
 })
 ```
 
-Now, `loadPreferences` is available globally in your javascript code (ie: `window.myAPI.loadPreferences`).
+Now, `loadPreferences` is available to renderer code as `window.myAPI.loadPreferences()`.
 
 ::: warning
-Make sure to pick names which do not colide with existing `Window` keys.
+Choose a name that does not collide with an existing `Window` property.
 :::
 
-Using the above code with an `invoke` to `load-prefs` in the main thread would have code like this:
+Handle the corresponding `load-prefs` invocation in the main process:
 
 ```js
 ipcMain.handle('myAPI:load-prefs', () => {
@@ -107,11 +100,13 @@ ipcMain.handle('myAPI:load-prefs', () => {
 
 ## Custom path to the preload script
 
-Should you wish to change the location of the preload script (and/or even the main thread file) then edit the `/quasar.config` file:
+Change the main-process source with `sourceFiles.electronMain`. Configure one or more preload sources with `electron.preloadScripts`; entries are relative to `/src-electron` and omit the extension:
 
 ```js /quasar.config file
-// should you wish to change default files
 sourceFiles: {
-  electronMain: 'src-electron/electron-main.js'
+  electronMain: 'src-electron/electron-main'
+},
+electron: {
+  preloadScripts: [ 'electron-preload', 'secondary-preload' ]
 }
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-security-concerns.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-security-concerns.md
@@ -1,114 +1,98 @@
 ---
 title: Electron Security Concerns
-desc: (@quasar/app-vite) The things you should know about security in a Quasar desktop app.
+desc: (@quasar/app-vite) Security practices for a Quasar desktop app with Electron.
 ---
 
-If you are not vigilant when building Electron apps, you will probably be placing the users of your app in tangible digital danger. Things like XSS (Cross Site Scripting) and remote code execution can literally enable attackers to get deep access to the data in your app - and potentially even the underlying operating system.
+Electron applications combine web content with native desktop capabilities. A renderer vulnerability such as cross-site scripting can therefore have more serious consequences than the same vulnerability in a normal browser.
 
-Especially when working "in the open", i.e. as an open-source project, you will definitely want to consider hardening your application with code-signing and integrity checking. (See "Tips" section)
+Start with Electron's current [security checklist](https://www.electronjs.org/docs/latest/tutorial/security) and reassess it whenever Electron is upgraded or the application begins loading new content.
 
-::: danger
-Under no circumstances should you load and execute remote code. Instead, use only local files (packaged together with your application) to execute Node.js code in your main thread and/or preload script.
-:::
+## Keep the renderer isolated
 
-## Checklist: Security Recommendations
+Quasar's generated `BrowserWindow` keeps `contextIsolation` enabled. Current Electron versions also sandbox renderers by default and disable Node.js integration by default. Preserve those defaults:
 
-The Electron team itself makes the following recommendations:
+```js /src-electron/electron-main
+const mainWindow = new BrowserWindow({
+  webPreferences: {
+    contextIsolation: true,
+    sandbox: true,
+    nodeIntegration: false,
+    preload: path.join(import.meta.dirname, 'electron-preload.cjs')
+  }
+})
+```
 
-1.  Make sure that you leave `webPreferences` > `contextIsolation` set to `true`. Use the [preload script](/quasar-cli-vite/developing-electron-apps/electron-preload-script) to inject only must-have APIs to the renderer thread.
-2.  If you must load remote content and cannot work around that, then [only load secure content](https://electronjs.org/docs/tutorial/security#1-only-load-secure-content)
-3.  [Use `ses.setPermissionRequestHandler()` in all sessions that load remote content](https://electronjs.org/docs/tutorial/security#4-handle-session-permission-requests-from-remote-content)
-4.  [Do not disable `webSecurity`](https://electronjs.org/docs/tutorial/security#5-do-not-disable-websecurity)
-5.  [Do not set `allowRunningInsecureContent` to `true`](https://electronjs.org/docs/tutorial/security#7-do-not-set-allowrunninginsecurecontent-to-true)
-6.  [Do not enable experimental features](https://electronjs.org/docs/tutorial/security#8-do-not-enable-experimental-features)
-7.  [Do not use `enableBlinkFeatures`](https://electronjs.org/docs/tutorial/security#9-do-not-use-enableblinkfeatures)
-8.  [`<webview>`: Do not use `allowpopups`](https://electronjs.org/docs/tutorial/security#10-do-not-use-allowpopups)
-9.  [`<webview>`: Verify options and params](https://electronjs.org/docs/tutorial/security#11-verify-webview-options-before-creation)
-10. [Disable or limit navigation](https://electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation)
-11. [Disable or limit creation of new windows](https://electronjs.org/docs/tutorial/security#13-disable-or-limit-creation-of-new-windows)
+Do not disable `webSecurity` or enable `allowRunningInsecureContent`, experimental Blink features, or Node.js integration to work around an application problem.
 
-Except for items 3 and 4 above, Electron will put a warning in the dev console if one of the these issues have been detected.
+## Expose narrow preload APIs
 
-## Tips and Tricks
+Using `contextBridge` does not make an API safe by itself. Do not expose `ipcRenderer`, Node.js modules, or generic send/invoke methods to the renderer:
 
-#### Using CSP (Content Security Protocol)
+```js /src-electron/electron-preload
+// Bad: renderer code can invoke arbitrary channels
+contextBridge.exposeInMainWorld('electronAPI', {
+  invoke: ipcRenderer.invoke
+})
 
-Your `/index.html` file should contain a CSP meta tag in your `<head>`. Example:
+// Good: one operation with a fixed channel
+contextBridge.exposeInMainWorld('preferencesAPI', {
+  load: () => ipcRenderer.invoke('preferences:load')
+})
+```
+
+Validate arguments in the main process and validate the sender of every IPC request before returning data or performing privileged work. Do not send Electron event objects back across the bridge.
+
+## Control navigation and new windows
+
+An Electron window should not navigate to arbitrary content. Limit navigation and new-window creation to an explicit allowlist, and validate a URL before passing it to `shell.openExternal`:
+
+```js /src-electron/electron-main
+mainWindow.webContents.on('will-navigate', event => {
+  event.preventDefault()
+})
+
+mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  const parsed = new URL(url)
+
+  if (parsed.protocol === 'https:' && parsed.hostname === 'example.com') {
+    void shell.openExternal(parsed.href)
+  }
+
+  return { action: 'deny' }
+})
+```
+
+If your application must display remote content, use HTTPS, keep Node.js integration disabled, keep context isolation and sandboxing enabled, restrict permissions with `session.setPermissionRequestHandler()`, and isolate that content from privileged local windows.
+
+## Define a Content Security Policy
+
+Use a restrictive Content Security Policy in `/index.html`. Add only the origins and directives the application actually requires:
 
 ```html /index.html
-<head>
-  <meta
-    http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';<% if (ctx.dev) { %> connect-src 'self' ws://localhost:*; worker-src 'self' blob:;<% } %>"
-  />
-</head>
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+/>
 ```
 
-#### Communication Protocols
+Development may require additional `connect-src` entries for the Quasar development server and WebSocket connection. Do not carry broad development exceptions into production.
 
-You should know this by now, but if you are not using **https** / **sftp** / **wss** then the app's communications with the outside world can be very easily tampered with. Whatever you are building, please use a secure protocol everywhere.
+## Store files in appropriate locations
 
-#### Filesystem Access
+Treat application resources as read-only after packaging. Store mutable application data under a path returned by Electron's `app.getPath()`, commonly `userData`, and perform filesystem operations in the main process. Validate paths and input received over IPC to prevent a renderer from reading or overwriting arbitrary files.
 
-Having read & write permissions to the filesystem is the holy grail for penetration testers, and if your app enables this type of interaction, consider using IPC and multiple windows (with varying permissions) in order to minimize the attack surface.
+Use the operating system's credential storage or a well-reviewed secure-storage solution for secrets. Checksums detect accidental corruption but do not establish who published an artifact; use code signing for authenticity.
 
-#### Encryption
+## Ship and maintain trusted builds
 
-If the user of your application has secrets like wallet addresses, personal information or some other kind of trade secrets, keep that information encrypted when at rest, un-encrypt it in-memory only when it is needed and make sure to overwrite / destroy the object in memory when you are done with it. But no matter how you approach this, follow these four rules:
+- Keep Electron and production dependencies on supported, patched versions.
+- Lock and review dependency changes, and run the package manager's audit tooling in CI.
+- Sign distributed Windows and macOS builds; notarize macOS releases where required.
+- Deliver updates through HTTPS and verify signed update artifacts.
+- Consider disabling unused [Electron fuses](https://www.electronjs.org/docs/latest/tutorial/fuses) during packaging.
 
-1. use strong crypto (i.e. collision resistant and not md5)
-2. do not invent a novel type of encryption
-3. follow the implementation instructions explicitly
-4. think about the user-experience
+See Electron's [code-signing guide](https://www.electronjs.org/docs/latest/tutorial/code-signing) and the selected packager's signing configuration for platform-specific requirements.
 
-#### Disable developer tools in production
-
-You probably don't want rogue hoody-wearing menaces to be executing something like this in the console of your app:
-
-```js
-window.location = 'https://evilsite.com/looks-just-like-your-app'
-```
-
-The key-combination <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (or <kbd>ALT</kbd>+<kbd>CMD</kbd>+<kbd>I</kbd> on Mac) will open the dev tools and enable inspection of the application. It will even enable some degree of modification. Prevent the simple `evil maid` attack by catching these keypresses and `return false`.
-
-#### Publish checksums
-
-When you have built your binary blobs and want to publish them e.g. on GitHub, use `shasum` and post these results somewhere prominent (like on the GitHub release page for your project) and potentially on a public blockchain, such as [Steem](https://steemworld.org/@quasarframework).
-
-```
-$ shasum -a 256 myApp-v1.0.0_darwin-x64.dmg
-40ed03e0fb3c422e554c7e75d41ba71405a4a49d560b1bf92a00ea6f5cbd8daa myApp-v1.0.0_darwin-x64.dmg
-```
-
-#### Sign the builds
-
-Although not a hard requirement for sharing your app, signing code is a best practice - and it is required by both the MacOS and Windows stores. Read more about it at this [official Electron tutorial](https://electronjs.org/docs/tutorial/code-signing).
-
-#### Use SNYK
-
-[Snyk.io](https://snyk.io) is a service, CLI and even GitHub integration bot that tracks vulnerabilities in node modules by comparing the dependencies in your package.json with its list of compromised modules. In many cases their service can recommend minimum update versions or even provide modules that they themselves have patched. They also undertake research and vulnerability disclosure. For an example of something that should scare the socks off of you if you are doing anything with compressed files (zip, tar, etc.) check out their [writeup](https://snyk.io/research/zip-slip-vulnerability) and [list of affected software](https://github.com/snyk/zip-slip-vulnerability).
-
-#### For the truly paranoid
-
-Use a dedicated physical desktop machine for each platform target. If you have to keep this device online, make sure the OS is always updated, permits zero inbound connections from the internet / bluetooth (especially for shell / ssh) and run constant virus and rootkit checks.
-
-Permit only GPG-signed commits to be merged and require at least two team members (who did not make the PR) to review and approve the commit.
-
-Reconsider your node package management system:
-
-- use a private npm registry (like [JFrog](https://jfrog.com/))
-- fix your packages to specific versions known to work
-- use pnpm
-- audit each and every single module and its dependencies
-
-#### Pay to get hacked
-
-Somebody smart might have hacked your project (or an underlying library). If you are making money with this app, consider getting a [Hacker One](https://hackerone.com) account and running a constant bounty award. At least you'll be able to convince the hacker to be ethical and NOT sell the exploit to your competitor.
-
-#### Get help
-
-You may feel overwhelmed, because the awesomeness of Electron brings with it a great many headaches that you never wanted to think about. If this is the case, consider [reaching out](mailto:razvan.stoenescu@gmail.com) and getting expert support for the review, audit and hardening of your app by the team of seasoned devs that brought you the Quasar Framework.
-
-<q-separator class="q-mt-xl" />
-
-> Parts of this page have been taken from the official [Electron Security Guide](https://electronjs.org/docs/tutorial/security).
+::: warning
+Hiding DevTools is not a security boundary. Assume users can inspect and modify renderer code and keep all privileged authorization and validation in the main process.
+:::

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-upgrade-guide.md
@@ -7,19 +7,19 @@ desc: (@quasar/app-vite) Upgrading instructions when dealing with Electron in Qu
 
 When you add the Electron mode in a Quasar project for the first time you will get the latest version of the Electron package. At some point in time, you will want to upgrade the Electron version.
 
-Before upgrading Electron, please consult its release notes. Are there breaking changes?
+Review Electron's [breaking changes](https://www.electronjs.org/docs/latest/breaking-changes) and release notes before upgrading. Move through major versions deliberately and rebuild any native dependencies afterward.
 
 ```tabs
 <<| bash PNPM |>>
 # from /src-electron:
-pnpm add electron@latest
+pnpm add -D electron@latest
 <<| bash Yarn |>>
 # from /src-electron:
-yarn upgrade electron@latest
+yarn add -D electron@latest
 <<| bash NPM |>>
 # from /src-electron:
-npm install electron@latest
+npm install -D electron@latest
 <<| bash Bun |>>
 # from /src-electron:
-bun add electron@latest
+bun add -D electron@latest
 ```

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-with-typescript.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-with-typescript.md
@@ -3,7 +3,7 @@ title: Electron with TypeScript
 desc: (@quasar/app-vite) How to use TypeScript with Electron in Quasar
 ---
 
-In order to support Electron with TypeScript, you will need to rename the extension for your files in /src-electron from `.js` to `.ts` and make the necessary TS code changes.
+When Electron mode is added to a TypeScript Quasar project, Quasar creates TypeScript main and preload sources automatically. To convert an existing JavaScript Electron workspace, rename the files under `/src-electron` from `.js` to `.ts` and address any TypeScript errors. The default source configuration omits extensions, so it resolves either form.
 
 ::: tip
 `@electron/packager` and `electron-builder` export their configuration types from their own packages.
@@ -90,7 +90,7 @@ app.on('window-all-closed', () => {
  * Instead, use IPC to communicate with the main process and access packages and Node.js
  * functionality there.
  *
- * Example on injecting window.myAPI.doAThing() into renderer thread:
+ * Example of exposing window.myAPI.doAThing() to the renderer process:
  *
  *   import { contextBridge } from 'electron'
  *

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/frameless-electron-window.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/frameless-electron-window.md
@@ -8,7 +8,7 @@ related:
 
 A nice combo is to use frameless Electron window along with [QBar](/vue-components/bar) component. Here's why.
 
-## Main thread
+## Main process
 
 ### Setting frameless window
 
@@ -31,12 +31,12 @@ function createWindow() {
 
 // Add this function:
 function registerWindowControls() {
-  ipcMain.on('window:minimize', () => {
-    BrowserWindow.getFocusedWindow()?.minimize()
+  ipcMain.on('window:minimize', event => {
+    getSenderWindow(event)?.minimize()
   })
 
-  ipcMain.on('window:toggle-maximize', () => {
-    const win = BrowserWindow.getFocusedWindow()
+  ipcMain.on('window:toggle-maximize', event => {
+    const win = getSenderWindow(event)
     if (!win) return
 
     if (win.isMaximized()) {
@@ -46,9 +46,15 @@ function registerWindowControls() {
     }
   })
 
-  ipcMain.on('window:close', () => {
-    BrowserWindow.getFocusedWindow()?.close()
+  ipcMain.on('window:close', event => {
+    getSenderWindow(event)?.close()
   })
+}
+
+function getSenderWindow(event) {
+  const win = BrowserWindow.fromWebContents(event.sender)
+
+  return event.senderFrame === win?.webContents.mainFrame ? win : undefined
 }
 
 app.whenReady().then(async () => {
@@ -60,13 +66,13 @@ app.whenReady().then(async () => {
 
 ### The preload script
 
-We will expose our window API to the renderer thread through our `/src-electron/electron-preload` script:
+Expose the window API to the renderer process through `/src-electron/electron-preload`:
 
 ```js /src-electron/electron-preload
 import { contextBridge, ipcRenderer } from 'electron'
 
 // notice "myWindowAPI" (can be anything as long as we reference
-// the same name that we define here in the renderer thread)
+// the same name that we use in the renderer process)
 contextBridge.exposeInMainWorld('myWindowAPI', {
   minimize() {
     ipcRenderer.send('window:minimize')
@@ -80,19 +86,19 @@ contextBridge.exposeInMainWorld('myWindowAPI', {
 })
 ```
 
-## Renderer thread
+## Renderer process
 
 ### Handling window dragging
 
-When we use a frameless window (only frameless!) we also need a way for the user to be able to move the app window around the screen. You can use `q-electron-drag` and `q-electron-drag--exception` Quasar CSS helper classes for this.
+A frameless window needs a draggable region. Use the `q-electron-drag` and `q-electron-drag--exception` Quasar CSS helper classes.
 
 ```html
 <q-bar class="q-electron-drag"> ... </q-bar>
 ```
 
-What this does is that it allows the user to drag the app window when clicking, holding and simultaneously dragging the mouse on the screen.
+The class allows the user to drag the window from that region.
 
-While this is a good feature, you must also take into account that you'll need to specify some exceptions. There may be elements in your custom statusbar that you do not want to trigger the window dragging. By default, [QBtn](/vue-components/button) is **excepted from this behavior** (no need to do anything for this). Should you want to add exceptions to any children of the element having `q-electron-drag` class, you can attach the `q-electron-drag--exception` CSS class to them.
+Interactive children must not trigger dragging. [QBtn](/vue-components/button) is excluded automatically; add `q-electron-drag--exception` to other interactive children.
 
 Example of adding an exception to an icon:
 

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/installing-electron-dependencies.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/installing-electron-dependencies.md
@@ -3,7 +3,7 @@ title: Installing Electron-specific dependencies
 desc: (@quasar/app-vite) How to handle Electron-specific dependencies.
 ---
 
-Notice the `/src-electron/package.json` file in your generated `/src-electron` folder. The purpose of it is for you to be able to install packages used by the Electron mode directly under this folder (and not pollute the common `/src`).
+Use `/src-electron/package.json` for dependencies that belong to the Electron main process or its packaging workflow. Keeping them in this workspace prevents Electron-only packages from becoming renderer dependencies.
 
 ```json /src-electron/package.json
 {
@@ -13,37 +13,40 @@ Notice the `/src-electron/package.json` file in your generated `/src-electron` f
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@electron/packager": "^20.0.0",
-    "electron": "^41.3.0"
+    "electron": "^<installed-version>"
   }
 }
 ```
 
-Installing [Electron specific packages](https://zeke.github.io/electron.atom.io/userland/most_downloaded_packages):
+Quasar installs the selected packaging tool (`@electron/packager` or `electron-builder`) here on the first production build that needs it.
+
+From `/src-electron`, install packages used at runtime by the main process under `dependencies`. Install Electron, packaging tools, type packages, and other build-time tools under `devDependencies`:
 
 ```tabs
 <<| bash PNPM |>>
-# run in /src-electron for runtime deps (will be embedded to /dist):
+# Runtime dependency installed into the packaged app:
 pnpm add <deps>
 
-# run in /src-electron for deps used by the build system (eg. "electron")
+# Build-time dependency:
 pnpm add -D <dev-deps>
 <<| bash Yarn |>>
-# run in /src-electron for runtime deps (will be embedded to /dist):
+# Runtime dependency installed into the packaged app:
 yarn add <deps>
 
-# run in /src-electron for deps used by the build system (eg. "electron")
+# Build-time dependency:
 yarn add -D <dev-deps>
 <<| bash NPM |>>
-# run in /src-electron for runtime deps (will be embedded to /dist):
+# Runtime dependency installed into the packaged app:
 npm install <deps>
 
-# run in /src-electron for deps used by the build system (eg. "electron")
+# Build-time dependency:
 npm install -D <dev-deps>
 <<| bash Bun |>>
-# run in /src-electron for runtime deps (will be embedded to /dist):
+# Runtime dependency installed into the packaged app:
 bun add <deps>
 
-# run in /src-electron for deps used by the build system (eg. "electron")
+# Build-time dependency:
 bun add -D <dev-deps>
 ```
+
+Renderer dependencies imported by code under `/src` belong in the root `package.json` and are bundled by Vite.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/introduction.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/introduction.md
@@ -3,18 +3,18 @@ title: What is Electron
 desc: (@quasar/app-vite) Introduction about the technology behind Quasar desktop apps.
 ---
 
-[Electron](https://electronjs.org/) (formerly known as Atom Shell) is an open-source framework created by Cheng Zhao, and now developed by GitHub. **It allows for the development of desktop GUI applications** using front and back end components originally developed for web applications: Node.js runtime for the backend and Chromium for the frontend. Electron is the main GUI framework behind several notable open-source projects including GitHub's Atom and Microsoft's Visual Studio Code source code editors, the Tidal music streaming service desktop application and the Light Table IDE, in addition to the freeware desktop client for the Discord chat service.
+[Electron](https://www.electronjs.org/) is an open-source framework for building cross-platform desktop applications with JavaScript, HTML, and CSS. It embeds Chromium and Node.js, allowing a Quasar application to combine a web-based interface with native desktop capabilities.
 
-Each Electron app has two threads: one is the main thread (dealing with the App window and bootup), and one is the renderer thread (which is basically your UI web code). There is also a preload script to bridge the two "worlds".
+An Electron application normally uses multiple operating-system processes. The main process manages the application lifecycle and native windows. Each window loads the Quasar UI in a renderer process. A preload script can expose a narrow, controlled API from Electron to the renderer.
 
-## Renderer Thread
+## Renderer Process
 
-Electron uses Chromium for displaying web pages in a separate process called the render process. This thread deals with your UI code in `/src` folder. You won't be able to use the Node.js power here, but the preload script will allow you to bridge the UI with Node.js.
+Electron uses Chromium to display the UI code from `/src` in a renderer process. Quasar's default Electron template keeps Node.js integration disabled and context isolation enabled. Use a preload bridge and IPC when the UI needs a native capability.
 
-## Main Thread
+## Main Process
 
-In Electron, the process that runs package.json’s main script is called the main process. This is the script that runs in the main process and can display a GUI by initializing the renderer thread. This thread deals with your code in `/src-electron/electron-main.js`.
+The main process runs the package's `main` entry, manages the application lifecycle, and creates browser windows. In a Quasar project, its source is `/src-electron/electron-main.js` (or `.ts`).
 
 ## Preload Script
 
-The [preload script](/quasar-cli-vite/developing-electron-apps/electron-preload-script) (`/src-electron/electron-preload.js`) is a way for you to inject Node.js stuff into the renderer thread by using a bridge between it and the UI. You can expose APIs that you can then call from your UI.
+The [preload script](/quasar-cli-vite/developing-electron-apps/electron-preload-script) (`/src-electron/electron-preload.js` or `.ts`) runs before the renderer content. Use Electron's `contextBridge` to expose small, purpose-built APIs to the UI instead of exposing Node.js or Electron APIs directly.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/preparation.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/preparation.md
@@ -6,72 +6,54 @@ scope:
     l: src-electron
     c:
       - l: electron-assets
-        e: Assets that can be referenced from electron files
+        e: Assets that can be referenced from Electron files
         c:
           - l: icons
             e: Icons of your app for all platforms
             c:
               - l: icon.icns
-                e: Icon file for Darwin (MacOS) platform
+                e: Icon file for macOS
               - l: icon.ico
-                e: Icon file for win32 (Windows) platform
+                e: Icon file for Windows
               - l: icon.png
-                e: Tray icon file for all platforms
+                e: PNG icon used by Linux and at runtime
       - l: electron-preload.js
-        e: '(or .ts) Electron preload script (injects Node.js stuff into renderer thread)'
+        e: '(or .ts) Electron preload script (exposes a controlled API to the renderer)'
       - l: electron-main.js
-        e: '(or .ts) Main thread code'
+        e: '(or .ts) Main process code'
       - l: package.json
-        e: 'helps install Electron only deps directly under /src-electron'
+        e: 'Electron-specific dependencies'
 ---
 
-Before we dive in to the actual development, we need to do some preparation work.
+## Add Quasar Electron mode
 
-## Step 1: Add Quasar Electron Mode
-
-In order to develop/build a Quasar Electron app, we need to add the Electron mode to our Quasar project. What this does is that it pnpm/yarn/npm/bun installs some Electron packages and creates `/src-electron` folder.
+Add Electron mode to create `/src-electron` and install its workspace dependencies with your project's package manager:
 
 ```bash
 quasar mode add electron
 ```
 
-Every Electron app has two threads: the main thread (deals with the window and initialization code -- from the newly created folder `/src-electron`) and the renderer thread (which deals with the actual content of your app from `/src`).
+The main process and preload sources live in `/src-electron`; the renderer UI remains in `/src`.
 
 The new folder has the following structure:
 
 <DocTree :def="scope.tree" />
 
-### A note for Windows Users
+### Native dependencies
 
-If you run into errors during npm install about node-gyp, then you most likely do not have the proper build tools installed on your system. Build tools include items like Python and Visual Studio. Fortunately, there are a few packages to help simplify this process.
+Most Electron packages use prebuilt binaries and require no local compiler. A dependency containing a native Node.js addon may need to be rebuilt for Electron's ABI.
 
-The first item we need to check is our npm version and ensure that it is not outdated. This is accomplished using [npm-windows-upgrade](https://github.com/felixrieseberg/npm-windows-upgrade). If you are using yarn, then you can skip this check.
+On Windows, install Python 3 and Visual Studio's **Desktop development with C++** workload if a native dependency must compile. The Node.js installer can install the **Tools for Native Modules** for you. On macOS, install the Xcode Command Line Tools; on Linux, install Python, `make`, and a supported C/C++ compiler. See Electron's [native modules guide](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules/) for rebuilding and troubleshooting native dependencies.
 
-Once that is complete, we can then continue to setup the needed build tools. Using [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools), most of the dirty work is done for us. Installing this globally will in turn setup Visual C++ packages, Python, and more.
+## Start developing
 
-::: warning Note: April 2019
-In Powershell.exe (Run as Admin) `npm install --global windows-build-tools` seems to fail at the moment with errors pointing to python2 and vctools. You can get around this with Chocolatey. One-liner install:
-
-**Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))**
-
-and then run `choco upgrade python2 visualstudio2017-workload-vctools`.
-:::
-
-At this point things should successfully install, but if not then you will need a clean installation of Visual Studio. Please note that these are not problems with Quasar, but they are related to NPM and Windows.
-
-## Step 2: Start Developing
-
-If you want to jump right in and start developing, you can skip the previous step with "quasar mode" command and issue:
+Run:
 
 ```bash
 quasar dev -m electron
 
-# passing extra parameters and/or options to
-# underlying "electron" executable:
-quasar dev -m electron -- --no-sandbox --disable-setuid-sandbox
-# when on Windows and using Powershell:
-quasar dev -m electron '--' --no-sandbox --disable-setuid-sandbox
 ```
 
-This will add Electron mode automatically, if it is missing.
-It will open up an Electron window which will render your app along with Developer Tools opened side by side.
+This also adds Electron mode automatically when it is missing. It opens the application window and, with the default template, the renderer DevTools.
+
+Arguments after `--` are forwarded to the Electron executable. Avoid disabling Chromium's sandbox as a general workaround; doing so removes an important security boundary.

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/troubleshooting-and-tips.md
@@ -1,13 +1,11 @@
 ---
 title: Troubleshooting and Tips
-desc: (@quasar/app-vite) Tips and tricks for a Quasar desktop app with Electron.
+desc: (@quasar/app-vite) Troubleshooting a Quasar desktop app with Electron.
 ---
 
 ## Browser Devtools
 
-You probably want your app to only give access to the browser devtools on dev mode only. On the production version (without debugging enabled) you'll want to disable this behavior.
-
-While we're at it, why not also open devtools by default when we're on dev mode.
+The generated main-process file opens renderer DevTools when `import.meta.env.QUASAR_DEBUG` is true. This includes development and production builds created with `quasar build --debug`.
 
 ```js /src-electron/electron-main
 function createWindow () {
@@ -18,7 +16,7 @@ function createWindow () {
     mainWindow.webContents.openDevTools()
   }
   else {
-    // we're on production; no access to devtools pls
+    // Production build without --debug
     mainWindow.webContents.on('devtools-opened', () => {
       mainWindow.webContents.closeDevTools()
     })
@@ -26,13 +24,31 @@ function createWindow () {
 }
 ```
 
-## Debugging Main Process
+Do not treat hiding DevTools as a security control. Secure the renderer even when a user can inspect or modify its local state.
 
-When running your application in development you may have noticed a message from the main process mentioning a remote debugger. Ever since the release of electron@^1.7.2, remote debugging over the Inspect API was introduced and can be easily accessed by opening the provided link with Google Chrome or through another debugger that can remotely attach to the process using the default port of 5858, such as Visual Studio Code.
+## Debugging the main process
+
+In development, Quasar starts Electron's main process with Node's `--inspect` option. Attach a Node-compatible debugger, such as the Chrome DevTools page at `chrome://inspect` or a JavaScript debugger in your editor.
 
 ```bash
 Debugger listening on ws://127.0.0.1:5858/b285586a-6091-4c41-b6ea-0d389e6f9c93
 For help, see: https://nodejs.org/en/docs/inspector
 ```
 
-The port can vary, based on the quasar.config > electron > inspectPort setting. If the specified port is already occupied, the next closest available port will be used.
+Set the preferred port with `quasar.config > electron > inspectPort`. Quasar uses the closest available port when that port is occupied.
+
+## Native dependency fails to load
+
+An error mentioning `NODE_MODULE_VERSION`, `Module did not self-register`, or a missing `.node` file usually means a native dependency was built for a different Node.js ABI, operating system, or architecture. Install it under `/src-electron`, rebuild it for the Electron version used by the project, and verify that the target architecture is supported. See Electron's [native Node modules guide](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules/).
+
+After upgrading Electron, rebuild native dependencies before diagnosing application code.
+
+## Production build differs from development
+
+Build without packaging to inspect the application that is passed to Packager or Builder:
+
+```bash
+quasar build -m electron --skip-pkg
+```
+
+The result is `/dist/electron/UnPackaged`. Check its generated `package.json`, main and preload output, installed production dependencies, and renderer console. Do not edit this directory directly; fix the source or configuration and rebuild.


### PR DESCRIPTION
## Summary

- audit Electron mode configuration, runtime declarations, command help, and the complete Electron guide
- add the missing `electron.beforePackaging` configuration type
- align `registerQuasarRuntime()` with its synchronous runtime return value
- correct the live-update setup so Quasar runtime IPC handlers are registered before the preload bridge runs
- modernize native dependency, packaging, publishing, preload, filesystem, debugging, and upgrade guidance
- replace outdated security advice with current Electron recommendations and safer IPC examples

## Why

The Electron guide contained obsolete Windows tooling, stale process and packaging descriptions, unsafe or incomplete IPC examples, and configuration documentation that had drifted from the implementation. The public declarations also omitted a supported packaging hook and described a synchronous runtime function as asynchronous.

## Developer impact

Electron users receive current setup and troubleshooting guidance, safer examples, accurate package placement and upgrade commands, and complete TypeScript coverage for the packaging hook. Existing generated template structure remains unchanged.

## Validation

- repository formatting and lint checks passed
- staged-file commit hooks passed
- `git diff --check upstream/dev...HEAD`
- the full declaration project remains affected by pre-existing conflicting Node type packages and unrelated missing third-party declarations
