### PR TITLE
fix(ui): harden QUploader state handling

### DIFF
--- a/docs/src/pages/vue-components/uploader.md
+++ b/docs/src/pages/vue-components/uploader.md
@@ -81,9 +81,9 @@ You can also customize the HTTP headers and HTTP method through `headers` and `m
 
 ### Factory function
 
-There is a `factory` prop you can use which must be a Function. This function can return either an Object or a Promise resolving with an Object (and in case the Promise fails, `@factory-failed` event is emitted).
+There is a `factory` prop you can use which must be a Function. This function can return either an Object or a Promise resolving with an Object. The `@factory-failed` event is emitted if the function throws, returns an invalid value, or returns a Promise which is rejected or aborted.
 
-The Object described above can override the following QUploader props: `url`, `method`, `headers`, `formFields`, `fieldName`, `withCredentials`, `sendRaw`). The props of this Object can be Functions as well (of form `(file[s]) => value`):
+The Object described above can override the following QUploader props: `url`, `method`, `headers`, `formFields`, `fieldName`, `withCredentials`, and `sendRaw`. The props of this Object can be Functions as well (of form `(file[s]) => value`):
 
 <DocExample title="Promise-based factory function" file="FactoryPromise" />
 

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -93,7 +93,11 @@ export function getRenderer(getPlugin, expose) {
     file.__uploaded = status === 'uploaded' ? file.size : uploadedSize
 
     file.__progress =
-      status === 'uploaded' ? 1 : Math.min(0.9999, file.__uploaded / file.size)
+      status === 'uploaded'
+        ? 1
+        : file.size === 0
+          ? 0
+          : Math.min(0.9999, file.__uploaded / file.size)
 
     file.__progressLabel = getProgressLabel(file.__progress)
     proxy.$forceUpdate()
@@ -216,7 +220,9 @@ export function getRenderer(getPlugin, expose) {
 
   function removeUploadedFiles() {
     if (!props.disable) {
-      batchRemoveFiles(['uploaded'], () => {
+      batchRemoveFiles(['uploaded'], ({ size }) => {
+        state.uploadedSize.value -= size
+        uploadSize.value -= size
         state.uploadedFiles.value = []
       })
     }
@@ -259,10 +265,13 @@ export function getRenderer(getPlugin, expose) {
     if (props.disable) return
 
     if (file.__status === 'uploaded') {
+      state.uploadedSize.value -= file.size
+      uploadSize.value -= file.size
       state.uploadedFiles.value = state.uploadedFiles.value.filter(
         f => f.__key !== file.__key
       )
     } else if (file.__status === 'uploading') {
+      uploadSize.value -= file.size
       file.__abort()
     } else {
       uploadSize.value -= file.size

--- a/ui/src/components/uploader/xhr-uploader-plugin.js
+++ b/ui/src/components/uploader/xhr-uploader-plugin.js
@@ -31,6 +31,7 @@ function injectPlugin({ props, emit, helpers }) {
   const xhrs = ref([])
   const promises = ref([])
   const workingThreads = ref(0)
+  const abortedPromises = new WeakSet()
 
   const xhrProps = computed(() => ({
     url: getFn(props.url),
@@ -46,14 +47,17 @@ function injectPlugin({ props, emit, helpers }) {
   const isUploading = computed(() => workingThreads.value > 0)
   const isBusy = computed(() => promises.value.length !== 0)
 
-  let abortPromises
+  const getLiveFiles = files =>
+    files.filter(file => helpers.files.value.includes(file))
 
   function abort() {
     xhrs.value.forEach(x => {
       x.abort()
     })
 
-    if (promises.value.length !== 0) abortPromises = true
+    promises.value.forEach(promise => {
+      abortedPromises.add(promise)
+    })
   }
 
   function upload() {
@@ -72,54 +76,82 @@ function injectPlugin({ props, emit, helpers }) {
   function runFactory(files) {
     workingThreads.value++
 
+    const failed = (err, promise) => {
+      if (helpers.isAlive()) {
+        if (promise !== void 0) {
+          promises.value = promises.value.filter(p => p !== promise)
+        }
+
+        const liveFiles = getLiveFiles(files)
+
+        if (liveFiles.length !== 0) {
+          helpers.queuedFiles.value.push(...liveFiles)
+          liveFiles.forEach(f => {
+            helpers.updateFileStatus(f, 'failed')
+          })
+
+          emit('factoryFailed', err, liveFiles)
+        }
+
+        workingThreads.value--
+      }
+    }
+
     if (typeof props.factory !== 'function') {
-      performUpload(files, {})
+      startUpload({})
       return
     }
 
-    const res = props.factory(files)
+    let res
+    try {
+      res = props.factory(files)
+    } catch (err) {
+      failed(err)
+      return
+    }
 
-    if (!res) {
-      emit(
-        'factoryFailed',
-        new Error('QUploader: factory() does not return properly'),
-        files
-      )
-      workingThreads.value--
+    if (Object(res) !== res) {
+      failed(new Error('QUploader: factory() does not return properly'))
     } else if (
       typeof res.catch === 'function' &&
       typeof res.then === 'function'
     ) {
       promises.value.push(res)
 
-      const failed = err => {
-        if (helpers.isAlive()) {
-          promises.value = promises.value.filter(p => p !== res)
-
-          if (promises.value.length === 0) abortPromises = false
-
-          helpers.queuedFiles.value.push(...files)
-          files.forEach(f => {
-            helpers.updateFileStatus(f, 'failed')
-          })
-
-          emit('factoryFailed', err, files)
-          workingThreads.value--
-        }
-      }
-
       res
         .then(factory => {
-          if (abortPromises) {
-            failed(new Error('Aborted'))
+          if (abortedPromises.has(res)) {
+            failed(new Error('Aborted'), res)
+          } else if (Object(factory) !== factory) {
+            failed(
+              new Error('QUploader: factory() does not return properly'),
+              res
+            )
           } else if (helpers.isAlive()) {
             promises.value = promises.value.filter(p => p !== res)
-            performUpload(files, factory)
+            startUpload(factory)
           }
         })
-        .catch(failed)
+        .catch(err => {
+          failed(err, res)
+        })
     } else {
-      performUpload(files, res || {})
+      startUpload(res)
+    }
+
+    function startUpload(factory) {
+      const liveFiles = getLiveFiles(files)
+
+      if (liveFiles.length === 0) {
+        workingThreads.value--
+        return
+      }
+
+      try {
+        performUpload(liveFiles, factory)
+      } catch (err) {
+        failed(err)
+      }
     }
   }
 
@@ -136,6 +168,10 @@ function injectPlugin({ props, emit, helpers }) {
 
     if (!url) {
       console.error('q-uploader: invalid or no URL specified')
+      helpers.queuedFiles.value.push(...files)
+      files.forEach(f => {
+        helpers.updateFileStatus(f, 'failed')
+      })
       workingThreads.value--
       return
     }
@@ -166,7 +202,7 @@ function injectPlugin({ props, emit, helpers }) {
         let size = localUploadedSize - uploadIndexSize
         for (let i = uploadIndex; size > 0 && i < files.length; i++) {
           const file = files[i],
-            uploaded = size > file.size
+            uploaded = size >= file.size
 
           if (uploaded) {
             size -= file.size
@@ -186,19 +222,33 @@ function injectPlugin({ props, emit, helpers }) {
       if (xhr.readyState < 4) return
 
       if (xhr.status && xhr.status < 400) {
-        helpers.uploadedFiles.value.push(...files)
-        files.forEach(f => {
-          helpers.updateFileStatus(f, 'uploaded')
-        })
-        emit('uploaded', { files, xhr })
+        const liveFiles = getLiveFiles(files)
+        const liveUploadSize = liveFiles.reduce(
+          (total, file) => total + file.size,
+          0
+        )
+
+        helpers.uploadedSize.value += liveUploadSize - localUploadedSize
+
+        if (liveFiles.length !== 0) {
+          helpers.uploadedFiles.value.push(...liveFiles)
+          liveFiles.forEach(f => {
+            helpers.updateFileStatus(f, 'uploaded')
+          })
+          emit('uploaded', { files: liveFiles, xhr })
+        }
       } else {
         aborted = true
         helpers.uploadedSize.value -= localUploadedSize
-        helpers.queuedFiles.value.push(...files)
-        files.forEach(f => {
-          helpers.updateFileStatus(f, 'failed')
-        })
-        emit('failed', { files, xhr })
+
+        const liveFiles = getLiveFiles(files)
+        if (liveFiles.length !== 0) {
+          helpers.queuedFiles.value.push(...liveFiles)
+          liveFiles.forEach(f => {
+            helpers.updateFileStatus(f, 'failed')
+          })
+          emit('failed', { files: liveFiles, xhr })
+        }
       }
 
       workingThreads.value--

--- a/ui/src/components/uploader/xhr-uploader-plugin.json
+++ b/ui/src/components/uploader/xhr-uploader-plugin.json
@@ -103,7 +103,7 @@
         }
       },
       "returns": {
-        "type": "String",
+        "type": "Array",
         "desc": "An array consisting of objects with header definitions"
       },
       "category": "upload"
@@ -138,8 +138,8 @@
         }
       },
       "returns": {
-        "type": "String",
-        "desc": "An array consists of objects with additional fields definitions (used by Form to be uploaded)"
+        "type": "Array",
+        "desc": "An array consisting of objects with additional field definitions (used by FormData to be uploaded)"
       },
       "category": "upload"
     },
@@ -264,7 +264,7 @@
     },
 
     "factory-failed": {
-      "desc": "Emitted when factory function is supplied with a Promise which is rejected",
+      "desc": "Emitted when the factory function throws, returns an invalid value, or supplies a Promise which is rejected or aborted",
       "params": {
         "err": {
           "type": "Error",

--- a/ui/src/composables/private.use-file/use-file.js
+++ b/ui/src/composables/private.use-file/use-file.js
@@ -105,7 +105,9 @@ export default function useFile({
       files = filterFiles(files, rejectedFiles, 'accept', file =>
         extensions.value.some(
           ext =>
-            file.type.toUpperCase().startsWith(ext) ||
+            (ext.endsWith('/')
+              ? file.type.toUpperCase().startsWith(ext)
+              : file.type.toUpperCase() === ext) ||
             file.name.toUpperCase().endsWith(ext)
         )
       )
@@ -137,19 +139,23 @@ export default function useFile({
 
     // Compute key to use for each file
     files.forEach(file => {
-      file.__key =
-        file.webkitRelativePath + file.lastModified + file.name + file.size
+      file.__key = JSON.stringify([
+        file.webkitRelativePath,
+        file.lastModified,
+        file.name,
+        file.size
+      ])
     })
 
     if (append) {
       // Avoid duplicate files
-      const filenameMap = currentFileList.map(entry => entry.__key)
-      files = filterFiles(
-        files,
-        rejectedFiles,
-        'duplicate',
-        file => !filenameMap.includes(file.__key)
-      )
+      const filenameSet = new Set(currentFileList.map(entry => entry.__key))
+      files = filterFiles(files, rejectedFiles, 'duplicate', file => {
+        if (filenameSet.has(file.__key)) return false
+
+        filenameSet.add(file.__key)
+        return true
+      })
     }
 
     if (files.length === 0) {
@@ -162,8 +168,11 @@ export default function useFile({
         : 0
 
       files = filterFiles(files, rejectedFiles, 'max-total-size', file => {
-        size += file.size
-        return size <= maxTotalSizeNumber.value
+        const newSize = size + file.size
+        if (newSize > maxTotalSizeNumber.value) return false
+
+        size = newSize
+        return true
       })
 
       if (files.length === 0) {


### PR DESCRIPTION
## Summary

- keep aggregate upload size and progress counters accurate when completed, queued, or active files are removed
- make factory execution resilient to synchronous exceptions, invalid return values, rejected promises, and independently aborted promises
- prevent files removed while a factory or XHR is pending from being uploaded, requeued, or reported by delayed events
- correct file acceptance, duplicate detection, maximum-total-size filtering, zero-byte progress, and batch progress boundary handling
- align the QUploader factory documentation and API metadata with runtime behavior

## Why

A deep review of QUploader found several state paths that could leave its visible files, retry queue, byte counters, and emitted payloads out of sync.

The factory implementation used one shared abort flag for all pending promises, did not catch synchronous factory/setup failures, and accepted invalid resolved values. More subtly, a file removed while an asynchronous factory was pending could still be uploaded after resolution. Removing a file from an active XHR could also allow the completion handler to requeue or report a file no longer owned by the uploader.

The upload byte counters also retained completed-file sizes after removal and could stop below 100% when a successful request did not produce a final progress event. File filtering had related boundary issues: exact MIME values were treated as prefixes, duplicates within one newly selected batch were not rejected, and an oversized rejected file incorrectly consumed the remaining `maxTotalSize` allowance for later candidates.

## Behavioral changes

- Pending work is reconciled against the uploader's current live file list before upload, retry, status updates, and event emission.
- Aborting one pending factory no longer aborts unrelated factories.
- Removed files cannot reappear in the retry queue or distort aggregate progress.
- Factory failures return live files to a retryable failed state and emit `factory-failed` consistently.
- Successful XHR completion accounts for all uploaded bytes even when the browser omits a final progress event.
- Exact MIME entries, wildcard MIME entries, and filename extensions follow their distinct matching semantics.
- Duplicate and total-size validation proceeds correctly within a single selection batch.

## Validation

- Rebased cleanly onto current `upstream/dev`.
- Completed the full Quasar UI production build successfully.
- Oxfmt passed for all five changed files.
- Oxlint passed with warnings denied.
- `git diff --check` passed.
- Commit-time formatting and lint checks passed.