### PR TITLE
fix(app-vite): normalize SSG parent paths

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -32,10 +32,9 @@ function getParseVueRouterRoutesFn(quasarConf) {
   const parseVueRouterRoutes = ({ routes, parentPath, opts }) => {
     for (const route of routes) {
       const routePath = route.path
-      const fullPath =
-        routePath === ''
-          ? parentPath
-          : `${parentPath}/${routePath}`.replaceAll(multiSlashRE, '/')
+      const fullPath = (
+        routePath === '' ? parentPath : `${parentPath}/${routePath}`
+      ).replaceAll(multiSlashRE, '/')
 
       if (opts.isCrawlIgnoreMatch?.(fullPath)) {
         opts.acc.crawlIgnoredRoutes.push(route)


### PR DESCRIPTION
## Summary

Normalize the resolved SSG route path after selecting either the inherited parent path or the joined child path.

## Why

PR #18388 correctly made a default child with `path: ""` inherit its parent path so development and production apply exact route patterns consistently. In that branch of the conditional, however, the caller-supplied `parentPath` bypassed the existing multi-slash normalization.

Moving `replaceAll(multiSlashRE, "/")` after the conditional keeps the default-child behavior while applying the same sanitation to both path sources. This matters because `parentPath` is part of the public `parseVueRouterRoutes()` input and is used directly by CSR and crawl-ignore matching.

## Impact

- caller-supplied parent paths are normalized before route-pattern matching
- empty default children continue to retain their parent route identity
- non-empty child paths preserve the existing normalized join behavior

## Validation

- `node --check app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxlint --deny-warnings app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxfmt --check app-vite/lib/modes/ssg/ssg-builder.js`
- `git diff --check`
- repository commit-time formatting and lint checks passed