### PR TITLE
fix(ui): clean up deferred lifecycle work

### DIFF
--- a/ui/src/components/editor/QEditor.js
+++ b/ui/src/components/editor/QEditor.js
@@ -113,7 +113,9 @@ export default createComponent({
 
     const editable = computed(() => !props.readonly && !props.disable)
 
-    let defaultFont, offsetBottom
+    let defaultFont,
+      offsetBottom,
+      refreshToolbarTimer = null
     let lastEmit = props.modelValue
 
     if (!__QUASAR_SSR_SERVER__) {
@@ -648,7 +650,12 @@ export default createComponent({
     }
 
     function refreshToolbar() {
-      setTimeout(() => {
+      if (refreshToolbarTimer !== null) {
+        clearTimeout(refreshToolbarTimer)
+      }
+
+      refreshToolbarTimer = setTimeout(() => {
+        refreshToolbarTimer = null
         editLinkUrl.value = null
         proxy.$forceUpdate()
       }, 1)
@@ -673,6 +680,10 @@ export default createComponent({
     })
 
     onBeforeUnmount(() => {
+      if (refreshToolbarTimer !== null) {
+        clearTimeout(refreshToolbarTimer)
+      }
+
       document.removeEventListener('selectionchange', onSelectionchange)
     })
 

--- a/ui/src/components/resize-observer/QResizeObserver.js
+++ b/ui/src/components/resize-observer/QResizeObserver.js
@@ -73,10 +73,13 @@ export default createComponent({
     proxy.trigger = trigger
 
     if (hasObserver) {
-      let observer
+      let observer,
+        isDestroyed = false
 
       // initialize as soon as possible
       const init = stop => {
+        if (isDestroyed) return
+
         targetEl = proxy.$el.parentNode
 
         if (targetEl) {
@@ -95,6 +98,8 @@ export default createComponent({
       })
 
       onBeforeUnmount(() => {
+        isDestroyed = true
+
         if (timer !== null) clearTimeout(timer)
 
         if (observer !== void 0) {
@@ -113,7 +118,8 @@ export default createComponent({
     // no observer, so fallback to old iframe method
     const { isHydrated } = useHydration()
 
-    let curDocView
+    let curDocView,
+      isDestroyed = false
 
     const cleanup = () => {
       if (timer !== null) {
@@ -142,12 +148,17 @@ export default createComponent({
 
     onMounted(() => {
       nextTick(() => {
+        if (isDestroyed) return
+
         targetEl = proxy.$el
         if (targetEl) onObjLoad()
       })
     })
 
-    onBeforeUnmount(cleanup)
+    onBeforeUnmount(() => {
+      isDestroyed = true
+      cleanup()
+    })
 
     return () => {
       if (isHydrated.value) {

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -23,7 +23,9 @@ export default function useFullscreen() {
   const vm = getCurrentInstance()
   const { props, emit, proxy } = vm
 
-  let historyEntry, fullscreenFillerNode
+  let historyEntry,
+    fullscreenFillerNode,
+    isUnmounting = false
   const inFullscreen = ref(false)
 
   if (vmHasRouter(vm)) {
@@ -89,7 +91,7 @@ export default function useFullscreen() {
     if (counter === 0) {
       document.body.classList.remove('q-body--fullscreen-mixin')
 
-      if (proxy.$el.scrollIntoView !== void 0) {
+      if (!isUnmounting && proxy.$el.scrollIntoView !== void 0) {
         setTimeout(() => {
           proxy.$el.scrollIntoView()
         }, 0)
@@ -105,7 +107,10 @@ export default function useFullscreen() {
     if (props.fullscreen) setFullscreen()
   })
 
-  onBeforeUnmount(exitFullscreen)
+  onBeforeUnmount(() => {
+    isUnmounting = true
+    exitFullscreen()
+  })
 
   // expose public methods
   Object.assign(proxy, {

--- a/ui/src/directives/intersection/Intersection.js
+++ b/ui/src/directives/intersection/Intersection.js
@@ -27,7 +27,7 @@ function update(el, ctx, value) {
 
   if (changed) {
     ctx.cfg = cfg
-    ctx.observer?.unobserve(el)
+    ctx.observer?.disconnect()
 
     ctx.observer = new IntersectionObserver(([entry]) => {
       if (typeof ctx.handler === 'function') {
@@ -55,7 +55,7 @@ function destroy(el) {
   const ctx = el.__qvisible
 
   if (ctx !== void 0) {
-    ctx.observer?.unobserve(el)
+    ctx.observer?.disconnect()
     delete el.__qvisible
   }
 }


### PR DESCRIPTION
## Summary

This lifecycle audit prevents deferred component work and observers from surviving teardown or being attached after teardown.

- Coalesce QEditor toolbar refreshes and cancel the pending timer before unmount.
- Guard both QResizeObserver initialization paths against deferred setup after unmount.
- Avoid scheduling fullscreen scroll restoration while its component is being destroyed.
- Fully disconnect Intersection directive observers when their configuration changes or the directive is removed.

## Why

### QEditor

Each toolbar refresh previously created an independent timer which retained the component instance and could call forceUpdate after unmount. Keeping one pending refresh preserves the intended delayed update while avoiding redundant work, and teardown now cancels it.

### QResizeObserver

Observer initialization may be deferred with nextTick when the parent is not immediately available. The iframe fallback also defers initialization. If the component unmounted before that callback ran, the callback could still attach an observer or resize listener after the normal cleanup hook had already completed. Both paths now stop deferred initialization once teardown begins.

### Fullscreen

Leaving fullscreen normally schedules scrollIntoView so the restored component is brought back into view. The same exit routine also runs from onBeforeUnmount, where scheduling that callback is unnecessary and risks accessing the component element after destruction. Scroll restoration is now skipped only for teardown; ordinary fullscreen exits remain unchanged.

### Intersection directive

Each directive instance owns a single observer and target. disconnect() expresses that ownership correctly and releases all observation state when replacing or destroying the observer, instead of merely removing the current target.

No public API behavior changes.

## Validation

- Built the Quasar UI package successfully.
- Passed the full UI test suite: 1,060 tests across 99 files.
- Passed Oxfmt and Oxlint.
- Passed git diff --check.

The build and test suite were run serially for the final validation.