### PR TITLE
fix(app-vite): match CSR routes with trailing slashes

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -1,8 +1,8 @@
 import { join } from 'node:path'
 import { merge } from 'webpack-merge'
-import picomatch from 'picomatch'
 
 import { AppBuilder } from '../../app-builder.js'
+import { getRouteMatcher } from '../../utils/get-route-matcher.js'
 import { quasarSsgConfig } from './ssg-config.js'
 import {
   getProdSsrRenderTemplateFileContent,
@@ -26,7 +26,7 @@ function getParseVueRouterRoutesFn(quasarConf) {
   const { clientSideRenderingRoutes } = quasarConf.ssg
   const isCSRMatch =
     clientSideRenderingRoutes.length !== 0
-      ? picomatch(clientSideRenderingRoutes)
+      ? getRouteMatcher(clientSideRenderingRoutes)
       : () => false
 
   const parseVueRouterRoutes = ({ routes, parentPath, opts }) => {
@@ -141,7 +141,9 @@ function getParseVueRouterRoutesFn(quasarConf) {
         acc,
         verbose,
         isCrawlIgnoreMatch:
-          crawlIgnoreRoutes.length !== 0 ? picomatch(crawlIgnoreRoutes) : null
+          crawlIgnoreRoutes.length !== 0
+            ? getRouteMatcher(crawlIgnoreRoutes)
+            : null
       }
     })
 

--- a/app-vite/lib/modes/ssg/ssg-devserver.js
+++ b/app-vite/lib/modes/ssg/ssg-devserver.js
@@ -1,12 +1,12 @@
 import { readFileSync } from 'node:fs'
 import { createServer, createServerModuleRunner } from 'vite'
 import { watch as chokidarWatch } from 'chokidar'
-import picomatch from 'picomatch'
 import serialize from 'serialize-javascript'
 import { green } from 'kolorist'
 
 import { AppDevserver } from '../../app-devserver.js'
 import { getPackage } from '../../utils/get-package.js'
+import { getRouteMatcher } from '../../utils/get-route-matcher.js'
 import { openBrowser } from '../../utils/open-browser.js'
 import { dot, info, log, warn } from '../../utils/logger.js'
 import { debounce } from '../../utils/rate-limit.js'
@@ -126,7 +126,7 @@ export class QuasarModeDevserver extends AppDevserver {
       return
     }
 
-    const isMatch = picomatch(clientSideRenderingRoutes)
+    const isMatch = getRouteMatcher(clientSideRenderingRoutes)
     const { publicPath } = quasarConf.build
 
     this.#isCsrRoute =

--- a/app-vite/lib/modes/ssr/ssr-devserver.js
+++ b/app-vite/lib/modes/ssr/ssr-devserver.js
@@ -3,12 +3,12 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { createServer, createServerModuleRunner } from 'vite'
 import { watch as chokidarWatch } from 'chokidar'
-import picomatch from 'picomatch'
 import serialize from 'serialize-javascript'
 import { green } from 'kolorist'
 
 import { AppDevserver } from '../../app-devserver.js'
 import { getPackage } from '../../utils/get-package.js'
+import { getRouteMatcher } from '../../utils/get-route-matcher.js'
 import { openBrowser } from '../../utils/open-browser.js'
 import { dot, info, log, progress, warn } from '../../utils/logger.js'
 import { debounce } from '../../utils/rate-limit.js'
@@ -165,7 +165,7 @@ export class QuasarModeDevserver extends AppDevserver {
       return
     }
 
-    const isMatch = picomatch(clientSideRenderingRoutes)
+    const isMatch = getRouteMatcher(clientSideRenderingRoutes)
     const { publicPath } = quasarConf.build
 
     this.#isCsrRoute =

--- a/app-vite/lib/utils/get-route-matcher.js
+++ b/app-vite/lib/utils/get-route-matcher.js
@@ -1,0 +1,13 @@
+import picomatch from 'picomatch'
+
+const trailingSlashRE = /\/+$/
+
+export function getRouteMatcher(patterns) {
+  const isMatch = picomatch(patterns)
+
+  return route =>
+    isMatch(route) ||
+    (route.length > 1 &&
+      route.endsWith('/') &&
+      isMatch(route.replace(trailingSlashRE, '')))
+}

--- a/app-vite/templates/entry/ssr-prod-webserver.js
+++ b/app-vite/templates/entry/ssr-prod-webserver.js
@@ -40,6 +40,15 @@ const csrHtml = readFileSync(
   'utf8'
 )
 const isCsrRoute = picomatch(<%= JSON.stringify(quasarConf.ssr.clientSideRenderingRoutes) %>)
+const trailingSlashRE = /\/+$/
+
+function isCsrRouteMatch(route) {
+  return isCsrRoute(route) || (
+    route.length > 1
+    && route.endsWith('/')
+    && isCsrRoute(route.replace(trailingSlashRE, ''))
+  )
+}
 
 function fastExtractPath(url) {
   let endIdx = url.length
@@ -112,7 +121,7 @@ function renderStoreState (ssrContext) {
 async function render (ssrContext) {
   <% if (quasarConf.ssr.clientSideRenderingRoutes.length !== 0) { %>
   if (
-    isCsrRoute(
+    isCsrRouteMatch(
       fastExtractPath(ssrContext.url || ssrContext.req.url)<% if (quasarConf.build.publicPath !== '/') { %>.replace(publicPath, '/')<% } %>
     )
   ) return csrHtml


### PR DESCRIPTION
## Summary

Treat a trailing slash as an optional URL form when matching CSR and SSG crawl-ignore route patterns.

A canonical pattern such as `/csr` now matches both `/csr` and `/csr/`, including applications deployed under a non-root `publicPath`.

## Why

Vue Router is non-strict by default and resolves `/csr` and `/csr/` to the same route. Picomatch operates on strings, however, so an exact `clientSideRenderingRoutes: ["/csr"]` pattern previously selected CSR for `/csr` but not `/csr/`. This produced inconsistent rendering for equivalent URLs.

The new shared App Vite matcher first checks the original route. If that does not match and the non-root route has trailing slashes, it retries after removing those slashes. Checking the original value first preserves explicitly slash-terminated patterns and normal Picomatch glob behavior. The root route remains unchanged.

## Coverage

The matcher is applied consistently to:

- SSG development CSR selection
- SSG production CSR and `crawlIgnoreRoutes` parsing
- SSR development CSR selection
- the generated SSR production webserver

## Validation

- verified exact `/csr` against `/csr`, `/csr/`, and `/csr///`
- verified direct-child glob behavior remains unchanged
- verified `/` remains distinct
- verified explicitly slash-terminated patterns still match their original route
- completed a production SSR documentation build with `clientSideRenderingRoutes: ["/csr"]` enabled
- `pnpm exec oxlint --deny-warnings` passed for all changed JavaScript files
- `pnpm exec oxfmt --check` passed
- `git diff --check` passed
- repository commit-time formatting and lint checks passed