### PR TITLE
fix(QInput): defer masking during IME composition (#16618, #16629)

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -94,7 +94,18 @@ export default createComponent({
     const formDomProps = useFileFormDomProps(props, /* type guard */ true)
     const hasValue = computed(() => fieldValueIsFilled(innerValue.value))
 
-    const onComposition = useKeyComposition(onInput)
+    const onKeyComposition = useKeyComposition(onInput)
+
+    function onComposition(e) {
+      if (hasMask.value && e.type === 'compositionstart') {
+        // A mask must not rewrite the value while an IME owns the composition.
+        // Keep unmasked controls on the shared detection path for keyboard compatibility.
+        e.target.qComposing = true
+        return
+      }
+
+      onKeyComposition(e)
+    }
 
     const state = useFieldState({ changeEvent: true })
 

--- a/ui/src/components/input/QInput.test.js
+++ b/ui/src/components/input/QInput.test.js
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import QInput from './QInput.js'
+
+describe('[QInput IME composition]', () => {
+  test('defers masking for each composed digit until composition ends', async () => {
+    const onUpdateModelValue = vi.fn()
+    const wrapper = mount(QInput, {
+      props: {
+        modelValue: '',
+        mask: '####/##/##',
+        'onUpdate:modelValue': onUpdateModelValue
+      }
+    })
+    const input = wrapper.get('input')
+
+    for (const [index, value] of ['2', '20', '202', '2023'].entries()) {
+      const data = value.at(-1)
+
+      await input.trigger('compositionstart')
+
+      input.element.value = value
+      await input.trigger('input', {
+        data,
+        inputType: 'insertCompositionText'
+      })
+
+      expect(onUpdateModelValue).toHaveBeenCalledTimes(index)
+      expect(input.element.value).toBe(value)
+
+      await input.trigger('compositionend', { data })
+    }
+
+    expect(onUpdateModelValue.mock.calls).toEqual([
+      ['2'],
+      ['20'],
+      ['202'],
+      ['2023/']
+    ])
+    expect(onUpdateModelValue).toHaveBeenLastCalledWith('2023/')
+    expect(input.element.value).toBe('2023/')
+  })
+
+  test('keeps immediate updates for unmasked compositionstart-only input', async () => {
+    const onUpdateModelValue = vi.fn()
+    const wrapper = mount(QInput, {
+      props: {
+        modelValue: '',
+        'onUpdate:modelValue': onUpdateModelValue
+      }
+    })
+    const input = wrapper.get('input')
+
+    await input.trigger('compositionstart')
+
+    input.element.value = 'a'
+    await input.trigger('input', {
+      data: 'a',
+      inputType: 'insertCompositionText'
+    })
+
+    expect(onUpdateModelValue).toHaveBeenCalledOnce()
+    expect(onUpdateModelValue).toHaveBeenLastCalledWith('a')
+  })
+
+  test('keeps immediate masking for input outside composition', async () => {
+    const onUpdateModelValue = vi.fn()
+    const wrapper = mount(QInput, {
+      props: {
+        modelValue: '',
+        mask: '####/##/##',
+        'onUpdate:modelValue': onUpdateModelValue
+      }
+    })
+    const input = wrapper.get('input')
+
+    input.element.value = '2023'
+    await input.trigger('input', { inputType: 'insertText' })
+
+    expect(onUpdateModelValue).toHaveBeenCalledOnce()
+    expect(onUpdateModelValue).toHaveBeenLastCalledWith('2023/')
+    expect(input.element.value).toBe('2023/')
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

**Other information:**

## Summary

- Defer QInput mask processing while an IME composition is active.
- Scope `compositionstart` handling to masked QInput instances.
- Preserve the existing shared composition detection for unmasked QInput and QSelect.
- Add regression coverage for Microsoft IME numeric input and the compatibility boundary.

## Root cause

Microsoft Chinese IME emits composition events for numeric keypad input, but its `compositionupdate.data` contains digits rather than CJK characters. The shared composition helper therefore does not mark the input as composing, and a mask can rewrite the intermediate value before the terminal composition event. Around a mask delimiter, this can duplicate the last digit.

A previous global `compositionstart` approach was reverted because some older Android keyboards emit composition events for ordinary input and consequently delayed QInput/QSelect updates. This change applies that behavior only when QInput has an active mask, where rewriting an in-progress composition is unsafe.

This is an internal behavior correction and does not add or change public API, so no documentation update is required.

## Validation

- Focused QInput tests: 3 passed
- Full UI unit suite: 1,080 tests passed across 103 files
- Oxfmt and Oxlint checks passed for the changed files
- `git diff --check` passed

Fixes #16618
Fixes #16629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved masked input behavior when entering text with IME keyboards.
  - Prevented partially composed characters from being reformatted prematurely.
  - Ensured completed composition updates apply the correct mask and value.
  - Preserved immediate updates for unmasked fields and standard input events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->