### PR TITLE
fix(app-vite): clarify SSG render failures

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -340,13 +340,35 @@ export class QuasarModeBuilder extends AppBuilder {
         })
       } catch (err) {
         console.log()
-        console.error(err)
-        console.error('\nOffending SSG page definition:')
+        console.error('Offending SSG page definition:')
         console.error(page)
 
+        const pageIdentifier =
+          `route "${page.route}"` + `${page.label ? ` [${page.label}]` : ''}`
+
+        if (err?.routeNotFound) {
+          fatal(
+            `Failed to render SSG page for ${pageIdentifier}:` +
+              ' Vue Router did not match the route.',
+            'FAIL'
+          )
+        }
+
+        if (err?.redirectUrl) {
+          fatal(
+            `Failed to render SSG page for ${pageIdentifier}:` +
+              ` the route redirects to "${err.redirectUrl}".` +
+              ' Generate the destination route instead.',
+            'FAIL'
+          )
+        }
+
+        console.error('\nRender error:')
+        console.error(err)
+
         fatal(
-          `Failed to render SSG page for route "${page.route}"` +
-            `${page.label ? ` [${page.label}]` : ''}. Check details above.`,
+          `Failed to render SSG page for ${pageIdentifier}.` +
+            ' Check details above.',
           'FAIL'
         )
       }


### PR DESCRIPTION
## Summary

- report unmatched Vue Router routes explicitly during an SSG production build
- report redirecting routes with their destination and actionable guidance
- retain the offending SSG page definition for every failure
- label ordinary exceptions as render errors before printing their details

## Why

The SSG development server already distinguishes route-not-found and redirect outcomes, but the production builder printed their internal sentinel objects and then ended with the same generic fatal message used for unexpected rendering exceptions. That made invalid page definitions and redirect routes harder to diagnose during a build, even though the renderer supplied enough information to explain the failure.

This aligns the production-build diagnostics with the clearer development behavior while preserving the existing generic path for actual exceptions. A redirecting page now directs the developer to generate its destination route instead.

## Validation

- `pnpm exec oxlint app-vite/lib/modes/ssg/ssg-builder.js`
- `git diff --check`
- repository commit-time formatting and lint checks passed