### PR TITLE
fix(ui): harden QTable interactions

### DIFF
--- a/docs/src/pages/vue-components/table.md
+++ b/docs/src/pages/vue-components/table.md
@@ -335,7 +335,7 @@ Below, we use a slot which gets applied to each body cell:
 
 <DocExample title="Body-cell slot" file="SlotBodyCell" />
 
-We can also customize only one particular column only. The syntax for this slot is `body-cell-[name]`, where `[name]` should be replaced by the property of each row which is used as the row-key.
+You can also customize a particular column. The syntax for this slot is `body-cell-[name]`, where `[name]` is the column's `name` from the `columns` definition.
 
 <DocExample title="Body-cell-[name] slot" file="SlotBodyCellName" />
 
@@ -349,7 +349,7 @@ Below, we use a slot which gets applied to each header cell:
 
 <DocExample title="Header-cell slot" file="SlotHeaderCell" />
 
-We can also customize only one particular header cell only. The syntax for this slot is `header-cell-[name]`, where `[name]` should be replaced by the property of each row which is used as the row-key.
+You can also customize a particular header cell. The syntax for this slot is `header-cell-[name]`, where `[name]` is the column's `name` from the `columns` definition.
 
 <DocExample title="Header-cell-[name] slot" file="SlotHeaderCellName" />
 

