### PR TITLE
fix(ui): align form control behavior

### DIFF
--- a/docs/src/pages/vue-components/date.md
+++ b/docs/src/pages/vue-components/date.md
@@ -201,4 +201,6 @@ When using the persian calendar, the mask for QDate is forced to `YYYY/MM/DD`.
 
 When dealing with a native form which has an `action` and a `method` (eg. when using Quasar with ASP.NET controllers), you need to specify the `name` property on QDate, otherwise formData will not contain it (if it should):
 
+The browser converts the model to a String. When using `multiple` or `range`, use your own hidden inputs if the server requires individual dates or structured range data.
+
 <DocExample title="Native form" file="NativeForm" />

--- a/docs/src/pages/vue-components/input.md
+++ b/docs/src/pages/vue-components/input.md
@@ -78,10 +78,6 @@ Please check these resources for more information about native attributes (for i
 
 As a helper, you can use `clearable` prop so user can reset model to `null` through an appended icon. The second QInput in the example below is the equivalent of using `clearable`.
 
-::: warning
-Won't work with `v-model` managed input modifiers such as `.trim` because in that case Vue doesn't handle `null` values.
-:::
-
 <DocExample title="Clearable" file="Clearable" />
 
 ### Input types

--- a/docs/src/pages/vue-components/range.md
+++ b/docs/src/pages/vue-components/range.md
@@ -124,4 +124,6 @@ Use the `drag-range` or `drag-only-range` props to allow the user to move the se
 
 When dealing with a native form which has an `action` and a `method` (eg. when using Quasar with ASP.NET controllers), you need to specify the `name` property on QRange, otherwise formData will not contain it (if it should):
 
+The submitted value contains the minimum and maximum values separated by a pipe (`min|max`).
+
 <DocExample title="Native form" file="NativeForm" />

--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -179,6 +179,13 @@ export default createComponent({
     watch(
       () => props.modelValue,
       v => {
+        if (emitTimer !== null) {
+          cancelPendingValueEmission()
+          typedNumber = false
+          stopValueWatcher = false
+          delete temp.value
+        }
+
         if (hasMask.value) {
           if (stopValueWatcher) {
             stopValueWatcher = false
@@ -332,6 +339,22 @@ export default createComponent({
       }
     }
 
+    function cancelPendingValueEmission() {
+      if (emitTimer !== null) {
+        clearTimeout(emitTimer)
+        emitTimer = null
+      }
+
+      emitValueFn = void 0
+    }
+
+    function onClear() {
+      cancelPendingValueEmission()
+      typedNumber = false
+      stopValueWatcher = false
+      delete temp.value
+    }
+
     // textarea only
     function adjustHeight() {
       requestAnimationFrame(() => {
@@ -445,6 +468,7 @@ export default createComponent({
       inputRef,
 
       emitValue,
+      onClear,
 
       hasValue,
 

--- a/ui/src/components/input/use-mask.js
+++ b/ui/src/components/input/use-mask.js
@@ -148,6 +148,14 @@ export default function useMask(props, emit, emitValue, inputRef) {
     }
   )
 
+  watch(
+    () => props.maskTokens,
+    () => {
+      if (hasMask.value) updateMaskValue(innerValue.value, true)
+    },
+    { deep: true }
+  )
+
   function getInitialMaskedValue() {
     updateMaskInternals()
 
@@ -311,8 +319,8 @@ export default function useMask(props, emit, emitValue, inputRef) {
 
   function updateMaskValue(rawVal, updateMaskInternalsFlag, inputType) {
     const inp = inputRef.value,
-      end = inp.selectionEnd,
-      endReverse = inp.value.length - end,
+      end = inp?.selectionEnd ?? 0,
+      endReverse = inp === null ? 0 : inp.value.length - end,
       unmasked = unmaskValue(rawVal)
 
     // Update here so unmask uses the original fillChar
@@ -323,11 +331,11 @@ export default function useMask(props, emit, emitValue, inputRef) {
       changed = innerValue.value !== masked
 
     // We want to avoid "flickering" so we set value immediately
-    if (inp.value !== masked) inp.value = masked
+    if (inp !== null && inp.value !== masked) inp.value = masked
 
     if (changed) innerValue.value = masked
 
-    if (document.activeElement === inp) {
+    if (inp !== null && document.activeElement === inp) {
       nextTick(() => {
         if (masked === maskReplaced) {
           const cursor = props.reverseFillMask ? maskReplaced.length : 0

--- a/ui/src/components/range/QRange.js
+++ b/ui/src/components/range/QRange.js
@@ -191,6 +191,7 @@ export default createComponent({
 
     const maxEvents = computed(() => getEvents('max'))
     const getMaxThumb = methods.getThumbRenderFn({
+      injectFormInput: false,
       focusValue: 'max',
       getNodeData: () => ({
         ...maxEvents.value,
@@ -349,7 +350,7 @@ export default createComponent({
       // If either of the values to be emitted are null, set them to the defaults the user has entered.
       model.value =
         model.value.min === null || model.value.max === null
-          ? { min: pos.min || props.min, max: pos.max || props.max }
+          ? { min: pos.min ?? props.min, max: pos.max ?? props.max }
           : { min: pos.min, max: pos.max }
 
       if (!props.snap || props.step === 0) {

--- a/ui/src/components/slider/use-slider.js
+++ b/ui/src/components/slider/use-slider.js
@@ -596,10 +596,14 @@ export default function useSlider({
             ]
           )
         )
+      }
 
-        if (props.name !== void 0 && !props.disable) {
-          injectFormInput(thumbContent, 'push')
-        }
+      if (
+        thumb.injectFormInput !== false &&
+        props.name !== void 0 &&
+        !props.disable
+      ) {
+        injectFormInput(thumbContent, 'push')
       }
 
       return h(

--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -388,6 +388,8 @@ export default function useField(state) {
       state.inputRef.value.value = null
     }
 
+    state.onClear?.()
+
     emit('update:modelValue', null)
     if (state.changeEvent) emit('change', null)
     emit('clear', props.modelValue)

--- a/ui/src/composables/private.use-key-composition/use-key-composition.js
+++ b/ui/src/composables/private.use-key-composition/use-key-composition.js
@@ -9,7 +9,12 @@ const isPlainText = /[a-z0-9_ -]$/i
 
 export default function useKeyComposition(onInput) {
   return function onComposition(e) {
-    if (e.type === 'compositionend' || e.type === 'change') {
+    if (e.type === 'compositionstart') {
+      e.target.qComposing = true
+    } else if (e.type === 'change') {
+      e.target.qComposing = false
+      onInput(e)
+    } else if (e.type === 'compositionend') {
       if (!e.target.qComposing) return
       e.target.qComposing = false
       onInput(e)


### PR DESCRIPTION
## Summary

This form-control audit aligns clearing, debounced updates, autofill, IME composition, reactive masks, native form submission, and QRange boundary handling.

- Prevent pending debounced QInput values from overriding a clear action or a newer external model value.
- Synchronize QInput and QSelect when browsers report autofill through change rather than input.
- Treat compositionstart as the beginning of IME composition for all input methods while retaining the existing legacy detection fallback.
- Recompile QInput masks when maskTokens changes and make pre-mount mask updates safe.
- Render QSlider and QRange native form inputs independently of visual labels.
- Submit one native QRange value rather than one duplicate per thumb.
- Preserve zero-valued QRange boundaries when initializing a previously null model.
- Correct the related QInput, QDate, and QRange documentation.

## QInput clear and debounce ordering

The shared field clear action emits null immediately. QInput previously kept any pending debounced value alive, allowing that stale value to emit afterward and replace the cleared model. A pending user value could similarly overwrite a newer programmatic model update.

QInput now cancels and discards pending value emission state before a shared clear, and an incoming model update supersedes any still-pending debounced input. Clearing remains immediate and non-debounced. Other useField consumers are unchanged because the new clear hook is optional.

## Autofill and IME composition

QInput and QSelect both route composition and change events through useKeyComposition. Their comments state that change handles browsers which do not emit input for autocomplete, but the helper previously ignored change unless qComposing was already set. The model therefore remained stale in the exact autofill fallback case.

A change event now always passes the native value through the normal input handler after ending any composition state. Existing duplicate-emission guards and value comparisons keep ordinary input/change sequences stable.

Composition state now starts on the standard compositionstart event rather than waiting for a later language-specific compositionupdate heuristic. This prevents intermediate values from leaking for IMEs outside the prior Japanese, Chinese, and Korean detection ranges. The existing update-time detection remains as a fallback for older or unusual browser event sequences.

## Reactive masks

maskTokens participates in the computed token table, but no watcher rebuilt the compiled mask expressions when that prop changed. Runtime token updates therefore continued using stale rules until another mask-related prop happened to change. QInput now recompiles and reapplies the mask when custom tokens change, including deep mutations.

Mask reapplication can be triggered before the native input ref exists, especially during parent updates around mounting. Cursor and DOM synchronization are now conditional on the element being available; the internal masked value and emitted model still update normally.

## Slider native form submission

The shared slider renderer injected its hidden form input inside the label-rendering branch. QSlider and QRange therefore submitted no native value unless label or label-always was enabled, even when name was supplied. Native form participation is now independent of presentation props.

QRange renders two thumbs through the same helper, which previously produced two identical hidden inputs whenever the label branch was active. The range now designates one thumb as the form-input owner, yielding a single name=min|max entry. QSlider retains its single input. Disabled controls continue to be omitted, while readonly controls continue to submit their value.

## QRange zero values

When either range boundary began as null, initialization used logical OR to fall back to the configured limits. A legitimate calculated value of 0 was therefore replaced whenever the configured minimum or maximum was nonzero. Nullish fallback now distinguishes an absent value from zero.

## Documentation

- Removed the QInput warning that clearable cannot work with v-model.trim. Vue applies model modifiers only to String payloads, so null passes through unchanged.
- Documented that native QRange values use the existing min|max representation.
- Documented that browsers stringify QDate models and that multiple/range users should supply their own hidden inputs when structured server data is required.

## Impact

- Clear actions and external model updates cannot be undone by stale debounced input.
- Autofill and a broader range of IMEs synchronize consistently in QInput and QSelect.
- Runtime custom mask changes take effect immediately.
- Named sliders and ranges submit regardless of label visibility, with no duplicate QRange entry.
- Zero remains a valid range boundary.
- No public API changes.

## Validation

- Passed the full UI test suite: 1,060 tests across 99 files.
- Built the Quasar UI package successfully.
- Built the documentation site successfully, including 637 SSG pages.
- Passed Oxfmt and Oxlint.
- Passed git diff --check.