### PR TITLE
fix(linear-progress): Fix reverse direction under subtree RTL

### DIFF
--- a/ui/src/components/linear-progress/QLinearProgress.js
+++ b/ui/src/components/linear-progress/QLinearProgress.js
@@ -18,11 +18,9 @@ const defaultSizes = {
   xl: 14
 }
 
-function width(val, reverse, $q) {
+function width(val) {
   return {
-    transform: reverse
-      ? `translateX(${$q.lang.rtl ? '-' : ''}100%) scale3d(${-val},1,1)`
-      : `scale3d(${val},1,1)`
+    transform: `scale3d(${val},1,1)`
   }
 }
 
@@ -62,7 +60,6 @@ export default createComponent({
     const sizeStyle = useSize(props, defaultSizes)
 
     const motion = computed(() => props.indeterminate || props.query)
-    const widthReverse = computed(() => props.reverse !== props.query)
     const style = computed(() => ({
       ...(sizeStyle.value !== null ? sizeStyle.value : {}),
       '--q-linear-progress-speed': `${props.animationSpeed}ms`
@@ -77,11 +74,7 @@ export default createComponent({
     )
 
     const trackStyle = computed(() =>
-      width(
-        props.buffer !== void 0 ? props.buffer : 1,
-        widthReverse.value,
-        proxy.$q
-      )
+      width(props.buffer !== void 0 ? props.buffer : 1)
     )
     const transitionSuffix = computed(
       () => `with${props.instantFeedback ? 'out' : ''}-transition`
@@ -96,7 +89,7 @@ export default createComponent({
     )
 
     const modelStyle = computed(() =>
-      width(motion.value ? 1 : props.value, widthReverse.value, proxy.$q)
+      width(motion.value ? 1 : props.value)
     )
     const modelClass = computed(
       () =>

--- a/ui/src/components/linear-progress/QLinearProgress.sass
+++ b/ui/src/components/linear-progress/QLinearProgress.sass
@@ -16,8 +16,13 @@
 
   &--reverse
     .q-linear-progress
-      &__model, &__track
-        transform-origin: 0 100%
+      &__model--determinate, &__track
+        transform-origin: 100% 0
+
+      // motion modes span the full width, so anchoring cannot reverse them: mirror them in place
+      &__model--indeterminate, &__model--query
+        transform-origin: 50% 0
+        scale: -1 1
 
   &__model
 


### PR DESCRIPTION
<!-- Suggested title: fix(linear-progress): Fix reverse direction under subtree RTL -->

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] Any necessary documentation has been added or updated, or explained in the PR's description — *no API change; `reverse` behaves as documented, in more cases than before*

**Other information:**

### The bug

`QLinearProgress` with `reverse` — and with `query` / `indeterminate reverse`, which use the same path — renders its content **entirely outside the bar** when `dir="rtl"` is set on a subtree while the app language stays LTR. On a 300px bar at value 0.3 the 90px fill lands at x=`[600,690]`, so the bar just looks empty.

That is the pattern `docs/src/pages/options/rtl-support.md` recommends:

> add `dir="ltr"` or `dir="rtl"` HTML attribute to the outermost DOM element / component template […] this DIV and all its content will use RTL mode **regardless of Quasar language pack RTL settings**

![linear-progress under subtree RTL, before and after](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/rtl-lp-fix-before-after.png)

The animated modes are the easier ones to miss, so here they are moving. `indeterminate` is the control — it has no `reverse` and is unaffected. `query` and `indeterminate reverse` are simply *absent* on the left:

![query and indeterminate reverse animating, before and after](https://raw.githubusercontent.com/evnchn/quasar/pr-assets/rtl-lp-animated.gif)

### The fix

The component had two disagreeing sources of truth for "am I RTL?" — the JS read the app-global `$q.lang.rtl`, the generated CSS read the DOM `[dir]`. They agree when RTL is set app-wide, which is why the supported path looks fine and this went unnoticed. This PR lets the CSS own direction, since it is already the half keyed to `[dir]`:

- `width()` always returns a plain `scale3d(val,1,1)` — the `translateX` and negative scale go away, along with the `$q` argument and the `widthReverse` computed.
- **Determinate** bars scale from the far edge, so their reverse `transform-origin` flips from `0 100%` to `100% 0` and rtlcss mirrors it per `[dir]`.
- **`indeterminate` / `query`** span the full width, so an origin cannot reverse them at all — they are mirrored **in place about their centre**, which is direction-agnostic and needs no mirroring.

### Verification — pixel-exact, against the invariants that define the feature

Rather than eyeballing, this is checked against the three mirror relationships the props *mean*, comparing rendered PNGs pixel by pixel (a pixel counts as differing if any channel is off by more than 24, to tolerate anti-aliasing):

| | invariant |
|---|---|
| **M1** | `reverse` == exact horizontal mirror of plain |
| **M3** | `query` == exact horizontal mirror of `indeterminate` |
| **M4** | `indeterminate reverse` == exact horizontal mirror of `indeterminate` |

Animations are frozen (`animation-play-state: paused` plus a fixed negative `animation-delay`) so a given phase is deterministic and directly comparable — the animated modes are verified, not just the static ones. Determinate transitions are disabled in the harness so no capture lands mid-transition.

Three contexts: **A** an LTR app, **B** an app-level RTL app (`Quasar.lang.set(lang.he)`), **C** an LTR app with `dir="rtl"` on a subtree.

| engine | build | M1 (A/B/C) | M3 (A/B/C) | M4 (A/B/C) |
|---|---|---|---|---|
| Chromium | before | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% |
| Chromium | **after** | ✅ ✅ **✅** | ✅ ✅ **✅** | ✅ ✅ **✅** |
| WebKit | before | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% |
| WebKit | **after** | ✅ ✅ **✅** | ✅ ✅ **✅** | ✅ ✅ **✅** |
| Firefox | before | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% | ✅ ✅ ❌ 100% |
| Firefox | **after** | ✅ ✅ **✅** | ✅ ✅ **✅** | ✅ ✅ **✅** |

Every ✅ is **0.0% differing pixels**. A fourth invariant — plain under `dir="rtl"` == mirror of plain under `dir="ltr"` — passes in all six rows, before and after, confirming the non-reverse path was never affected.

The failures land exactly where the bug is (context C) and nowhere else, so contexts A and B — the two configurations that work today — are provably untouched.

<details>
<summary><b>Why it broke — the two sources of truth</b></summary>

- **JS** picked the translate sign from the app-global flag:
  ```js
  transform: reverse
    ? `translateX(${$q.lang.rtl ? '-' : ''}100%) scale3d(${-val},1,1)`
    : `scale3d(${val},1,1)`
  ```
- **CSS** picked `transform-origin` from the DOM attribute, via rtlcss mirroring of `transform-origin: 0 100%`:
  ```css
  [dir=ltr] .q-linear-progress--reverse …__{model,track} { transform-origin: 0 100% }
  [dir=rtl] .q-linear-progress--reverse …__{model,track} { transform-origin: 100% 100% }
  ```

With a subtree `dir="rtl"`, `$q.lang.rtl` stays `false` while the `[dir=rtl]` rule matches — so the JS emits `translateX(+100%)` against an origin flipped to the right edge, and the box is pushed out by twice its width.

The fix reuses the mechanism already in place rather than adding one: `postcss-rtlcss` is the single authority for mirroring physical CSS values off `[dir]`, and `$q.lang.rtl` already sets that attribute (`ui/src/plugins/lang/Lang.js`). Components that opt *out* of mirroring do so with `/* rtl:ignore */` (`QFab.sass`, `QTabs.sass`, `QTime.sass`); `QLinearProgress.sass` has no such opt-out, so it is currently mirrorable and the bug was the component fighting that from JS as well.
</details>

<details>
<summary><b>Why the two reverse cases are separate rules</b></summary>

The old single transform bundled two different jobs, which is what made this subtle:

- for a **determinate** bar, `reverse` means *anchor the fill to the other edge* — expressible as a `transform-origin`, and rightly direction-dependent;
- for **`query` / `indeterminate reverse`**, the model is full width and its own scale is `1`, so moving its `transform-origin` cannot reverse anything. What `reverse` means there is *mirror the animated pseudo-elements*, which the old code achieved by giving the full-width parent a `translateX(100%) scale3d(-1,1,1)` — a horizontal flip in place.

An earlier revision of this PR handled only the determinate case and silently dropped the motion mirror, which would have made `query` animate in the same direction as `indeterminate`. The M3/M4 invariants above exist specifically to catch that; the in-place centre mirror restores it.

Because a centre flip is symmetric, rtlcss leaves that rule **unprefixed** — it needs no `[dir]` variant, which is the tell that it is genuinely direction-agnostic. Verbatim from the compiled stylesheet:

```css
.q-linear-progress--reverse .q-linear-progress__model--indeterminate,
.q-linear-progress--reverse .q-linear-progress__model--query { transform-origin: 50% 0; scale: -1 1 }
```

The determinate origin rule is scoped to `&__model--determinate` so the two do not collide — the `[dir]`-prefixed rule would otherwise out-specify the unprefixed one and win.

(`--query` is carried in the selector only to match the existing `&--indeterminate, &--query` pairing elsewhere in the file; `modelClass` in fact only ever emits `--determinate` or `--indeterminate`, so `query` reaches this rule via `--indeterminate`.)
</details>

<details>
<summary><b>Scope — what this deliberately does not do</b></summary>

The diff is 2 files, +11 −13.

- **Removed the `reverse` / `$q` parameters instead of leaving them unused.** Keeping the signature and ignoring the arguments would leave `widthReverse` as a computed still wired up and recalculated every render while doing nothing — a zombie is harder to spot in review than an absence. Removing them also collapses the two call sites from 5 lines each to 1.
- **Kept `width()` as a helper** even though it is now a one-line body with two call sites — the file's idiom names every piece of render logic (`motion`, `transitionSuffix`, `stripeStyle`), and inlining is a wash.
- **Kept the `computed()` wrappers** on `trackStyle` / `modelStyle`; collapsing them would drop Vue's memoization.
- **Left `const { proxy } = getCurrentInstance()` alone** — still used on the next line by `useDark(props, proxy.$q)`.
- **The `reverse !== query` XOR is gone, deliberately.** `widthReverse` used XOR while the CSS class is applied on `reverse || query` (OR) — two different booleans for one visual effect. Direction and mirroring are now both expressed in CSS off the single OR-gated class.
- **No test added.** `ui/src/components/linear-progress/` has no test file, and the co-located tests that exist for sibling components (e.g. `circular-progress.test.js`) are API-shape assertions that never mount the component — none would catch this. The pixel-mirror harness above is what actually verifies it; happy to contribute it in whatever form you'd want if a rendering test belongs in the repo.
- **No API/docs change.** `QLinearProgress.json` describes `reverse` as "Reverse direction of progress" — direction-neutral, true before and after.

**Related, deliberately not touched:** `QCircularProgress.js` computes its inline transform from `$q.lang.rtl` in the same shape (`($q.lang.rtl ? -1 : 1) * props.angle`, plus a `scale3d(-1,1,1)` gated on `props.reverse !== ($q.lang.rtl === true)`), and `use-slider.js` does something similar. I have not verified whether they misbehave under a subtree `dir`, so I have left them alone rather than presenting this as a one-off.
</details>

<details>
<summary><b>Reproduction</b></summary>

```html
<!doctype html>
<html dir="ltr">
  <head><link href="https://cdn.jsdelivr.net/npm/quasar@2.22.0/dist/quasar.rtl.prod.css" rel="stylesheet"></head>
  <body>
    <div id="q-app"></div>
    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/quasar@2.22.0/dist/quasar.umd.prod.js"></script>
    <script>
      Vue.createApp({ template: `
        <div dir="rtl" style="width:300px">
          <q-linear-progress :value="0.3" reverse />
          <q-linear-progress query />
        </div>` }).use(Quasar).mount('#q-app');
    </script>
  </body>
</html>
```

Both bars render empty. Remove `dir="rtl"` and they appear.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linear progress bar animations across determinate, indeterminate, and query modes.
  - Corrected animation direction and positioning, including right-to-left layouts.
  - Ensured progress indicators display consistently during active motion and buffering states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->