### PR TITLE
fix(QSlideItem): preserve pending action side

### DIFF
--- a/ui/src/components/slide-item/QSlideItem.js
+++ b/ui/src/components/slide-item/QSlideItem.js
@@ -105,10 +105,11 @@ export default createComponent({
           node.style.transform = `translate${pan.axis}(${pan.dir * 100}%)`
 
           if (timer !== null) clearTimeout(timer)
+          const showing = pan.showing
           timer = setTimeout(() => {
             timer = null
-            emit(pan.showing, { reset })
-            emit('action', { side: pan.showing, reset })
+            emit(showing, { reset })
+            emit('action', { side: showing, reset })
           }, 230)
         } else {
           node.style.transform = 'translate(0,0)'


### PR DESCRIPTION
## Summary

- snapshot the completed QSlideItem side before scheduling its delayed action
- prevent a subsequent gesture from changing the side emitted by an earlier transition

Fixes #18216.

## Why

QSlideItem waits 230 ms for the completed slide transition before emitting the directional event and the generic `action` event. The callback currently reads `pan.showing` when that timer fires.

`pan` is shared gesture state and is replaced whenever another pan starts. If the user begins or releases another interaction during that 230 ms window, the pending callback can observe the newer gesture state instead of the side that completed the original transition. Depending on timing, the directional event may therefore use the wrong side or no side at all.

The issue is particularly visible with conditional side slots because handling one action can alter which directions remain available. It is separate from #16902: that issue corrected Vue's reuse of conditional-side DOM nodes and their refs, while this change addresses delayed code retaining mutable gesture state.

Capturing `pan.showing` when the transition completes gives each pending action a stable side without changing gesture thresholds, animation timing, event payloads, slot behavior, or reset semantics.

## Validation

- reviewed the conditional-slot lifecycle and overlapping-gesture timing path
- confirmed the delayed callback no longer reads mutable `pan` state
- completed the full Quasar UI build and API parity validation
- Oxlint passed
- Oxfmt passed
- `git diff --check` passed
- commit-time formatting and lint checks passed
