### PR TITLE
fix(QMenu): don't close popups shielded by a modal QDialog (#18091)

### DIFF
--- a/ui/src/utils/private.click-outside/click-outside.js
+++ b/ui/src/utils/private.click-outside/click-outside.js
@@ -22,30 +22,45 @@ function globalHandler(evt) {
     return
   }
 
-  // check last portal vm if it's
-  // a QDialog and not in seamless mode
-  let portalIndex = portalProxyList.length - 1
+  // a modal (non-seamless) QDialog shields popups opened before it,
+  // so only popups opened after it can be closed by this click (#18091)
+  let closableContentEls = null
+  let sawClosablePortal = false
 
-  while (portalIndex >= 0) {
-    const proxy = portalProxyList[portalIndex].$
+  for (let i = portalProxyList.length - 1; i >= 0; i--) {
+    const proxy = portalProxyList[i].$
+    const name = proxy.type.name
 
     // skip QTooltip portals
-    if (proxy.type.name === 'QTooltip') {
-      portalIndex--
+    if (name === 'QTooltip') {
       continue
     }
 
-    if (proxy.type.name !== 'QDialog') {
-      break
+    if (name === 'QDialog') {
+      if (proxy.props.seamless !== true) {
+        if (sawClosablePortal === false) return
+
+        closableContentEls = new Set(
+          portalProxyList.slice(i + 1).map(vm => vm.contentEl)
+        )
+        break
+      }
+
+      continue
     }
 
-    if (!proxy.props.seamless) return
-
-    portalIndex--
+    sawClosablePortal = true
   }
 
   for (let i = registeredList.length - 1; i >= 0; i--) {
     const state = registeredList[i]
+
+    if (
+      closableContentEls !== null &&
+      !closableContentEls.has(state.innerRef.value)
+    ) {
+      return
+    }
 
     if (
       (state.anchorEl.value === null ||

--- a/ui/src/utils/private.click-outside/click-outside.test.js
+++ b/ui/src/utils/private.click-outside/click-outside.test.js
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { addClickOutside, removeClickOutside } from './click-outside.js'
+import { portalProxyList } from '../private.portal/portal.js'
+
+// Elements and clickOutside states created during a test, cleaned up after.
+const createdEls = []
+const registeredStates = []
+
+function createEl() {
+  const el = document.createElement('div')
+  document.body.append(el)
+  createdEls.push(el)
+  return el
+}
+
+// Register a fake portal (QMenu / QDialog / QTooltip) in the shared
+// portalProxyList, mimicking what usePortal.showPortal() does.
+function pushPortal(name, { seamless = false } = {}) {
+  const contentEl = createEl()
+  portalProxyList.push({
+    contentEl,
+    $: { type: { name }, props: { seamless } }
+  })
+  return contentEl
+}
+
+// Register a closable popup (QMenu-like) both as a portal and as a
+// clickOutside listener, returning its content element and the spy.
+function pushMenu() {
+  const contentEl = pushPortal('QMenu')
+  const onClickOutside = vi.fn()
+  const state = {
+    anchorEl: { value: null },
+    innerRef: { value: contentEl },
+    onClickOutside
+  }
+  addClickOutside(state)
+  registeredStates.push(state)
+  return { contentEl, onClickOutside }
+}
+
+function mousedownOn(el) {
+  el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+}
+
+afterEach(() => {
+  registeredStates.forEach(removeClickOutside)
+  registeredStates.length = 0
+  portalProxyList.length = 0
+  createdEls.forEach(el => el.remove())
+  createdEls.length = 0
+  vi.restoreAllMocks()
+})
+
+describe('[click-outside]', () => {
+  test('closes nested menus that have no dialog between them', () => {
+    // stack (open order): outer QMenu -> inner QMenu
+    const outer = pushMenu()
+    const inner = pushMenu()
+
+    // click somewhere outside both menus
+    mousedownOn(createEl())
+
+    expect(inner.onClickOutside).toHaveBeenCalledTimes(1)
+    expect(outer.onClickOutside).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not close a menu shielded by a modal dialog (issue #18091)', () => {
+    // stack (open order): outer QMenu -> modal QDialog -> inner QMenu
+    const outer = pushMenu()
+    const dialogEl = pushPortal('QDialog', { seamless: false })
+    const inner = pushMenu()
+
+    // click inside the dialog, but outside the inner menu popup
+    mousedownOn(dialogEl)
+
+    // only the inner Select popup should close
+    expect(inner.onClickOutside).toHaveBeenCalledTimes(1)
+    // the outer Select popup stays open (shielded by the dialog backdrop)
+    expect(outer.onClickOutside).not.toHaveBeenCalled()
+  })
+
+  test('a seamless dialog is not a boundary (has no backdrop)', () => {
+    // stack (open order): outer QMenu -> seamless QDialog -> inner QMenu
+    const outer = pushMenu()
+    const dialogEl = pushPortal('QDialog', { seamless: true })
+    const inner = pushMenu()
+
+    // click inside the seamless dialog, outside the inner menu popup
+    mousedownOn(dialogEl)
+
+    // without a backdrop, both menus close as before
+    expect(inner.onClickOutside).toHaveBeenCalledTimes(1)
+    expect(outer.onClickOutside).toHaveBeenCalledTimes(1)
+  })
+
+  test('a modal dialog on top closes nothing beneath it', () => {
+    // stack (open order): outer QMenu -> modal QDialog (top-most)
+    const outer = pushMenu()
+    const dialogEl = pushPortal('QDialog', { seamless: false })
+
+    mousedownOn(dialogEl)
+
+    expect(outer.onClickOutside).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/utils/private.click-outside/click-outside.test.js
+++ b/ui/src/utils/private.click-outside/click-outside.test.js
@@ -104,4 +104,18 @@ describe('[click-outside]', () => {
 
     expect(outer.onClickOutside).not.toHaveBeenCalled()
   })
+
+  test('a QTooltip above a modal dialog does not unshield an earlier menu', () => {
+    // stack (open order): outer QMenu -> modal QDialog -> QTooltip
+    // the QTooltip is skipped while scanning for the dialog boundary; that
+    // skip must not let the click reach the menu opened before the dialog
+    const outer = pushMenu()
+    const dialogEl = pushPortal('QDialog', { seamless: false })
+    pushPortal('QTooltip')
+
+    // click inside the dialog, outside every popup
+    mousedownOn(dialogEl)
+
+    expect(outer.onClickOutside).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix

**Does this PR introduce a breaking change?**
- [x] No

Closes #18091 (also the older #16207).

**Problem**
When a popup (e.g. a QSelect dropdown) is open, a modal QDialog is opened on top of it, and another popup is opened inside that dialog, clicking inside the dialog to dismiss the inner popup also closes the outer one.

**Cause**
The global click-outside handler walks the list of open popups from the innermost outward and only accounted for a modal QDialog when it was the top-most portal. A dialog sitting in the middle of the stack was ignored, so the click leaked through it and closed the popups opened before the dialog.

**Fix**
Find the top-most modal (non-seamless) QDialog in the portal stack and allow the click to close only the popups opened after it; its backdrop shields everything opened before. Single shared util changed, public API unaffected.

**Tests**
Added unit tests in `click-outside.test.js` (nested menus without a dialog; modal dialog as a boundary — #18091; seamless dialog is not a boundary; modal dialog on top closes nothing). Existing dialog/select/tooltip/menu/utils suites stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved click-outside handling to properly respect modal (non-seamless) dialog shielding.
  - Prevented underlying menus from closing when covered by an active modal dialog.
  - Confirmed correct behavior for nested menus and seamless dialogs, including preserving expected “unshield” boundaries.

- **Tests**
  - Added/verified automated coverage for modal shielding, nested menus, seamless dialogs, top-most modal precedence, and tooltip interactions above dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->