### PR TITLE
fix(ui): improve SSR hydration safety

### DIFF
--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -73,7 +73,7 @@ When clicking on title then the QDate's view is changed to the calendar and when
 
 When model is unfilled (like `null`, `void 0` / `undefined`) QDate still has to show the calendar for a month of a year. You can use `default-year-month` prop for this, otherwise the current month of the year will be shown:
 
-When server-side rendering an unfilled QDate, set `default-year-month` explicitly. Otherwise, a server and browser in different time zones can select different initial months during hydration.
+When server-side rendering an unfilled QDate in SSR or SSG modes, set `default-year-month` explicitly. Otherwise, a server and browser in different time zones can select different initial months during hydration.
 
 <DocExample title="Default year month" file="DefaultYearMonth" overflow />
 

--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -73,6 +73,8 @@ When clicking on title then the QDate's view is changed to the calendar and when
 
 When model is unfilled (like `null`, `void 0` / `undefined`) QDate still has to show the calendar for a month of a year. You can use `default-year-month` prop for this, otherwise the current month of the year will be shown:
 
+When server-side rendering an unfilled QDate, set `default-year-month` explicitly. Otherwise, a server and browser in different time zones can select different initial months during hydration.
+
 <DocExample title="Default year month" file="DefaultYearMonth" overflow />
 
 The default view can be changed.

