### PR TITLE
feat(app-vite): share common SSR and SSG config

### DIFF
--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -41,6 +41,39 @@ const quasarModesList = [
   'ssg'
 ]
 
+const sharedSsrSsgConfigProps = [
+  'pwa',
+  'pwaOfflineHtmlFilename',
+  'clientSideRenderingRoutes',
+  'manualStoreSerialization',
+  'manualStoreSsrContextInjection',
+  'manualStoreHydration',
+  'manualPostHydrationTrigger'
+]
+
+function inheritSsrSsgConfig({ ctx, userCfg, rawQuasarConf }) {
+  const targetMode = ctx.mode.ssr === true ? 'ssr' : 'ssg'
+  const sourceMode = targetMode === 'ssr' ? 'ssg' : 'ssr'
+  const targetConfig = userCfg[targetMode]
+  const sourceConfig = userCfg[sourceMode]
+
+  if (sourceConfig === void 0) {
+    return
+  }
+
+  sharedSsrSsgConfigProps.forEach(prop => {
+    if (targetConfig?.[prop] === void 0 && sourceConfig[prop] !== void 0) {
+      const value = sourceConfig[prop]
+
+      // Use the raw user config so mode defaults never become inherited values.
+      // Clone arrays so App Extensions can independently modify either mode.
+      rawQuasarConf[targetMode][prop] = Array.isArray(value)
+        ? [...value]
+        : value
+    }
+  })
+}
+
 const urlRegex = /^http(s)?:\/\//i
 const defaultPortMapping = {
   spa: 9000,
@@ -827,6 +860,14 @@ export class QuasarConfigFile {
       },
       userCfg
     )
