### PR TITLE
feat(ui): support configurable Shadow DOM teleport targets

### DIFF
--- a/docs/src/assets/menu.js
+++ b/docs/src/assets/menu.js
@@ -88,6 +88,10 @@ export default [
       {
         name: 'Transitions',
         path: 'transitions'
+      },
+      {
+        name: 'Teleport Target',
+        path: 'teleport-target'
       }
     ]
   },

--- a/docs/src/pages/options/teleport-target.md
+++ b/docs/src/pages/options/teleport-target.md
@@ -1,0 +1,43 @@
+---
+title: Teleport Target
+desc: Configuring where Quasar places dialogs, menus and other teleported content.
+related:
+  - /quasar-cli-vite/quasar-config-file
+  - /quasar-cli-webpack/quasar-config-file
+---
+
+Quasar normally appends dialogs, menus, tooltips and other globally managed content to `document.body`. You can configure another target when the application is hosted in a Shadow DOM or another isolated document subtree.
+
+## Quasar CLI
+
+Set `framework.config.teleportTarget` to a selector. The element must exist before Quasar creates its first teleported component.
+
+```js /quasar.config.js
+export default defineConfig(() => ({
+  framework: {
+    config: {
+      teleportTarget: '#my-app-overlays'
+    }
+  }
+}))
+```
+
+Quasar CLI serializes `framework.config` while generating the application entry. Consequently, use a selector here rather than a DOM element or function.
+
+## Runtime configuration and Shadow DOM
+
+When installing the Quasar Vue plugin directly, the target may be an `Element`, a `ShadowRoot`, or a function returning either one:
+
+```js
+app.use(Quasar, {
+  config: {
+    teleportTarget: () => customElement.shadowRoot
+  }
+})
+```
+
+Load the Quasar stylesheet inside the same Shadow Root so that teleported components receive the framework styles. Quasar applies its root CSS custom properties to `:host` as well as `:root` for this use case.
+
+::: warning One target per Quasar runtime
+The Quasar configuration and global portal registry are shared by a Quasar runtime. Multiple independently configured teleport targets are not supported. If several custom-element instances share one runtime, provide one common target.
+:::

--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -22,7 +22,7 @@ import usePortal from '../../composables/private.use-portal/use-portal.js'
 import usePreventScroll from '../../composables/private.use-prevent-scroll/use-prevent-scroll.js'
 
 import { createComponent } from '../../utils/private.create/create.js'
