### PR TITLE
fix(QFab): keep action order physical under RTL

### DIFF
--- a/ui/src/components/fab/QFab.sass
+++ b/ui/src/components/fab/QFab.sass
@@ -107,6 +107,7 @@
       height: 56px
       left: 100% #{"/* rtl:ignore */"}
       margin-left: 9px #{"/* rtl:ignore */"}
+      flex-direction: row #{"/* rtl:row-reverse */"}
 
     &--left
       transform-origin: 100% 50% #{"/* rtl:ignore */"}
@@ -114,7 +115,7 @@
       height: 56px
       right: 100% #{"/* rtl:ignore */"}
       margin-right: 9px #{"/* rtl:ignore */"}
-      flex-direction: row-reverse
+      flex-direction: row-reverse #{"/* rtl:row */"}
 
     &--up
       transform-origin: 50% 100%


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

Under `dir="rtl"`, the visual order of FAB actions changes. Nothing else does: LTR **rendering** is unchanged, and `--up`/`--down` are untouched. (The generated LTR CSS is not byte-identical — it gains an explicit `flex-direction: row` on `--right` — but `row` is the flexbox initial value and `flex-direction` is not inherited, so it is inert; measured LTR offsets are identical before and after.)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] It's been tested on an Electron app — *Electron 43.2.0; before/after captured, see below*
- [x] Any necessary documentation has been added or updated, or explained in the PR's description — *no API change*
- [ ] It's been tested on a Cordova (iOS, Android) app — **iOS done, Android not run.** Built and ran as a real Cordova app on the iOS Simulator (cordova-ios 8.1.1, iOS 18.7, WKWebView); before/after captured. The Android half was not run — no Gradle on the build machine, and Android's WebView is Chromium, already covered by the Electron and desktop-Chromium runs.

There is no upstream issue to reference in the title — this is a follow-up to quasarframework/quasar#18413, reported downstream at zauberzeug/nicegui#6165 by @roximn148.

As with quasarframework/quasar#18413, this is a `.sass`-only change, so it doesn't match the `tests-on-pr` / `build-types` path filters and no CI checks are triggered on this PR by design.

**Other information:**

quasarframework/quasar#18413 made the actions *container* physically placed under RTL, which fixed the overlap. But the order *within* the container is still text-relative: `flex-direction: row` / `row-reverse` resolve against `direction`, so under RTL flexbox lays the actions out in the opposite order and **the first action ends up farthest from the parent FAB**:

| `direction` | LTR (correct) | RTL before this PR | RTL after this PR |
|---|---|---|---|
| `right` | `[FAB] 1 2 3` | `[FAB] 3 2 1` | `[FAB] 1 2 3` |
| `left` | `3 2 1 [FAB]` | `1 2 3 [FAB]` | `3 2 1 [FAB]` |

![QFab RTL action order, before and after](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/qfab-rtl-order.png)

This was never an authored decision — `postcss-rtlcss` does not mirror `flex-direction` on its own. Building `dev` today yields **844** `[dir=…]`-scoped rules and **not one** of them sets `flex-direction`; the four this PR adds are the first (they exist only because a value directive states them explicitly). So the flip is an unnoticed side effect of flexbox being direction-aware, not something anyone wrote down. It also leaves `right`/`left` as the only FAB directions whose order depends on text direction: `up`/`down` use `column`/`column-reverse`, which `direction` does not affect, so they have always been physical in both position and order.

<details>
<summary><b>Why the first action should be the one nearest the FAB</b></summary>

Being upfront about the strength of the evidence: **I could not find a spec sentence that literally mandates "the first action is nearest the FAB."** If one exists I'd welcome the pointer. What the guidelines do support is the weaker but sufficient premise — that a FAB menu is defined by its spatial relationship to the FAB it opened from:

