### PR TITLE
fix(app-vite): SSR/SSG dev -> only inject critical CSS of SFCs rendered in current request

### DIFF
--- a/app-vite/lib/modes/ssg/ssg-devserver.js
+++ b/app-vite/lib/modes/ssg/ssg-devserver.js
@@ -17,6 +17,7 @@ import {
 } from '../../plugins/vite.html.js'
 
 import {
+  getRenderedSfcFiles,
   injectCriticalCssPath,
   logServerMessage,
   renderStoreState
@@ -211,6 +212,7 @@ export class QuasarModeDevserver extends AppDevserver {
         if (entryModules) {
           const criticalCSS = {
             seenNodes: new Set(),
+            renderedSfcFiles: getRenderedSfcFiles(ssrContext, rootFolder),
             ssrContext,
             nonce:
               ssrContext.nonce !== void 0 ? ` nonce="${ssrContext.nonce}"` : ''

--- a/app-vite/lib/modes/ssr/ssr-devserver.js
+++ b/app-vite/lib/modes/ssr/ssr-devserver.js
@@ -19,6 +19,7 @@ import {
 } from '../../plugins/vite.html.js'
 
 import {
+  getRenderedSfcFiles,
   injectCriticalCssPath,
   logServerMessage,
   renderStoreState
@@ -292,6 +293,10 @@ export class QuasarModeDevserver extends AppDevserver {
         if (entryModules) {
           const criticalCSS = {
             seenNodes: new Set(),
+            renderedSfcFiles: getRenderedSfcFiles(
+              ssrContext,
+              this.#pathMap.rootFolder
+            ),
             ssrContext,
             nonce:
               ssrContext.nonce !== void 0 ? ` nonce="${ssrContext.nonce}"` : ''

--- a/app-vite/lib/modes/ssr/ssr-utils.js
+++ b/app-vite/lib/modes/ssr/ssr-utils.js
@@ -1,5 +1,7 @@
+import { join } from 'node:path'
 import serialize from 'serialize-javascript'
 import { green } from 'kolorist'
+import { normalizePath } from 'vite'
 
 import { dot, info, log } from '../../utils/logger.js'
 
@@ -23,12 +25,35 @@ export function logServerMessage(title, msg, additional) {
 
 const styleUrlRE = /\.(css|sass|scss|less|styl|stylus|pcss|postcss|sss)(\?.*)?$/
 const inlineStyleRE = /[?&]inline\b/
+const vueSfcUrlRE = /\.vue$/
+
+/**
+ * The SFCs rendered during the current request, as absolute file paths.
+ * Populated by @vitejs/plugin-vue with paths relative to the Vite root.
+ */
+export function getRenderedSfcFiles(ssrContext, rootFolder) {
+  const files = new Set()
+  for (const filename of ssrContext.modules ?? []) {
+    files.add(normalizePath(join(rootFolder, filename)))
+  }
+  return files
+}
 
 export function injectCriticalCssPath(nodeList, criticalCSS) {
-  for (const { url, importedModules } of nodeList) {
+  for (const { url, file, importedModules } of nodeList) {
     // Prevent infinite loops from circular dependencies
     if (criticalCSS.seenNodes.has(url)) continue
     criticalCSS.seenNodes.add(url)
+
+    // The module graph accumulates modules across requests and HMR.
+    // We skip SFCs that did not render in this request, otherwise
+    // styles from previously visited routes would be injected anyway.
+    // Note: this doesn't cover non-SFC imports, e.g. .js files, which
+    // import CSS files directly themselves. But, it's rare and not
+    // have an important effect, just a bit of extra CSS.
+    if (vueSfcUrlRE.test(url) && !criticalCSS.renderedSfcFiles.has(file)) {
+      continue
+    }
 
     if (
       !inlineStyleRE.test(url) &&


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch (or `v[X]` branch)

**Other information:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved critical CSS handling during SSR and static-site development.
  * Prevented unnecessary stylesheet links from being injected for Vue components that were not rendered during the current request.
  * Improved CSS output accuracy across requests and hot-module updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->