### PR TITLE
fix(ui): preserve fullscreen portal target

### DIFF
--- a/ui/src/utils/private.config/nodes.js
+++ b/ui/src/utils/private.config/nodes.js
@@ -5,7 +5,8 @@ const nodesList = []
 const portalTypeList = []
 
 let portalIndex = 1
-let target = __QUASAR_SSR_SERVER__ ? void 0 : document.body
+let configuredTarget = __QUASAR_SSR_SERVER__ ? void 0 : document.body
+let target = configuredTarget
 
 export function createGlobalNode(id, portalType) {
   const el = document.createElement('div')
@@ -20,9 +21,14 @@ export function createGlobalNode(id, portalType) {
     }
   }
 
-  const configuredTarget = getTeleportTarget()
-  if (configuredTarget !== target) {
-    changeGlobalNodesTarget(configuredTarget)
+  const newConfiguredTarget = getTeleportTarget()
+  if (newConfiguredTarget !== configuredTarget) {
+    const targetIsConfigured = target === configuredTarget
+    configuredTarget = newConfiguredTarget
+
+    if (targetIsConfigured) {
+      changeGlobalNodesTarget(configuredTarget)
+    }
   }
 
   target.append(el)

--- a/ui/src/utils/private.config/nodes.test.js
+++ b/ui/src/utils/private.config/nodes.test.js
@@ -124,6 +124,36 @@ describe('[nodes API]', () => {
           expect(node.parentElement).toBe(newTargetEl)
         })
       })
+
+      test('preserves target for subsequently created nodes', () => {
+        const configuredTarget = document.createElement('div')
+        const fullscreenTarget = document.createElement('div')
+        document.body.append(configuredTarget, fullscreenTarget)
+
+        globalConfig.teleportTarget = configuredTarget
+        changeGlobalNodesTarget(configuredTarget)
+
+        const firstNode = createGlobalNode('before-fullscreen')
+        let secondNode
+
+        try {
+          expect(firstNode.parentElement).toBe(configuredTarget)
+
+          changeGlobalNodesTarget(fullscreenTarget)
+          secondNode = createGlobalNode('during-fullscreen')
+
+          expect(firstNode.parentElement).toBe(fullscreenTarget)
+          expect(secondNode.parentElement).toBe(fullscreenTarget)
+        } finally {
+          changeGlobalNodesTarget(document.body)
+          removeGlobalNode(firstNode)
+          if (secondNode !== void 0) {
+            removeGlobalNode(secondNode)
+          }
+          configuredTarget.remove()
+          fullscreenTarget.remove()
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- keep the configured teleport target separate from the active global-node target
- preserve AppFullscreen's temporary target when portals are created during native fullscreen
- add regression coverage for portals created before and during fullscreen

## Root cause

`createGlobalNode()` re-resolved `config.teleportTarget` for every new portal and compared it directly with the active target. AppFullscreen temporarily changes that active target to a non-document fullscreen element. Creating any additional portal then treated the intentional difference as a configuration change and moved all existing portals back to the configured target, outside the fullscreen subtree.

## Fix

Track the last resolved configured target independently from the active target. Configuration changes still migrate global nodes when the configured target is active, while temporary targets such as AppFullscreen remain authoritative until their owner restores the configured target.

The existing nested-dialog relocation logic remains unchanged.

## User impact

Dialogs, menus, tooltips, notifications, and other global portals created during native fullscreen remain inside the fullscreen element and therefore stay visible and interactive.

## Validation

- `pnpm --filter quasar-ui-test exec vitest run ../src/utils/private.config/nodes.test.js ../src/plugins/app-fullscreen/AppFullscreen.test.js` — 23 tests passed
- `pnpm --filter quasar test` — 100 files and 1,071 tests passed
- `pnpm lint:ui:check`
- `pnpm --filter quasar build`
- `pnpm --filter quasar test:specs:ci`
