### PR TITLE
fix(app-vite): align lifecycle hook types

### DIFF
--- a/app-vite/lib/cmd/build.js
+++ b/app-vite/lib/cmd/build.js
@@ -185,7 +185,7 @@ appBuilder
       await quasarConf.build.afterBuild({ quasarConf })
     }
 
-    // run possible beforeBuild hooks
+    // run possible afterBuild hooks
     await ctx.appExt.runAppExtensionHook('afterBuild', async hook => {
       hook.api.logger.log(`Running afterBuild hook...`)
       await hook.fn(hook.api, { quasarConf })

--- a/app-vite/types/app-extension.d.ts
+++ b/app-vite/types/app-extension.d.ts
@@ -5,6 +5,8 @@ import type { RolldownOptions } from "rolldown";
 import type { QuasarAppPathsResolve } from "./app-paths.d.ts";
 import type {
   QuasarConf,
+  QuasarHookParams,
+  QuasarPublishParams,
   ResolvedQuasarConfValue
 } from "./configuration/conf.d.ts";
 import type { QuasarContext } from "./configuration/context.d.ts";
@@ -490,7 +492,7 @@ export interface IndexAPI extends BaseAPI, SharedIndexInstallAPI {
    * @param payload The payload containing the Quasar configuration object
    */
   readonly beforeDev: Callback<
-    (api: IndexAPI, payload: { quasarConf: QuasarConf }) => Promise<void> | void
+    (api: IndexAPI, payload: QuasarHookParams) => Promise<void> | void
   >;
   /**
    * Register a callback to be called after the "quasar dev" command.
@@ -499,7 +501,7 @@ export interface IndexAPI extends BaseAPI, SharedIndexInstallAPI {
    * @param payload The payload containing the Quasar configuration object
    */
   readonly afterDev: Callback<
-    (api: IndexAPI, payload: { quasarConf: QuasarConf }) => Promise<void> | void
+    (api: IndexAPI, payload: QuasarHookParams) => Promise<void> | void
   >;
   /**
    * Run hook before Quasar builds app for production ("quasar build").
@@ -509,7 +511,7 @@ export interface IndexAPI extends BaseAPI, SharedIndexInstallAPI {
    *   (api, { quasarConf }) => ?Promise
    */
   readonly beforeBuild: Callback<
-    (api: IndexAPI, payload: { quasarConf: QuasarConf }) => Promise<void> | void
+    (api: IndexAPI, payload: QuasarHookParams) => Promise<void> | void
   >;
   /**
    * Register a callback to be called after the "quasar build" command.
@@ -518,7 +520,7 @@ export interface IndexAPI extends BaseAPI, SharedIndexInstallAPI {
    * @param payload The payload containing the Quasar configuration object
    */
   readonly afterBuild: Callback<
-    (api: IndexAPI, payload: { quasarConf: QuasarConf }) => Promise<void> | void
+    (api: IndexAPI, payload: QuasarHookParams) => Promise<void> | void
   >;
   /**
    * Run hook if publishing was requested ("quasar build -P"),
@@ -532,10 +534,7 @@ export interface IndexAPI extends BaseAPI, SharedIndexInstallAPI {
    *      * distDir - folder where distributables were built
    */
   readonly onPublish: Callback<
-    (
-      api: IndexAPI,
-      opts: { arg: string; distDir: string }
-    ) => Promise<void> | void
+    (api: IndexAPI, opts: QuasarPublishParams) => Promise<void> | void
   >;
 }
 

--- a/app-vite/types/configuration/build.d.ts
+++ b/app-vite/types/configuration/build.d.ts
@@ -1,7 +1,7 @@
 import { Plugin, UserConfig as ViteUserConfig } from "vite";
 import { Options as VuePluginOptions } from "@vitejs/plugin-vue";
 import { CompilerOptions, TypeAcquisition } from "typescript";
-import { QuasarHookParams } from "./conf";
+import { QuasarHookParams, QuasarPublishParams } from "./conf";
 import type { Options as VueRouterVitePluginOptions } from "vue-router/dist/unplugin/options.d.mts";
 
 interface HtmlMinifierOptions {
@@ -458,7 +458,7 @@ interface QuasarStaticBuildConfiguration {
    *
    * @param params {@link QuasarHookParams}
    */
-  beforeDev?: (params: QuasarHookParams) => void;
+  beforeDev?: (params: QuasarHookParams) => void | Promise<void>;
   /**
    * Run hook after Quasar dev server is started (`quasar dev`).
    * At this point, the dev server has been started and is available should you wish to do something with it.
@@ -466,7 +466,7 @@ interface QuasarStaticBuildConfiguration {
    *
    * @param params {@link QuasarHookParams}
    */
-  afterDev?: (params: QuasarHookParams) => void;
+  afterDev?: (params: QuasarHookParams) => void | Promise<void>;
   /**
    * Run hook before Quasar builds app for production (`quasar build`).
    * At this point, the distributables folder hasn’t been created yet.
@@ -474,7 +474,7 @@ interface QuasarStaticBuildConfiguration {
    *
    * @param params {@link QuasarHookParams}
    */
-  beforeBuild?: (params: QuasarHookParams) => void;
+  beforeBuild?: (params: QuasarHookParams) => void | Promise<void>;
   /**
    * Run hook after Quasar built app for production (`quasar build`).
    * At this point, the distributables folder has been created and is available
@@ -483,15 +483,15 @@ interface QuasarStaticBuildConfiguration {
    *
    * @param params {@link QuasarHookParams}
    */
-  afterBuild?: (params: QuasarHookParams) => void;
+  afterBuild?: (params: QuasarHookParams) => void | Promise<void>;
   /**
    * Run hook if publishing was requested (`quasar build -P`),
    *  after Quasar built app for production and the afterBuild hook (if specified) was executed.
    * Can use async/await or directly return a Promise.
-   * `opts` is Object of form `{arg, distDir}`,
-   * where “arg” is the argument supplied (if any) to -P parameter.
+   *
+   * @param params {@link QuasarPublishParams}
    */
-  onPublish?: (ops: { arg: string; distDir: string }) => void;
+  onPublish?: (params: QuasarPublishParams) => void | Promise<void>;
 }
 
 /**

--- a/app-vite/types/configuration/conf.d.ts
+++ b/app-vite/types/configuration/conf.d.ts
@@ -119,6 +119,13 @@ export interface QuasarHookParams {
   quasarConf: QuasarConf;
 }
 
+export interface QuasarPublishParams extends QuasarHookParams {
+  /** Argument supplied to the `--publish`/`-P` parameter. */
+  arg: string;
+  /** Folder where the distributables were built. */
+  distDir: string;
+}
+
 export interface QuasarConf
   extends BaseQuasarConfiguration, QuasarMobileConfiguration {
   /**

--- a/docs/src/pages/quasar-cli-vite/quasar-config-file.md
+++ b/docs/src/pages/quasar-cli-vite/quasar-config-file.md
@@ -422,7 +422,7 @@ devServer: {
 import { Plugin, UserConfig as ViteUserConfig } from 'vite'
 import { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import { CompilerOptions, TypeAcquisition } from 'typescript'
-import { QuasarHookParams } from './conf'
+import { QuasarHookParams, QuasarPublishParams } from './conf'
 import type { Options as VueRouterVitePluginOptions } from 'vue-router/dist/unplugin/options.d.mts'
 
 interface HtmlMinifierOptions {
@@ -845,34 +845,34 @@ interface QuasarStaticBuildConfiguration {
    * like starting some backend or any other service that the app relies on.
    * Can use async/await or directly return a Promise.
    */
-  beforeDev?: (params: QuasarHookParams) => void
+  beforeDev?: (params: QuasarHookParams) => void | Promise<void>
   /**
    * Run hook after Quasar dev server is started (`quasar dev`).
    * At this point, the dev server has been started and is available should you wish to do something with it.
    * Can use async/await or directly return a Promise.
    */
-  afterDev?: (params: QuasarHookParams) => void
+  afterDev?: (params: QuasarHookParams) => void | Promise<void>
   /**
    * Run hook before Quasar builds app for production (`quasar build`).
    * At this point, the distributables folder hasn’t been created yet.
    * Can use async/await or directly return a Promise.
    */
-  beforeBuild?: (params: QuasarHookParams) => void
+  beforeBuild?: (params: QuasarHookParams) => void | Promise<void>
   /**
    * Run hook after Quasar built app for production (`quasar build`).
    * At this point, the distributables folder has been created and is available
    *  should you wish to do something with it.
    * Can use async/await or directly return a Promise.
    */
-  afterBuild?: (params: QuasarHookParams) => void
+  afterBuild?: (params: QuasarHookParams) => void | Promise<void>
   /**
    * Run hook if publishing was requested (`quasar build -P`),
    *  after Quasar built app for production and the afterBuild hook (if specified) was executed.
    * Can use async/await or directly return a Promise.
-   * `opts` is Object of form `{arg, distDir}`,
-   * where “arg” is the argument supplied (if any) to -P parameter.
+   *
+   * @param params {@link QuasarPublishParams}
    */
-  onPublish?: (ops: { arg: string; distDir: string }) => void
+  onPublish?: (params: QuasarPublishParams) => void | Promise<void>
 }
 
 /**


### PR DESCRIPTION
## What changed

- align project and App Extension lifecycle-hook declarations with their awaited runtime behavior
- add a shared publish payload type that includes `arg`, `distDir`, and the runtime-provided `quasarConf`
- update the mirrored `quasar.config` API reference
- correct the mislabeled `afterBuild` runtime comment

## Why

The CLI awaits all five lifecycle hooks, but the project configuration declarations exposed only `void` return types. The `onPublish` declarations also omitted `quasarConf`, even though the runtime supplies it and the App Extension JSDoc documents it. This caused the public API types and reference documentation to drift from actual behavior.

There is no change to hook execution order or runtime behavior.

## Validation

- `git diff --check`
- focused `oxfmt --check`
- focused `oxlint`
- repository pre-commit formatting and lint checks

A full declaration compile remains blocked by pre-existing dependency declaration conflicts in this checkout (including simultaneous Node 22 and Node 26 types); none of those diagnostics reference this change.