### PR TITLE
fix(QCarousel): initialize navigation state on render

### DIFF
--- a/ui/src/components/carousel/QCarousel.js
+++ b/ui/src/components/carousel/QCarousel.js
@@ -89,6 +89,7 @@ export default createComponent({
 
     const {
       updatePanelsList,
+      updatePanelIndex,
       getPanelContent,
       panelDirectives,
       goToPanel,
@@ -322,6 +323,7 @@ export default createComponent({
 
     return () => {
       panelsLen = updatePanelsList(slots)
+      updatePanelIndex()
 
       return h(
         'div',


### PR DESCRIPTION
## Summary

- initialize QCarousel's panel index before rendering its navigation controls
- restore the correct initial `active` value for the custom `navigation-icon` slot
- restore initial arrow visibility for animated carousels

## Why

QCarousel's panel index is intentionally non-reactive to avoid an unnecessary second render. For animated carousels, however, `getPanelContent()` delegates panel rendering to a lazy transition slot. The navigation controls are therefore created before that slot initializes `panelIndex`, leaving every navigation item inactive on the first render. A later interaction causes another render and makes the state appear correct.

Updating the index immediately after collecting the current panels makes it available to all controls during the same render. This preserves the non-reactive optimization and does not restore the duplicate initial render fixed previously.

Fixes #17776.

## Validation

- `pnpm exec oxlint ui/src/components/carousel/QCarousel.js`
- `pnpm exec oxfmt --check ui/src/components/carousel/QCarousel.js`
- `git diff --check`
- commit-time formatting and lint checks passed

The repository-wide `pnpm lint:ui:check` formatting phase passed, but its lint phase could not load `ui/playground/.quasar/tsconfig.json` because that generated development file is not present in this checkout.
