### PR TITLE
fix(app-vite): SSG -> honor absolute nested routes

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-builder.js
+++ b/app-vite/lib/modes/ssg/ssg-builder.js
@@ -101,7 +101,11 @@ function getParseVueRouterRoutesFn(quasarConf) {
     for (const route of routes) {
       const routePath = route.path
       const fullPath = (
-        routePath === '' ? parentPath : `${parentPath}/${routePath}`
+        routePath === ''
+          ? parentPath
+          : routePath.startsWith('/')
+            ? routePath
+            : `${parentPath}/${routePath}`
       ).replaceAll(multiSlashRE, '/')
 
       const ssgPage = {


### PR DESCRIPTION
## Summary

- preserve nested route paths that begin with `/` as absolute paths
- continue inheriting the parent for empty paths and prefixing relative child paths
- keep recursive child, dynamic-param, crawl-ignore, and CSR handling unchanged

## Problem

`parseVueRouterRoutes()` always joined a child route path to its parent. For a route such as `{ path: '/parent', children: [{ path: '/absolute' }] }`, it therefore generated `/parent/absolute`.

Vue Router treats a nested path beginning with `/` as root-absolute and resolves that record to `/absolute`. The SSG helper now follows the same rule, preventing it from rendering the wrong URL and output path.

## Verification

- exercised the real parser before and after the change with relative, absolute, empty, grandchild, and dynamic-param routes
- compared the result with the installed Vue Router matcher
- `node --check app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxfmt --check app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm exec oxlint app-vite/lib/modes/ssg/ssg-builder.js`
- `pnpm --filter @quasar/app-vite build`
- `pnpm --filter @quasar/app-vite build:ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected static site generation for nested routes that begin with a leading slash.
  * Ensured absolute route paths are preserved instead of being incorrectly combined with parent paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->