### PR TITLE
fix(ui): handle fullscreen KeepAlive lifecycle

### DIFF
--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -110,6 +110,7 @@ export default function useFullscreen() {
     } else {
       fullscreenFillerNode.remove()
     }
+
     inFullscreen.value = false
 
     counter = Math.max(0, counter - 1)

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -1,5 +1,6 @@
 import {
   getCurrentInstance,
+  onActivated,
   onBeforeMount,
   onBeforeUnmount,
   onDeactivated,
@@ -96,7 +97,7 @@ export default function useFullscreen() {
     History.add(historyEntry)
   }
 
-  function exitFullscreen() {
+  function exitFullscreenImpl(shouldRestoreElement) {
     if (!inFullscreen.value) return
 
     if (historyEntry !== void 0) {
@@ -104,7 +105,11 @@ export default function useFullscreen() {
       historyEntry = void 0
     }
 
-    fullscreenFillerNode.replaceWith(proxy.$el)
+    if (shouldRestoreElement === true) {
+      fullscreenFillerNode.replaceWith(proxy.$el)
+    } else {
+      fullscreenFillerNode.remove()
+    }
     inFullscreen.value = false
 
     counter = Math.max(0, counter - 1)
@@ -139,6 +144,10 @@ export default function useFullscreen() {
     })
   }
 
+  function exitFullscreen() {
+    exitFullscreenImpl(true)
+  }
+
   onBeforeMount(() => {
     fullscreenFillerNode = document.createElement('span')
   })
@@ -147,7 +156,14 @@ export default function useFullscreen() {
     if (props.fullscreen) setFullscreen()
   })
 
-  onDeactivated(exitFullscreen)
+  onDeactivated(() => {
+    // A direct child of KeepAlive has already been moved to its storage
+    // container at this point. Its filler must not move it back into the DOM.
+    exitFullscreenImpl(proxy.$el.isConnected)
+  })
+  onActivated(() => {
+    if (props.fullscreen) setFullscreen()
+  })
   onBeforeUnmount(exitFullscreen)
 
   // expose public methods

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { KeepAlive, defineComponent, h, ref } from 'vue'
+
+import useFullscreen, {
+  useFullscreenEmits,
+  useFullscreenProps
+} from './use-fullscreen.js'
+
+let wrapper, mountTarget
+
+afterEach(() => {
+  wrapper?.unmount()
+  mountTarget?.remove()
+  wrapper = mountTarget = void 0
+})
+
+const FullscreenComponent = defineComponent({
+  name: 'FullscreenComponent',
+  props: useFullscreenProps,
+  emits: useFullscreenEmits,
+
+  setup() {
+    const { inFullscreen } = useFullscreen()
+
+    return () =>
+      h(
+        'section',
+        {
+          'data-test': 'fullscreen-component',
+          'data-fullscreen': inFullscreen.value
+        },
+        'Fullscreen component'
+      )
+  }
+})
+
+const OtherComponent = defineComponent({
+  name: 'OtherComponent',
+  setup: () => () => h('section', { 'data-test': 'other-component' })
+})
+
+describe('[useFullscreen API]', () => {
+  describe('[KeepAlive lifecycle]', () => {
+    test('does not move a deactivated root back into the live DOM', async () => {
+      const showFullscreen = ref(true)
+
+      mountTarget = document.createElement('div')
+      document.body.append(mountTarget)
+
+      wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            h(KeepAlive, null, () =>
+              showFullscreen.value === true
+                ? h(FullscreenComponent, { fullscreen: true })
+                : h(OtherComponent)
+            )
+        }),
+        { attachTo: mountTarget }
+      )
+
+      await flushPromises()
+
+      const getFullscreenElement = () =>
+        document.body.querySelector('[data-test="fullscreen-component"]')
+
+      expect(getFullscreenElement()).not.toBeNull()
+      expect(getFullscreenElement().dataset.fullscreen).toBe('true')
+      expect(document.body.classList.contains('q-body--fullscreen-mixin')).toBe(
+        true
+      )
+
+      showFullscreen.value = false
+      await flushPromises()
+
+      expect(getFullscreenElement()).toBeNull()
+      expect(wrapper.find('[data-test="other-component"]').exists()).toBe(true)
+      expect(document.body.classList.contains('q-body--fullscreen-mixin')).toBe(
+        false
+      )
+
+      showFullscreen.value = true
+      await flushPromises()
+
+      expect(getFullscreenElement()).not.toBeNull()
+      expect(getFullscreenElement().dataset.fullscreen).toBe('true')
+      expect(document.body.classList.contains('q-body--fullscreen-mixin')).toBe(
+        true
+      )
+    })
+
+    test('restores a nested fullscreen component to cached content', async () => {
+      const showFullscreen = ref(true)
+      const CachedComponent = defineComponent({
+        name: 'CachedComponent',
+        setup: () => () =>
+          h('main', null, [h(FullscreenComponent, { fullscreen: true })])
+      })
+
+      mountTarget = document.createElement('div')
+      document.body.append(mountTarget)
+
+      wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            h(KeepAlive, null, () =>
+              showFullscreen.value === true
+                ? h(CachedComponent)
+                : h(OtherComponent)
+            )
+        }),
+        { attachTo: mountTarget }
+      )
+
+      await flushPromises()
+
+      const getFullscreenElement = () =>
+        document.body.querySelector('[data-test="fullscreen-component"]')
+
+      expect(getFullscreenElement()).not.toBeNull()
+
+      showFullscreen.value = false
+      await flushPromises()
+
+      expect(getFullscreenElement()).toBeNull()
+      expect(wrapper.find('[data-test="other-component"]').exists()).toBe(true)
+
+      showFullscreen.value = true
+      await flushPromises()
+
+      expect(getFullscreenElement()).not.toBeNull()
+      expect(getFullscreenElement().dataset.fullscreen).toBe('true')
+    })
+  })
+})


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

This follows up the `useFullscreen()` lifecycle changes from #18411.

When a fullscreen component is the direct child of `<KeepAlive>`, Vue moves its root into the KeepAlive storage container before invoking `onDeactivated()`. The fullscreen cleanup then used the live filler node to move that cached root back into the document. The deactivated component remained visible, and reactivation left its root outside the application container.

This change:

- removes the filler without relocating the root when Vue has already cached it;
- continues restoring nested fullscreen components into cached parent content;
- honors a still-enabled `fullscreen` prop when the component is activated again; and
- adds regression coverage for both direct and nested KeepAlive usage.

Validation:

- `pnpm --filter quasar test` — 102 test files and 1,075 tests passed
- `pnpm exec oxfmt --check ui/src/composables/private.use-fullscreen/use-fullscreen.js ui/src/composables/private.use-fullscreen/use-fullscreen.test.js`
- `pnpm exec oxlint --deny-warnings ui/src/composables/private.use-fullscreen/use-fullscreen.js ui/src/composables/private.use-fullscreen/use-fullscreen.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fullscreen exit/restore behavior for cached views when deactivating and reactivating.
  - Added lifecycle handling so fullscreen correctly re-enters when the component becomes active again.
  - Ensured fullscreen styling and DOM placement are cleaned up and restored appropriately, including nested cached scenarios.

- **Tests**
  - Added Vitest coverage for fullscreen behavior with `KeepAlive`, including deactivation/reactivation and nested cached components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->