### PR TITLE
docs(ui): explain Material Symbols variations

### DIFF
--- a/docs/src/pages/vue-components/icon.md
+++ b/docs/src/pages/vue-components/icon.md
@@ -65,6 +65,54 @@ If you are using webfont-based icons, make sure that you [installed the icon lib
 | line-awesome              | la[s,r,l,d,b] la-                                | "las la-atom"                            | QIcon "name" property is same as "class" attribute value in Line Awesome docs examples (where they show `<i>` tags); **@quasar/extras v1.5+** |
 | bootstrap-icons           | bi-                                              | bi-bug-fill                              | Notice the use of dash characters; **@quasar/extras v1.10+**                                                                                  |
 
+### Material Symbols variations
+
+Material Symbols does not have a separate filled font. Its Outlined, Rounded, and Sharp fonts each expose variable axes for fill (`FILL`), weight (`wght`), grade (`GRAD`), and optical size (`opsz`). The Material Symbols webfonts supplied by `@quasar/extras` include these axes.
+
+You can control them on an individual icon:
+
+```html
+<q-icon
+  name="sym_o_home"
+  style="font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24"
+/>
+```
+
+For reusable, runtime-configurable variations, scope CSS custom properties to the Material Symbols webfont classes:
+
+```css
+.q-icon.material-symbols-outlined,
+.q-icon.material-symbols-rounded,
+.q-icon.material-symbols-sharp {
+  font-variation-settings:
+    'FILL' var(--material-symbol-fill, 0),
+    'wght' var(--material-symbol-weight, 400),
+    'GRAD' var(--material-symbol-grade, 0),
+    'opsz' var(--material-symbol-optical-size, 24);
+}
+
+.q-icon.material-symbol-filled {
+  --material-symbol-fill: 1;
+}
+```
+
+```html
+<q-icon name="sym_o_home" />
+<q-icon name="sym_o_home" class="material-symbol-filled" />
+
+<q-icon
+  name="sym_r_favorite"
+  class="material-symbol-filled"
+  style="--material-symbol-weight: 600; --material-symbol-grade: 100; --material-symbol-optical-size: 48"
+/>
+```
+
+CSS custom properties allow per-icon changes, state changes, and runtime theming. Sass variables can instead be used when you only need fixed, project-wide values at build time.
+
+::: warning SVG icon sets
+Variable font axes apply only to Material Symbols webfonts. The Material Symbols SVG exports from `@quasar/extras` contain static paths and cannot be changed with `font-variation-settings`.
+:::
+
 ### Naming convention
 
 #### Material Icons (Google)


### PR DESCRIPTION
## Summary

- explain that Material Symbols uses variable font axes rather than a separate filled font
- document per-icon control of `FILL`, `wght`, `GRAD`, and `opsz`
- provide scoped CSS custom-property examples for reusable and runtime-configurable variants
- distinguish runtime CSS custom properties from compile-time Sass variables
- clarify that variable-font axes cannot modify the static Material Symbols SVG exports

## Why

Discussion #17136 shows that users reasonably expect a separate Material Symbols Filled pack because the older Material Icons collection has one. Google instead distributes Material Symbols as Outlined, Rounded, and Sharp variable fonts; each font provides its filled form through the `FILL` axis.

Quasar Extras already bundles Material Symbols fonts containing the full variation axes, but the QIcon guide only documented the icon-name prefixes. Without axis guidance, users either reverted to the older Material Icons pack or applied broad `.q-icon` rules that also target unrelated icon libraries.

The new examples scope variation settings to Quasar's Material Symbols classes and show how CSS custom properties can control individual icons, application states, and runtime themes safely.

Refs: https://github.com/quasarframework/quasar/discussions/17136
Official Google guide: https://developers.google.com/fonts/docs/material_symbols

## User impact

Users can render filled, weighted, graded, and optically sized Material Symbols through QIcon without loading a second font or affecting other icon libraries. SVG users are also warned that static paths do not support variable-font axes.

## Validation

- Completed the full Quasar documentation SSG+PWA production build.
- Workbox compiled successfully.
- All 637 SSG pages rendered successfully.
- Oxfmt passed.
- `git diff --check` passed.
- Commit-time formatting and lint checks passed.