### PR TITLE
fix(ui): improve keyboard accessibility

### DIFF
--- a/docs/src/pages/vue-components/rating.md
+++ b/docs/src/pages/vue-components/rating.md
@@ -17,6 +17,8 @@ Quasar Rating is a Component which allows users to rate items, usually known as 
 
 <DocExample title="Custom number of choices" file="Max" />
 
+QRating uses radio-group keyboard behavior. `Arrow Right` and `Arrow Down` select the next value, while `Arrow Left` and `Arrow Up` select the previous value. Navigation wraps at either end. `Space` or `Enter` selects the focused value.
+
 ### Icons
 
 <DocExample title="Image icons" file="Images" />

--- a/docs/src/pages/vue-components/tabs.md
+++ b/docs/src/pages/vue-components/tabs.md
@@ -43,6 +43,8 @@ QRouteTab won't and cannot work with the UMD version if you don't also install V
 
 <DocExample title="Basic" file="Basic" />
 
+Use the arrow keys to move focus between tabs. Horizontal tabs use `Arrow Left` and `Arrow Right`; vertical tabs use `Arrow Up` and `Arrow Down`. Navigation wraps at either end, and `Home` or `End` moves focus to the first or last tab. Press `Space` or `Enter` to activate the focused tab.
+
 ### Outside, inside and visible on mobile arrows
 
 <DocExample title="Outside, inside and visible on mobile arrows" file="ArrowsModifiers" />

--- a/docs/src/pages/vue-components/time.md
+++ b/docs/src/pages/vue-components/time.md
@@ -25,6 +25,8 @@ Notice that the model is a String only.
 
 <DocExample title="Basic" file="Basic" overflow />
 
+The hour, minute, second, and AM/PM controls can be activated with `Space` or `Enter`. When an hour, minute, or second control has focus, use `Arrow Left` and `Arrow Right` to adjust its value.
+
 <DocExample title="Landscape" file="Landscape" overflow />
 
 ::: tip

--- a/docs/src/pages/vue-components/tree.md
+++ b/docs/src/pages/vue-components/tree.md
@@ -15,6 +15,16 @@ Quasar Tree represents a highly configurable component that displays hierarchica
 
 <DocExample title="Basic" file="Basic" />
 
+### Keyboard navigation
+
+When a tree node has focus:
+
+- `Arrow Up` and `Arrow Down` move focus through the visible nodes.
+- `Arrow Right` expands a collapsed parent or moves focus to its first visible child.
+- `Arrow Left` collapses an expanded parent or moves focus to its parent.
+- `Home` and `End` move focus to the first and last visible nodes.
+- `Enter` performs the node's default action; `Space` toggles its expansion.
+
 ### No connector lines
 
 <DocExample title="No connectors" file="NoConnectors" />
@@ -52,9 +62,9 @@ Notice (in the example below) the custom header and body slots.
 <DocExample title="Customizing nodes" file="SlotsCustomized" />
 
 ::: warning
-Clicking or pressing `SPACE` or `ENTER` on the custom header selects the tree item (and the custom header is blurred).
+Clicking or pressing `ENTER` on the custom header selects the tree item (and the custom header is blurred). Pressing `SPACE` toggles its expansion.
 
-If you don't want this to happen just wrap the content of the custom header in a `<div @click.stop @keypress.stop>` (or add the listeners to the respective component/element that is emitting them).
+If you don't want this to happen just wrap the content of the custom header in a `<div @click.stop @keydown.stop>` (or add the listeners to the respective component/element that is emitting them).
 :::
 
 ### Accordion, filtering and selectable

--- a/ui/src/components/chip/QChip.js
+++ b/ui/src/components/chip/QChip.js
@@ -15,6 +15,10 @@ import { createComponent } from '../../utils/private.create/create.js'
 import { stopAndPrevent } from '../../utils/event/event.js'
 import { hDir, hMergeSlotSafely } from '../../utils/private.render/render.js'
 