+
+    if (this.#ctx.mode.ssr || this.#ctx.mode.ssg) {
+      inheritSsrSsgConfig({
+        ctx: this.#ctx,
+        userCfg,
+        rawQuasarConf
+      })
+    }
 
     const metaConf = {
       debugging: Boolean(this.#ctx.dev || this.#ctx.debug),

--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -42,7 +42,6 @@ const quasarModesList = [
 ]
 
 const sharedSsrSsgConfigProps = [
-  'pwa',
   'pwaOfflineHtmlFilename',
   'clientSideRenderingRoutes',
   'manualStoreSerialization',

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -5,6 +5,10 @@ interface QuasarSsrManifest {
   [key: string]: string[];
 }
 
+/**
+ * Properties also available in the SSR configuration inherit their explicitly
+ * configured SSR value when omitted here. An SSG value always takes precedence.
+ */
 export interface QuasarSsgConfiguration {
   /**
    * If a PWA should take over or just a SPA.

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -24,7 +24,7 @@ export interface QuasarSsgConfiguration {
    * don't conflict with it! Also, it shouldn't clash with the
    * "clientSideRenderingHtmlFilename" option if you are using that.
    *
-   * @default 'offline.html'
+   * @default ssr.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
    */
   pwaOfflineHtmlFilename?: string;
 
@@ -89,7 +89,7 @@ export interface QuasarSsgConfiguration {
    *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
    *
    * @example ['/dashboard', '/admin/**']
-   * @default []
+   * @default ssr.clientSideRenderingRoutes (when configured), otherwise []
    */
   clientSideRenderingRoutes?: string[];
 
@@ -128,13 +128,13 @@ export interface QuasarSsgConfiguration {
   /**
    * Manually serialize the store state and provide it yourself
    * as window.__INITIAL_STATE__ to the client-side (through a <script> tag)
-   * @default false
+   * @default ssr.manualStoreSerialization (when configured), otherwise false
    */
   manualStoreSerialization?: boolean;
 
   /**
    * Manually inject the store state into ssrContext.state
-   * @default false
+   * @default ssr.manualStoreSsrContextInjection (when configured), otherwise false
    */
   manualStoreSsrContextInjection?: boolean;
 
@@ -143,14 +143,14 @@ export interface QuasarSsgConfiguration {
    *
    * For Pinia: store.state.value = window.__INITIAL_STATE__
    *
-   * @default false
+   * @default ssr.manualStoreHydration (when configured), otherwise false
    */
   manualStoreHydration?: boolean;
 
   /**
    * Manually call $q.onSSRHydrated() instead of letting Quasar CLI do it.
    * This announces that client-side code should takeover.
-   * @default false
+   * @default ssr.manualPostHydrationTrigger (when configured), otherwise false
    */
   manualPostHydrationTrigger?: boolean;
 

--- a/app-vite/types/configuration/ssr-conf.d.ts
+++ b/app-vite/types/configuration/ssr-conf.d.ts
@@ -22,7 +22,7 @@ export interface QuasarSsrConfiguration {
    *
    * Do NOT use index.html as name as it will mess SSR up!
    *
-   * @default 'offline.html'
+   * @default ssg.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
    */
   pwaOfflineHtmlFilename?: string;
 
@@ -73,20 +73,20 @@ export interface QuasarSsrConfiguration {
    *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
    *
    * @example ['/dashboard', '/admin/**']
-   * @default []
+   * @default ssg.clientSideRenderingRoutes (when configured), otherwise []
    */
   clientSideRenderingRoutes?: string[];
 
   /**
    * Manually serialize the store state and provide it yourself
    * as window.__INITIAL_STATE__ to the client-side (through a <script> tag)
-   * @default false
+   * @default ssg.manualStoreSerialization (when configured), otherwise false
    */
   manualStoreSerialization?: boolean;
 
   /**
    * Manually inject the store state into ssrContext.state
-   * @default false
+   * @default ssg.manualStoreSsrContextInjection (when configured), otherwise false
    */
   manualStoreSsrContextInjection?: boolean;
 
@@ -95,14 +95,14 @@ export interface QuasarSsrConfiguration {
    *
    * For Pinia: store.state.value = window.__INITIAL_STATE__
    *
-   * @default false
+   * @default ssg.manualStoreHydration (when configured), otherwise false
    */
   manualStoreHydration?: boolean;
 
   /**
    * Manually call $q.onSSRHydrated() instead of letting Quasar CLI do it.
    * This announces that client-side code should takeover.
-   * @default false
+   * @default ssg.manualPostHydrationTrigger (when configured), otherwise false
    */
   manualPostHydrationTrigger?: boolean;
 

--- a/app-vite/types/configuration/ssr-conf.d.ts
+++ b/app-vite/types/configuration/ssr-conf.d.ts
@@ -5,6 +5,10 @@ export interface QuasarSsrManifest {
   [key: string]: string[];
 }
 
+/**
+ * Properties also available in the SSG configuration inherit their explicitly
+ * configured SSG value when omitted here. An SSR value always takes precedence.
+ */
 export interface QuasarSsrConfiguration {
   /**
    * If a PWA should take over or just a SPA.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -82,7 +82,7 @@ return {
      * don't conflict with it! Also, it shouldn't clash with the
      * "clientSideRenderingHtmlFilename" option if you are using that.
      *
-     * @default 'offline.html'
+     * @default ssr.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
      */
     pwaOfflineHtmlFilename?: string;
 
@@ -147,7 +147,7 @@ return {
      *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
      *
      * @example ['/dashboard', '/admin/**']
-     * @default []
+     * @default ssr.clientSideRenderingRoutes (when configured), otherwise []
      */
     clientSideRenderingRoutes?: string[];
 
@@ -182,13 +182,13 @@ return {
     /**
      * Manually serialize the store state and provide it yourself
      * as window.__INITIAL_STATE__ to the client-side (through a <script> tag)
-     * @default false
+     * @default ssr.manualStoreSerialization (when configured), otherwise false
      */
     manualStoreSerialization?: boolean;
 
     /**
      * Manually inject the store state into ssrContext.state
-     * @default false
+     * @default ssr.manualStoreSsrContextInjection (when configured), otherwise false
      */
     manualStoreSsrContextInjection?: boolean;
 
@@ -197,14 +197,14 @@ return {
      *
      * For Pinia: store.state.value = window.__INITIAL_STATE__
      *
-     * @default false
+     * @default ssr.manualStoreHydration (when configured), otherwise false
      */
     manualStoreHydration?: boolean;
 
     /**
      * Manually call $q.onSSRHydrated() instead of letting Quasar CLI do it.
      * This announces that client-side code should takeover.
-     * @default false
+     * @default ssr.manualPostHydrationTrigger (when configured), otherwise false
      */
     manualPostHydrationTrigger?: boolean;
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
 }))
 ```
 
-This applies to `pwa`, `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. Mode-specific options and extension hooks are not shared.
+This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
 
 A typical configuration needs only a few options:
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -21,6 +21,23 @@ The Quasar SSG Mode is currently in the "beta" stage. Based on the community fee
 
 The `ssg` section controls generated fallback files, client-rendered routes, PWA takeover, store hydration, and advanced build hooks. Page generation itself belongs in `/src-ssg/ssg-renderer`.
 
+Options shared by the `ssg` and `ssr` sections can be configured once. When a shared option is omitted from `ssg`, Quasar uses an explicitly configured value from `ssr`. A value specified in `ssg`, including `false` or an empty array, always takes precedence.
+
+```js /quasar.config file
+export default defineConfig(() => ({
+  ssr: {
+    // Also used by SSG because SSG does not override it
+    clientSideRenderingRoutes: ['/admin/**']
+  },
+
+  ssg: {
+    error404HtmlFilename: '404.html'
+  }
+}))
+```
+
+This applies to `pwa`, `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. Mode-specific options and extension hooks are not shared.
+
 A typical configuration needs only a few options:
 
 ```js /quasar.config file

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
@@ -22,6 +22,23 @@ scope:
 
 This is the place where you can configure some SSR options. Like if you want the client side to takeover as a SPA (Single Page Application -- the default behaviour), or as a PWA (Progressive Web App).
 
+Options shared by the `ssr` and `ssg` sections can be configured once. When a shared option is omitted from `ssr`, Quasar uses an explicitly configured value from `ssg`. A value specified in `ssr`, including `false` or an empty array, always takes precedence.
+
+```js /quasar.config file
+export default defineConfig(() => ({
+  ssr: {
+    prodPort: 3000
+  },
+
+  ssg: {
+    // Also used by SSR because SSR does not override it
+    clientSideRenderingRoutes: ['/admin/**']
+  }
+}))
+```
+
+This applies to `pwa`, `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. Mode-specific options and extension hooks are not shared.
+
 ```ts /quasar.config file
 return {
   // ...

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
@@ -37,7 +37,7 @@ export default defineConfig(() => ({
 }))
 ```
 
-This applies to `pwa`, `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. Mode-specific options and extension hooks are not shared.
+This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
 
 ```ts /quasar.config file
 return {

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
@@ -56,7 +56,7 @@ return {
      *
      * Do NOT use index.html as name as it will mess SSR up!
      *
-     * @default 'offline.html'
+     * @default ssg.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
      */
     pwaOfflineHtmlFilename?: string;
 
@@ -105,20 +105,20 @@ return {
      *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
      *
      * @example ['/dashboard', '/admin/**']
-     * @default []
+     * @default ssg.clientSideRenderingRoutes (when configured), otherwise []
      */
     clientSideRenderingRoutes?: string[];
 
     /**
      * Manually serialize the store state and provide it yourself
      * as window.__INITIAL_STATE__ to the client-side (through a <script> tag)
-     * @default false
+     * @default ssg.manualStoreSerialization (when configured), otherwise false
      */
     manualStoreSerialization?: boolean;
 
     /**
      * Manually inject the store state into ssrContext.state
-     * @default false
+     * @default ssg.manualStoreSsrContextInjection (when configured), otherwise false
      */
     manualStoreSsrContextInjection?: boolean;
 
@@ -127,14 +127,14 @@ return {
      *
      * For Pinia: store.state.value = window.__INITIAL_STATE__
      *
-     * @default false
+     * @default ssg.manualStoreHydration (when configured), otherwise false
      */
     manualStoreHydration?: boolean;
 
     /**
      * Manually call $q.onSSRHydrated() instead of letting Quasar CLI do it.
      * This announces that client-side code should takeover.
-     * @default false
+     * @default ssg.manualPostHydrationTrigger (when configured), otherwise false
      */
     manualPostHydrationTrigger?: boolean;
 


### PR DESCRIPTION
## Summary

- let SSR and SSG reuse explicitly configured values for their common behavioral options
- preserve mode-specific overrides, including `false` and empty arrays
- keep PWA takeover activation explicit for each build mode
- document the inheritance and precedence in both configuration guides and type declarations

## Why

SSR and SSG expose the same configuration for client-only route patterns, PWA support files, and manual store/hydration behavior. Applications supporting both modes currently have to duplicate those values. Keeping the two copies aligned is unnecessary work and allows configuration drift.

The active mode now falls back to the corresponding option from the other mode only when that option was explicitly supplied by the user and omitted from the active mode. Its own explicit value always wins.

The implementation deliberately reads the raw user configuration rather than the normalized configuration. This prevents built-in defaults such as `false` and `[]` from being mistaken for user intent and inherited by the other mode. Inherited arrays are cloned before App Extensions run so extensions can modify either mode independently.

The shared allowlist is limited to:

- `pwaOfflineHtmlFilename`
- `clientSideRenderingRoutes`
- `manualStoreSerialization`
- `manualStoreSsrContextInjection`
- `manualStoreHydration`
- `manualPostHydrationTrigger`

The `pwa` boolean is intentionally excluded. It enables PWA takeover for a particular build mode, so omission retains that mode default rather than silently inheriting a deployment decision from the other mode. Sharing `pwaOfflineHtmlFilename` remains safe because the filename cannot enable PWA by itself.

Other mode-specific filenames, server settings, and extension hooks remain independent.

## Precedence

1. Explicit active-mode value, including `false` or `[]`
2. Explicit value from the other rendering mode
3. Quasar built-in default

## Validation

- staged-file Oxfmt and Oxlint checks passed during both commits
- targeted Oxlint passed for `app-vite/lib/quasar-config-file.js`
- repository-wide Oxfmt check passed
- `git diff --check` passed
- repository-wide Oxlint was also run; it reached existing generated-state failures because the playground `.quasar/tsconfig.json` files and generated `HasSsg` export are absent in this checkout