### PR TITLE
fix(ui): align runtime public surface behavior

### DIFF
--- a/docs/src/pages/vue-composables/use-interval.md
+++ b/docs/src/pages/vue-composables/use-interval.md
@@ -24,7 +24,7 @@ setup () {
 
 ```js
 function useInterval(): {
-  registerInterval(fn: () => void, interval: string | number): void;
+  registerInterval(fn: () => void, interval?: string | number): void;
   removeInterval(): void;
 };
 ```

--- a/docs/src/pages/vue-composables/use-render-cache.md
+++ b/docs/src/pages/vue-composables/use-render-cache.md
@@ -33,7 +33,10 @@ setup () {
 
 ```ts
 function useRenderCache(): {
-  getCache: <T = any>(key: string, defaultValue?: T | (() => T)) => T
+  getCache: {
+    <T>(key: string, defaultValue: T | (() => T)): T
+    <T = any>(key: string): T | undefined
+  }
   setCache: <T = any>(key: string, value: T) => void
   hasCache: (key: string) => boolean
   clearCache: (key?: string) => void
@@ -68,9 +71,7 @@ export default {
       return acc
     }
 
-    return () => {
-      h('div', getContent)
-    }
+    return () => h('div', getContent())
   }
 }
 ```

--- a/docs/src/pages/vue-composables/use-split-attrs.md
+++ b/docs/src/pages/vue-composables/use-split-attrs.md
@@ -26,8 +26,13 @@ setup () {
 import { Ref } from 'vue'
 
 function useSplitAttrs(): {
-  attributes: Ref<Record<string, string | null | undefined>>;
-  listeners: Ref<Record<string, (...args: any[]) => any>>;
+  attributes: Ref<Record<string, unknown>>;
+  listeners: Ref<
+    Record<
+      string,
+      ((...args: any[]) => any) | ((...args: any[]) => any)[]
+    >
+  >;
 };
 ```
 

--- a/docs/src/pages/vue-directives/touch-repeat.md
+++ b/docs/src/pages/vue-directives/touch-repeat.md
@@ -50,7 +50,7 @@ When you want to handle key events too, use [keycodes](https://keycode.info/) as
 <div v-touch-repeat.65.70="myHandler">...</div>
 ```
 
-There are some special modifiers that you do not require to write the equivalent keycode: `space`, `tab`, `enter`.
+For common keys, you can use the named modifiers `esc`, `tab`, `enter`, `space`, `up`, `left`, `right`, `down`, and `delete` instead of writing their keycodes. The `delete` modifier handles both Backspace and Delete.
 
 ### Inhibiting TouchRepeat
 

--- a/ui/src/components/scroll-area/QScrollArea.js
+++ b/ui/src/components/scroll-area/QScrollArea.js
@@ -62,11 +62,11 @@ export default createComponent({
 
     verticalOffset: {
       type: Array,
-      default: [0, 0]
+      default: () => [0, 0]
     },
     horizontalOffset: {
       type: Array,
-      default: [0, 0]
+      default: () => [0, 0]
     },
 
     contentStyle: [Array, String, Object],

--- a/ui/src/composables/use-render-cache/use-render-cache.js
+++ b/ui/src/composables/use-render-cache/use-render-cache.js
@@ -1,17 +1,22 @@
 export default function useRenderCache() {
+  if (__QUASAR_SSR_SERVER__) {
+    return {
+      getCache: (_, defaultValue) =>
+        typeof defaultValue === 'function' ? defaultValue() : defaultValue,
+      setCache() {},
+      hasCache: () => false,
+      clearCache() {}
+    }
+  }
+
   let cache = Object.create(null)
 
   return {
-    getCache: __QUASAR_SSR_SERVER__
-      ? (_, defaultValue) =>
-          typeof defaultValue === 'function' ? defaultValue() : defaultValue
-      : (key, defaultValue) =>
-          cache[key] === void 0
-            ? (cache[key] =
-                typeof defaultValue === 'function'
-                  ? defaultValue()
-                  : defaultValue)
-            : cache[key],
+    getCache: (key, defaultValue) =>
+      Object.hasOwn(cache, key)
+        ? cache[key]
+        : (cache[key] =
+            typeof defaultValue === 'function' ? defaultValue() : defaultValue),
 
     setCache(key, obj) {
       cache[key] = obj

--- a/ui/src/directives/touch-repeat/TouchRepeat.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.js
@@ -49,7 +49,9 @@ export default createDirective(
                 ? keyCodes[key.toLowerCase()]
                 : parsedKey
 
-              if (keyCode >= 0) acc.push(keyCode)
+              if (keyCode !== void 0) {
+                acc.push(...[keyCode].flat())
+              }
             }
             return acc
           }, [])

--- a/ui/src/plugins/cookies/Cookies.js
+++ b/ui/src/plugins/cookies/Cookies.js
@@ -20,7 +20,11 @@ function read(string) {
   // Replace server-side written pluses with spaces.
   // If we can't decode the cookie, ignore it, it's unusable.
   // If we can't parse the cookie, ignore it, it's unusable.
-  string = decodeURIComponent(string.replaceAll('+', ' '))
+  try {
+    string = decodeURIComponent(string.replaceAll('+', ' '))
+  } catch {
+    return
+  }
 
   try {
     const parsed = JSON.parse(string)
@@ -56,7 +60,12 @@ function parseExpireToSeconds(str) {
     totalSeconds += value * numberUnitMultiplierMap[unit]
   }
 
-  return hasMatch ? totalSeconds : void 0
+  if (hasMatch) return totalSeconds
+
+  const timestamp = Date.parse(str)
+  return Number.isNaN(timestamp)
+    ? void 0
+    : Math.round((timestamp - Date.now()) / 1000)
 }
 
 // oxlint-disable-next-line default-param-last
@@ -69,9 +78,12 @@ function set(key, val, opts = {}, ssr) {
     if (Number.isFinite(opts.expires)) {
       maxAge = Math.round(opts.expires * 86_400) // 86400 seconds in a day
     } else if (opts.expires instanceof Date) {
-      maxAge = Math.round((opts.expires.getTime() - Date.now()) / 1000)
+      const timestamp = opts.expires.getTime()
+      if (Number.isFinite(timestamp)) {
+        maxAge = Math.round((timestamp - Date.now()) / 1000)
+      }
     }
-    // String check (eg. "15m", "1h" -> must return seconds)
+    // String check (eg. "15m", "1h", or a date string)
     else if (typeof opts.expires === 'string') {
       maxAge = parseExpireToSeconds(opts.expires)
     }
@@ -104,13 +116,11 @@ function set(key, val, opts = {}, ssr) {
     let all = ssr.req.headers.cookie || ''
 
     if (maxAge !== void 0 && isDeletion) {
-      const localVal = get(key, ssr)
-      if (localVal !== void 0) {
-        all = all
-          .replace(`${key}=${localVal}; `, '')
-          .replace(`; ${key}=${localVal}`, '')
-          .replace(`${key}=${localVal}`, '')
-      }
+      const encodedKey = encodeURIComponent(key)
+      all = all
+        .split('; ')
+        .filter(entry => entry.split('=', 1)[0] !== encodedKey)
+        .join('; ')
     } else {
       all = all ? `${keyValue}; ${all}` : keyValue
     }
@@ -135,13 +145,19 @@ function get(key, ssr) {
 
   for (; i < l; i++) {
     parts = cookies[i].split('=')
-    name = decodeURIComponent(parts.shift())
+
+    try {
+      name = decodeURIComponent(parts.shift())
+    } catch {
+      continue
+    }
+
     cookie = parts.join('=')
 
     if (!key) {
       result[name] = cookie
     } else if (key === name) {
-      result = read(cookie)
+      result = read(cookie) ?? null
       break
     }
   }

--- a/ui/types/composables.d.ts
+++ b/ui/types/composables.d.ts
@@ -5,7 +5,7 @@ import { QVueGlobals } from "./globals";
 
 interface useDialogPluginComponent {
   <T = any>(): {
-    dialogRef: Ref<QDialog | undefined>;
+    dialogRef: Ref<QDialog | null>;
     onDialogHide: () => void;
     onDialogOK: (payload?: T) => void;
     onDialogCancel: () => void;
@@ -32,7 +32,7 @@ export function useHydration(): {
 };
 
 export function useInterval(): {
-  registerInterval: (fn: () => void, interval: string | number) => void;
+  registerInterval: (fn: () => void, interval?: string | number) => void;
   removeInterval: () => void;
 };
 
@@ -46,15 +46,20 @@ export function useMeta(options: MetaOptions | (() => MetaOptions)): void;
 export function useQuasar(): QVueGlobals;
 
 export function useRenderCache(): {
-  getCache: <T = any>(key: string, defaultValue?: T | (() => T)) => T;
+  getCache: {
+    <T>(key: string, defaultValue: T | (() => T)): T;
+    <T = any>(key: string): T | undefined;
+  };
   setCache: <T = any>(key: string, value: T) => void;
   hasCache: (key: string) => boolean;
   clearCache: (key?: string) => void;
 };
 
 export function useSplitAttrs(): {
-  attributes: Ref<Record<string, string | null | undefined>>;
-  listeners: Ref<Record<string, (...args: any[]) => any>>;
+  attributes: Ref<Record<string, unknown>>;
+  listeners: Ref<
+    Record<string, ((...args: any[]) => any) | ((...args: any[]) => any)[]>
+  >;
 };
 
 export function useTick(): {


### PR DESCRIPTION
## Summary

- fix runtime inconsistencies found while auditing Quasar's public components, directives, plugins, and composables
- harden Cookies parsing and expiry handling, including SSR cookie removal
- align `useRenderCache` behavior, composable typings, and documentation with their public contracts

## Details

- use factory defaults for `QScrollArea` offset arrays
- make TouchRepeat's `.delete` modifier recognize both Backspace and Delete, and document its named key modifiers
- prevent malformed percent-encoded cookies from throwing, support documented raw date-string expiries, avoid invalid `Max-Age` values, and make SSR removal work with encoded cookie names
- keep `useRenderCache` inert during SSR and allow `undefined` to be stored as a real client-side cache value
- correct the `useRenderCache` example and overload, make `useInterval`'s delay optional, broaden `useSplitAttrs` attribute/listener types, and align the dialog-ref nullability type

## Validation

- inventoried 123 components, 11 directives, 17 plugins, and 12 public composables
- `pnpm --filter quasar build`
- Quasar UI test suite: 99 files and 1,060 tests passed
- direct SSR checks for Cookies and `useRenderCache`
- `pnpm --filter quasar.dev build` (637 SSG pages rendered)
- Oxfmt passed
- Oxlint passed
- `git diff --check` passed

No permanent audit scripts or new tests are included in this PR.