+function preventSpace(e) {
+  if (e.keyCode === 32) stopAndPrevent(e)
+}
+
 export const defaultSizes = {
   xs: 8,
   sm: 10,
@@ -116,7 +120,11 @@ export default createComponent({
     const attributes = computed(() => {
       const chip = props.disable
         ? { tabindex: -1, 'aria-disabled': 'true' }
-        : { tabindex: props.tabindex || 0 }
+        : {
+            tabindex: props.tabindex || 0,
+            role: 'button',
+            'aria-pressed': props.selected ? 'true' : 'false'
+          }
 
       const remove = {
         ...chip,
@@ -129,7 +137,10 @@ export default createComponent({
     })
 
     function onKeyup(e) {
-      if (e.keyCode === 13 /* ENTER */) onClick(e)
+      if ([13, 32].includes(e.keyCode)) {
+        onClick(e)
+        stopAndPrevent(e)
+      }
     }
 
     function onClick(e) {
@@ -140,7 +151,7 @@ export default createComponent({
     }
 
     function onRemove(e) {
-      if (e.keyCode === void 0 || e.keyCode === 13) {
+      if (e.keyCode === void 0 || [13, 32].includes(e.keyCode)) {
         stopAndPrevent(e)
         if (!props.disable) {
           emit('update:modelValue', false)
@@ -196,6 +207,7 @@ export default createComponent({
             name: removeIcon.value,
             ...attributes.value.remove,
             onClick: onRemove,
+            onKeydown: preventSpace,
             onKeyup: onRemove
           })
         )
@@ -213,7 +225,11 @@ export default createComponent({
       }
 
       if (isClickable.value) {
-        Object.assign(data, attributes.value.chip, { onClick, onKeyup })
+        Object.assign(data, attributes.value.chip, {
+          onClick,
+          onKeydown: preventSpace,
+          onKeyup
+        })
       }
 
       return hDir(

--- a/ui/src/components/expansion-item/QExpansionItem.js
+++ b/ui/src/components/expansion-item/QExpansionItem.js
@@ -33,6 +33,10 @@ import { hSlot } from '../../utils/private.render/render.js'
 import uid from '../../utils/uid/uid.js'
 
 const itemGroups = shallowReactive({})
+
+function preventSpace(e) {
+  if (e.keyCode === 32) stopAndPrevent(e)
+}
 const LINK_PROPS = Object.keys(useRouterLinkProps)
 
 export default createComponent({
@@ -176,7 +180,7 @@ export default createComponent({
     }
 
     function toggleIconKeyboard(e) {
-      if (e.keyCode === 13) toggleIcon(e, true)
+      if ([13, 32].includes(e.keyCode)) toggleIcon(e, true)
     }
 
     function toggleIcon(e, keyboard) {
@@ -259,6 +263,7 @@ export default createComponent({
           tabindex: 0,
           ...toggleAriaAttrs.value,
           onClick: toggleIcon,
+          onKeydown: preventSpace,
           onKeyup: toggleIconKeyboard
         })
 

--- a/ui/src/components/item/QItem.js
+++ b/ui/src/components/item/QItem.js
@@ -118,6 +118,10 @@ export default createComponent({
       emit('keyup', e)
     }
 
+    function onKeydown(e) {
+      if (isClickable.value && e.keyCode === 32) stopAndPrevent(e)
+    }
+
     function getContent() {
       const child = hUniqueSlot(slots.default, [])
 
@@ -139,8 +143,13 @@ export default createComponent({
         ref: rootRef,
         class: classes.value,
         style: style.value,
-        role: 'listitem',
+        role: hasLink.value
+          ? void 0
+          : isClickable.value
+            ? 'button'
+            : 'listitem',
         onClick,
+        onKeydown,
         onKeyup
       }
 

--- a/ui/src/components/rating/QRating.js
+++ b/ui/src/components/rating/QRating.js
@@ -102,7 +102,7 @@ export default createComponent({
             : props.iconSelected,
         halfIconLen,
         halfIcon:
-          halfIconLen > 0 ? props.iconHalf[selIconLen - 1] : props.iconHalf,
+          halfIconLen > 0 ? props.iconHalf[halfIconLen - 1] : props.iconHalf,
         colorLen,
         color: colorLen > 0 ? props.color[colorLen - 1] : props.color,
         selColorLen,
@@ -138,7 +138,12 @@ export default createComponent({
       const acc = [],
         icons = iconData.value,
         ceil = Math.ceil(props.modelValue),
-        tabindex = editable.value ? 0 : null
+        tabIndex =
+          Number.isInteger(props.modelValue) &&
+          props.modelValue >= 1 &&
+          props.modelValue <= props.max
+            ? props.modelValue
+            : 1
 
       const halfIndex =
         props.iconHalf === void 0 || ceil === props.modelValue ? -1 : ceil
@@ -191,7 +196,7 @@ export default createComponent({
                   : icons.icon) || $q.iconSet.rating.icon,
 
           attrs: {
-            tabindex,
+            tabindex: editable.value ? (i === tabIndex ? 0 : -1) : null,
             role: 'radio',
             'aria-checked': props.modelValue === i ? 'true' : 'false',
             'aria-label': iconLabel.value(i, name)
@@ -242,7 +247,7 @@ export default createComponent({
       }
     }
 
-    function onKeyup(e, i) {
+    function onKeydown(e, i) {
       switch (e.keyCode) {
         case 13:
         case 32: {
@@ -250,19 +255,19 @@ export default createComponent({
           return stopAndPrevent(e)
         }
         case 37: // LEFT ARROW
-        case 40: {
-          // DOWN ARROW
-          if (iconRefs[`rt${i - 1}`]) {
-            iconRefs[`rt${i - 1}`].focus()
-          }
+        case 38: {
+          // UP ARROW
+          const next = i === 1 ? Number(props.max) : i - 1
+          iconRefs[`rt${next}`]?.focus()
+          set(next)
           return stopAndPrevent(e)
         }
         case 39: // RIGHT ARROW
-        case 38: {
-          // UP ARROW
-          if (iconRefs[`rt${i + 1}`]) {
-            iconRefs[`rt${i + 1}`].focus()
-          }
+        case 40: {
+          // DOWN ARROW
+          const next = i === Number(props.max) ? 1 : i + 1
+          iconRefs[`rt${next}`]?.focus()
+          set(next)
           return stopAndPrevent(e)
         }
       }
@@ -303,8 +308,8 @@ export default createComponent({
                 setHoverValue(i)
               },
               onBlur: resetMouseModel,
-              onKeyup(e) {
-                onKeyup(e, i)
+              onKeydown(e) {
+                onKeydown(e, i)
               }
             },
             hMergeSlot(slots[`tip-${i}`], [

--- a/ui/src/components/stepper/StepHeader.js
+++ b/ui/src/components/stepper/StepHeader.js
@@ -4,6 +4,11 @@ import QIcon from '../icon/QIcon.js'
 import Ripple from '../../directives/ripple/Ripple.js'
 
 import { createComponent } from '../../utils/private.create/create.js'
+import { stopAndPrevent } from '../../utils/event/event.js'
+
+function preventSpace(e) {
+  if (e.keyCode === 32) stopAndPrevent(e)
+}
 
 export default createComponent({
   name: 'StepHeader',
@@ -134,8 +139,9 @@ export default createComponent({
     }
 
     function onKeyup(e) {
-      if (e.keyCode === 13 && !isActive.value) {
-        props.goToPanel(props.step.name)
+      if ([13, 32].includes(e.keyCode)) {
+        if (!isActive.value) props.goToPanel(props.step.name)
+        stopAndPrevent(e)
       }
     }
 
@@ -144,7 +150,10 @@ export default createComponent({
 
       if (headerNav.value) {
         data.onClick = onActivate
+        data.onKeydown = preventSpace
         data.onKeyup = onKeyup
+        data.role = 'button'
+        data['aria-current'] = isActive.value ? 'step' : void 0
 
         Object.assign(
           data,

--- a/ui/src/components/tabs/QTabs.js
+++ b/ui/src/components/tabs/QTabs.js
@@ -386,13 +386,11 @@ export default createComponent({
       const dir = dirPrev ? -1 : dirNext ? 1 : void 0
 
       if (dir !== void 0) {
-        const rtlDir = isRTL.value ? -1 : 1
-        const index = tabs.indexOf(fromEl) + dir * rtlDir
+        const rtlDir = props.vertical !== true && isRTL.value ? -1 : 1
+        const index = (tabs.indexOf(fromEl) + dir * rtlDir + len) % len
 
-        if (index >= 0 && index < len) {
-          scrollToTabEl(tabs[index])
-          tabs[index].focus({ preventScroll: true })
-        }
+        scrollToTabEl(tabs[index])
+        tabs[index].focus({ preventScroll: true })
 
         return true
       }
@@ -700,6 +698,7 @@ export default createComponent({
           ref: rootRef,
           class: classes.value,
           role: 'tablist',
+          'aria-orientation': props.vertical ? 'vertical' : 'horizontal',
           onFocusin,
           onFocusout
         },

--- a/ui/src/components/time/QTime.js
+++ b/ui/src/components/time/QTime.js
@@ -29,7 +29,7 @@ import useDatetime, {
 import { createComponent } from '../../utils/private.create/create.js'
 import { hSlot } from '../../utils/private.render/render.js'
 import { __splitDate, formatDate } from '../../utils/date/date.js'
-import { position } from '../../utils/event/event.js'
+import { position, stopAndPrevent } from '../../utils/event/event.js'
 import { pad } from '../../utils/format/format.js'
 import { vmIsDestroyed } from '../../utils/private.vm/vm.js'
 
@@ -56,6 +56,10 @@ function getCurrentTime() {
     second: d.getSeconds(),
     millisecond: d.getMilliseconds()
   }
+}
+
+function preventSpace(e) {
+  if (e.keyCode === 32) stopAndPrevent(e)
 }
 
 function getWheelDist(a, b, threshold) {
@@ -536,11 +540,17 @@ export default createComponent({
     }
 
     function setAmOnKey(e) {
-      if (e.keyCode === 13) setAm()
+      if ([13, 32].includes(e.keyCode)) {
+        setAm()
+        stopAndPrevent(e)
+      }
     }
 
     function setPmOnKey(e) {
-      if (e.keyCode === 13) setPm()
+      if ([13, 32].includes(e.keyCode)) {
+        setPm()
+        stopAndPrevent(e)
+      }
     }
 
     function onClick(evt) {
@@ -562,9 +572,9 @@ export default createComponent({
     }
 
     function onKeyupHour(e) {
-      if (e.keyCode === 13) {
-        // ENTER
+      if ([13, 32].includes(e.keyCode)) {
         view.value = 'hour'
+        stopAndPrevent(e)
       } else if ([37, 39].includes(e.keyCode)) {
         const payload = e.keyCode === 37 ? -1 : 1
 
@@ -598,9 +608,9 @@ export default createComponent({
     }
 
     function onKeyupMinute(e) {
-      if (e.keyCode === 13) {
-        // ENTER
+      if ([13, 32].includes(e.keyCode)) {
         view.value = 'minute'
+        stopAndPrevent(e)
       } else if ([37, 39].includes(e.keyCode)) {
         const payload = e.keyCode === 37 ? -1 : 1
 
@@ -631,9 +641,9 @@ export default createComponent({
     }
 
     function onKeyupSecond(e) {
-      if (e.keyCode === 13) {
-        // ENTER
+      if ([13, 32].includes(e.keyCode)) {
         view.value = 'second'
+        stopAndPrevent(e)
       } else if ([37, 39].includes(e.keyCode)) {
         const payload = e.keyCode === 37 ? -1 : 1
 
@@ -642,7 +652,7 @@ export default createComponent({
 
           if (values.length === 0) return
 
-          if (innerModel.value.seconds === null) {
+          if (innerModel.value.second === null) {
             setSecond(values[0])
           } else {
             const index =
@@ -806,7 +816,10 @@ export default createComponent({
                 ? 'q-time__link--active'
                 : 'cursor-pointer'),
             tabindex: tabindex.value,
+            role: 'button',
+            'aria-pressed': view.value === 'hour' ? 'true' : 'false',
             onClick: setView.hour,
+            onKeydown: preventSpace,
             onKeyup: onKeyupHour
           },
           stringModel.value.hour
@@ -824,6 +837,9 @@ export default createComponent({
                     ? 'q-time__link--active'
                     : 'cursor-pointer'),
                 tabindex: tabindex.value,
+                role: 'button',
+                'aria-pressed': view.value === 'minute' ? 'true' : 'false',
+                onKeydown: preventSpace,
                 onKeyup: onKeyupMinute,
                 onClick: setView.minute
               }
@@ -846,6 +862,9 @@ export default createComponent({
                       ? 'q-time__link--active'
                       : 'cursor-pointer'),
                   tabindex: tabindex.value,
+                  role: 'button',
+                  'aria-pressed': view.value === 'second' ? 'true' : 'false',
+                  onKeydown: preventSpace,
                   onKeyup: onKeyupSecond,
                   onClick: setView.second
                 }
@@ -881,7 +900,10 @@ export default createComponent({
                     'q-time__link ' +
                     (isAM.value ? 'q-time__link--active' : 'cursor-pointer'),
                   tabindex: tabindex.value,
+                  role: 'button',
+                  'aria-pressed': isAM.value ? 'true' : 'false',
                   onClick: setAm,
+                  onKeydown: preventSpace,
                   onKeyup: setAmOnKey
                 },
                 'AM'
@@ -894,7 +916,10 @@ export default createComponent({
                     'q-time__link ' +
                     (isAM.value ? 'cursor-pointer' : 'q-time__link--active'),
                   tabindex: tabindex.value,
+                  role: 'button',
+                  'aria-pressed': isAM.value ? 'false' : 'true',
                   onClick: setPm,
+                  onKeydown: preventSpace,
                   onKeyup: setPmOnKey
                 },
                 'PM'

--- a/ui/src/components/tree/QTree.js
+++ b/ui/src/components/tree/QTree.js
@@ -118,11 +118,14 @@ export default createComponent({
     const lazy = ref({})
     const innerTicked = ref(props.ticked || [])
     const innerExpanded = ref(props.expanded || [])
+    const focusedKey = ref(null)
 
-    let blurTargets = {}
+    let blurTargets = {},
+      headerTargets = {}
 
     onBeforeUpdate(() => {
       blurTargets = {}
+      headerTargets = {}
     })
 
     const classes = computed(
@@ -304,6 +307,38 @@ export default createComponent({
 
       props.nodes.forEach(node => travel(node, null))
       return acc
+    })
+
+    const focusableKeys = computed(() => {
+      const acc = []
+
+      function travel(nodes) {
+        nodes.forEach(node => {
+          const localMeta = meta.value[node[props.nodeKey]]
+
+          if (props.filter && localMeta.matchesFilter !== true) return
+          if (localMeta.link === true) acc.push(localMeta.key)
+
+          if (
+            localMeta.expanded === true &&
+            Array.isArray(node[props.childrenKey])
+          ) {
+            travel(node[props.childrenKey])
+          }
+        })
+      }
+
+      travel(props.nodes)
+      return acc
+    })
+
+    const tabKey = computed(() => {
+      const keys = focusableKeys.value
+
+      if (keys.includes(focusedKey.value)) return focusedKey.value
+
+      const selected = keys.find(key => meta.value[key].selected === true)
+      return selected !== void 0 ? selected : keys[0]
     })
 
     watch(
@@ -576,18 +611,36 @@ export default createComponent({
                   : '') +
                 (m.selected === true ? ' q-tree__node--selected' : '') +
                 (m.disabled === true ? ' q-tree__node--disabled' : ''),
-              tabindex: m.link === true ? 0 : -1,
-              ariaExpanded: children.length !== 0 ? m.expanded : null,
+              ref: el => {
+                headerTargets[m.key] = el
+              },
+              tabindex: m.link === true && m.key === tabKey.value ? 0 : -1,
+              'aria-expanded': isParent
+                ? m.expanded
+                  ? 'true'
+                  : 'false'
+                : null,
+              'aria-selected': m.selectable
+                ? m.selected
+                  ? 'true'
+                  : 'false'
+                : null,
+              'aria-disabled': m.disabled === true ? 'true' : null,
               role: 'treeitem',
+              onFocus() {
+                if (m.link === true) focusedKey.value = m.key
+              },
               onClick: e => {
                 onClick(node, m, e)
               },
-              onKeypress(e) {
+              onKeydown(e) {
                 if (shouldIgnoreKey(e) !== true) {
                   if (e.keyCode === 13) {
                     onClick(node, m, e, true)
                   } else if (e.keyCode === 32) {
                     onExpandClick(node, m, e, true)
+                  } else if (onNavigationKey(m, e.keyCode)) {
+                    stopAndPrevent(e)
                   }
                 }
               }
@@ -722,7 +775,72 @@ export default createComponent({
       blurTargets[key]?.focus()
     }
 
+    function focusNode(key) {
+      if (key !== void 0) {
+        focusedKey.value = key
+        headerTargets[key]?.focus()
+      }
+    }
+
+    function getFirstFocusableChild(children) {
+      for (const child of children) {
+        if (props.filter && child.matchesFilter !== true) continue
+        if (child.link === true) return child.key
+
+        if (child.expanded === true) {
+          const key = getFirstFocusableChild(child.children)
+          if (key !== void 0) return key
+        }
+      }
+    }
+
+    function onNavigationKey(localMeta, keyCode) {
+      const keys = focusableKeys.value,
+        index = keys.indexOf(localMeta.key)
+
+      if (keyCode === 36) {
+        focusNode(keys[0])
+        return true
+      }
+      if (keyCode === 35) {
+        focusNode(keys.at(-1))
+        return true
+      }
+      if (keyCode === 38) {
+        focusNode(keys[index - 1])
+        return true
+      }
+      if (keyCode === 40) {
+        focusNode(keys[index + 1])
+        return true
+      }
+      if (keyCode === 39) {
+        if (localMeta.isParent !== true && !localMeta.lazy) return true
+
+        if (localMeta.expanded !== true) {
+          setExpanded(localMeta.key, true)
+        } else {
+          focusNode(getFirstFocusableChild(localMeta.children))
+        }
+        return true
+      }
+      if (keyCode === 37) {
+        if (localMeta.expanded === true) {
+          setExpanded(localMeta.key, false)
+        } else {
+          let parent = localMeta.parent
+          while (parent !== null && parent.link !== true) parent = parent.parent
+          focusNode(parent?.key)
+        }
+        return true
+      }
+
+      return false
+    }
+
     function onClick(node, localMeta, e, keyboard) {
+      if (localMeta.link === true) focusedKey.value = localMeta.key
+
       if (keyboard !== true && localMeta.selectable !== false) {
         blur(localMeta.key)
       }
@@ -749,6 +867,8 @@ export default createComponent({
     }
 
     function onExpandClick(node, localMeta, e, keyboard) {
+      if (localMeta.link === true) focusedKey.value = localMeta.key
+
       if (e !== void 0) {
         stopAndPrevent(e)
       }


### PR DESCRIPTION
## Summary

This audits Quasar's keyboard-accessible component surfaces and aligns the affected widgets with their advertised semantics and the WAI-ARIA Authoring Practices.

- add complete visible-node keyboard navigation and roving focus to QTree
- align QRating and QTabs with their radio-group and tab-list keyboard contracts
- make button-like controls consistently support both Space and Enter
- correct two runtime defects found while tracing the affected keyboard paths
- document the supported keyboard interactions

## Justification

### QTree

QTree already rendered `tree` and `treeitem` roles, but every actionable node used `tabindex="0"` and the tree only handled Enter and Space. A widget declaring tree semantics is expected to have one Tab stop and use arrow keys to navigate within the composite widget.

This adds roving focus; Up, Down, Left, Right, Home, and End handling; and explicit expanded, selected, and disabled state. Navigation is based on the visible node model, so collapsed and filtered nodes are not keyboard destinations. Existing Enter and Space behavior is preserved.

### QRating

QRating declares `radiogroup` and `radio` roles, but every rating value was included in the page Tab sequence. Arrow keys moved focus without selecting the new value and stopped at either end.

The checked value is now the group's single Tab stop. Arrow navigation wraps and updates the selection, matching standard radio-group behavior. Space and Enter continue to select the focused value.

While reviewing this path, the fallback for an `icon-half` array was also found to index it with `selIconLen`. It now correctly uses `halfIconLen`; arrays of different lengths could previously select the wrong fallback icon.

### QTabs

QTabs already implements most of the tab-list interaction model. This adds its missing `aria-orientation`, wraps focus at either end, and prevents RTL from reversing Up/Down navigation in a vertical tab list. RTL direction only applies to horizontal Left/Right navigation.

### QTime

The hour, minute, second, and AM/PM selectors are focusable and clickable but did not expose button semantics or support Space activation. They now declare their button and pressed states and support both Space and Enter without allowing Space to scroll the page.

This also fixes a concrete second-navigation bug. The keyboard path checked `innerModel.value.seconds`, but the model field is singular: `innerModel.value.second`. As a result, the null-second initialization branch could never be selected as intended.

### Shared button-like controls

- clickable QItem instances now expose button semantics, while router links retain their native link semantics
- selectable and removable QChip controls support Space as well as Enter and expose their pressed state
- QExpansionItem's separate expansion toggle supports Space as required by its existing button role
- navigable step headers expose button/current-step semantics and support Space as well as Enter

These controls previously handled activation on keyup only, which also allowed Space to perform its default page-scroll action. Space is now prevented on keydown and activated on keyup, retaining the existing click/ripple behavior.

## Documentation

The Tree, Rating, Tabs, and QTime pages now describe their supported keyboard interactions. The Tree custom-header warning was also corrected: Enter performs the node action, while Space toggles expansion, and the implementation listens to `keydown` rather than the deprecated `keypress` event.

## References

- [WAI-ARIA Tree View Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/)
- [WAI-ARIA Radio Group Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/)
- [WAI-ARIA Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
- [WAI-ARIA Disclosure Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)

## Validation

- `pnpm --filter quasar build`
- `pnpm --filter quasar-ui-test test --run`: 99 test files and 1,060 tests passed
- `pnpm --filter quasar.dev build`: 637 SSG pages rendered successfully
- Oxfmt passed
- Oxlint passed
- `git diff --check` passed
