### PR TITLE
fix(app-vite): harden SSG renderer error handling

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -513,7 +513,11 @@ export class QuasarModeBuilder extends AppBuilder {
           if (result) html = result
         }
       } catch (err) {
-        if (retryCount < ssgRendererRetryCount) {
+        if (
+          err?.routeNotFound !== true &&
+          err?.redirectUrl === void 0 &&
+          retryCount < ssgRendererRetryCount
+        ) {
           retryCount++
 
           if (onSsgRendererError !== 'ignore') {
@@ -524,12 +528,11 @@ export class QuasarModeBuilder extends AppBuilder {
             )
           }
 
-          const { promise, resolve } = Promise.withResolvers()
-          setTimeout(() => {
-            renderPage(ssgPage, retryCount).then(resolve)
-          }, ssgRendererRetryDelay)
+          await new Promise(resolve => {
+            setTimeout(resolve, ssgRendererRetryDelay)
+          })
 
-          return promise
+          return renderPage(ssgPage, retryCount)
         }
 
         if (err?.routeNotFound) {

--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -15,6 +15,7 @@ import { buildPwaServiceWorker, injectPwaManifest } from '../pwa/pwa-utils.js'
 const multiSlashRE = /\/{2,}/g
 const ssrManifestIdQueryRE = /vue\?vue/
 const ssrManifestIdQueryReplaceRE = /vue\?vue.*$/
+const synthetic404Route = '/______get-a-quasar-404-page______'
 
 function getSsgPageIdentifier(ssgPage) {
   return (
@@ -448,7 +449,7 @@ export class QuasarModeBuilder extends AppBuilder {
 
     if (this.quasarConf.ssg.error404HtmlFilename) {
       ssgPageList.push({
-        route: '/______get-a-quasar-404-page______',
+        route: synthetic404Route,
         label: '404 page',
         dir: '',
         filename: this.quasarConf.ssg.error404HtmlFilename
@@ -534,7 +535,10 @@ export class QuasarModeBuilder extends AppBuilder {
         if (err?.routeNotFound) {
           await handleError({
             err,
-            reason: 'Vue Router did not match the route',
+            reason:
+              ssgPage.route === synthetic404Route
+                ? 'Vue Router did not match the synthetic 404 route. Add a catch-all route or set quasar.config.ssg.error404HtmlFilename to false'
+                : 'Vue Router did not match the route',
             ssgPage
           })
         } else if (err?.redirectUrl) {

--- a/app-vite/lib/quasar-config-file.js
+++ b/app-vite/lib/quasar-config-file.js
@@ -950,6 +950,21 @@ export class QuasarConfigFile {
         cfg.ssg.clientSideRenderingHtmlFilename =
           cfg.ssg.clientSideRenderingRoutes.length !== 0 ? 'csr.html' : false
       }
+
+      const ssgRendererConcurrency = Number(cfg.ssg.ssgRendererConcurrency)
+      cfg.ssg.ssgRendererConcurrency = Number.isFinite(ssgRendererConcurrency)
+        ? Math.max(1, Math.floor(ssgRendererConcurrency))
+        : 1
+
+      const ssgRendererRetryCount = Number(cfg.ssg.ssgRendererRetryCount)
+      cfg.ssg.ssgRendererRetryCount = Number.isFinite(ssgRendererRetryCount)
+        ? Math.max(0, Math.floor(ssgRendererRetryCount))
+        : 0
+
+      const ssgRendererRetryDelay = Number(cfg.ssg.ssgRendererRetryDelay)
+      cfg.ssg.ssgRendererRetryDelay = Number.isFinite(ssgRendererRetryDelay)
+        ? Math.max(0, ssgRendererRetryDelay)
+        : 1000
     }
 
     if (this.#ctx.dev) {

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -71,9 +71,9 @@ export interface SsgPage {
 
 export interface OnSsgRendererErrorFunctionParams {
   /**
-   * The error object that was thrown during the SSG rendering process.
+   * The value that was thrown during the SSG rendering process.
    */
-  err: Error;
+  err: unknown;
 
   /**
    * The extra reason for the error, if available.
@@ -134,6 +134,8 @@ export interface QuasarSsgConfiguration {
    * The maximum number of SSG pages to render concurrently.
    * This can speed up rendering that includes asynchronous work, such as data fetching.
    * The render jobs run concurrently in the same Node.js thread.
+   * Asynchronous work from different pages can be interleaved, and any module-level
+   * state is shared between all pages being rendered.
    *
    * @default 1
    */

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -142,15 +142,16 @@ export interface QuasarSsgConfiguration {
   ssgRendererConcurrency?: number;
 
   /**
-   * The number of times for the SSG rendering process to retry
+   * The non-negative number of times for the SSG rendering process to retry
    * rendering a page if an error occurs during the SSG rendering process.
+   * Redirects and unmatched routes are not retried.
    *
    * @default 0
    */
   ssgRendererRetryCount?: number;
 
   /**
-   * The delay in milliseconds between retries for the SSG rendering process.
+   * The non-negative delay in milliseconds between retries for the SSG rendering process.
    * This can help avoid overwhelming the system or external resources when retrying.
    *
    * @default 1000

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -101,7 +101,7 @@ ssg: {
         reason,
         ssgPage
       }: {
-        err: Error;
+        err: unknown;
         reason?: string;
         ssgPage: SsgPage;
       }) => void | Promise<void>);
@@ -110,6 +110,8 @@ ssg: {
    * The maximum number of SSG pages to render concurrently.
    * This can speed up rendering that includes asynchronous work, such as data fetching.
    * The render jobs run concurrently in the same Node.js thread.
+   * Asynchronous work from different pages can be interleaved, and any module-level
+   * state is shared between all pages being rendered.
    *
    * @default 1
    */

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -118,15 +118,16 @@ ssg: {
   ssgRendererConcurrency?: number;
 
   /**
-   * The number of times for the SSG rendering process to retry
+   * The non-negative number of times for the SSG rendering process to retry
    * rendering a page if an error occurs during the SSG rendering process.
+   * Redirects and unmatched routes are not retried.
    *
    * @default 0
    */
   ssgRendererRetryCount?: number;
 
   /**
-   * The delay in milliseconds between retries for the SSG rendering process.
+   * The non-negative delay in milliseconds between retries for the SSG rendering process.
    * This can help avoid overwhelming the system or external resources when retrying.
    *
    * @default 1000


### PR DESCRIPTION
## Summary

- type the value passed to `onSsgRendererError` as `unknown`, matching JavaScript throw semantics and the existing redirect and route-not-found sentinel objects
- provide actionable guidance when the internally generated SSG 404 page cannot be rendered
- document that concurrent SSG rendering interleaves asynchronous page work and shares module-level state
- preserve rejection propagation across delayed renderer retries
- avoid retrying deterministic redirects and unmatched routes
- normalize renderer concurrency, retry count, and retry delay values

## Why

A follow-up review of the recently added SSG renderer controls identified contract, diagnostics, and retry lifecycle gaps after #18392.

The renderer does not exclusively catch `Error` instances: Vue Router redirects and unmatched routes currently reach the handler as plain objects. Publishing `err: Error` therefore gives custom handlers an unsafe guarantee. `unknown` accurately describes arbitrary thrown values and requires handlers to narrow them before use.

The generated 404 page uses an internal synthetic route. When that route is not matched under a non-abort policy, the build previously reported only the generic route mismatch and could finish without the configured `404.html`. The dedicated reason now explains the two corrective choices: add a catch-all Vue Router route or disable generation with `ssg.error404HtmlFilename: false`.

The initial retry implementation wrapped recursive attempts in a promise that forwarded fulfillment but not rejection. A rejection from a custom error handler or later render work could therefore leave the SSG build waiting indefinitely. Waiting for the delay first and returning the recursive render promise preserves both fulfillment and rejection.

Redirects and route-not-found sentinels describe deterministic routing outcomes, so delaying and repeating them cannot produce a successful render. They now proceed directly to the configured error policy. Runtime configuration is also normalized to prevent negative, fractional, or non-finite values from producing surprising pool or retry behavior.

Finally, SSG renderer concurrency is a promise pool on one Node.js thread. Pages can interleave asynchronous work and observe the same module-level state, so this behavior is now stated alongside the option in both the public type documentation and the docs page. The branch is based on the upstream change that defaults concurrency to `1`.

## Validation

- reviewed upstream commits `28d2653977` and `a7db1323f6`
- Oxlint passed for the modified implementation
- Oxfmt checks passed for all modified files
- repository pre-commit formatting and lint checks passed
- `git diff --check` passed