### PR TITLE
fix(app-vite): align shared configuration API

### DIFF
--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -1205,8 +1205,8 @@ export class QuasarConfigFile {
     cfg.preFetch ||= false
 
     if (
-      this.#ctx.mode.capacitor &
-      (cfg.capacitor.capacitorCliPreparationParams.length === 0)
+      this.#ctx.mode.capacitor &&
+      cfg.capacitor.capacitorCliPreparationParams.length === 0
     ) {
       cfg.capacitor.capacitorCliPreparationParams = [
         'sync',

--- a/app-vite/types/configuration/build.d.ts
+++ b/app-vite/types/configuration/build.d.ts
@@ -138,11 +138,6 @@ interface QuasarStaticBuildConfiguration {
   vueRouterBase?: string;
 
   /**
-   * Automatically open remote Vue Devtools when running in development mode.
-   */
-  vueDevtools?: boolean;
-
-  /**
    * Should the Vue Options API be available? If all your components only use Composition API
    * it would make sense performance-wise to disable Vue Options API for a compile speedup.
    *
@@ -401,7 +396,7 @@ interface QuasarStaticBuildConfiguration {
     file?: string | string[];
     /**
      * Filter the env files variables & Node.js process.env variables
-     * that are exposed to the app code. This does not affects props
+     * that are exposed to the app code. This does not affect properties
      * assigned directly to the quasar.config > build > define prop.
      */
     filter?: (
@@ -410,7 +405,7 @@ interface QuasarStaticBuildConfiguration {
     ) => Record<string, string>;
 
     /**
-     * Ignore auto-infering and declaring type for these variables;
+     * Ignore automatically inferring and declaring types for these variables.
      * Variables can come from process.env (terminal variables) or
      * dotenv files or quasar.config > build > define/defineEnv.
      *

--- a/app-vite/types/configuration/conf.d.ts
+++ b/app-vite/types/configuration/conf.d.ts
@@ -25,6 +25,8 @@ import type { QuasarContext } from "./context.d.ts";
 type DevServerOptions = Omit<ViteServerOptions, "open" | "https"> & {
   open?: Omit<OpenOptions, "wait"> | boolean;
   https?: ViteServerOptions["https"] | boolean;
+  /** Automatically open remote Vue DevTools in development mode. */
+  vueDevtools?: boolean;
 };
 
 /**
@@ -94,11 +96,11 @@ interface BaseQuasarConfiguration {
    */
   animations?: "all" | QuasarAnimations[];
   /**
-   * Vite server [options](https://vitejs.dev/config/#server-options).
+   * Vite server [options](https://vite.dev/config/server-options).
    * Some properties are overwritten based on the Quasar mode you're using in order
    * to ensure a correct config.
-   * Note: if you're proxying the development server (i.e. using a cloud IDE),
-   * set the `public` setting to your public application URL.
+   * If a reverse proxy or cloud IDE changes the public origin, configure
+   * `origin` and the HMR WebSocket options for the externally visible URL.
    *
    * @type options {@link DevServerOptions}
    */

--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -353,7 +353,7 @@ animations?: QuasarAnimationsConfiguration | 'all';
 
 ### devServer
 
-More info: [Vite server options](https://vitejs.dev/config/#server-options)
+More info: [Vite server options](https://vite.dev/config/server-options)
 
 ```ts
 import { ServerOptions as ViteServerOptions } from "vite";
@@ -361,21 +361,22 @@ import { Options as OpenOptions } from "open";
 type DevServerOptions = Omit<ViteServerOptions, "open" | "https"> & {
   open?: Omit<OpenOptions, "wait"> | boolean;
   https?: ViteServerOptions["https"] | boolean;
+  vueDevtools?: boolean;
 };
 
 /**
- * Vite "server" options.
+ * Vite server options.
  * Some properties are overwritten based on the Quasar mode you're using in order
  * to ensure a correct config.
- * Note: if you're proxying the development server (i.e. using a cloud IDE),
- * set the `public` setting to your public application URL.
+ * If a reverse proxy or cloud IDE changes the public origin, configure
+ * `origin` and the HMR WebSocket options for the externally visible URL.
  */
 devServer?: DevServerOptions;
 ```
 
 Apart from these options, Quasar CLI tampers with some and you will experience them differently than on a Vite app:
 
-Using `open` prop to open with a specific browser and not with the default browser of your OS (check [supported values](https://github.com/sindresorhus/open#options)). The `options` param described in previous link is what you should configure quasar.config file > devSever > open with. Some examples:
+Use the `open` property to select a browser instead of using the operating system default (see the [`open` options](https://github.com/sindresorhus/open#options)). Configure those options under `quasar.config > devServer > open`. For example:
 
 ```js /quasar.config file
 // opens Google Chrome
@@ -408,7 +409,7 @@ devServer: {
 }
 ```
 
-You can also configure automatically opening remote Vue Devtools:
+You can also open remote Vue DevTools automatically:
 
 ```js /quasar.config file
 devServer: {
@@ -547,11 +548,6 @@ interface QuasarStaticBuildConfiguration {
    * Should not need to configure this, unless absolutely needed.
    */
   vueRouterBase?: string
-
-  /**
-   * Automatically open remote Vue Devtools when running in development mode.
-   */
-  vueDevtools?: boolean
 
   /**
    * Should the Vue Options API be available? If all your components only use Composition API
@@ -804,7 +800,7 @@ interface QuasarStaticBuildConfiguration {
     file?: string | string[]
     /**
      * Filter the env files variables & Node.js process.env variables
-     * that are exposed to the app code. This does not affects props
+     * that are exposed to the app code. This does not affect properties
      * assigned directly to the quasar.config > build > define prop.
      */
     filter?: (
@@ -917,7 +913,7 @@ interface QuasarDynamicBuildConfiguration {
 
 See these references for more info:
 
-- [Vite server options](https://vitejs.dev/config/#server-options)
+- [Vite server options](https://vite.dev/config/server-options)
 - [Vite Vue Plugin options](/quasar-cli-vite/handling-vite#vite-vue-plugin-options)
 - [Adding Vite plugins](/quasar-cli-vite/handling-vite#adding-vite-plugins)
 - [Folder Aliases](/quasar-cli-vite/handling-vite#folder-aliases)


### PR DESCRIPTION
## Summary

- move `vueDevtools` to the public `devServer` type, matching runtime behavior and existing usage docs
- replace obsolete `devServer.public` guidance with current Vite origin and HMR guidance
- update Vite server documentation links and clarify the custom browser-open option
- replace a bitwise Capacitor configuration condition with logical short-circuiting
- correct nearby environment-option wording

## Root cause

A configuration type refactor placed `vueDevtools` under `build` even though Quasar reads it from `devServer`. The server documentation also retained a `public` option from older tooling that is not part of the current Vite server API.

## Developer impact

TypeScript users can configure the documented `devServer.vueDevtools` option without a type error, and reverse-proxy guidance now points to supported Vite options.

## Validation

- repository formatting and lint checks passed
- staged-file commit hooks passed
- `git diff --check upstream/dev...HEAD`
