### PR TITLE
fix(cli): harden package upgrades

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 # Quasar Framework CLI (Global)
 
-> Build high-performance VueJS user interfaces in record time: responsive Single Page Apps, SSR Apps, PWAs, Browser extensions, Hybrid Mobile Apps and Electron Apps. If you want, all using the same codebase!
+> Build high-performance Vue.js user interfaces in record time: responsive Single Page Apps, SSR Apps, PWAs, browser extensions, hybrid mobile apps and Electron apps. If you want, all using the same codebase!
 
 <img src="https://img.shields.io/npm/v/%40quasar/cli.svg?label=@quasar/cli">
 

--- a/cli/lib/cmd/create.js
+++ b/cli/lib/cmd/create.js
@@ -3,7 +3,7 @@ console.log(`
 
    npm init quasar@latest
      (or)
-   yarn create quasar@latest
+   yarn create quasar
      (or)
    pnpm create quasar@latest
      (or)

--- a/cli/lib/cmd/create.js
+++ b/cli/lib/cmd/create.js
@@ -1,13 +1,13 @@
 console.log(`
  · For scaffolding an official Quasar project please use this instead:
 
-   npm init quasar
+   npm init quasar@latest
      (or)
-   yarn create quasar
+   yarn create quasar@latest
      (or)
-   pnpm create quasar
+   pnpm create quasar@latest
      (or)
-   bun create quasar
+   bun create quasar@latest
 
  · For scaffolding a custom starter kit please use this instead:
 

--- a/cli/lib/cmd/upgrade.js
+++ b/cli/lib/cmd/upgrade.js
@@ -112,7 +112,13 @@ const getVersionTask = async (
       `${green(packageName)}: ${currentVersionLabel} → ${red('Skipping!')}` +
       ` - NPM registry returned an error`
     )
-  } else if (currentVersion !== latestVersion) {
+  }
+
+  if (packageName === 'quasar') {
+    quasarVersion = latestVersion
+  }
+
+  if (currentVersion !== latestVersion) {
     depsTarget.push({
       packageName,
       latestVersion
@@ -120,10 +126,6 @@ const getVersionTask = async (
 
     updateAvailable = true
     return `${green(packageName)}: ${currentVersionLabel} → ${green(latestVersion)}`
-  }
-
-  if (packageName === 'quasar') {
-    quasarVersion = latestVersion
   }
 
   return `${green(packageName)}: ${currentVersionLabel} ✅ `
@@ -179,7 +181,7 @@ if (!updateAvailable) {
 function getQuasarVersionPrefix(version) {
   if (!version) return ''
 
-  const matches = version.match(/^(\d)/)
+  const matches = version.match(/^(\d+)/)
   if (!matches || !matches[1]) return ''
 
   const major = Number.parseInt(matches[1], 10)
@@ -228,8 +230,8 @@ if (!argv.install) {
 
       if (packageList.length !== initialValues.length) {
         Object.keys(deps).forEach(type => {
-          deps[type] = deps[type].filter(
-            dep => !packageList.includes(dep.packageName)
+          deps[type] = deps[type].filter(dep =>
+            packageList.includes(dep.packageName)
           )
         })
       }

--- a/cli/lib/get-argv.js
+++ b/cli/lib/get-argv.js
@@ -18,7 +18,7 @@ export function getArgv(options, { strict = true } = {}) {
       // Should be handled if (argv.help) in the caller
       __warn() {
         warn(
-          err?.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+          err instanceof Error
             ? err.message
             : 'Unknown error while parsing arguments'
         )

--- a/cli/lib/node-packager.js
+++ b/cli/lib/node-packager.js
@@ -11,7 +11,7 @@ const versionRegex = /^(\d+)\.[\d]+\.[\d]+-?(alpha|beta|rc)?/
 
 function getNpmRegistryUrl() {
   try {
-    const url = execSync('npm config get registry')
+    const url = String(execSync('npm config get registry')).trim()
     if (url) {
       return url.endsWith('/') ? url : url + '/'
     }
@@ -21,33 +21,18 @@ function getNpmRegistryUrl() {
 }
 
 async function getPackageVersionList(packageName, npmRegistryUrl) {
-  const https = await import('node:https')
-  const url = `${npmRegistryUrl}${packageName}`
+  try {
+    const url = new URL(encodeURIComponent(packageName), npmRegistryUrl)
+    const response = await fetch(url)
+    if (!response.ok) return null
 
-  return new Promise(resolve => {
-    https.get(url, async response => {
-      let data = ''
+    const json = await response.json()
+    const versionList = Object.keys(json.versions || {})
 
-      try {
-        for await (const chunk of response) {
-          data += chunk
-        }
-      } catch {
-        resolve(null)
-        return
-      }
-
-      try {
-        const json = JSON.parse(data)
-        const versionList = Object.keys(json.versions)
-
-        resolve(versionList.length !== 0 ? versionList : null)
-      } catch {
-        // oxlint-disable-next-line promise/no-multiple-resolved
-        resolve(null)
-      }
-    })
-  })
+    return versionList.length !== 0 ? versionList : null
+  } catch {
+    return null
+  }
 }
 
 // returns a Promise!
@@ -161,7 +146,7 @@ class PackageManager {
 
   async getPackageLatestVersion({
     packageName,
-    npmRegistryUrl = this.#npmRegistryUrl,
+    npmRegistryUrl = this.npmRegistryUrl,
     currentVersion = null,
     majorVersion = false,
     preReleaseVersion = false
@@ -176,7 +161,10 @@ class PackageManager {
       return versionList.at(-1)
     }
 
-    const [, major, prerelease] = currentVersion.match(versionRegex)
+    const versionMatch = currentVersion.match(versionRegex)
+    if (versionMatch === null) return null
+
+    const [, major, prerelease] = versionMatch
     const majorSyntax = majorVersion ? String.raw`(\d+)` : major
     const regex = new RegExp(
       prerelease || preReleaseVersion

--- a/docs/src/pages/start/quick-start.md
+++ b/docs/src/pages/start/quick-start.md
@@ -11,7 +11,7 @@ If you are a more advanced Vue developer, we invite you to start off by [decidin
 
 ## Prerequisites
 
-Make sure that you have Node.js >=22 (or any newer **LTS Node.js version**) and PNPM v11+ or Yarn v1 classic or or NPM or Bun installed on your machine. Again, please do not use non LTS versions of Node.js.
+Make sure that you have Node.js >=22 (or any newer **LTS Node.js version**) and PNPM v11+, Yarn v1 classic, NPM or Bun installed on your machine. Again, please do not use non-LTS versions of Node.js.
 
 ## Step 1: Create a Project
 


### PR DESCRIPTION
## Summary

- fix configured npm registry detection and make registry requests robust
- upgrade only the packages selected in the interactive prompt
- improve upgrade version handling, release-note links, and CLI parse errors
- refresh project-creation commands and small CLI documentation drift

## Details

The global CLI previously called `.endsWith()` on the `Buffer` returned by `execSync('npm config get registry')`. That threw and was silently caught, so `quasar upgrade` ignored the user's configured npm registry and fell back to npmjs unless `--registry` was supplied explicitly.

Registry lookup now normalizes the command output and uses the Node.js Fetch API. This supports HTTP and HTTPS registries, redirects, response status checks, scoped package encoding, and graceful network or JSON failures.

The interactive upgrade filter was also inverted. When a user deselected some available updates, the CLI retained and installed the deselected packages instead of the selected packages. The filter now preserves only the user's selection.

Additional corrections:

- malformed installed versions return a registry-check failure instead of crashing version parsing
- registry lookup initializes correctly even if the getter was not read first
- Quasar's target major is retained when an update is available, producing the version-specific release-notes link
- release-note prefixes support multi-digit major versions
- missing CLI option values report the actual parser error
- `quasar create` recommends the `@latest` scaffolding commands
- minor CLI README and Quick Start wording drift is corrected

## Validation

- exercised `quasar upgrade` end to end from a synthetic Quasar project against a local HTTP registry
- verified npm-configured custom registry detection
- verified scoped package URL encoding and compatible/major version selection
- verified version-specific release-note guidance
- verified missing option-value error reporting
- verified symlinked workspace and ESM local CLI dispatch
- verified legacy CommonJS local CLI dispatch
- ran Oxfmt, Oxlint, Node syntax checks, and `git diff --check`
