### PR TITLE
fix(app-vite): normalize default SSG child routes

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -32,10 +32,10 @@ function getParseVueRouterRoutesFn(quasarConf) {
   const parseVueRouterRoutes = ({ routes, parentPath, opts }) => {
     for (const route of routes) {
       const routePath = route.path
-      const fullPath = `${parentPath}/${routePath}`.replaceAll(
-        multiSlashRE,
-        '/'
-      )
+      const fullPath =
+        routePath === ''
+          ? parentPath
+          : `${parentPath}/${routePath}`.replaceAll(multiSlashRE, '/')
 
       if (opts.isCrawlIgnoreMatch?.(fullPath)) {
         opts.acc.crawlIgnoredRoutes.push(route)


### PR DESCRIPTION
## Summary

Preserve the parent path when `parseVueRouterRoutes()` encounters a default child whose Vue Router path is an empty string.

## Why

For a route tree such as:

```js
{
  path: "/admin",
  children: [
    { path: "", component: AdminPage },
    { path: "users", component: UsersPage }
  ]
}
```

the production SSG parser previously joined the empty child path as `/admin/`. Development checks the requested route as `/admin`, so an exact `clientSideRenderingRoutes: ["/admin"]` pattern could select CSR during development while the production parser still included the default child in its SSG page list.

An empty child represents its parent route. The parser now inherits `parentPath` directly for that case. Non-empty child paths continue through the existing normalized join, so `/admin` plus `users` remains `/admin/users`.

## Impact

- exact CSR patterns behave consistently for default child routes in development and production SSG builds
- `crawlIgnoreRoutes` uses the same normalized default-child identity
- non-empty route parsing is unchanged

## Validation

- `node --check app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxlint --deny-warnings app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxfmt --check app-vite/lib/modes/ssg/ssg-builder.js`
- `git diff --check`
- repository commit-time formatting and lint checks passed