### PR TITLE
fix(QInput): preserve focused value with v-model.trim

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -42,6 +42,7 @@ export default createComponent({
     modelValue: __QUASAR_SSR_SERVER__
       ? {} // SSR does not know about FileList
       : [String, Number, FileList],
+    modelModifiers: Object,
 
     shadowText: String,
 
@@ -203,6 +204,14 @@ export default createComponent({
               delete temp.value
             }
           }
+
+          if (
+            props.modelModifiers?.trim === true &&
+            Object.hasOwn(temp, 'value') &&
+            (typeof temp.value !== 'string' || temp.value.trim() !== v)
+          ) {
+            delete temp.value
+          }
         }
 
         // textarea only
@@ -275,6 +284,10 @@ export default createComponent({
       if (hasMask.value) {
         updateMaskValue(val, false, e.inputType)
       } else {
+        if (props.modelModifiers?.trim === true) {
+          temp.value = val
+        }
+
         emitValue(val)
 
         if (isTypeText.value && e.target === document.activeElement) {
@@ -307,7 +320,11 @@ export default createComponent({
       emitValueFn = () => {
         emitTimer = null
 
-        if (props.type !== 'number' && Object.hasOwn(temp, 'value')) {
+        if (
+          props.type !== 'number' &&
+          (props.modelModifiers?.trim !== true || hasMask.value) &&
+          Object.hasOwn(temp, 'value')
+        ) {
           delete temp.value
         }
 

--- a/ui/src/components/input/QInput.json
+++ b/ui/src/components/input/QInput.json
@@ -17,6 +17,13 @@
       "examples": ["# v-model=\"myText\""]
     },
 
+    "model-modifiers": {
+      "type": "Object",
+      "desc": "Modifiers supplied by Vue for the component's v-model binding",
+      "examples": ["{ trim: true }"],
+      "internal": true
+    },
+
     "shadow-text": {
       "type": "String",
       "desc": "Text to be displayed as shadow at the end of the text in the control; Does NOT applies to type=file",


### PR DESCRIPTION
## Summary

- preserve QInput's raw value while a `v-model.trim` control is focused
- normalize the displayed value when editing finishes
- continue applying genuinely different external model updates

Fixes #18294.

## Why

Vue already trims the value emitted through a component's `update:modelValue` listener. The problem in #18294 is the subsequent DOM synchronization:

1. The user types a trailing space.
2. QInput emits the raw value, and Vue correctly trims it before updating the parent model.
3. An unrelated reactive mutation causes QInput to render again.
4. QInput writes the trimmed model back to its native control, removing the space while the user is still typing.

Vue's native `v-model.trim` directive deliberately avoids that final write while the input is focused when the raw DOM value and model are equivalent after trimming. This change gives QInput the same behavior.

## About `modelModifiers`

This does not introduce a new user-facing Quasar option. `modelModifiers` is Vue's documented mechanism for supplying modifiers to a component using `v-model`; Vue generates `{ trim: true }` from `v-model.trim` automatically.

Declaring the prop lets QInput consume that Vue metadata normally instead of reading internal VNode state or allowing it to fall through toward the native input. Its API entry is marked `internal`, so users continue to write only:

```vue
<q-input v-model.trim="subject" />
```

QInput retains the raw value only for an active, unmasked trim interaction. If an incoming model value is not equivalent to the raw value after trimming, the temporary value is discarded so the external update remains authoritative. Existing masked-input handling is left unchanged.

## Validation

- reproduced #18294 with an additional reactive mutation in the `update:modelValue` handler
- confirmed the bound model is trimmed while the focused native input retains the trailing space
- confirmed blur normalizes the displayed value
- confirmed a genuinely different external model update replaces the temporary raw value
- completed the full Quasar UI build and API parity validation
- Oxlint passed
- Oxfmt passed
- `git diff --check` passed
- commit-time formatting and lint checks passed
