### PR TITLE
fix(app-vite): simplify SSG renderer retries

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -484,7 +484,7 @@ export class QuasarModeBuilder extends AppBuilder {
     const handleError = getSsgRendererErrorHandler(onSsgRendererError)
     let errorsEncountered = 0
 
-    const renderPage = async (ssgPage, retryCount = 0) => {
+    const renderPage = async ssgPage => {
       const ssrContext = ssgPage.ssrContext ?? {}
       const url =
         'http://localhost' +
@@ -494,71 +494,77 @@ export class QuasarModeBuilder extends AppBuilder {
         )
 
       let html
-      try {
-        html = await renderSsgPage(
-          {
-            ...ssrContext,
-            url,
-            req: {
-              headers: {},
-              ...ssrContext.req,
-              url
-            }
-          },
-          !isNoPreloadMatcher?.(ssgPage.route)
-        )
+      let retryCount = 0
 
-        if (typeof ssgPage.transformHtml === 'function') {
-          const result = await ssgPage.transformHtml(html)
-          if (result) html = result
-        }
-      } catch (err) {
-        if (
-          err?.routeNotFound !== true &&
-          err?.redirectUrl === void 0 &&
-          retryCount < ssgRendererRetryCount
-        ) {
-          retryCount++
+      while (true) {
+        try {
+          html = await renderSsgPage(
+            {
+              ...ssrContext,
+              url,
+              req: {
+                headers: {},
+                ...ssrContext.req,
+                url
+              }
+            },
+            !isNoPreloadMatcher?.(ssgPage.route)
+          )
 
-          if (onSsgRendererError !== 'ignore') {
-            warn(
-              `Failed to render SSG page for ${getSsgPageIdentifier(ssgPage)}.` +
-                ` Retrying in ${ssgRendererRetryDelay}ms...` +
-                ` (${retryCount}/${ssgRendererRetryCount})`
-            )
+          if (typeof ssgPage.transformHtml === 'function') {
+            const result = await ssgPage.transformHtml(html)
+            if (result) html = result
           }
 
-          await new Promise(resolve => {
-            setTimeout(resolve, ssgRendererRetryDelay)
-          })
+          break
+        } catch (err) {
+          if (
+            err?.routeNotFound !== true &&
+            err?.redirectUrl === void 0 &&
+            retryCount < ssgRendererRetryCount
+          ) {
+            retryCount++
 
-          return renderPage(ssgPage, retryCount)
+            if (onSsgRendererError !== 'ignore') {
+              warn(
+                `Failed to render SSG page for ${getSsgPageIdentifier(ssgPage)}.` +
+                  ` Retrying in ${ssgRendererRetryDelay}ms...` +
+                  ` (${retryCount}/${ssgRendererRetryCount})`
+              )
+            }
+
+            await new Promise(resolve => {
+              setTimeout(resolve, ssgRendererRetryDelay)
+            })
+
+            continue
+          }
+
+          if (err?.routeNotFound) {
+            await handleError({
+              err,
+              reason:
+                ssgPage.route === synthetic404Route
+                  ? 'Vue Router did not match the synthetic 404 route. Add a catch-all route or set quasar.config.ssg.error404HtmlFilename to false'
+                  : 'Vue Router did not match the route',
+              ssgPage
+            })
+          } else if (err?.redirectUrl) {
+            await handleError({
+              err,
+              reason: `The route redirects to "${err.redirectUrl}". Generate the destination route instead.`,
+              ssgPage
+            })
+          } else {
+            await handleError({
+              err,
+              ssgPage
+            })
+          }
+
+          errorsEncountered++
+          return
         }
-
-        if (err?.routeNotFound) {
-          await handleError({
-            err,
-            reason:
-              ssgPage.route === synthetic404Route
-                ? 'Vue Router did not match the synthetic 404 route. Add a catch-all route or set quasar.config.ssg.error404HtmlFilename to false'
-                : 'Vue Router did not match the route',
-            ssgPage
-          })
-        } else if (err?.redirectUrl) {
-          await handleError({
-            err,
-            reason: `The route redirects to "${err.redirectUrl}". Generate the destination route instead.`,
-            ssgPage
-          })
-        } else {
-          await handleError({
-            err,
-            ssgPage
-          })
-        }
-
-        errorsEncountered++
-        return
       }
 
       const filename = join(

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -73,7 +73,7 @@ export interface OnSsgRendererErrorFunctionParams {
   /**
    * The value that was thrown during the SSG rendering process.
    */
-  err: Error | { routeNotFound: true } | { redirectUrl: string };
+  err: unknown;
 
   /**
    * The extra reason for the error, if available.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -101,7 +101,7 @@ ssg: {
         reason,
         ssgPage
       }: {
-        err: Error | { routeNotFound: true } | { redirectUrl: string };
+        err: unknown;
         reason?: string;
         ssgPage: SsgPage;
       }) => void | Promise<void>);


### PR DESCRIPTION
## Summary

- express SSG page retries as an explicit attempt loop instead of recursive `renderPage()` calls
- type `onSsgRendererError` thrown values as `unknown`

## Why

The retry implementation added before #18393 is functionally safe after its rejection-propagation fix, but each failed attempt still recursively invokes the complete page-render function. An explicit loop keeps the retry counter, delay, success exit, and final error path in one frame. It preserves the existing behavior: redirects and unmatched routes bypass retries, retriable failures wait for the configured delay, and only exhausted failures reach `onSsgRendererError`.

The current public error union lists `Error` and Quasar internal redirect and route-not-found sentinels. That union cannot describe all runtime values because application rendering, asynchronous data loading, and `transformHtml()` are user-controlled JavaScript and may throw any value. `unknown` accurately models the boundary and requires custom handlers to narrow the value before inspecting it.

## Validation

- based on the latest upstream `dev`, including #18393
- Oxlint passed
- Oxfmt passed
- repository pre-commit formatting and lint checks passed
- `git diff --check` passed