### PR TITLE
fix(QUploader): remove files before aborting uploads

### DIFF
--- a/ui/src/components/uploader/QUploader.test.js
+++ b/ui/src/components/uploader/QUploader.test.js
@@ -1,0 +1,120 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import QUploader from './QUploader.js'
+
+let wrapper
+const xhrs = []
+
+class MockXMLHttpRequest {
+  constructor() {
+    xhrs.push(this)
+    this.readyState = 0
+    this.status = 0
+    this.listeners = {}
+    this.upload = { addEventListener: vi.fn() }
+    this.abort = vi.fn(() => {
+      this.readyState = 4
+      this.listeners.readystatechange()
+    })
+  }
+
+  addEventListener(name, handler) {
+    this.listeners[name] = handler
+  }
+
+  open() {}
+
+  send() {}
+
+  setRequestHeader() {}
+}
+
+beforeEach(() => {
+  xhrs.length = 0
+  vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest)
+})
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('[QUploader API]', () => {
+  describe('[Methods]', () => {
+    describe('[(method)removeFile]', () => {
+      test('does not fail an uploading file removed during a synchronous abort', () => {
+        const onFailed = vi.fn()
+        const onRemoved = vi.fn()
+
+        wrapper = mount(QUploader, {
+          props: {
+            url: '/upload',
+            noThumbnails: true,
+            onFailed,
+            onRemoved
+          }
+        })
+
+        const file = new File(['content'], 'file.txt', {
+          type: 'text/plain'
+        })
+
+        wrapper.vm.addFiles([file])
+        wrapper.vm.upload()
+
+        expect(file.__status).toBe('uploading')
+
+        const [xhr] = xhrs
+        wrapper.vm.removeFile(file)
+
+        expect(xhr.abort).toHaveBeenCalledOnce()
+        expect(onFailed).not.toHaveBeenCalled()
+        expect(onRemoved).toHaveBeenCalledOnce()
+        expect(onRemoved).toHaveBeenCalledWith([file])
+        expect(wrapper.vm.files).toEqual([])
+        expect(wrapper.vm.queuedFiles).toEqual([])
+      })
+
+      test('only fails remaining live files when aborting a batch', () => {
+        const onFailed = vi.fn()
+        const onRemoved = vi.fn()
+
+        wrapper = mount(QUploader, {
+          props: {
+            url: '/upload',
+            batch: true,
+            multiple: true,
+            noThumbnails: true,
+            onFailed,
+            onRemoved
+          }
+        })
+
+        const removedFile = new File(['removed'], 'removed.txt', {
+          type: 'text/plain'
+        })
+        const liveFile = new File(['live'], 'live.txt', {
+          type: 'text/plain'
+        })
+
+        wrapper.vm.addFiles([removedFile, liveFile])
+        wrapper.vm.upload()
+
+        const [xhr] = xhrs
+        wrapper.vm.removeFile(removedFile)
+
+        expect(xhr.abort).toHaveBeenCalledOnce()
+        expect(onFailed).toHaveBeenCalledOnce()
+        expect(onFailed.mock.calls[0][0].files).toEqual([liveFile])
+        expect(onRemoved).toHaveBeenCalledWith([removedFile])
+        expect(wrapper.vm.files).toEqual([liveFile])
+        expect(wrapper.vm.queuedFiles).toEqual([liveFile])
+        expect(liveFile.__status).toBe('failed')
+      })
+    })
+  })
+})

--- a/ui/src/components/uploader/uploader-core.js
+++ b/ui/src/components/uploader/uploader-core.js
@@ -264,15 +264,16 @@ export function getRenderer(getPlugin, expose) {
   function removeFile(file) {
     if (props.disable) return
 
+    const isUploading = file.__status === 'uploading'
+
     if (file.__status === 'uploaded') {
       state.uploadedSize.value -= file.size
       uploadSize.value -= file.size
       state.uploadedFiles.value = state.uploadedFiles.value.filter(
         f => f.__key !== file.__key
       )
-    } else if (file.__status === 'uploading') {
+    } else if (isUploading) {
       uploadSize.value -= file.size
-      file.__abort()
     } else {
       uploadSize.value -= file.size
     }
@@ -290,6 +291,11 @@ export function getRenderer(getPlugin, expose) {
     state.queuedFiles.value = state.queuedFiles.value.filter(
       f => f.__key !== file.__key
     )
+
+    if (isUploading) {
+      file.__abort()
+    }
+
     emit('removed', [file])
   }
 


### PR DESCRIPTION
## Summary

- remove an uploading file from live and queued state before aborting its request
- prevent synchronous XHR terminal callbacks from marking the removed file as failed
- add coverage for both single-file and shared batch uploads

## Problem

`removeFile()` called `file.__abort()` before removing the file from `state.files`. An XHR abort can synchronously fire `readystatechange`, so the XHR plugin still considered that file live, marked it failed, requeued it, and emitted `failed` immediately before the core emitted `removed`.

This follow-up to #18397 makes live state authoritative before aborting. For batch uploads, remaining live files are still marked failed and requeued while the removed file is excluded.

## Verification

- `pnpm --filter quasar-ui-test exec vitest run ../src/components/uploader/QUploader.test.js` — 2 tests passed
- `pnpm --filter quasar test` — 102 files, 1,074 tests passed
- `pnpm lint:ui:check`
- `pnpm --filter quasar build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file removal during active uploads.
  * Prevented removed files from triggering incorrect upload failure callbacks.
  * Ensured upload and queued-file lists remain accurate after removal.
  * Preserved correct failure handling for other files during batch uploads.

* **Tests**
  * Added coverage for aborting and removing files during individual and batch uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->