### PR TITLE
fix(app-vite): use a proper parser for routesDynamicParamsMap expansion

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { merge } from 'webpack-merge'
 
 import { AppBuilder } from '../../app-builder.js'
+import { getPackage } from '../../utils/get-package.js'
 import { getRouteMatcher } from '../../utils/get-route-matcher.js'
 import { quasarSsgConfig } from './ssg-config.js'
 import {
@@ -87,7 +88,7 @@ function getSsgRendererErrorHandler(onSsgRendererError) {
   )
 }
 
-function getParseVueRouterRoutesFn(quasarConf) {
+function getParseVueRouterRoutesFn(quasarConf, createRouterMatcher) {
   const { clientSideRenderingRoutes } = quasarConf.ssg
   const isCSRMatch =
     clientSideRenderingRoutes.length !== 0
@@ -159,46 +160,55 @@ function getParseVueRouterRoutesFn(quasarConf) {
         } else {
           opts.dynamicRoutesMatched.push(fullPath)
 
+          /**
+           * Reuse the vue-router path parser so param substitution has
+           * the exact router.resolve() semantics (optional, repeatable
+           * and custom regex params, special chars in values).
+           */
+          const routeParser = createRouterMatcher(
+            [{ path: fullPath, component: {} }],
+            {}
+          ).getRoutes()[0]
+          const paramNames = new Set(
+            routeParser.keys.map(paramKey => paramKey.name)
+          )
+
           for (const dynamicEntry of dynamicMap) {
-            let dynamicFullPath = fullPath
-            for (const [key, value] of Object.entries(dynamicEntry)) {
-              if (dynamicFullPath.includes(`:${key}`) === false) {
+            // stringify() silently ignores extra keys, so catch typos here
+            for (const paramName of Object.keys(dynamicEntry)) {
+              if (paramNames.has(paramName) === false) {
                 fatal(
-                  `Dynamic param ":${key}" not found in route: ${dynamicFullPath}`,
+                  `Dynamic param ":${paramName}" not found in route: ${fullPath}`,
                   'parseVueRouterRoutes() FAILED'
                 )
               }
-
-              dynamicFullPath =
-                value === ''
-                  ? dynamicFullPath.replaceAll(`/:${key}?`, '')
-                  : dynamicFullPath
-                      .replaceAll(`:${key}?`, value)
-                      .replaceAll(`:${key}`, value)
             }
 
-            const dynamicSsgPage = {
-              ...ssgPage,
-              route: dynamicFullPath
-            }
-
-            if (dynamicFullPath.includes(':')) {
-              const routeBanner =
-                dynamicFullPath !== fullPath ? ` (${fullPath})` : ''
-
+            let dynamicFullPath
+            try {
+              dynamicFullPath = routeParser.stringify(dynamicEntry)
+            } catch (err) {
               fatal(
-                `Not all dynamic params defined for route: ${dynamicFullPath}${routeBanner}`,
+                `Failed to expand dynamic route "${fullPath}" with params` +
+                  ` ${JSON.stringify(dynamicEntry)}: ${err.message}`,
                 'parseVueRouterRoutes() FAILED'
               )
-            } else if (route.children) {
+            }
+
+            if (route.children) {
               parseVueRouterRoutes({
                 routes: route.children,
                 parentPath: dynamicFullPath,
                 opts
               })
-            } else {
-              opts.acc.ssgPages.push(dynamicSsgPage)
+
+              continue
             }
+
+            opts.acc.ssgPages.push({
+              ...ssgPage,
+              route: dynamicFullPath
+            })
           }
         }
 
@@ -504,10 +514,26 @@ export class QuasarModeBuilder extends AppBuilder {
       join(this.quasarConf.build.distDir, '__ssg__/ssg-script.js')
     )
 
+    const vueRouterPkg = await getPackage(
+      'vue-router',
+      this.quasarConf.ctx.appPaths.appDir
+    )
+
+    if (vueRouterPkg?.createRouterMatcher === void 0) {
+      fatal(
+        "Could not load createRouterMatcher() from your app's vue-router package." +
+          ' Make sure vue-router >= 5 is installed.',
+        'SSG FAIL'
+      )
+    }
+
     const ssgPageList = await getSsgPages({
       ctx: this.quasarConf.ctx,
       quasarConfSsg: this.quasarConf.ssg,
-      parseVueRouterRoutes: getParseVueRouterRoutesFn(this.quasarConf),
+      parseVueRouterRoutes: getParseVueRouterRoutesFn(
+        this.quasarConf,
+        vueRouterPkg.createRouterMatcher
+      ),
       getFilenameBasedRoutes: () => this.#getFilenameBasedRoutes()
     })
 

--- a/app-vite/types/ssg/index.d.ts
+++ b/app-vite/types/ssg/index.d.ts
@@ -54,10 +54,20 @@ export type SsgParseVueRouterParams = {
    * Each entry in the array should be an object where the keys are the dynamic
    * segment names and the values are the corresponding values to use for those segments.
    *
+   * The expansion uses the vue-router path parser, so all vue-router param
+   * syntaxes are supported, with the same semantics as router.resolve().
+   *
    * Note on optional route parameters (eg. /user/:id?):
-   * Use { [name]: "" } (empty string as value) for optional params. Do not miss the
-   * optional param in the object.
-   * Example: { "/user/:id?": [{ id: "" }] } will generate a SSG page for /user route.
+   * Omit the param key or use an empty string as its value to drop the segment.
+   * Example: { "/user/:id?": [{ id: "" }] } will generate a SSG page for the /user route.
+   *
+   * Note on repeatable route parameters (eg. /chapters/:chapter+):
+   * Use an array as the value to fill the repeated segments.
+   * Example: { "/chapters/:chapter+": [{ chapter: ["one", "two"] }] } generates /chapters/one/two.
+   *
+   * Note on custom regex parameters (eg. /items/:id(\\d+)):
+   * Values are substituted without being validated against the custom regex,
+   * matching the router.resolve() behavior.
    *
    * @example { "/user/:id": [{ id: 1 }, { id: 2 }] }
    * @example { "/product/:category/:id": [{ category: "electronics", id: 123 }, { category: "books", id: 456 }] }
@@ -65,7 +75,7 @@ export type SsgParseVueRouterParams = {
    */
   routesDynamicParamsMap?: Record<
     string,
-    Array<Record<string, string | number>>
+    Record<string, string | number | (string | number)[]>[]
   >;
 
   /**

--- a/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
+++ b/docs/src/pages/quasar-cli-vite/developing-ssg/ssg-renderer.md
@@ -217,10 +217,20 @@ type SsgParseVueRouterParams = {
    * Each entry in the array should be an object where the keys are the dynamic
    * segment names and the values are the corresponding values to use for those segments.
    *
+   * The expansion uses the vue-router path parser, so all vue-router param
+   * syntaxes are supported, with the same semantics as router.resolve().
+   *
    * Note on optional route parameters (eg. /user/:id?):
-   * Use { [name]: "" } (empty string as value) for optional params. Do not omit any
-   * optional params in the object.
-   * Example: { "/user/:id?": [{ id: "" }] } will generate a SSG page for /user route.
+   * Omit the param key or use an empty string as its value to drop the segment.
+   * Example: { "/user/:id?": [{ id: "" }] } will generate a SSG page for the /user route.
+   *
+   * Note on repeatable route parameters (eg. /chapters/:chapter+):
+   * Use an array as the value to fill the repeated segments.
+   * Example: { "/chapters/:chapter+": [{ chapter: ["one", "two"] }] } generates /chapters/one/two.
+   *
+   * Note on custom regex parameters (eg. /items/:id(\\d+)):
+   * Values are substituted without being validated against the custom regex,
+   * matching the router.resolve() behavior.
    *
    * @example { "/user/:id": [{ id: 1 }, { id: 2 }] }
    * @example { "/product/:category/:id": [{ category: "electronics", id: 123 }, { category: "books", id: 456 }] }
@@ -228,7 +238,7 @@ type SsgParseVueRouterParams = {
    */
   routesDynamicParamsMap?: Record<
     string,
-    Array<Record<string, string | number>>
+    Record<string, string | number | (string | number)[]>[]
   >;
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)
- Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Other information:**

Replaces the simple string `replaceAll` logic with the app's own `vue-router` `createRouterMatcher` + `stringify()`. It fixes various issues:
- order-dependent corruption when a param name prefixes another (:id vs :idx)
- "$"-pattern interpretation corrupting values containing $&
- false "not all params defined" failures for values containing ":"
- silent garbage output for custom regex params (/n/:id(\d+) now -> /n/7)
- silent garbage output for repeatable params (:chapters+ now supports arrays)

Optional-param "" sentinel and all previously-working outputs are unchanged. Missing required params now fail with vue-router's own error message.

A note, `createRouterMatcher` is marked as internal, but exported, looks proper, and has a docs page entry. So, I'd say we can depend on it. There is a validation message just in case, so that if it's no longer exported, removed, etc. we print an error message instead of an unclear error. Open to alternative suggestions, the main aim of this PR is to highlight these issues and a potential solution.