### PR TITLE
fix(QDialog): restore scroll after URL metadata changes

### DIFF
--- a/ui/src/utils/scroll/prevent-scroll.js
+++ b/ui/src/utils/scroll/prevent-scroll.js
@@ -12,7 +12,7 @@ let registered = 0,
   vpPendingUpdate = false,
   bodyLeft,
   bodyTop,
-  href,
+  routePath,
   closeTimer = null
 
 function onAppleScroll(e) {
@@ -59,7 +59,7 @@ function apply(action) {
     bodyLeft = body.style.left
     bodyTop = body.style.top
 
-    href = window.location.href
+    routePath = window.location.pathname
 
     body.style.left = `-${scrollPositionX}px`
     body.style.top = `-${scrollPositionY}px`
@@ -137,8 +137,8 @@ function apply(action) {
     body.style.left = bodyLeft
     body.style.top = bodyTop
 
-    // scroll back only if route has not changed
-    if (window.location.href === href) {
+    // scroll back only if route path has not changed
+    if (window.location.pathname === routePath) {
       window.scrollTo(scrollPositionX, scrollPositionY)
     }
 


### PR DESCRIPTION
## Summary

Fixes #18185.

QDialog saves the page scroll position while its body-scroll lock is active. The restoration guard currently compares the complete URL, which causes a query-string or fragment change to suppress restoration even though the document route path has not changed.

This stores the pathname when the lock is applied and compares it when the lock is released. Query and fragment changes can therefore restore the saved position, while navigation to a different pathname still avoids restoring stale scroll coordinates.

## Relationship to #18190

This is an alternative to #18190, rebased on the current `dev` branch.

The earlier PR has the right behavioral goal, but retains the complete URL and constructs a `URL` during cleanup. This version instead stores the exact value needed by the guard, names it `routePath`, and performs a direct pathname comparison. That keeps the invariant explicit and avoids parsing a value that does not otherwise need to be retained.

## Validation

- Oxlint passed.
- Oxfmt passed.
- `git diff --check` passed.
