### PR TITLE
fix(app-vite): resolve App Extension assets from their package

### DIFF
--- a/app-vite/lib/app-extension/AppExtensionInstance.js
+++ b/app-vite/lib/app-extension/AppExtensionInstance.js
@@ -1,5 +1,5 @@
-import { relative, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { closeSync, openSync, readSync } from 'node:fs'
 import fse from 'fs-extra'
 
@@ -290,7 +290,8 @@ export class AppExtensionInstance {
       {
         ctx: this.#ctx,
         extId: this.extId,
-        prompts: this.getPrompts()
+        prompts: this.getPrompts(),
+        packageDir: dirname(fileURLToPath(this.#packageParentUrl))
       },
       this.#appExtJson
     )

--- a/app-vite/lib/app-extension/api-classes/IndexAPI.js
+++ b/app-vite/lib/app-extension/api-classes/IndexAPI.js
@@ -11,10 +11,13 @@ import { BaseAPI } from './BaseAPI.js'
 export class IndexAPI extends BaseAPI {
   prompts
 
+  #packageDir
+
   constructor(opts, appExtJson) {
     super(opts)
 
     this.prompts = opts.prompts
+    this.#packageDir = opts.packageDir
     this.#appExtJson = appExtJson
   }
 
@@ -316,6 +319,6 @@ export class IndexAPI extends BaseAPI {
   }
 
   #addHook(name, fn) {
-    this.#hooks[name].push({ fn, api: this })
+    this.#hooks[name].push({ fn, api: this, packageDir: this.#packageDir })
   }
 }

--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -11,6 +11,7 @@ import { error, fatal, log, tip, warn } from './utils/logger.js'
 import { appFilesValidations } from './utils/app-files-validations.js'
 import { getPackageMajorVersion } from './utils/get-package-major-version.js'
 import { resolveExtension } from './utils/resolve-extension.js'
+import { getPackagePath } from './utils/get-package-path.js'
 import { ensureElectronArgv } from './utils/ensure-argv.js'
 import { quasarRolldownVueShimPlugin } from './plugins/rolldown.vue-shim.js'
 import {
@@ -120,6 +121,66 @@ function parseAssetProperty(prefix) {
             : `${prefix}/${asset.path}`
           : asset.path
     }
+  }
+}
+
+const appExtensionAssetPaths = [['css'], ['boot'], ['ssr', 'middlewares']]
+
+function getAssetList(cfg, path) {
+  return path.reduce((value, key) => value?.[key], cfg)
+}
+
+function getTildeAssetPath(asset) {
+  const path = typeof asset === 'string' ? asset : asset?.path
+  return typeof path === 'string' && path[0] === '~' ? path : void 0
+}
+
+function getTildeAssetCounts(cfg) {
+  const assetCounts = new Map()
+
+  for (const path of appExtensionAssetPaths) {
+    const list = getAssetList(cfg, path)
+    if (!Array.isArray(list)) continue
+
+    const counts = new Map()
+    assetCounts.set(path, counts)
+
+    for (const asset of list) {
+      const assetPath = getTildeAssetPath(asset)
+      if (assetPath !== void 0) {
+        counts.set(assetPath, (counts.get(assetPath) || 0) + 1)
+      }
+    }
+  }
+
+  return assetCounts
+}
+
+function resolveAppExtensionAssets(cfg, previousAssetCounts, packageDir) {
+  for (const path of appExtensionAssetPaths) {
+    const list = getAssetList(cfg, path)
+    if (!Array.isArray(list)) continue
+
+    const previousCounts = previousAssetCounts.get(path) || new Map()
+
+    list.forEach((asset, index) => {
+      const assetPath = getTildeAssetPath(asset)
+      if (assetPath === void 0) return
+
+      const previousCount = previousCounts.get(assetPath) || 0
+      if (previousCount !== 0) {
+        previousCounts.set(assetPath, previousCount - 1)
+        return
+      }
+
+      const resolvedPath = getPackagePath(assetPath.slice(1), packageDir)
+      if (resolvedPath === void 0) return
+
+      list[index] =
+        typeof asset === 'string'
+          ? `~${resolvedPath}`
+          : { ...asset, path: `~${resolvedPath}` }
+    })
   }
 }
 
@@ -786,10 +847,16 @@ export class QuasarConfigFile {
         'extendQuasarConf',
         async hook => {
           hook.api.logger.log('Extending quasar.config file configuration...')
+          const tildeAssetCounts = getTildeAssetCounts(rawQuasarConf)
           const overrides = await hook.fn(rawQuasarConf, hook.api)
           if (Object(overrides) === overrides) {
             rawQuasarConf = merge(rawQuasarConf, overrides)
           }
+          resolveAppExtensionAssets(
+            rawQuasarConf,
+            tildeAssetCounts,
+            hook.packageDir
+          )
         }
       )
     } catch (err) {


### PR DESCRIPTION
## Summary

- resolve assets added by an App Extension relative to that extension's installed package
- preserve the existing resolution behavior for assets declared by the host application
- support extension-provided `css`, `boot`, and `ssr.middlewares` entries, including string and object forms

## Why

This was found through [quasar-ui-qmarkdown#412](https://github.com/quasarframework/quasar-ui-qmarkdown/issues/412). QMarkdown's App Extension declared its stylesheet using:

```js
css: ['~@quasar/quasar-ui-qmarkdown/src/index.scss']
```

The App Extension depends on the UI package, but under an isolated pnpm layout that transitive dependency is not visible from the host application's generated entry file. Quasar currently strips the `~` and leaves Vite to resolve the resulting bare import from the host application, so the build fails even though the dependency is correctly installed beneath the App Extension.

QMarkdown 3.0.1 contains a local workaround that imports the stylesheet from its extension-owned boot file. That fixes the immediate user report, but each affected App Extension would otherwise need the same workaround.

This change addresses the underlying behavior in Quasar. Each `extendQuasarConf` hook retains the directory of the App Extension that registered it. New `~` assets contributed by that hook are resolved from that package context before Quasar generates its entry files. Existing host-application entries are left alone, and Quasar does not search unrelated App Extensions for a matching dependency.

## Validation

- Packed the modified `@quasar/app-vite`.
- Installed it in an isolated pnpm application.
- Used QMarkdown 3.0.0 with its original `css: ['~@quasar/quasar-ui-qmarkdown/src/index.scss']` declaration.
- Confirmed both the transitive stylesheet and App Extension boot file resolved inside the extension's pnpm dependency tree.
- Completed a production SPA build successfully.
- Oxlint passed.
- `git diff --check` passed.
- The repository's commit-time formatting and lint checks passed.