--- a/ui/src/components/table/QTable.js
+++ b/ui/src/components/table/QTable.js
@@ -201,15 +201,17 @@ export default createComponent({
     )
 
     watch(
-      () =>
-        props.tableStyle +
-        props.tableClass +
-        props.tableHeaderStyle +
-        props.tableHeaderClass +
-        containerClass.value,
+      [
+        () => props.tableStyle,
+        () => props.tableClass,
+        () => props.tableHeaderStyle,
+        () => props.tableHeaderClass,
+        containerClass
+      ],
       () => {
         if (hasVirtScroll.value) virtScrollRef.value?.reset()
-      }
+      },
+      { deep: true }
     )
 
     const {
@@ -1095,13 +1097,13 @@ export default createComponent({
 
                 if (props.onRowClick !== void 0) {
                   data.onClick = evt => {
-                    emit('RowClick', evt, scope.row, scope.pageIndex)
+                    emit('rowClick', evt, scope.row, scope.pageIndex)
                   }
                 }
 
                 if (props.onRowDblclick !== void 0) {
                   data.onDblclick = evt => {
-                    emit('RowDblclick', evt, scope.row, scope.pageIndex)
+                    emit('rowDblclick', evt, scope.row, scope.pageIndex)
                   }
                 }
 

--- a/ui/src/components/table/QTh.js
+++ b/ui/src/components/table/QTh.js
@@ -25,6 +25,14 @@ export default createComponent({
       emit('click', evt)
     }
 
+    const onKeyup = (evt, col) => {
+      if (evt.key === 'Enter' || evt.key === ' ') {
+        props.props.sort(col)
+        onClick(evt)
+        evt.preventDefault()
+      }
+    }
+
     return () => {
       if (props.props === void 0) {
         return h(
@@ -40,7 +48,7 @@ export default createComponent({
       let col, child
       const name = vm.vnode.key
 
-      if (name) {
+      if (name !== null) {
         col = props.props.colsMap[name]
         if (col === void 0) return
       } else {
@@ -68,6 +76,17 @@ export default createComponent({
         onClick: evt => {
           if (col.sortable) props.props.sort(col)
           onClick(evt)
+        }
+      }
+
+      if (col.sortable) {
+        data.tabindex = 0
+        data['aria-sort'] = col.__ariaSort
+        data.onKeydown = evt => {
+          if (evt.key === ' ') evt.preventDefault()
+        }
+        data.onKeyup = evt => {
+          onKeyup(evt, col)
         }
       }
 

--- a/ui/src/components/table/table-column-selection.js
+++ b/ui/src/components/table/table-column-selection.js
@@ -48,6 +48,14 @@ export function useTableColumnSelection(
         ...col,
         align,
         __iconClass: `q-table__sort-icon q-table__sort-icon--${align}`,
+        __ariaSort:
+          col.sortable === true
+            ? col.name === sortBy
+              ? descending
+                ? 'descending'
+                : 'ascending'
+              : 'none'
+            : void 0,
         __thClass:
           alignClass +
           (col.headerClasses !== void 0 ? ' ' + col.headerClasses : '') +
@@ -74,7 +82,7 @@ export function useTableColumnSelection(
   })
 
   const computedColsMap = computed(() => {
-    const names = {}
+    const names = Object.create(null)
     computedCols.value.forEach(col => {
       names[col.name] = col
     })

--- a/ui/src/components/table/table-pagination.js
+++ b/ui/src/components/table/table-pagination.js
@@ -64,8 +64,11 @@ export function useTablePaginationState(vm, getCellValue) {
   function requestServerInteraction(prop = {}) {
     nextTick(() => {
       emit('request', {
-        pagination: prop.pagination || computedPagination.value,
-        filter: prop.filter || props.filter,
+        pagination:
+          prop.pagination === void 0
+            ? computedPagination.value
+            : prop.pagination,
+        filter: prop.filter === void 0 ? props.filter : prop.filter,
         getCellValue
       })
     })

--- a/ui/src/components/table/table-row-selection.js
+++ b/ui/src/components/table/table-row-selection.js
@@ -15,13 +15,9 @@ export const useTableRowSelectionProps = {
 export const useTableRowSelectionEmits = ['update:selected', 'selection']
 
 export function useTableRowSelection(props, emit, computedRows, getRowKey) {
-  const selectedKeys = computed(() => {
-    const keys = {}
-    props.selected.map(getRowKey.value).forEach(key => {
-      keys[key] = true
-    })
-    return keys
-  })
+  const selectedKeys = computed(
+    () => new Set(props.selected.map(getRowKey.value))
+  )
 
   const hasSelectionMode = computed(() => props.selection !== 'none')
   const singleSelection = computed(() => props.selection === 'single')
@@ -29,19 +25,23 @@ export function useTableRowSelection(props, emit, computedRows, getRowKey) {
   const allRowsSelected = computed(
     () =>
       computedRows.value.length !== 0 &&
-      computedRows.value.every(row => selectedKeys.value[getRowKey.value(row)])
+      computedRows.value.every(row =>
+        selectedKeys.value.has(getRowKey.value(row))
+      )
   )
 
   const someRowsSelected = computed(
     () =>
       !allRowsSelected.value &&
-      computedRows.value.some(row => selectedKeys.value[getRowKey.value(row)])
+      computedRows.value.some(row =>
+        selectedKeys.value.has(getRowKey.value(row))
+      )
   )
 
   const rowsSelectedNumber = computed(() => props.selected.length)
 
   function isRowSelected(key) {
-    return selectedKeys.value[key] === true
+    return selectedKeys.value.has(key)
   }
 
   function clearSelection() {


### PR DESCRIPTION
## Summary

This deep-dive audit tightens QTable behavior across interaction accessibility, grid-mode events, row and column identity, server-side requests, virtual scrolling, and the corresponding slot documentation.

## What changed and why

### Make sortable headers keyboard accessible

Sortable headers were clickable but could not receive focus or be operated from the keyboard. QTh now:

- makes sortable headers focusable;
- supports both Enter and Space activation;
- prevents Space from scrolling the page while activating a sort;
- exposes `aria-sort` as `none`, `ascending`, or `descending`; and
- emits the existing click event for keyboard activation, preserving parity with pointer interaction.

This gives keyboard and assistive-technology users access to the same sorting behavior without changing non-sortable headers.

### Emit the documented row events in grid mode

The standard table renderer emitted `rowClick` and `rowDblclick`, while the default grid renderer used `RowClick` and `RowDblclick`. Those differently capitalized names did not match QTable's declared events or the listener props used to enable the handlers.

Grid mode now emits the same documented event names and payloads as table mode.

### Preserve arbitrary primitive row keys safely

Selection state previously indexed row keys on a normal object. Special string keys such as `__proto__` cannot be represented reliably that way and can collide with inherited object properties.

The selection lookup now uses a `Set`, which preserves primitive key identity and avoids prototype-key collisions while retaining constant-time membership checks.

### Protect column lookup from prototype-key collisions

The internal column-name map had the same normal-object limitation. It now uses a null-prototype object so legitimate names such as `constructor` or `__proto__` remain addressable through named slots and public column lookup paths.

### Respect explicitly cleared server-side filters

`requestServerInteraction()` selected overrides with logical OR. Passing an empty string to request unfiltered server data therefore restored the current filter instead of forwarding the requested value.

The method now falls back only when an override is `undefined`, allowing explicit empty values to reach the `request` event while preserving the existing default behavior.

### Reset virtual-scroll measurements for reactive style changes

The virtual-scroll reset watcher concatenated style and class props into a string. Object and array values collapse to generic strings, so replacing or mutating reactive style objects could leave cached row measurements stale.

The watcher now observes each source directly and deeply, ensuring layout-affecting table and header changes invalidate the virtual-scroll measurements.

### Correct the named-slot documentation

The Table documentation said the suffix for `body-cell-[name]` and `header-cell-[name]` came from `row-key`. These slots are selected by the column definition's `name`. The guidance now matches QTable's implementation and API JSON.

## Validation

- All 99 UI test files passed.
- All 1,060 UI tests passed.
- The complete Quasar UI production build passed.
- Oxlint passed with warnings denied.
- Oxfmt validation passed.
- `git diff --check` passed.
