### PR TITLE
fix(QTooltip): detect focus-visible descendant

### DIFF
--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -344,7 +344,7 @@ export default createComponent({
 
     function onFocusin(evt) {
       const el = evt.target
-      if (el === null) return
+      if (!el) return
 
       // only react to keyboard focus, not to focus coming from a pointer,
       // so the tooltip doesn't pop up when the target is clicked;

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -343,7 +343,7 @@ export default createComponent({
     }
 
     function onFocusin(evt) {
-      const el = anchorEl.value
+      const el = evt.target
       if (el === null) return
 
       // only react to keyboard focus, not to focus coming from a pointer,

--- a/ui/src/components/tooltip/QTooltip.test.js
+++ b/ui/src/components/tooltip/QTooltip.test.js
@@ -1,0 +1,46 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import QTooltip from './QTooltip.js'
+
+let wrapper
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('[QTooltip API]', () => {
+  describe('[Generic]', () => {
+    test('shows when a focus-visible descendant receives focus', async () => {
+      wrapper = mount({
+        components: { QTooltip },
+        template: `
+          <div data-test="anchor">
+            <button data-test="focus-target">Focus target</button>
+            <q-tooltip>Tooltip content</q-tooltip>
+          </div>
+        `
+      })
+
+      const anchor = wrapper.get('[data-test="anchor"]')
+      const focusTarget = wrapper.get('[data-test="focus-target"]')
+
+      vi.spyOn(anchor.element, 'matches').mockReturnValue(false)
+      vi.spyOn(focusTarget.element, 'matches').mockReturnValue(true)
+
+      await focusTarget.trigger('focusin')
+      await vi.runAllTimersAsync()
+      await flushPromises()
+
+      expect(wrapper.findComponent({ name: 'QPortal' }).exists()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- inspect the bubbling `focusin` event target when checking `:focus-visible`
- preserve the existing pointer-focus filtering and unsupported-selector fallback
- add a regression test for a composite anchor with a focusable descendant

## Problem

QTooltip listens for `focusin` on its anchor, so focus from nested controls bubbles to that handler. The handler checked `anchorEl.matches(':focus-visible')`, however, rather than the descendant that actually received focus. Composite anchors such as QInput therefore failed to show their tooltip for keyboard focus because the outer anchor did not match `:focus-visible` even when its internal input did.

This is a focused follow-up to #18318. It intentionally leaves the separate hover/focus ownership and `aria-describedby` behavior unchanged.

## Verification

- `pnpm --filter quasar-ui-test exec vitest run ../src/components/tooltip/QTooltip.test.js`
- `pnpm --filter quasar test` — 101 files, 1,072 tests passed
- `pnpm lint:ui:check`
- `pnpm --filter quasar build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip keyboard-focus behavior by basing activation on the actual focused element, improving focus-visible handling when tooltips appear after delayed show.

* **Tests**
  * Added unit tests to confirm the tooltip’s portal is created when a focus-visible descendant triggers a focus-in event (using fake timers and async flushes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->