### PR TITLE
fix(ui): harden overlay focus lifecycle

### DIFF
--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -138,6 +138,7 @@ export default createComponent({
       hideOnRouteChange,
       handleShow,
       handleHide,
+      handleRouteChange,
       processOnMount: true
     })
 
@@ -253,13 +254,15 @@ export default createComponent({
       hidePortal()
 
       if (refocusTarget !== null) {
-        ;(
+        const target =
           (evt?.type.indexOf('key') === 0
             ? refocusTarget.closest('[tabindex]:not([tabindex^="-"])')
             : void 0) || refocusTarget
-        ).focus()
 
         refocusTarget = null
+        addFocusFn(() => {
+          if (target.isConnected) target.focus()
+        })
       }
 
       // should removeTimeout() if this gets removed
@@ -268,6 +271,10 @@ export default createComponent({
         animating.value = false
         emit('hide', evt)
       }, props.transitionDuration)
+    }
+
+    function handleRouteChange() {
+      refocusTarget = null
     }
 
     function focus(selector) {

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -137,6 +137,7 @@ export default createComponent({
       canShow,
       handleShow,
       handleHide,
+      handleRouteChange,
       hideOnRouteChange,
       processOnMount: true
     })
@@ -297,13 +298,15 @@ export default createComponent({
           // menu was not closed from a mouse or touch clickOutside
           !evt.qClickOutside)
       ) {
-        ;(
+        const target =
           (evt?.type.indexOf('key') === 0
             ? refocusTarget.closest('[tabindex]:not([tabindex^="-"])')
             : void 0) || refocusTarget
-        ).focus()
 
         refocusTarget = null
+        addFocusFn(() => {
+          if (target.isConnected) target.focus()
+        })
       }
 
       // should removeTimeout() if this gets removed
@@ -311,6 +314,10 @@ export default createComponent({
         hidePortal(true) // done hiding, now destroy
         emit('hide', evt)
       }, props.transitionDuration)
+    }
+
+    function handleRouteChange() {
+      refocusTarget = null
     }
 
     function anchorCleanup(hiding) {

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -22,6 +22,7 @@ import useTransition, {
 } from '../../composables/private.use-transition/use-transition.js'
 import useTick from '../../composables/use-tick/use-tick.js'
 import useTimeout from '../../composables/use-timeout/use-timeout.js'
+import useId from '../../composables/use-id/use-id.js'
 
 import { createComponent } from '../../utils/private.create/create.js'
 import { getScrollTarget, scrollTargetProp } from '../../utils/scroll/scroll.js'
@@ -38,6 +39,8 @@ import {
   validateOffset,
   validatePosition
 } from '../../utils/private.position-engine/position-engine.js'
+
+let nonSelectableCount = 0
 
 export default createComponent({
   name: 'QTooltip',
@@ -101,7 +104,11 @@ export default createComponent({
   emits: [...useModelToggleEmits],
 
   setup(props, { slots, emit, attrs }) {
-    let unwatchPosition, observer
+    let unwatchPosition,
+      observer,
+      removeNonSelectableTimer,
+      hasNonSelectable = false,
+      describedBy
 
     const vm = getCurrentInstance()
     const {
@@ -110,6 +117,8 @@ export default createComponent({
 
     const innerRef = ref(null)
     const showing = ref(false)
+    const targetUid = useId()
+    const tooltipId = computed(() => attrs.id || targetUid.value)
 
     const anchorOrigin = computed(() =>
       parsePosition(props.anchor, $q.lang.rtl)
@@ -186,6 +195,7 @@ export default createComponent({
 
     function handleShow(evt) {
       showPortal()
+      addAriaDescription()
 
       // should removeTick() if this gets removed
       registerTick(() => {
@@ -255,6 +265,8 @@ export default createComponent({
 
       unconfigureScrollTarget()
       cleanEvt(anchorEvents, 'tooltipTemp')
+      removeAriaDescription()
+      setNonSelectable(false)
     }
 
     function updatePosition() {
@@ -271,8 +283,13 @@ export default createComponent({
 
     function delayShow(evt) {
       if ($q.platform.is.mobile) {
+        if (removeNonSelectableTimer !== void 0) {
+          clearTimeout(removeNonSelectableTimer)
+          removeNonSelectableTimer = void 0
+        }
+
         clearSelection()
-        document.body.classList.add('non-selectable')
+        setNonSelectable(true)
 
         const target = anchorEl.value
         const evts = ['touchmove', 'touchcancel', 'touchend', 'click'].map(
@@ -292,8 +309,9 @@ export default createComponent({
         cleanEvt(anchorEvents, 'tooltipTemp')
         clearSelection()
         // delay needed otherwise selection still occurs
-        setTimeout(() => {
-          document.body.classList.remove('non-selectable')
+        removeNonSelectableTimer = setTimeout(() => {
+          removeNonSelectableTimer = void 0
+          setNonSelectable(false)
         }, 10)
       }
 
@@ -316,6 +334,51 @@ export default createComponent({
       addEvt(anchorEvents, 'anchor', evts)
     }
 
+    function setNonSelectable(state) {
+      if (hasNonSelectable === state) return
+
+      hasNonSelectable = state
+      nonSelectableCount += state ? 1 : -1
+      document.body.classList.toggle('non-selectable', nonSelectableCount > 0)
+
+      if (!state && removeNonSelectableTimer !== void 0) {
+        clearTimeout(removeNonSelectableTimer)
+        removeNonSelectableTimer = void 0
+      }
+    }
+
+    function addAriaDescription() {
+      const el = anchorEl.value,
+        id = tooltipId.value
+
+      if (el === null || id === void 0) return
+
+      const ids = (el.getAttribute('aria-describedby') || '')
+        .split(/\s+/)
+        .filter(Boolean)
+
+      describedBy = { el, id, added: !ids.includes(id) }
+
+      if (describedBy.added) {
+        ids.push(id)
+        el.setAttribute('aria-describedby', ids.join(' '))
+      }
+    }
+
+    function removeAriaDescription() {
+      if (describedBy?.added === true) {
+        const { el, id } = describedBy,
+          value = (el.getAttribute('aria-describedby') || '')
+            .split(/\s+/)
+            .filter(entry => entry !== '' && entry !== id)
+
+        if (value.length === 0) el.removeAttribute('aria-describedby')
+        else el.setAttribute('aria-describedby', value.join(' '))
+      }
+
+      describedBy = void 0
+    }
+
     function configureScrollTarget() {
       if (anchorEl.value !== null || props.scrollTarget !== void 0) {
         localScrollTarget.value = getScrollTarget(
@@ -334,6 +397,7 @@ export default createComponent({
             'div',
             {
               ...attrs,
+              id: tooltipId.value,
               ref: innerRef,
               class: [
                 'q-tooltip q-tooltip--style q-position-engine no-pointer-events',

--- a/ui/src/composables/private.use-model-toggle/use-model-toggle.js
+++ b/ui/src/composables/private.use-model-toggle/use-model-toggle.js
@@ -21,6 +21,7 @@ export default function useModelToggle({
   hideOnRouteChange, // optional
   handleShow, // optional
   handleHide, // optional
+  handleRouteChange, // optional
   processOnMount // optional
 }) {
   const vm = getCurrentInstance()
@@ -127,6 +128,7 @@ export default function useModelToggle({
       () => proxy.$route.fullPath,
       () => {
         if (hideOnRouteChange.value && showing.value) {
+          handleRouteChange?.()
           hide()
         }
       }


### PR DESCRIPTION
## Summary

This audits Quasar's overlay and focus lifecycle across dialogs, menus, tooltips, portals, route changes, and overlapping transitions.

- coordinate dialog and menu refocus with the existing portal focus queue
- avoid restoring focus into a view that is being left during navigation
- connect QTooltip to its anchor through `aria-describedby`
- prevent mobile tooltip selection locks from leaking or racing

## Justification

### Dialog and menu focus restoration

QDialog and QMenu already route their initial focus through Quasar's shared focus manager. Their closing refocus bypassed that manager and called `focus()` immediately, even though the closing portal still held a transition wait flag.

That creates a race when one overlay closes while another opens: the closing overlay can restore its old target after the new overlay has begun managing focus. It can also attempt to focus an element that was removed while the overlay was open.

Refocus now goes through `addFocusFn()`, matching the opening lifecycle. This has three effects:

- restoration waits until the portal transition wait state clears
- when multiple focus requests overlap, the focus manager retains the final intended target
- detached targets are ignored instead of leaving focus pointed at stale UI

Normal programmatic, Escape-key, and nested-overlay closes continue to restore focus to the original connected target.

### Route-driven dismissal

The router watcher previously called the same hide path as an ordinary programmatic close. QDialog and QMenu consequently tried to restore focus to their trigger in the route being left. Depending on transition timing, that could move focus and scroll back into stale content while the destination route was mounting.

`useModelToggle` now provides an internal route-change hook before it invokes `hide()`. QDialog and QMenu use the hook to discard their stored refocus target. This preserves their existing dismissal events and transition behavior while allowing focus to remain under control of the destination view.

### Tooltip relationship

QTooltip rendered `role="tooltip"`, but it did not give the tooltip a stable ID or reference it from its anchor. Assistive technology therefore had no programmatic relationship between the trigger and the description.

Each tooltip now receives a generated ID unless the user supplied one. While visible, that ID is added to the anchor's `aria-describedby` token list. Existing descriptions are preserved, duplicate IDs are avoided, and only the token added by QTooltip is removed during cleanup.

### Mobile selection cleanup

Touch activation temporarily adds `non-selectable` to `<body>` so a long press does not select page text. Cleanup previously depended on the matching touch-end path. If the tooltip or its owner unmounted first, the class could remain on `<body>` and disable text selection throughout the application.

Selection locking is now owned by the tooltip lifecycle and always released during cleanup. A small shared reference count also handles overlapping or rapidly changing tooltips: one tooltip cannot remove the body class while another still requires it, and a delayed cleanup from one tooltip cannot override a newer tooltip's state.

## Validation

- `pnpm --filter quasar build`
- `pnpm --filter quasar-ui-test test --run`: 99 test files and 1,060 tests passed
- Oxfmt passed
- Oxlint passed
- `git diff --check` passed
