### PR TITLE
fix(app-vite): align SSG, SSR and PWA contracts

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -317,7 +317,12 @@ export class QuasarModeBuilder extends AppBuilder {
               }
             }
 
-            if (this.quasarConf.ssg.clientSideRenderingHtmlFilename) {
+            if (
+              this.quasarConf.ssg.clientSideRenderingHtmlFilename &&
+              (this.quasarConf.ssg.pwa !== true ||
+                this.quasarConf.ssg.clientSideRenderingHtmlFilename !==
+                  this.quasarConf.ssg.pwaOfflineHtmlFilename)
+            ) {
               const hasFile = await this.writeFile(
                 `${this.quasarConf.ssg.clientSideRenderingHtmlFilename}`,
                 content,
@@ -513,7 +518,7 @@ export class QuasarModeBuilder extends AppBuilder {
 
           if (typeof ssgPage.transformHtml === 'function') {
             const result = await ssgPage.transformHtml(html)
-            if (result) html = result
+            if (typeof result === 'string') html = result
           }
 
           break

--- a/app-vite/templates/ssg/js/ssg-renderer.js
+++ b/app-vite/templates/ssg/js/ssg-renderer.js
@@ -28,7 +28,7 @@ import routes from '@/router/routes'
  *
  *  Optional SSR context to use when rendering the page.
  *  If not provided, the default SSR context will be used.
- *  ssrContext?: QSsrContext;
+ *  ssrContext?: SsgPageSsrContext;
  *
  * You can use the `ctx` parameter to access appPaths, among
  * other things, to help you resolve paths to your pages then

--- a/app-vite/templates/ssg/ts/ssg-renderer.ts
+++ b/app-vite/templates/ssg/ts/ssg-renderer.ts
@@ -28,7 +28,7 @@ import routes from '@/router/routes';
  *
  *  Optional SSR context to use when rendering the page.
  *  If not provided, the default SSR context will be used.
- *  ssrContext?: QSsrContext;
+ *  ssrContext?: SsgPageSsrContext;
  *
  * You can use the `ctx` parameter to access appPaths, among
  * other things, to help you resolve paths to your pages then

--- a/app-vite/types/configuration/pwa-conf.d.ts
+++ b/app-vite/types/configuration/pwa-conf.d.ts
@@ -52,6 +52,7 @@ export interface PwaManifestOptions {
   description?: string;
   dir?: PwaManifestDirection;
   display?: PwaManifestDisplay;
+  display_override?: PwaManifestDisplay[];
   iarc_rating_id?: string;
   icons?: PwaManifestIcon | PwaManifestIcon[];
   inject?: boolean;
@@ -79,6 +80,10 @@ interface InjectPWAMetaTagsParams {
  * behavior and also tweak your `manifest.json`.
  */
 export interface QuasarPwaConfiguration {
+  /**
+   * Workbox operating mode.
+   * @default 'GenerateSW'
+   */
   workboxMode?: "GenerateSW" | "InjectManifest";
 
   /**

--- a/app-vite/types/configuration/ssg-conf.d.ts
+++ b/app-vite/types/configuration/ssg-conf.d.ts
@@ -8,6 +8,11 @@ interface QuasarSsrManifest {
   [key: string]: string[];
 }
 
+export type SsgPageSsrContext = Partial<Omit<QSsrContext, "req" | "res">> & {
+  req?: Partial<QSsrContext["req"]>;
+  res?: Partial<QSsrContext["res"]>;
+};
+
 export interface SsgPage {
   /**
    * The vue-router route to render.
@@ -46,9 +51,9 @@ export interface SsgPage {
    * type. Gets merged into the ssrContext so you don't have to
    * define all its props.
    *
-   * @type QSsrContext {@link QSsrContext}
+   * @type SsgPageSsrContext {@link SsgPageSsrContext}
    */
-  ssrContext?: QSsrContext;
+  ssrContext?: SsgPageSsrContext;
 
   /**
    * Callback function that is called after rendering the SSG page.
@@ -186,8 +191,8 @@ export interface QuasarSsgConfiguration {
    *
    * If you are building a SSG+PWA app, you might want to directly use the
    * `pwaOfflineHtmlFilename` as the empty shell html file instead,
-   * as it will have the same content. Otherwise, make sure to use a different
-   * name otherwise it will clash with the `pwaOfflineHtmlFilename` one!
+   * as it will have the same content. If you do not reuse that filename,
+   * choose a different one to avoid a generated-file conflict.
    *
    * If not explicitly configured and `clientSideRenderingRoutes`
    * is not its default value (an empty array), then this option will
@@ -276,10 +281,11 @@ export interface QuasarSsgConfiguration {
   /**
    * When using SSG+PWA, this is the name of the
    * PWA index html file that the client-side fallbacks to.
+   * For production only.
    *
    * Make sure to name it so that the SSG generated html files
-   * don't conflict with it! Also, it shouldn't clash with the
-   * "clientSideRenderingHtmlFilename" option if you are using that.
+   * don't conflict with it. It may intentionally match
+   * `clientSideRenderingHtmlFilename` to reuse the same application shell.
    *
    * @default ssr.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
    */

--- a/app-vite/types/configuration/ssr-conf.d.ts
+++ b/app-vite/types/configuration/ssr-conf.d.ts
@@ -191,6 +191,7 @@ export interface QuasarSsrConfiguration {
   /**
    * When using SSR+PWA, this is the name of the
    * PWA index html file that the client-side fallbacks to.
+   * For production only.
    *
    * Do NOT use index.html as name as it will mess SSR up!
    *

--- a/app-vite/types/ssg/index.d.ts
+++ b/app-vite/types/ssg/index.d.ts
@@ -34,6 +34,8 @@ export type SsgParseVueRouterParams = {
   /**
    * Optional list of routes to ignore during the parsing process.
    * You can use picomatch patterns to match the routes you want to ignore.
+   * A matched route is omitted, but its children are still traversed and
+   * evaluated against the patterns.
    * https://www.npmjs.com/package/picomatch
    *
    * Note on picomatch patterns:
@@ -125,6 +127,7 @@ export interface SsgGetPagesParams {
    * @param {SsgParseVueRouterParams} options - The configuration object. {@link SsgParseVueRouterParams}
    * @param {RouteRecordRaw[]} options.routes - Vue Router routes definition to parse. {@link RouteRecordRaw}
    * @param {string} [options.parentPath='/'] - Optional parent path to use for these routes.
+   * @param {string[]} [options.crawlIgnoreRoutes=[]] - Optional picomatch patterns for routes to omit while still traversing their children.
    * @param {boolean} [options.verbose=false] - Optional flag to enable verbose logging. If true, it logs ignored routes with dynamic parameters.
    * @returns {SsgParseVueRouterResult} {@link SsgParseVueRouterResult}
    */

--- a/docs/src/pages/quasar-cli-vite/developing-pwa/configuring-pwa.md
+++ b/docs/src/pages/quasar-cli-vite/developing-pwa/configuring-pwa.md
@@ -44,6 +44,10 @@ This is the place where you can configure Workbox behavior and also tweak your m
 
 ```ts
 pwa: {
+  /**
+   * Workbox operating mode.
+   * @default 'GenerateSW'
+   */
   workboxMode?: "GenerateSW" | "InjectManifest";
 
   /**
@@ -62,7 +66,9 @@ pwa: {
    * Should you need some dynamic changes to the /src-pwa/manifest.json,
    * use this method to do it.
    */
-  extendPWAManifestJson?: (json: PwaManifestOptions) => void;
+  extendPWAManifestJson?: (
+    json: PwaManifestOptions
+  ) => void | PwaManifestOptions | Promise<void | PwaManifestOptions>;
 
   /**
    * Does the PWA manifest tag requires crossorigin auth?
@@ -111,7 +117,7 @@ pwa: {
   /**
    * Extend the generated `.quasar/tsconfig.pwa-sw.json` file.
    *
-   * NOT async! Can directly modify the "config" parameter or
+   * NOT async! Can directly modify the "tsConfig" parameter or
    * return a new one that will be merged with the default one.
    */
   extendPWASwTsConfig (tsConfig) {

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/configuring-ssg.md
@@ -43,7 +43,7 @@ A typical configuration needs only a few options:
 ```js /quasar.config file
 export default defineConfig(() => ({
   ssg: {
-    // Generate a PWA service worker and offline shell
+    // Keep PWA takeover disabled
     pwa: false,
 
     // Generate dist/ssg/404.html
@@ -57,7 +57,7 @@ export default defineConfig(() => ({
      *   "/admin/*" matches only direct sub-routes of /admin
      *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
      */
-    clientSideRenderingRoutes: ['/account{,/**}', '/admin']
+    clientSideRenderingRoutes: ['/account/**', '/admin']
   }
 }))
 ```
@@ -162,8 +162,8 @@ ssg: {
     *
     * If you are building a SSG+PWA app, you might want to directly use the
     * `pwaOfflineHtmlFilename` as the empty shell html file instead,
-    * as it will have the same content. Otherwise, make sure to use a different
-    * name otherwise it will clash with the `pwaOfflineHtmlFilename` one!
+    * as it will have the same content. If you do not reuse that filename,
+    * choose a different one to avoid a generated-file conflict.
     *
     * If not explicitly configured and `clientSideRenderingRoutes`
     * is not its default value (an empty array), then this option will
@@ -248,10 +248,11 @@ ssg: {
   /**
     * When using SSG+PWA, this is the name of the
     * PWA index html file that the client-side fallbacks to.
+    * For production only.
     *
     * Make sure to name it so that the SSG generated html files
-    * don't conflict with it! Also, it shouldn't clash with the
-    * "clientSideRenderingHtmlFilename" option if you are using that.
+    * don't conflict with it. It may intentionally match
+    * `clientSideRenderingHtmlFilename` to reuse the same application shell.
     *
     * @default ssr.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
     */

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/deploying.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/deploying.md
@@ -88,7 +88,7 @@ export default defineConfig(() => {
        *   "/admin/*" matches only direct sub-routes of /admin
        *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
        */
-      clientSideRenderingRoutes: ['/dashboard{,/**}', '/admin']
+      clientSideRenderingRoutes: ['/dashboard/**', '/admin']
     }
   }
 })

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/hybrid-ssg-with-partial-csr.md
@@ -29,8 +29,8 @@ ssg: {
    *
    * If you are building a SSG+PWA app, you might want to directly use the
    * `pwaOfflineHtmlFilename` as the empty shell html file instead,
-   * as it will have the same content. Otherwise, make sure to use a different
-   * name otherwise it will clash with the `pwaOfflineHtmlFilename` one!
+   * as it will have the same content. If you do not reuse that filename,
+   * choose a different one to avoid a generated-file conflict.
    *
    * If not explicitly configured and `clientSideRenderingRoutes`
    * is not its default value (an empty array), then this option will
@@ -62,7 +62,7 @@ ssg: {
    *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
    *
    * @example ['/dashboard', '/admin/**']
-   * @default []
+   * @default ssr.clientSideRenderingRoutes (when configured), otherwise []
    */
   clientSideRenderingRoutes?: string[];
 }
@@ -82,7 +82,7 @@ ssg: {
    *   "/admin/*" matches only direct sub-routes of /admin
    *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
    */
-  clientSideRenderingRoutes: ['/account{,/**}', '/admin']
+  clientSideRenderingRoutes: ['/account/**', '/admin']
 }
 ```
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
@@ -163,6 +163,7 @@ interface SsgGetPagesParams {
    * @param {SsgParseVueRouterParams} options - The configuration object.
    * @param {RouteRecordRaw[]} options.routes - Vue Router routes definition to parse.
    * @param {string} [options.parentPath='/'] - Optional parent path to use for these routes.
+   * @param {string[]} [options.crawlIgnoreRoutes=[]] - Optional picomatch patterns for routes to omit while still traversing their children.
    * @param {boolean} [options.verbose=false] - Optional flag to enable verbose logging. If true, it logs ignored routes with dynamic parameters.
    * @returns {SsgParseVueRouterResult}
    */
@@ -196,6 +197,8 @@ type SsgParseVueRouterParams = {
   /**
    * Optional list of routes to ignore during the parsing process.
    * You can use picomatch patterns to match the routes you want to ignore.
+   * A matched route is omitted, but its children are still traversed and
+   * evaluated against the patterns.
    * https://www.npmjs.com/package/picomatch
    *
    * Note on picomatch patterns:
@@ -254,6 +257,13 @@ type SsgParseVueRouterResult = {
   ignoredCsrRoutes: RouteRecordRaw[];
 };
 <<| ts SsgPage Signature |>>
+type SsgPageSsrContext = Partial<
+  Omit<QSsrContext, "req" | "res">
+> & {
+  req?: Partial<QSsrContext["req"]>;
+  res?: Partial<QSsrContext["res"]>;
+};
+
 interface SsgPage {
   /**
    * The vue-router route to render.
@@ -292,9 +302,9 @@ interface SsgPage {
    * type. Gets merged into the ssrContext so you don't have to
    * define all its props.
    *
-   * @type QSsrContext
+   * @type SsgPageSsrContext
    */
-  ssrContext?: QSsrContext;
+  ssrContext?: SsgPageSsrContext;
 
   /**
    * Callback function that is called after rendering the SSG page.

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-pwa.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-with-pwa.md
@@ -20,12 +20,13 @@ ssg: {
   /**
    * When using SSG+PWA, this is the name of the
    * PWA index html file that the client-side fallbacks to.
+   * For production only.
    *
    * Make sure to name it so that the SSG generated html files
-   * don't conflict with it! Also, it shouldn't clash with the
-   * "clientSideRenderingHtmlFilename" option if you are using that.
+   * don't conflict with it. It may intentionally match
+   * `clientSideRenderingHtmlFilename` to reuse the same application shell.
    *
-   * @default 'offline.html'
+   * @default ssr.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
    */
   pwaOfflineHtmlFilename?: string;
 

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/hybrid-ssr-with-partial-csr.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/hybrid-ssr-with-partial-csr.md
@@ -28,7 +28,7 @@ ssr: {
    *   "/admin/{users,settings}" matches both exact routes /admin/users and /admin/settings
    *
    * @example ['/dashboard', '/admin/**']
-   * @default []
+   * @default ssg.clientSideRenderingRoutes (when configured), otherwise []
    */
   clientSideRenderingRoutes?: string[];
 }

--- a/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-with-pwa.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssr/ssr-with-pwa.md
@@ -22,7 +22,7 @@ return {
      *
      * Do NOT use index.html as name as it will mess SSR up!
      *
-     * @default 'offline.html'
+     * @default ssg.pwaOfflineHtmlFilename (when configured), otherwise 'offline.html'
      */
     pwaOfflineHtmlFilename?: string;
 
@@ -57,6 +57,6 @@ return {
 }
 ```
 
-The first request of a **new** client will be served from the webserver (so SSR supplies the initial page content). The PWA gets installed then it takes over on client side. All further requests will be served from cache (unless you have some custom configuration to change that).
+The first request from a **new** client is served by the webserver, so SSR supplies the initial page content. Once installed, the service worker can handle later navigations. Whether a request is served from cache, the network, or the offline shell depends on the selected Workbox mode and configuration.
 
 > For more information on PWA, head on to [PWA Introduction](/quasar-cli-vite/developing-pwa/introduction) and read the whole PWA Guide section.


### PR DESCRIPTION
## Summary

- align SSG, SSR and PWA documentation with the current runtime configuration inheritance and route-matching behavior
- allow SSG+PWA to intentionally reuse one generated application shell for PWA offline fallback and client-side-rendered routes
- align public SSG page context and HTML transformation types with supported runtime behavior
- fill gaps in the PWA manifest and extension-hook contracts

## Why

A final semantic audit found several places where the runtime, TypeScript declarations, templates and documentation had drifted apart.

Most importantly, the docs recommend using `pwaOfflineHtmlFilename` as the CSR shell when both files have identical content, but the production builder treated that configuration as a duplicate-file error. The builder now writes the shared shell once while retaining collision checks for genuinely different generated outputs.

The audit also found that `SsgPage.ssrContext` was declared as a complete `QSsrContext`, even though it is merged into the generated context and documented examples correctly provide only selected fields. A dedicated partial context type now represents that contract.

Additional corrections document SSR/SSG cross-mode defaults, clarify that ignored crawl routes do not prevent child traversal, replace redundant route patterns, expose the runtime-provided PWA `display_override` property, and accurately describe Workbox navigation behavior.

## User impact

- SSG+PWA users can reuse one offline/CSR shell as documented.
- TypeScript users can provide partial page-specific SSR context without fabricating framework-owned fields.
- Empty-string results from `transformHtml()` are now honored.
- Configuration reference pages accurately describe inheritance, production-only settings, route matching, hook signatures and Workbox behavior.

## Validation

- Built the complete Quasar documentation site in SSG+PWA production mode.
- Workbox compiled the service worker successfully.
- All 637 SSG pages rendered successfully.
- Oxfmt passed.
- Oxlint passed.
- `git diff --check` passed.
- Commit-time formatting and lint checks passed.