--- a/docs/src/pages/vue-components/time.md
+++ b/docs/src/pages/vue-components/time.md
@@ -51,6 +51,8 @@ The `mask` prop tokens can be found at [Quasar Utils > Date utils](/quasar-utils
 
 ::: warning Note on SSR/SSG
 Using `x` or `X` (timestamps) in the mask may cause hydration errors on the client, because decoding the model String must be done with `new Date()` which takes into account the local timezone. As a result, if the server is in a different timezone than the client, then the rendered output of the server will differ than the one on the client so hydration will fail.
+
+If the mask contains date tokens, set `default-date` explicitly when using SSR or SSG. The runtime default is the current local date, which can differ between the server and browser.
 :::
 
 ::: danger Note on persian calendar

--- a/docs/src/pages/vue-composables/use-interval.md
+++ b/docs/src/pages/vue-composables/use-interval.md
@@ -7,6 +7,8 @@ badge: Quasar v2.15.1+
 
 The `useInterval()` composable is similar in scope with the native `setInterval()`, with some key differences. The composable takes care of "cancelling" the interval if your component gets destroyed and you can also override the executing Function while it's running.
 
+On an SSR server, registering an interval is a no-op. Start server-side work explicitly outside the component rendering lifecycle rather than creating a timer during `setup()`.
+
 ## Syntax
 
 ```js

--- a/docs/src/pages/vue-composables/use-timeout.md
+++ b/docs/src/pages/vue-composables/use-timeout.md
@@ -11,7 +11,9 @@ In other words, if you want to schedule a function after a delay but you might w
 
 The useTimeout composable also automatically cancels (if it was registered and still pending) when your component gets destroyed.
 
-On an SSR server, registering a timeout is a no-op. Start server-side work explicitly outside the component rendering lifecycle rather than creating a timer during `setup()`.
+::: tip
+On the server-side of SSR or SSG modes, registering a timeout is a no-op. Start server-side work explicitly outside the component rendering lifecycle rather than creating a timer during `setup()`.
+:::
 
 ## Syntax
 

--- a/docs/src/pages/vue-composables/use-timeout.md
+++ b/docs/src/pages/vue-composables/use-timeout.md
@@ -11,6 +11,8 @@ In other words, if you want to schedule a function after a delay but you might w
 
 The useTimeout composable also automatically cancels (if it was registered and still pending) when your component gets destroyed.
 
+On an SSR server, registering a timeout is a no-op. Start server-side work explicitly outside the component rendering lifecycle rather than creating a timer during `setup()`.
+
 ## Syntax
 
 ```js

--- a/ui/src/components/date/QDate.js
+++ b/ui/src/components/date/QDate.js
@@ -14,6 +14,7 @@ import useDark, {
   useDarkProps
 } from '../../composables/private.use-dark/use-dark.js'
 import useRenderCache from '../../composables/use-render-cache/use-render-cache.js'
+import useHydration from '../../composables/use-hydration/use-hydration.js'
 import {
   useFormAttrs,
   useFormInject,
@@ -124,6 +125,7 @@ export default createComponent({
 
     const isDark = useDark(props, $q)
     const { getCache } = useRenderCache()
+    const { isHydrated } = useHydration()
     const { tabindex, headerClass, getLocale, getCurrentDate } = useDatetime(
       props,
       $q
@@ -736,6 +738,7 @@ export default createComponent({
       }
 
       if (
+        isHydrated.value &&
         viewModel.value.year === today.value.year &&
         viewModel.value.month === today.value.month
       ) {
@@ -1478,7 +1481,8 @@ export default createComponent({
       ],
 
       Months() {
-        const currentYear = viewModel.value.year === today.value.year
+        const currentYear =
+          isHydrated.value && viewModel.value.year === today.value.year
         const isDisabled = month =>
           (minNav.value !== null &&
             viewModel.value.year === minNav.value.year &&
@@ -1565,7 +1569,10 @@ export default createComponent({
               [
                 h(QBtn, {
                   key: 'yr' + i,
-                  class: today.value.year === i ? 'q-date__today' : null,
+                  class:
+                    isHydrated.value && today.value.year === i
+                      ? 'q-date__today'
+                      : null,
                   flat: !active,
                   label: i,
                   dense: true,

--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -21,6 +21,8 @@ import useFullscreen, {
 } from '../../composables/private.use-fullscreen/use-fullscreen.js'
 import useSplitAttrs from '../../composables/use-split-attrs/use-split-attrs.js'
 
+import { isRuntimeSsrPreHydration } from '../../plugins/platform/Platform.js'
+
 import { createComponent } from '../../utils/private.create/create.js'
 import { stopAndPrevent } from '../../utils/event/event.js'
 import extend from '../../utils/extend/extend.js'
@@ -115,6 +117,8 @@ export default createComponent({
 
     let defaultFont, offsetBottom
     let lastEmit = props.modelValue
+    const renderInitialContent =
+      __QUASAR_SSR_SERVER__ || isRuntimeSsrPreHydration.value
 
     if (!__QUASAR_SSR_SERVER__) {
       document.execCommand(
@@ -745,7 +749,7 @@ export default createComponent({
             class: innerClass.value,
             contenteditable: editable.value,
             placeholder: props.placeholder,
-            ...(__QUASAR_SSR_SERVER__ ? { innerHTML: props.modelValue } : {}),
+            ...(renderInitialContent ? { innerHTML: props.modelValue } : {}),
             ...splitAttrs.listeners.value,
             onInput,
             onKeydown,

--- a/ui/src/composables/use-interval/use-interval.js
+++ b/ui/src/composables/use-interval/use-interval.js
@@ -1,6 +1,7 @@
 import { getCurrentInstance, onBeforeUnmount, onDeactivated } from 'vue'
 
 import { vmIsDestroyed } from '../../utils/private.vm/vm.js'
+import { noop } from '../../utils/event/event.js'
 
 /*
  * Usage:
@@ -9,6 +10,13 @@ import { vmIsDestroyed } from '../../utils/private.vm/vm.js'
  */
 
 export default function useInterval() {
+  if (__QUASAR_SSR_SERVER__) {
+    return {
+      removeInterval: noop,
+      registerInterval: noop
+    }
+  }
+
   let timer = null
   const vm = getCurrentInstance()
 

--- a/ui/src/composables/use-timeout/use-timeout.js
+++ b/ui/src/composables/use-timeout/use-timeout.js
@@ -1,6 +1,7 @@
 import { getCurrentInstance, onBeforeUnmount, onDeactivated } from 'vue'
 
 import { vmIsDestroyed } from '../../utils/private.vm/vm.js'
+import { noop } from '../../utils/event/event.js'
 
 /*
  * Usage:
@@ -9,6 +10,13 @@ import { vmIsDestroyed } from '../../utils/private.vm/vm.js'
  */
 
 export default function useTimeout() {
+  if (__QUASAR_SSR_SERVER__) {
+    return {
+      removeTimeout: noop,
+      registerTimeout: noop
+    }
+  }
+
   let timer = null
   const vm = getCurrentInstance()
 


### PR DESCRIPTION
## Summary

This audit improves SSR and hydration safety in QEditor, QDate, useInterval, and useTimeout, and documents the related SSR behavior.

- Preserve QEditor model content in the client hydration VNode so it matches the server-rendered contenteditable element.
- Defer QDate local “today” styling until hydration completes, avoiding class mismatches when the server and browser use different dates or time zones.
- Make useInterval and useTimeout registration a no-op during server rendering so component setup does not create Node timers that can outlive the request.
- Document explicit QDate and QTime defaults for timezone-stable SSR/SSG output, plus the timer composables’ server behavior.

## Why

QEditor rendered modelValue as inner HTML on the server, but omitted it from the hydration-side VNode until the mounted hook synchronized the editor. This could make Vue hydrate populated server DOM against an empty client VNode.

QDate derives its “today” classes from the local date. A server and browser on opposite sides of a date boundary can therefore produce different classes during hydration. Deferring that cosmetic state preserves identical initial markup while still applying the browser-local highlight after mounting. Applications rendering an unfilled calendar should also provide default-year-month when a stable initial month is required. QTime has the equivalent default-date consideration when its mask contains date tokens.

The timer composables previously called the Node timer APIs when registered during SSR setup. Those timers do not contribute to the synchronous render and can survive beyond the request because server-rendered component instances do not follow the browser mounting lifecycle.

SPA behavior remains unchanged.

## Validation

- Built the Quasar UI package successfully.
- Built the documentation site successfully, including 637 SSG pages.
- Passed the full UI test suite: 1,060 tests across 99 files.
- Passed Oxfmt and Oxlint.
- Passed git diff --check.
- Served the generated SSG output and checked QEditor, QDate, and QTime in headless Chrome without hydration warnings, mismatches, or console errors.
- Repeated the hydration checks across time zones: the SSG output was built in America/Edmonton and loaded with the browser set to Pacific/Kiritimati.