### PR TITLE
fix(css): emit override-mode RTL so nested dir subtrees don't double-apply

### DIFF
--- a/create-quasar/templates/app/vite-3/js/BASE/postcss.config.js
+++ b/create-quasar/templates/app/vite-3/js/BASE/postcss.config.js
@@ -24,6 +24,6 @@ export default {
     // 1. yarn/pnpm/bun/npm install postcss-rtlcss
     // 2. optionally set quasar.config.js > framework > lang to an RTL language
     // 3. uncomment the following line (and its import statement above):
-    // rtlcss()
+    // rtlcss({ mode: 'override' })
   ]
 }

--- a/create-quasar/templates/app/vite-3/ts/BASE/postcss.config.js
+++ b/create-quasar/templates/app/vite-3/ts/BASE/postcss.config.js
@@ -24,6 +24,6 @@ export default {
     // 1. yarn/pnpm/bun/npm install postcss-rtlcss
     // 2. optionally set quasar.config.js > framework > lang to an RTL language
     // 3. uncomment the following line (and its import statement above):
-    // rtlcss()
+    // rtlcss({ mode: 'override' })
   ]
 }

--- a/docs/src/pages/options/rtl-support.md
+++ b/docs/src/pages/options/rtl-support.md
@@ -41,7 +41,7 @@ export default {
     // 1. yarn/pnpm/bun/npm install postcss-rtlcss
     // 2. optionally set quasar.config.js > framework > lang to an RTL language
     // 3. uncomment the following line (and its import statement above):
-    rtlcss()
+    rtlcss({ mode: 'override' })
   ]
 }
 ```

--- a/ui/build/script.build.css.js
+++ b/ui/build/script.build.css.js
@@ -11,7 +11,7 @@ import {
   writeFile
 } from './build.utils.js'
 
-const postCssRtl = postcss([rtl({})])
+const postCssRtl = postcss([rtl({ mode: 'override' })])
 const sassUseRE = /@use\s+['"][^'"]+['"]/g
 
 function moveUseStatementsToTop(code) {

--- a/ui/playground/__postcss.config.js
+++ b/ui/playground/__postcss.config.js
@@ -6,5 +6,5 @@
 import rtlcss from 'postcss-rtlcss'
 
 export default {
-  plugins: [rtlcss()]
+  plugins: [rtlcss({ mode: 'override' })]
 }


### PR DESCRIPTION
<!-- Suggested title: fix(css): emit override-mode RTL so nested dir subtrees don't double-apply -->

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

The generated `.rtl` CSS changes shape (LTR values are no longer `[dir=ltr]`-prefixed), but computed styles and geometry are unchanged in both top-level directions — measured below. One semantic change worth a release note is called out under *Impact*.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] Any necessary documentation has been added or updated — *the RTL docs page carries the same config change*

**Other information:**

### The bug — documented behaviour that doesn't hold

`docs/src/pages/options/rtl-support.md` tells users to mark exceptions with a `dir` attribute:

> Sometimes you'll need to make exceptions for whole DOM elements / components. In this case, add `dir="ltr"` or `dir="rtl"` HTML attribute to the outermost DOM element / component template:
> ```html
> <div dir="rtl">
>   <!-- this DIV and all its content will use RTL mode
>        regardless of Quasar language pack RTL settings -->
> </div>
> ```

That does not currently work. Inside such a subtree, layout breaks outright:

| helper | LTR | inside a `dir="rtl"` subtree | should be |
|---|---|---|---|
| `.absolute-center` | 72px wide | **0px wide** — background, border and hit-target vanish | 72px |
| `.absolute-right` | 42px, hugs right | **200px** (full container) | 42px, hugs left |
| `.absolute-left` | 33px, hugs left | **200px** (full container) | 33px, hugs right |
| `.q-breadcrumbs__separator` | `margin-left: 8px` | `margin-left: 8px` **and** `margin-right: 8px` | one side only |

![nested dir RTL, before and after](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/rtl-nested-before-after.png)

### Why

`postcss-rtlcss` in its default `combined` mode emits both directions as **descendant** selectors:

```css
[dir=ltr] .absolute-center { left: 50%;  transform: translate(-50%, -50%) }
[dir=rtl] .absolute-center { right: 50%; transform: translate(50%, -50%) }
```

An element inside a `dir="rtl"` subtree of a `dir="ltr"` document has **both** a `[dir=ltr]` ancestor and a `[dir=rtl]` ancestor, so **both rules match**. They set opposite physical properties, neither resets the other, and the box ends up over-constrained.

It is not specific to the position helpers: of the **529** mirrored rule pairs in the generated stylesheet, **423** set at least one property the opposite rule never resets — most commonly `margin-right` (199), `margin-left` (198), `right` (112), `left` (112), `padding-left`/`padding-right` (76 each). The `left`/`right` leaks give the severe failures above; the margin/padding leaks give doubled spacing.

It also can't be sidestepped: Quasar sets `dir="ltr"` on `<html>` at boot even when the page has no `dir` attribute, so the moment an app follows the docs and marks a subtree `dir="rtl"`, every mirrored rule inside it double-applies. (Live toggle on one page: with `<html dir="ltr">` the RTL subtree breaks; with `<html dir="rtl">` the LTR subtree breaks instead; with the attribute removed entirely, both are correct.)

### The fix

`override` mode emits the LTR values unprefixed plus an `[dir=rtl]` rule that **explicitly resets the opposite property** — `left: auto` is precisely the missing neutraliser:

```css
/* combined (today) */                      /* override (this PR) */
[dir=ltr] .absolute-center { left: 50% }    .absolute-center { left: 50%; ... }
[dir=rtl] .absolute-center { right: 50% }   [dir=rtl] .absolute-center { left: auto; right: 50%; ... }
```

Applied in **both** places RTL CSS gets produced, since fixing only one would leave half the users broken:

1. `ui/build/script.build.css.js` — the shipped `quasar.rtl.css` / `quasar.rtl.prod.css` bundles (UMD/CDN consumers).
2. The app-level PostCSS pipeline that Quasar CLI projects run themselves — `create-quasar` templates (js + ts), `ui/playground`, and the snippet on the RTL docs page. CLI apps import `quasar.css`/`quasar.sass` and add `rtlcss()` to their own `postcss.config.js`, so they never touch the prebuilt `.rtl` bundle and would otherwise keep the old behaviour.

### Impact

**Consumers of `quasar.css` / `quasar.prod.css` directly see no package CSS change** — `postCssRtl` only feeds the `.rtl` variants in `renderAsset()`. For everyone else:

| | combined (today) | override (this PR) |
|---|---|---|
| total rules | 3,357 | 3,254 |
| `[dir=ltr]`-prefixed selectors | 539 | **0** |
| `[dir=rtl]`-prefixed selectors | 539 | 539 |
| declarations under `[dir=rtl]` | 489 | **847** (+358 explicit resets) |
| file size (expanded) | 299,749 B | 295,907 B (−1.3%) |

**Specificity.** Each formerly `[dir=ltr]`-prefixed selector loses one attribute selector's worth of specificity (529 distinct selectors affected). Two checks on what that does to the cascade:

- *Inside Quasar:* for all **529**, the resolved set of LTR declarations is **identical** between modes — comparing base-vs-prefixed resolved by specificity in `combined` against source order in `override`. Zero differences, including the `!important` case (`.q-position-engine`, where `override` correctly emits `margin-left: 0 !important` as the reset).
- *For app authors:* the one real semantic change. An app rule like `.q-btn { margin-left: 4px }` previously **lost** to `[dir=ltr] .q-btn` on specificity; now it ties and wins by source order. Overriding Quasar in an RTL build gets *easier* — a loosening, not a tightening — but it is a behaviour change and deserves a release note.

**Runtime.** Beyond geometry, I compared **29 computed properties** (`left/right/top/bottom`, all four margins/paddings, border widths, all four border radii, `text-align`, `direction`, `float`, `transform`, `transform-origin`, flex properties, colors) on **every** element of a ~20-component page:

| document | elements | computed-style differences |
|---|---|---|
| `<html dir="ltr">` | 211 | **0** |
| `<html dir="rtl">` | 211 | **0** |

<details>
<summary><b>Verification — measured, cross-engine</b></summary>

Built `ui/src/css/index.sass` through `sass` + `postcss-rtlcss` in both modes and measured rendered geometry.

**Fixes the bug** — `dir="rtl"` subtree inside `<html dir="ltr">`, element widths (expected ≈33px shrink-to-fit; 0 = collapsed, 200 = stretched):

| | Chromium | WebKit | Firefox |
|---|---|---|---|
| `.absolute-center` combined → override | 0 → **33** | 0 → **35** | 0 → **35** |
| `.absolute-left` combined → override | 200 → **33** | 200 → **35** | 200 → **35** |
| `.absolute-right` combined → override | 200 → **33** | 200 → **35** | 200 → **35** |

LTR values are unchanged by the switch in every engine. The components exercised in the regression fixture were `QBanner`, `QBar`, `QInput`, `QSelect`, `QChip`, `QBtn`, `QBadge`, `QItem`, `QExpansionItem`, `QTabs`, `QTimeline`, `QLinearProgress`, `QCircularProgress`, `QSlider`, `QRating`, `QCheckbox`, `QRadio`, `QToggle`, `QBreadcrumbs`, `QPagination`, `QTable`, `QStepper`.

**Honest limitation** — this does not make nested opposite-direction subtrees fully correct, because a descendant selector cannot express "nearest `dir` wins". Under `<html dir="rtl">`, a `dir="ltr"` island still inherits RTL physical styles. But the failure mode is downgraded from *broken box* to *mirrored side*: measured on `.absolute-right` in an LTR island inside an RTL document, `combined` gives a stretched 200px box, `override` gives a correctly-sized box on the wrong side. Fully honouring the documented `dir="ltr"` island would need `:dir()`, whose support (Chrome 120) is above Quasar's current baseline.
</details>

<details>
<summary><b>Reproduction</b></summary>

```html
<!doctype html>
<html dir="ltr">
  <head><link href="https://cdn.jsdelivr.net/npm/quasar@2.22.0/dist/quasar.rtl.prod.css" rel="stylesheet"></head>
  <body>
    <div style="position:relative;width:200px;height:34px;background:#eee" dir="rtl">
      <div class="absolute-center" style="background:#fdd">TEXT</div>
    </div>
    <script>console.log(document.querySelector('.absolute-center').getBoundingClientRect().width)</script>
  </body>
</html>
```

Logs `0`. Remove `dir="rtl"` from the box, or `dir="ltr"` from `<html>`, and it logs the correct width.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-to-left stylesheet generation by applying override mode consistently, helping RTL styles take precedence where needed.
* **Documentation**
  * Updated RTL configuration guidance and examples to use the recommended override mode.
* **Developer Experience**
  * Updated project templates and the CSS playground configuration so new projects use the same RTL behavior by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->