-import { childHasFocus } from '../../utils/dom/dom.js'
+import { childHasFocus, getActualActiveElement } from '../../utils/dom/dom.js'
 import { hSlot } from '../../utils/private.render/render.js'
 import {
   addEscapeKey,
@@ -194,8 +194,8 @@ export default createComponent({
       addToHistory()
 
       refocusTarget =
-        !props.noRefocus && document.activeElement !== null
-          ? document.activeElement
+        !props.noRefocus && getActualActiveElement() !== null
+          ? getActualActiveElement()
           : null
 
       updateMaximized(props.maximized)
@@ -204,16 +204,16 @@ export default createComponent({
 
       if (props.noFocus) removeTick()
       else {
-        document.activeElement?.blur()
+        getActualActiveElement()?.blur()
         registerTick(focus)
       }
 
       // should removeTimeout() if this gets removed
       registerTimeout(() => {
         if (vm.proxy.$q.platform.is.ios) {
-          if (!props.seamless && document.activeElement) {
+          if (!props.seamless && getActualActiveElement()) {
             const { top, bottom } =
-                document.activeElement.getBoundingClientRect(),
+                getActualActiveElement().getBoundingClientRect(),
               { innerHeight } = window,
               height =
                 window.visualViewport !== void 0
@@ -231,7 +231,7 @@ export default createComponent({
               )
             }
 
-            document.activeElement.scrollIntoView()
+            getActualActiveElement().scrollIntoView()
           }
 
           // required in order to avoid the "double-tap needed" issue
@@ -291,7 +291,7 @@ export default createComponent({
           }
         }
 
-        if (!node.contains(document.activeElement)) {
+        if (!node.contains(getActualActiveElement())) {
           node =
             node.querySelector(
               '[autofocus][tabindex], [data-autofocus][tabindex]'

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -39,7 +39,7 @@ import {
   addFocusout,
   removeFocusout
 } from '../../utils/private.focus/focusout.js'
-import { childHasFocus } from '../../utils/dom/dom.js'
+import { childHasFocus, getActualActiveElement } from '../../utils/dom/dom.js'
 import {
   addClickOutside,
   removeClickOutside
@@ -209,7 +209,7 @@ export default createComponent({
       addFocusFn(() => {
         let node = innerRef.value
 
-        if (node && !node.contains(document.activeElement)) {
+        if (node && !node.contains(getActualActiveElement())) {
           node =
             node.querySelector(
               '[autofocus][tabindex], [data-autofocus][tabindex]'
@@ -225,7 +225,7 @@ export default createComponent({
     }
 
     function handleShow(evt) {
-      refocusTarget = props.noRefocus ? null : document.activeElement
+      refocusTarget = props.noRefocus ? null : getActualActiveElement()
 
       addFocusout(onFocusout)
 
@@ -260,7 +260,7 @@ export default createComponent({
       }
 
       if (!props.noFocus) {
-        document.activeElement.blur()
+        getActualActiveElement()?.blur()
       }
 
       // should removeTick() if this gets removed

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -28,6 +28,7 @@ import { createComponent } from '../../utils/private.create/create.js'
 import { getScrollTarget, scrollTargetProp } from '../../utils/scroll/scroll.js'
 import { addEvt, cleanEvt, stopAndPrevent } from '../../utils/event/event.js'
 import { clearSelection } from '../../utils/private.selection/selection.js'
+import { getTeleportTargetElement } from '../../utils/private.dom/teleport-target.js'
 import { hSlot } from '../../utils/private.render/render.js'
 import {
   addClickOutside,
@@ -339,7 +340,10 @@ export default createComponent({
 
       hasNonSelectable = state
       nonSelectableCount += state ? 1 : -1
-      document.body.classList.toggle('non-selectable', nonSelectableCount > 0)
+      getTeleportTargetElement().classList.toggle(
+        'non-selectable',
+        nonSelectableCount > 0
+      )
 
       if (!state && removeNonSelectableTimer !== void 0) {
         clearTimeout(removeNonSelectableTimer)

--- a/ui/src/composables/private.use-field/use-field.js
+++ b/ui/src/composables/private.use-field/use-field.js
@@ -307,8 +307,15 @@ export default function useField(state) {
     return acc
   })
 
+  function getActiveEl() {
+    return (
+      state.rootRef.value?.getRootNode?.().activeElement ??
+      document.activeElement
+    )
+  }
+
   function focusHandler() {
-    const el = document.activeElement
+    const el = getActiveEl()
     let target = state.targetRef?.value
 
     if (target && (el === null || el.id !== state.targetUid.value)) {
@@ -328,7 +335,7 @@ export default function useField(state) {
 
   function blur() {
     removeFocusFn(focusHandler)
-    const el = document.activeElement
+    const el = getActiveEl()
     if (el !== null && state.rootRef.value.contains(el)) {
       el.blur()
     }
@@ -356,7 +363,7 @@ export default function useField(state) {
         (state.hasPopupOpen ||
           state.controlRef === void 0 ||
           state.controlRef.value === null ||
-          state.controlRef.value.contains(document.activeElement))
+          state.controlRef.value.contains(getActiveEl()))
       ) {
         return
       }
@@ -377,8 +384,8 @@ export default function useField(state) {
     if (!$q.platform.is.mobile) {
       const el = state.targetRef?.value || state.rootRef.value
       el.focus()
-    } else if (state.rootRef.value.contains(document.activeElement)) {
-      document.activeElement.blur()
+    } else if (state.rootRef.value.contains(getActiveEl())) {
+      getActiveEl().blur()
     }
 
     if (props.type === 'file') {

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -8,6 +8,10 @@ import {
 } from 'vue'
 
 import History from '../../plugins/private.history/History.js'
+import {
+  getTeleportTarget,
+  getTeleportTargetElement
+} from '../../utils/private.dom/teleport-target.js'
 import { vmHasRouter } from '../../utils/private.vm/vm.js'
 
 let counter = 0
@@ -25,6 +29,8 @@ export default function useFullscreen() {
 
   let historyEntry,
     fullscreenFillerNode,
+    fullscreenTarget,
+    fullscreenTargetElement,
     isUnmounting = false
   const inFullscreen = ref(false)
 
@@ -62,11 +68,13 @@ export default function useFullscreen() {
 
     inFullscreen.value = true
     proxy.$el.replaceWith(fullscreenFillerNode)
-    document.body.append(proxy.$el)
+    fullscreenTarget = getTeleportTarget()
+    fullscreenTargetElement = getTeleportTargetElement()
+    fullscreenTarget.append(proxy.$el)
 
     counter++
     if (counter === 1) {
-      document.body.classList.add('q-body--fullscreen-mixin')
+      fullscreenTargetElement.classList.add('q-body--fullscreen-mixin')
     }
 
     historyEntry = {
@@ -89,7 +97,7 @@ export default function useFullscreen() {
     counter = Math.max(0, counter - 1)
 
     if (counter === 0) {
-      document.body.classList.remove('q-body--fullscreen-mixin')
+      fullscreenTargetElement.classList.remove('q-body--fullscreen-mixin')
 
       if (!isUnmounting && proxy.$el.scrollIntoView !== void 0) {
         setTimeout(() => {

--- a/ui/src/css/core/animations.sass
+++ b/ui/src/css/core/animations.sass
@@ -3,7 +3,7 @@
  * Adapted from: https://github.com/animate-css/animate.css/blob/6828621a01e145119db6194dc9b4d37325b48aa5/source/_base.css
  */
 
-\:root
+\:root, :host
   --animate-duration: #{$animate-duration}
   --animate-delay: #{$animate-delay}
   --animate-repeat: #{$animate-repeat}

--- a/ui/src/css/core/colors.sass
+++ b/ui/src/css/core/colors.sass
@@ -1,4 +1,4 @@
-\:root
+\:root, :host
   --q-primary:      #{$primary}
   --q-secondary:    #{$secondary}
   --q-accent:       #{$accent}

--- a/ui/src/css/core/size.sass
+++ b/ui/src/css/core/size.sass
@@ -1,6 +1,6 @@
 @use 'sass:map'
 
-\:root
+\:root, :host
   @each $name, $size in $sizes
     #{"--q-size-"}#{$name}: #{$size}
 

--- a/ui/src/css/core/transitions.sass
+++ b/ui/src/css/core/transitions.sass
@@ -1,5 +1,5 @@
 // should not need this, but it's good as fallback
-\:root
+\:root, :host
   --q-transition-duration: .3s
 
 .q-transition

--- a/ui/src/directives/touch-repeat/TouchRepeat.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.js
@@ -12,6 +12,7 @@ import {
 import { clearSelection } from '../../utils/private.selection/selection.js'
 import { isKeyCode } from '../../utils/private.keyboard/key-composition.js'
 import getSSRProps from '../../utils/private.noop-ssr-directive-transform/noop-ssr-directive-transform.js'
+import { getTeleportTargetElement } from '../../utils/private.dom/teleport-target.js'
 
 const keyCodes = {
     esc: 27,
@@ -32,7 +33,7 @@ function shouldEnd(evt, origin) {
 }
 
 function removeBodyNonSelectable() {
-  document.body.classList.remove('non-selectable')
+  getTeleportTargetElement().classList.remove('non-selectable')
 }
 
 export default createDirective(
@@ -135,7 +136,7 @@ export default createDirective(
               }
 
               if (client.is.mobile) {
-                document.body.classList.add('non-selectable')
+                getTeleportTargetElement().classList.add('non-selectable')
                 clearSelection()
                 ctx.styleCleanup = styleCleanup
               }
@@ -164,7 +165,7 @@ export default createDirective(
 
                   if (!client.is.mobile) {
                     document.documentElement.style.cursor = 'pointer'
-                    document.body.classList.add('non-selectable')
+                    getTeleportTargetElement().classList.add('non-selectable')
                     clearSelection()
                     ctx.styleCleanup = styleCleanup
                   }

--- a/ui/src/plugins/app-fullscreen/AppFullscreen.js
+++ b/ui/src/plugins/app-fullscreen/AppFullscreen.js
@@ -1,5 +1,6 @@
 import { createReactivePlugin } from '../../utils/private.create/create.js'
 import { changeGlobalNodesTarget } from '../../utils/private.config/nodes.js'
+import { getTeleportTarget } from '../../utils/private.dom/teleport-target.js'
 
 const prefixes = {}
 
@@ -27,7 +28,9 @@ function updateEl() {
     : null)
 
   changeGlobalNodesTarget(
-    newEl === null || newEl === document.documentElement ? document.body : newEl
+    newEl === null || newEl === document.documentElement
+      ? getTeleportTarget()
+      : newEl
   )
 }
 

--- a/ui/src/plugins/dark/Dark.js
+++ b/ui/src/plugins/dark/Dark.js
@@ -1,4 +1,5 @@
 import { createReactivePlugin } from '../../utils/private.create/create.js'
+import { getTeleportTargetElement } from '../../utils/private.dom/teleport-target.js'
 
 const Plugin = createReactivePlugin(
   {
@@ -29,8 +30,9 @@ const Plugin = createReactivePlugin(
       }
 
       Plugin.isActive = val === true
-      document.body.classList.remove(`body--${val === true ? 'light' : 'dark'}`)
-      document.body.classList.add(`body--${val === true ? 'dark' : 'light'}`)
+      const target = getTeleportTargetElement()
+      target.classList.remove(`body--${val === true ? 'light' : 'dark'}`)
+      target.classList.add(`body--${val === true ? 'dark' : 'light'}`)
     },
 
     toggle() {
@@ -39,7 +41,7 @@ const Plugin = createReactivePlugin(
 
     install({ $q, ssrContext }) {
       const dark = __QUASAR_SSR_CLIENT__
-        ? document.body.classList.contains('body--dark')
+        ? getTeleportTargetElement().classList.contains('body--dark')
         : $q.config.dark
 
       if (__QUASAR_SSR_SERVER__) {

--- a/ui/src/utils/css-var/get-css-var.js
+++ b/ui/src/utils/css-var/get-css-var.js
@@ -1,12 +1,16 @@
-export default function getCssVar(propName, element = document.body) {
+import { getTeleportTargetElement } from '../private.dom/teleport-target.js'
+
+export default function getCssVar(propName, element) {
   if (typeof propName !== 'string') {
     throw new TypeError('Expected a string as propName')
   }
-  if (!(element instanceof Element)) {
+  const target = element === void 0 ? getTeleportTargetElement() : element
+
+  if (!(target instanceof Element)) {
     throw new TypeError('Expected a DOM element')
   }
 
   return (
-    getComputedStyle(element).getPropertyValue(`--q-${propName}`).trim() || null
+    getComputedStyle(target).getPropertyValue(`--q-${propName}`).trim() || null
   )
 }

--- a/ui/src/utils/css-var/set-css-var.js
+++ b/ui/src/utils/css-var/set-css-var.js
@@ -1,13 +1,17 @@
-export default function setCssVar(propName, value, element = document.body) {
+import { getTeleportTargetElement } from '../private.dom/teleport-target.js'
+
+export default function setCssVar(propName, value, element) {
   if (typeof propName !== 'string') {
     throw new TypeError('Expected a string as propName')
   }
   if (typeof value !== 'string') {
     throw new TypeError('Expected a string as value')
   }
-  if (!(element instanceof Element)) {
+  const target = element === void 0 ? getTeleportTargetElement() : element
+
+  if (!(target instanceof Element)) {
     throw new TypeError('Expected a DOM element')
   }
 
-  element.style.setProperty(`--q-${propName}`, value)
+  target.style.setProperty(`--q-${propName}`, value)
 }

--- a/ui/src/utils/dom/dom.js
+++ b/ui/src/utils/dom/dom.js
@@ -62,8 +62,20 @@ export function getElement(el) {
   }
 }
 
+export function getActualActiveElement() {
+  let el = document.activeElement
+
+  while (el?.shadowRoot?.activeElement) {
+    el = el.shadowRoot.activeElement
+  }
+
+  return el
+}
+
 // internal
 export function childHasFocus(el, focusedEl) {
+  focusedEl ??= getActualActiveElement()
+
   if (el === void 0 || el === null || el.contains(focusedEl)) {
     return true
   }

--- a/ui/src/utils/private.click-outside/click-outside.js
+++ b/ui/src/utils/private.click-outside/click-outside.js
@@ -13,6 +13,8 @@ function globalHandler(evt) {
   }
 
   const target = evt.target
+  const path =
+    typeof evt.composedPath === 'function' ? evt.composedPath() : void 0
 
   if (
     target === void 0 ||
@@ -46,14 +48,15 @@ function globalHandler(evt) {
 
   for (let i = registeredList.length - 1; i >= 0; i--) {
     const state = registeredList[i]
+    const anchor = state.anchorEl.value
+    const inner = state.innerRef.value
+    const isInside =
+      path !== void 0
+        ? path.includes(anchor) || (inner !== null && path.includes(inner))
+        : (anchor !== null && anchor.contains(target)) ||
+          (inner !== null && inner.contains(target))
 
-    if (
-      (state.anchorEl.value === null ||
-        !state.anchorEl.value.contains(target)) &&
-      (target === document.body ||
-        (state.innerRef.value !== null &&
-          !state.innerRef.value.contains(target)))
-    ) {
+    if (!isInside) {
       // mark the event as being processed by clickOutside
       // used to prevent refocus after menu close
       evt.qClickOutside = true

--- a/ui/src/utils/private.config/nodes.js
+++ b/ui/src/utils/private.config/nodes.js
@@ -1,4 +1,5 @@
 import { globalConfig } from '../private.config/instance-config.js'
+import { getTeleportTarget } from '../private.dom/teleport-target.js'
 
 const nodesList = []
 const portalTypeList = []
@@ -17,6 +18,11 @@ export function createGlobalNode(id, portalType) {
     if (cls !== void 0) {
       el.className = cls
     }
+  }
+
+  const configuredTarget = getTeleportTarget()
+  if (configuredTarget !== target) {
+    changeGlobalNodesTarget(configuredTarget)
   }
 
   target.append(el)
@@ -41,7 +47,7 @@ export function changeGlobalNodesTarget(newTarget) {
   target = newTarget
 
   if (
-    target === document.body ||
+    target === getTeleportTarget() ||
     // or we have less than 2 dialogs:
     portalTypeList.reduce(
       (acc, type) => (type === 'dialog' ? acc + 1 : acc),

--- a/ui/src/utils/private.config/nodes.test.js
+++ b/ui/src/utils/private.config/nodes.test.js
@@ -11,6 +11,7 @@ let el = null
 
 afterEach(() => {
   delete globalConfig.globalNodes
+  delete globalConfig.teleportTarget
 
   if (el !== null) {
     removeGlobalNode(el)
@@ -59,6 +60,30 @@ describe('[nodes API]', () => {
         expect(element.getAttribute('id')).toMatch(/^q-portal--portType--\d+$/)
         expect(element.getAttribute('class')).toBe('port-class')
         expect(element.parentNode).toBe(document.body)
+      })
+
+      test('uses configured selector target', () => {
+        const target = document.createElement('div')
+        target.id = 'teleport-target'
+        document.body.append(target)
+        globalConfig.teleportTarget = '#teleport-target'
+
+        el = createGlobalNode('configured-target')
+
+        expect(el.parentNode).toBe(target)
+        target.remove()
+      })
+
+      test('uses configured ShadowRoot target', () => {
+        const host = document.createElement('div')
+        document.body.append(host)
+        const shadowRoot = host.attachShadow({ mode: 'open' })
+        globalConfig.teleportTarget = () => shadowRoot
+
+        el = createGlobalNode('shadow-target')
+
+        expect(el.parentNode).toBe(shadowRoot)
+        host.remove()
       })
     })
 

--- a/ui/src/utils/private.dom/teleport-target.js
+++ b/ui/src/utils/private.dom/teleport-target.js
@@ -1,0 +1,35 @@
+import { globalConfig } from '../private.config/instance-config.js'
+
+function isValidTarget(target) {
+  return (
+    target instanceof Element ||
+    (typeof ShadowRoot !== 'undefined' && target instanceof ShadowRoot)
+  )
+}
+
+export function getTeleportTarget() {
+  if (__QUASAR_SSR_SERVER__) return void 0
+
+  const configured = globalConfig.teleportTarget
+  const target =
+    typeof configured === 'function'
+      ? configured()
+      : typeof configured === 'string'
+        ? document.querySelector(configured)
+        : configured
+
+  if (target === void 0) return document.body
+
+  if (!isValidTarget(target)) {
+    throw new TypeError(
+      'Quasar config.teleportTarget must resolve to an Element or ShadowRoot'
+    )
+  }
+
+  return target
+}
+
+export function getTeleportTargetElement() {
+  const target = getTeleportTarget()
+  return target instanceof ShadowRoot ? target.host : target
+}

--- a/ui/src/utils/private.dom/teleport-target.test.js
+++ b/ui/src/utils/private.dom/teleport-target.test.js
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { globalConfig } from '../private.config/instance-config.js'
+import {
+  getTeleportTarget,
+  getTeleportTargetElement
+} from './teleport-target.js'
+
+afterEach(() => {
+  delete globalConfig.teleportTarget
+  document.body.innerHTML = ''
+})
+
+describe('[teleport target]', () => {
+  test('defaults to document.body', () => {
+    expect(getTeleportTarget()).toBe(document.body)
+  })
+
+  test('resolves a selector', () => {
+    const target = document.createElement('div')
+    target.id = 'target'
+    document.body.append(target)
+    globalConfig.teleportTarget = '#target'
+
+    expect(getTeleportTarget()).toBe(target)
+  })
+
+  test('returns the host when an element target is required', () => {
+    const host = document.createElement('div')
+    const shadowRoot = host.attachShadow({ mode: 'open' })
+    globalConfig.teleportTarget = shadowRoot
+
+    expect(getTeleportTarget()).toBe(shadowRoot)
+    expect(getTeleportTargetElement()).toBe(host)
+  })
+
+  test('rejects unresolved selectors and invalid resolver results', () => {
+    globalConfig.teleportTarget = '#missing'
+    expect(() => getTeleportTarget()).toThrow(TypeError)
+
+    globalConfig.teleportTarget = () => null
+    expect(() => getTeleportTarget()).toThrow(TypeError)
+  })
+})

--- a/ui/types/config.d.ts
+++ b/ui/types/config.d.ts
@@ -9,5 +9,16 @@ export interface QuasarUIConfiguration {
   capacitor?: NativeMobileWrapperConfiguration;
   cordova?: NativeMobileWrapperConfiguration;
 
+  /**
+   * Target for Quasar-managed teleported content. A selector is required when
+   * configuring this through quasar.config; runtime plugin configuration may
+   * also provide an Element, ShadowRoot, or resolver function.
+   */
+  teleportTarget?:
+    | string
+    | Element
+    | ShadowRoot
+    | (() => Element | ShadowRoot | undefined);
+
   // The rest will be augmented by auto-generated code
 }


### PR DESCRIPTION
## Summary

- add a typed `config.teleportTarget` contract for Quasar-managed portals
- support selector targets from Quasar CLI configuration and `Element`/`ShadowRoot`/resolver targets during direct runtime installation
- keep global nodes, fullscreen handling, dark-mode classes, CSS-variable helpers, selection guards, focus handling, and click-outside behavior aligned with the configured target
- add Shadow DOM-aware focus and composed-event handling
- expose Quasar root custom properties through both `:root` and `:host`
- document the configuration boundaries and single-target runtime limitation
- add focused selector, ShadowRoot, invalid-target, and portal-placement tests

## Relationship to #18280

This is a replacement implementation of the feature proposed in #18280. That PR identified a valuable requirement and provided useful prior art, but it should not be merged unchanged because it is now conflicted with `dev` and has several unresolved contract problems:

- its documented `config.root: () => ...` example is placed in `quasar.config`, where App Vite serializes `framework.config` with `JSON.stringify()` and therefore drops functions
- the new option has no public TypeScript configuration contract
- exiting native fullscreen restores portal nodes to `document.body` instead of the configured Shadow Root
- its `composedPath()` fallback treats every event as an outside click when that API is unavailable
- its CSS-variable helpers weaken the existing explicit-element validation contract
- it describes multiple Web Component instances even though Quasar's configuration and portal registry provide one shared target per runtime
- it does not include focused Shadow DOM regression tests

This PR uses the narrower name `teleportTarget` rather than `root`, distinguishes serializable CLI configuration from runtime-only DOM values, validates resolved targets, preserves existing helper behavior, restores portals correctly after fullscreen, retains a safe `contains()` fallback for click-outside behavior, and documents the one-target limitation explicitly.

Credit to @TobyMosque and #18280 for identifying the Shadow DOM teleport requirement and exploring the affected UI surfaces.

## Configuration

Quasar CLI configuration uses a serializable selector:

```js
framework: {
  config: {
    teleportTarget: '#my-app-overlays'
  }
}
```

Direct Vue plugin installation may resolve a Shadow Root at runtime:

```js
app.use(Quasar, {
  config: {
    teleportTarget: () => customElement.shadowRoot
  }
})
```

## Validation

- `pnpm --filter quasar-ui-test exec vitest run ../src/utils/private.dom/teleport-target.test.js ../src/utils/private.config/nodes.test.js ../src/utils/dom/dom.test.js --reporter=verbose`
  - 3 test files passed
  - 35 tests passed
- Oxlint passed for all modified JavaScript files
- Oxfmt passed for all modified files
- `pnpm --filter quasar build` passed
- `git diff --check` passed