> "A FAB menu opens from a FAB to show multiple related actions. **It should always appear in the same place as the FAB that opened it.**"
> — [Material Design 3, FAB menu guidelines](https://m3.material.io/components/fab-menu/guidelines)

If the group is anchored to the FAB, then which end of the group touches the FAB is meaningful, and the authored order should run outward from it — which is exactly what LTR does today, in all four directions, and what RTL does today for `up`/`down`.

The general RTL rule is that layout *is* mirrored, and Material says so plainly — the carve-out is for elements whose direction refers to something physical rather than to reading order:

> "UIs for languages that are read from right-to-left (RTL), such as Arabic and Hebrew, should be mirrored to ensure content is easy to understand."
> "Do not mirror media playback buttons and the media progress indicator as they **refer to the direction of tape being played, not the direction of time**."
> — [Material Design, Bidirectionality](https://m2.material.io/design/usability/bidirectionality.html)

That carve-out is written about icons, not layout, so I won't overstate it — but it is the same principle quasarframework/quasar#18413 applied when it made `direction="right"` mean physically-right regardless of `dir`, and that decision is already merged. **This PR simply finishes it.** The strongest argument is internal consistency rather than an external citation: after quasarframework/quasar#18413, `right`/`left` are the only directions where a developer's authored order renders in one physical order under LTR and the reverse under RTL, while `up`/`down` — same component, same prop — do not.

One ecosystem data point, offered as context rather than as authority: MUI's `SpeedDial` is built identically (`direction="right"` → `flex-direction: row`, `"left"` → `row-reverse`) and its component source contains **zero** occurrences of `rtl`. So the flip is unexamined across implementations — evidence that nobody chose it, not evidence that it is right.
</details>

The fix is a value directive rather than `rtl:ignore` — there is nothing to suppress, since no mirroring happens; the RTL variant has to be stated explicitly:

```sass
&--right
  flex-direction: row #{"/* rtl:row-reverse */"}

&--left
  flex-direction: row-reverse #{"/* rtl:row */"}
```

<details>
<summary><b>Generated CSS (real <code>ui/src/css/index.sass</code> through sass + <code>postcss-rtlcss</code> with this repo's <code>rtl({})</code> config)</b></summary>

```css
.q-fab__actions--right { transform-origin: 0 50%; transform: scale(0.4) translateX(-62px); height: 56px; left: 100%; margin-left: 9px; }
[dir="ltr"] .q-fab__actions--right { flex-direction: row; }
[dir="rtl"] .q-fab__actions--right { flex-direction: row-reverse; }

.q-fab__actions--left { transform-origin: 100% 50%; transform: scale(0.4) translateX(62px); height: 56px; right: 100%; margin-right: 9px; }
[dir="ltr"] .q-fab__actions--left { flex-direction: row-reverse; }
[dir="rtl"] .q-fab__actions--left { flex-direction: row; }
```

The positioning declarations stay un-mirrored and un-split, so quasarframework/quasar#18413's `rtl:ignore` protection is unaffected.
</details>

<details>
<summary><b>Verification — measured, not eyeballed</b></summary>

Rendered all four `direction` values × `{ltr, rtl}` and asserted that **every action button's physical offset from its parent FAB centre is identical in RTL and LTR**, in both the opened and the closed/animating state, against the stylesheet built from this branch:

| Stylesheet | Chromium | WebKit | Firefox |
|---|---|---|---|
| `dev` as-is (i.e. with quasarframework/quasar#18413) | ❌ 12 violations | ❌ 12 violations | ❌ 12 violations |
| `dev` + this PR | ✅ parity | ✅ parity | ✅ parity |

All 12 violations are ordering — the positions are already correct thanks to quasarframework/quasar#18413. Example, `direction="right"`, action 1's offset from the FAB centre: LTR `+100px`, RTL `+200px` (farthest) before; identical after.

`up` and `down` show zero violations both before and after, confirming they are unaffected.
</details>

<details>
<summary><b>Platform verification — Cordova (iOS) and Electron</b></summary>

The same page was packaged as a real **Cordova app** (`cordova-ios@8.1.1`, built and run on the iOS 18.7 Simulator) and as a real **Electron app** (43.2.0). It measures itself at runtime and prints the verdict, so the screenshots carry the numbers:

![QFab RTL order on Cordova iOS and Electron](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/qfab-rtl-platforms.png)

| Runtime | Engine | `dev` as-is | `dev` + this PR |
|---|---|---|---|
| Cordova iOS Simulator (iOS 18.7) | WKWebView | ✗ RTL differs | ✓ RTL matches LTR |
| Electron 43.2.0 | Chromium | ✗ RTL differs | ✓ RTL matches LTR |

Electron, measured offsets from the FAB centre for `direction="right"`:

```
before   ltr [100, 168.2, 218.2]   rtl [199.8, 131.5, 81.5]   <- action 1 farthest
after    ltr [100, 168.2, 218.2]   rtl [ 99.8, 168.0, 218.0]  <- matches LTR
```

Android was not run: no Gradle on the build machine, and its WebView is Chromium, which the Electron and desktop-Chromium runs already cover.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-aligned floating action button layout in right-to-left interfaces.
  * Ensured action buttons display in the correct order and direction across language layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->