### PR TITLE
fix(app-vite): harden concurrent SSG rendering

### DIFF
--- a/app-vite/lib/app-builder.js
+++ b/app-vite/lib/app-builder.js
@@ -26,12 +26,23 @@ export class AppBuilder extends AppTool {
       ? filename
       : join(this.quasarConf.build.distDir, filename)
 
-    if (noOverwrite && fse.existsSync(target)) {
-      return true
-    }
-
     fse.ensureDirSync(dirname(target))
-    await fse.writeFile(target, content, 'utf8')
+
+    try {
+      await fse.writeFile(
+        target,
+        content,
+        noOverwrite === true
+          ? { encoding: 'utf8', flag: 'wx' }
+          : { encoding: 'utf8' }
+      )
+    } catch (err) {
+      if (noOverwrite === true && err.code === 'EEXIST') {
+        return true
+      }
+
+      throw err
+    }
   }
 
   async copyFiles(patterns, targetFolder = this.quasarConf.build.distDir) {

--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -462,14 +462,16 @@ export class QuasarModeBuilder extends AppBuilder {
         ? getRouteMatcher(noPreloadTagRoutes)
         : null
 
-    const threadsBanner =
-      ssgRendererConcurrency > 1 ? ` (${ssgRendererConcurrency} threads)` : ''
+    const concurrencyBanner =
+      ssgRendererConcurrency > 1
+        ? ` (concurrency: ${ssgRendererConcurrency})`
+        : ''
 
     const done = progress({
       tool: 'SSG',
       waitAction: 'Rendering',
       doneAction: 'Rendered',
-      target: `${ssgPageList.length} SSG page${ssgPageList.length > 1 ? 's' : ''}${threadsBanner}`
+      target: `${ssgPageList.length} SSG page${ssgPageList.length > 1 ? 's' : ''}${concurrencyBanner}`
     })
 
     const { onSsgRendererError } = this.quasarConf.ssg
@@ -570,7 +572,7 @@ export class QuasarModeBuilder extends AppBuilder {
     }
 
     if (errorsEncountered) {
-      if (['abort', 'error'].includes(onSsgRendererError)) {
+      if (!['warn', 'ignore'].includes(onSsgRendererError)) {
         fatal(
           `Failed to render ${errorsEncountered} SSG page${errorsEncountered > 1 ? 's' : ''}. Check details above.`,
           'FAIL'
@@ -592,7 +594,7 @@ export class QuasarModeBuilder extends AppBuilder {
       done({
         target:
           ` ${renderedCount}/${ssgPageList.length} SSG page` +
-          `${renderedCount > 1 ? 's' : ''}${threadsBanner}`
+          `${renderedCount > 1 ? 's' : ''}${concurrencyBanner}`
       })
     } else {
       done()

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -131,8 +131,9 @@ export interface QuasarSsgConfiguration {
   onSsgRendererError?: OnSsgRendererError;
 
   /**
-   * The number of threads to use for the SSG rendering process.
-   * This can help speed up the rendering of multiple pages by utilizing multiple CPU cores.
+   * The maximum number of SSG pages to render concurrently.
+   * This can speed up rendering that includes asynchronous work, such as data fetching.
+   * The render jobs run concurrently in the same Node.js thread.
    *
    * @default Math.max(1, os.availableParallelism() - 1)
    */

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
 }))
 ```
 
-This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
+This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, `noPreloadTagRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
 
 A typical configuration needs only a few options:
 
@@ -88,7 +88,7 @@ ssg: {
     *     process.exit(1)
     *   }
     *
-    * @type OnSsgBuildError
+    * @type OnSsgRendererError
     * @default 'abort'
     */
   onSsgRendererError?:
@@ -107,8 +107,9 @@ ssg: {
       }) => void | Promise<void>);
 
   /**
-   * The number of threads to use for the SSG rendering process.
-   * This can help speed up the rendering of multiple pages by utilizing multiple CPU cores.
+   * The maximum number of SSG pages to render concurrently.
+   * This can speed up rendering that includes asynchronous work, such as data fetching.
+   * The render jobs run concurrently in the same Node.js thread.
    *
    * @default Math.max(1, os.availableParallelism() - 1)
    */

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/configuring-ssr.md
@@ -37,7 +37,7 @@ export default defineConfig(() => ({
 }))
 ```
 
-This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
+This applies to `pwaOfflineHtmlFilename`, `clientSideRenderingRoutes`, `noPreloadTagRoutes`, and the `manualStore*` and `manualPostHydrationTrigger` options. The `pwa` option remains mode-specific so that enabling PWA takeover for one mode does not implicitly enable it for the other. Other mode-specific options and extension hooks are not shared.
 
 ```ts /quasar.config file
 return {


### PR DESCRIPTION
## Summary

- make no-overwrite file creation atomic during concurrent SSG rendering
- ensure custom renderer-error handlers still fail the build after accumulated errors
- describe SSG renderer concurrency as same-thread promise concurrency rather than CPU threads
- align the SSG type name and shared-option documentation

## Why

The new concurrent SSG renderer can attempt multiple output writes at once. `AppBuilder.writeFile()` previously implemented `noOverwrite` with `existsSync()` followed by an asynchronous write. Two pages targeting the same filename could both pass that check before either write completed, silently replacing the duplicate-output error with nondeterministic output.

The no-overwrite path now opens the target with the filesystem-exclusive `wx` flag. This makes file reservation atomic and maps `EEXIST` back to the existing duplicate-file result while propagating all other filesystem errors.

Custom `onSsgRendererError` callbacks were also documented as accumulating failures and failing the build unless the callback exits or throws. The final condition only failed for the literal `abort` and `error` modes, so a custom callback that returned successfully allowed a partial build to succeed. The failure condition now treats only `warn` and `ignore` as successful outcomes.

Finally, renderer concurrency uses multiple promise-processing lanes in one Node.js thread; it does not create worker threads or distribute Vue rendering across CPU cores. The types, docs, and progress banner now use accurate concurrency terminology while retaining the existing configuration API and default.

## Validation

- stress-tested `AppBuilder.writeFile()` with 100 simultaneous no-overwrite calls to the same target: exactly one file was created and 99 duplicates were rejected
- completed the full Quasar docs production SSG build successfully: 637 pages at concurrency 15
- targeted Oxfmt checks passed
- targeted Oxlint checks passed
- `git diff --check` passed
- staged-file formatting and lint checks passed during commit