### PR TITLE
fix(QCarousel): preserve scroll position after exiting fullscreen (#18215)

### DIFF
--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -290,7 +290,7 @@ export default createComponent({
         blurTarget !== document.activeElement
       ) {
         blurTarget.setAttribute('tabindex', -1)
-        blurTarget.focus()
+        blurTarget.focus({ preventScroll: true })
       }
 
       if (touchTarget === rootRef.value) {

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -31,7 +31,9 @@ export default function useFullscreen() {
 
   let historyEntry,
     fullscreenFillerNode,
-    isUnmounting = false
+    isUnmounting = false,
+    restoreFrame = null,
+    restoreToken = 0
   const inFullscreen = ref(false)
 
   if (vmHasRouter(vm)) {
@@ -63,8 +65,18 @@ export default function useFullscreen() {
     }
   }
 
+  function cancelScrollRestore() {
+    restoreToken++
+    if (restoreFrame !== null) {
+      cancelAnimationFrame(restoreFrame)
+      restoreFrame = null
+    }
+  }
+
   function setFullscreen() {
     if (inFullscreen.value) return
+
+    cancelScrollRestore()
 
     if (counter === 0) {
       bodyScrollPosition = {
@@ -106,8 +118,12 @@ export default function useFullscreen() {
 
       if (isUnmounting === false && bodyScrollPosition !== null) {
         const { left, top } = bodyScrollPosition
+        const token = ++restoreToken
         nextTick(() => {
-          requestAnimationFrame(() => {
+          if (token !== restoreToken || counter !== 0) return
+          restoreFrame = requestAnimationFrame(() => {
+            restoreFrame = null
+            if (token !== restoreToken || counter !== 0) return
             window.scrollTo(left, top)
           })
         })
@@ -128,6 +144,7 @@ export default function useFullscreen() {
   onBeforeUnmount(() => {
     isUnmounting = true
     exitFullscreen()
+    cancelScrollRestore()
   })
 
   // expose public methods

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -1,5 +1,6 @@
 import {
   getCurrentInstance,
+  nextTick,
   onBeforeMount,
   onBeforeUnmount,
   onMounted,
@@ -9,8 +10,13 @@ import {
 
 import History from '../../plugins/private.history/History.js'
 import { vmHasRouter } from '../../utils/private.vm/vm.js'
+import {
+  getHorizontalScrollPosition,
+  getVerticalScrollPosition
+} from '../../utils/scroll/scroll.js'
 
 let counter = 0
+let bodyScrollPosition = null
 
 export const useFullscreenProps = {
   fullscreen: Boolean,
@@ -60,6 +66,13 @@ export default function useFullscreen() {
   function setFullscreen() {
     if (inFullscreen.value) return
 
+    if (counter === 0) {
+      bodyScrollPosition = {
+        left: getHorizontalScrollPosition(window),
+        top: getVerticalScrollPosition(window)
+      }
+    }
+
     inFullscreen.value = true
     proxy.$el.replaceWith(fullscreenFillerNode)
     document.body.append(proxy.$el)
@@ -91,11 +104,16 @@ export default function useFullscreen() {
     if (counter === 0) {
       document.body.classList.remove('q-body--fullscreen-mixin')
 
-      if (!isUnmounting && proxy.$el.scrollIntoView !== void 0) {
-        setTimeout(() => {
-          proxy.$el.scrollIntoView()
-        }, 0)
+      if (isUnmounting === false && bodyScrollPosition !== null) {
+        const { left, top } = bodyScrollPosition
+        nextTick(() => {
+          requestAnimationFrame(() => {
+            window.scrollTo(left, top)
+          })
+        })
       }
+
+      bodyScrollPosition = null
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (`#18215`)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated — N/A (behavior fix, no API change)

**Other information:**

Fixes #18215 — the page scrolls to a different position after closing a `QCarousel` fullscreen. There are two independent root causes; each commit addresses one.

### 1. `useFullscreen` composable (QCarousel / QEditor / QTable)

While in fullscreen the `<body>` gets `position: fixed` (via `q-body--fullscreen-mixin`), which collapses the document scroll. On exit the code called `proxy.$el.scrollIntoView()`, which aligns the element's **top** to the viewport top rather than restoring the user's original scroll position — so the page jumps.

- The real scroll position is now saved **before** any DOM manipulation (moving the element out of flow shortens the document and can clamp `scrollY`), and only on the first entry (`counter === 0`).
- On exit it is restored with `window.scrollTo(...)` instead of `scrollIntoView()`. The restore runs inside `nextTick` + `requestAnimationFrame`: `nextTick` waits until the component removes the `fullscreen` (`position: fixed`) class and the document regains its full height — otherwise `scrollTo` would clamp to a temporarily shorter document (this was a visible jump when the fullscreen toggle sat in the upper half of the viewport); the `requestAnimationFrame` makes the restore the last scroll before paint, so no flicker.

### 2. `QBtn` — `focus({ preventScroll: true })`

On mouse/touch interaction `QBtn` moves focus to the internal, invisible `q-focus-helper` to hide the focus ring. Without `preventScroll`, focusing a button that is partially off-screen makes the browser scroll it into view,
shifting the viewport. In the fullscreen scenario this happened on the toggle click **before** the composable saved the scroll position, so the (already shifted) position was saved and restored — the carousel ended up in the middle
of the screen when more than half of the fullscreen button was below the fold.

This is a general improvement: clicking a partially visible button should never scroll the page.

Both fixes were verified in Chromium across scroll positions (fullscreen toggle in the upper half, lower half, and mostly below the fold). The APIs used (`window.scrollTo`, `focus({ preventScroll })`) are standard and behave the same across modern browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the page’s previous scroll position when exiting fullscreen.
  * Prevented unexpected scrolling when focus is restored during button cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->