### PR TITLE
fix(QFab): keep actions physically placed under RTL to prevent overlap

### DIFF
--- a/ui/src/components/fab/QFab.sass
+++ b/ui/src/components/fab/QFab.sass
@@ -100,19 +100,20 @@
     .q-btn
       margin: 5px
 
+    // physical direction, not text-based: don't let rtlcss mirror it
     &--right
-      transform-origin: 0 50%
-      transform: scale(.4) translateX(-62px)
+      transform-origin: 0 50% #{"/* rtl:ignore */"}
+      transform: scale(.4) translateX(-62px) #{"/* rtl:ignore */"}
       height: 56px
-      left: 100%
-      margin-left: 9px
+      left: 100% #{"/* rtl:ignore */"}
+      margin-left: 9px #{"/* rtl:ignore */"}
 
     &--left
-      transform-origin: 100% 50%
-      transform: scale(.4) translateX(62px)
+      transform-origin: 100% 50% #{"/* rtl:ignore */"}
+      transform: scale(.4) translateX(62px) #{"/* rtl:ignore */"}
       height: 56px
-      right: 100%
-      margin-right: 9px
+      right: 100% #{"/* rtl:ignore */"}
+      margin-right: 9px #{"/* rtl:ignore */"}
       flex-direction: row-reverse
 
     &--up


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] Any necessary documentation has been added or updated, or explained in the PR's description (behavior explained below; no docs change needed)

**Other information:**

### The bug

Under `dir="rtl"`, an opened `QFab` with a **horizontal** `direction` (`"right"`/`"left"`) misplaces its actions so they **overlap the parent FAB**.

`QFab.sass` authors the horizontal positioning LTR-only, and `postcss-rtlcss` mirrors it at build time. The mirrored rule (`[dir="rtl"] .q-fab__actions--right { right: 100%; margin-right: 9px; transform: scale(.4) translateX(62px) }`) mis-sizes the absolutely-positioned actions container — measured, it collapses to its 6px padding box while its buttons overflow onto the parent.

![before/after](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/qfab-rtl-before-after.png)

_Top: `dev` (overlap). Bottom: this PR (clean)._ Reported downstream at NiceGUI: https://github.com/zauberzeug/nicegui/issues/6165

### The fix

The `direction` prop names a **physical** placement (`up`/`down`/`left`/`right`), so the horizontal rules should not be mirrored by text direction. Annotate them with `/* rtl:ignore */` — the same idiom already used in `QSlider`, `QRating`, `QTabs`, and others — so rtlcss leaves them physical.

After the fix, `direction="right"` shows actions on the right and `direction="left"` on the left, **regardless of `dir`**, while the FAB button's own icon+label ordering keeps mirroring exactly as before. Vertical directions (`up`/`down`) are unchanged (their centering is symmetric and mirror-safe).

<details>
<summary><b>Verification (through Quasar's own build pipeline)</b></summary>

Compiled `QFab.sass` with `sass-embedded` + `postcss([rtl({})])` (`postcss-rtlcss@6.0.0`), matching `ui/build/script.build.css.js`:

**`dev` (before)** — the generated CSS contains the mirrored, overlapping rule:
```css
[dir="ltr"] .q-fab__actions--right { transform-origin:0 50%;  transform:scale(.4) translateX(-62px); left:100%;  margin-left:9px }
[dir="rtl"] .q-fab__actions--right { transform-origin:100% 50%; transform:scale(.4) translateX(62px); right:100%; margin-right:9px }  /* mis-sizes the container */
```

**This PR (after)** — a single, physical rule; no mirrored `[dir="rtl"]` variant is generated:
```css
.q-fab__actions--right { transform-origin:0 50%; transform:scale(.4) translateX(-62px); height:56px; left:100%; margin-left:9px }
```

Rendered check (open actions, `dir="rtl"`): container width restored (6px → ~198px), horizontal overlap with the parent FAB = **0px** for both `direction="right"` and `direction="left"`.

The full `pnpm build` was also run in CI (all green); the built `ui/dist/quasar.rtl.prod.css` emits the single physical rule with no mirrored variant:
```css
.q-fab__actions--right{transform-origin:0;height:56px;margin-left:9px;left:100%;transform:scale(.4)translate(-62px)}
```

(Note: `.sass`-only changes don't match the `tests-on-pr` / `build-types` path filters, so no CI checks are triggered on this PR by design.)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FAB action positioning in right-to-left layouts.
  * Preserved consistent alignment, movement, and spacing when actions are positioned to the left or right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->