### PR TITLE
fix(docs): update Capacitor v8 requirements

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/capacitor-version-support.md
+++ b/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/capacitor-version-support.md
@@ -20,14 +20,15 @@ It would also be wise to check the changelog of Capacitor itself to see what bre
 ::: warning Requirements
 
 - Node v22.22+
-- Xcode 16+ (for iOS)
+- Xcode 26+ (for iOS)
 - Xcode Command Line Tools
-- Homebrew
-- CocoaPods
-- Android Studio 2024.2.1+
-- Android SDK (API 23+)
+- iOS 15+
+- Android Studio Otter 2025.2.1+
+- Android SDK (minimum API 24; compile and target API 36)
 
 :::
+
+Capacitor v8 uses Swift Package Manager by default when adding a new iOS platform. CocoaPods is only required when maintaining or explicitly creating a CocoaPods-based iOS project.
 
 Assuming that you've installed Capacitor mode already, this is how your dependencies in `/src-capacitor/package.json` should look like:
 


### PR DESCRIPTION
## Summary

- update the Capacitor v8 Xcode and Android Studio requirements
- document the required iOS deployment target and Android SDK levels
- clarify that new Capacitor v8 iOS platforms use Swift Package Manager by default and only CocoaPods-based projects require CocoaPods

## Why

The Capacitor version guide correctly states that Quasar supports Capacitor v8, and current `@quasar/app-vite` scaffolds v8 packages. However, its v8 requirements were copied from the Capacitor v7 toolchain and no longer matched the official Capacitor 8 migration guide.

Capacitor v8 requires Xcode 26 rather than Xcode 16, iOS 15 rather than an unspecified deployment target, Android Studio Otter 2025.2.1 rather than 2024.2.1, minSdk 24 rather than API 23, and compile/target SDK 36. It also creates new iOS platforms with Swift Package Manager by default, so Homebrew and CocoaPods should not be presented as unconditional requirements.

Quasar's Node v22.22 minimum remains unchanged because it is stricter than Capacitor's Node 22 minimum and reflects the current `@quasar/app-vite` engine requirement.

Official reference: https://capacitorjs.com/docs/updating/8-0

## User impact

Developers upgrading for Capacitor v8-only plugins, including current payment SDKs, will see the native toolchain and platform requirements they actually need before beginning the migration.

## Validation

- Completed the full Quasar documentation SSG+PWA production build.
- Workbox compiled successfully.
- All 637 SSG pages rendered successfully.
- Oxfmt passed.
- `git diff --check` passed.
- Commit-time formatting and lint checks passed.