### PR TITLE
fix(ui): account for Android safe area insets

### DIFF
--- a/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/configuring-capacitor.md
+++ b/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/configuring-capacitor.md
@@ -175,7 +175,8 @@ return {
   framework: {
     config: {
       capacitor: {
-        iosStatusBarPadding: true / false // add the dynamic top padding on iOS mobile devices
+        iosStatusBarPadding: true / false, // add the dynamic top padding on iOS mobile devices
+        androidSafeAreaPadding: true / false // account for Android safe areas (default: true)
       }
     }
   }

--- a/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-capacitor-apps/troubleshooting-and-tips.md
@@ -59,15 +59,30 @@ If Capacitor reports that CocoaPods is unavailable or Xcode cannot load a Pods c
 
 Devices can reserve space for status bars, rounded corners, camera cutouts, and home indicators. Quasar components such as QHeader, QFooter, and Notify account for common safe-area cases, but test the app on multiple device shapes and orientations.
 
-For custom layout elements, use the standard CSS environment variables:
+On Android, Quasar uses the `--safe-area-inset-*` variables supplied by the [Capacitor 8 System Bars API](https://capacitorjs.com/docs/apis/system-bars) and falls back to the standard CSS environment variables. If your app handles Android safe areas itself, disable Quasar's automatic component padding:
+
+```js /quasar.config file
+framework: {
+  config: {
+    capacitor: {
+      androidSafeAreaPadding: false
+    }
+  }
+}
+```
+
+For custom layout elements, use the same fallback:
 
 ```css
 .top-element {
-  padding-top: env(safe-area-inset-top, 0px);
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
 }
 
 .bottom-element {
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-bottom: var(
+    --safe-area-inset-bottom,
+    env(safe-area-inset-bottom, 0px)
+  );
 }
 ```
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/configuring-cordova.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/configuring-cordova.md
@@ -90,6 +90,9 @@ return {
         // add the dynamic top padding on iOS mobile devices
         iosStatusBarPadding: true / false,
 
+        // account for Android safe areas (defaults to true)
+        androidSafeAreaPadding: true / false,
+
         // Quasar handles app exit on mobile phone back button.
         backButtonExit: true / false / '*' / ['/login', '/home', '/my-page'],
 

--- a/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
+++ b/docs/src/pages/quasar-cli-vite/developing-cordova-apps/troubleshooting-and-tips.md
@@ -79,7 +79,7 @@ Do not edit `/src-cordova/www` directly; Quasar overwrites it. Fix application c
 
 ## Safe areas
 
-Quasar components such as QHeader, QFooter, and Notify account for common safe-area cases. Test multiple devices and orientations. Custom layout elements can use the standard CSS environment variables:
+Quasar components such as QHeader, QFooter, and Notify account for common safe-area cases. Android native safe-area padding is enabled by default and can be disabled with `framework.config.cordova.androidSafeAreaPadding` if your app handles the insets itself. Test multiple devices and orientations. Custom layout elements can use the standard CSS environment variables:
 
 ```css
 body.cordova .top-element {

--- a/ui/src/components/dialog/QDialog.sass
+++ b/ui/src/components/dialog/QDialog.sass
@@ -81,12 +81,12 @@ body.platform-ios, body.platform-android:not(.native-mobile)
   .q-dialog__inner--minimized > div
     max-height: calc(100vh - 108px)
 
-body.q-ios-padding .q-dialog__inner
-  padding-top: $ios-statusbar-height !important
-  padding-top: env(safe-area-inset-top) !important
-  padding-bottom: env(safe-area-inset-bottom) !important
+body.q-ios-padding .q-dialog__inner,
+body.q-safe-area-padding .q-dialog__inner
+  padding-top: var(--q-safe-area-inset-top) !important
+  padding-bottom: var(--q-safe-area-inset-bottom) !important
   > div
-    max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important
+    max-height: calc(100vh - var(--q-safe-area-inset-top) - var(--q-safe-area-inset-bottom)) !important
 
 @media (max-width: $breakpoint-xs-max)
   .q-dialog__inner

--- a/ui/src/components/layout/QLayout.sass
+++ b/ui/src/components/layout/QLayout.sass
@@ -136,7 +136,7 @@ body.q-safe-area-padding
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
     padding-top: var(--q-safe-area-inset-top)
     min-height: calc(var(--q-safe-area-inset-top) + #{$toolbar-min-height})
-  .q-layout--standard .q-footer > .q-toolbar:last-child,
+  .q-layout--standard .q-footer > .q-toolbar:nth-last-child(1 of :not(.q-layout__shadow)),
   .q-layout--standard .q-footer > .q-tabs:nth-last-child(1 of :not(.q-layout__shadow)) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
     padding-bottom: var(--q-safe-area-inset-bottom)

--- a/ui/src/components/layout/QLayout.sass
+++ b/ui/src/components/layout/QLayout.sass
@@ -129,19 +129,18 @@
     display: inline-block
     pointer-events: auto
 
-body.q-ios-padding
+body.q-ios-padding,
+body.q-safe-area-padding
   .q-layout--standard .q-header > .q-toolbar:nth-child(1),
   .q-layout--standard .q-header > .q-tabs:nth-child(1) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
-    padding-top: $ios-statusbar-height
-    min-height: ($toolbar-min-height + $ios-statusbar-height)
-    padding-top: env(safe-area-inset-top)
-    min-height: calc(env(safe-area-inset-top) + #{$toolbar-min-height})
+    padding-top: var(--q-safe-area-inset-top)
+    min-height: calc(var(--q-safe-area-inset-top) + #{$toolbar-min-height})
   .q-layout--standard .q-footer > .q-toolbar:last-child,
   .q-layout--standard .q-footer > .q-tabs:nth-last-child(1 of :not(.q-layout__shadow)) .q-tabs__content,
   .q-layout--standard .q-drawer--top-padding .q-drawer__content
-    padding-bottom: env(safe-area-inset-bottom)
-    min-height: calc(env(safe-area-inset-bottom) + #{$toolbar-min-height})
+    padding-bottom: var(--q-safe-area-inset-bottom)
+    min-height: calc(var(--q-safe-area-inset-bottom) + #{$toolbar-min-height})
 
 .q-body--layout-animate
   .q-drawer__backdrop

--- a/ui/src/css/core/positioning.sass
+++ b/ui/src/css/core/positioning.sass
@@ -69,10 +69,10 @@
   max-width: 100vw
   max-height: 100vh
 
-body.q-ios-padding .fullscreen
-  padding-top: $ios-statusbar-height !important
-  padding-top: env(safe-area-inset-top) !important
-  padding-bottom: env(safe-area-inset-bottom) !important
+body.q-ios-padding .fullscreen,
+body.q-safe-area-padding .fullscreen
+  padding-top: var(--q-safe-area-inset-top) !important
+  padding-bottom: var(--q-safe-area-inset-bottom) !important
 
 .absolute-full, .fullscreen, .fixed-full
   top: 0

--- a/ui/src/css/normalize.sass
+++ b/ui/src/css/normalize.sass
@@ -18,6 +18,19 @@ html, body
   margin: 0
   box-sizing: border-box
 
+body.q-ios-padding
+  --q-safe-area-inset-top: #{$ios-statusbar-height}
+  --q-safe-area-inset-bottom: 0px
+
+@supports (padding-top: env(safe-area-inset-top))
+  body.q-ios-padding
+    --q-safe-area-inset-top: env(safe-area-inset-top, 0px)
+    --q-safe-area-inset-bottom: env(safe-area-inset-bottom, 0px)
+
+body.q-safe-area-padding
+  --q-safe-area-inset-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px))
+  --q-safe-area-inset-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))
+
 article,
 aside,
 details,

--- a/ui/src/plugins/notify/Notify.sass
+++ b/ui/src/plugins/notify/Notify.sass
@@ -14,12 +14,12 @@
   &--bottom
     bottom: 0
 
-body.q-ios-padding .q-notifications__list
+body.q-ios-padding .q-notifications__list,
+body.q-safe-area-padding .q-notifications__list
   &--center, &--top
-    top: $ios-statusbar-height
-    top: env(safe-area-inset-top)
+    top: var(--q-safe-area-inset-top)
   &--center, &--bottom
-    bottom: env(safe-area-inset-bottom)
+    bottom: var(--q-safe-area-inset-bottom)
 
 .q-notification
   box-shadow: $shadow-2

--- a/ui/src/plugins/private.body/Body.js
+++ b/ui/src/plugins/private.body/Body.js
@@ -9,7 +9,7 @@ function getMobilePlatform(is) {
   if (is.android) return 'android'
 }
 
-function getBodyClasses({ is, has, within }, cfg) {
+export function getBodyClasses({ is, has, within }, cfg) {
   const cls = [
     is.desktop ? 'desktop' : 'mobile',
     `${has.touch ? '' : 'no-'}touch`
@@ -22,11 +22,17 @@ function getBodyClasses({ is, has, within }, cfg) {
 
   if (is.nativeMobile) {
     const type = is.nativeMobileWrapper
+    const mobileCfg = cfg[type]
 
     cls.push(type, 'native-mobile')
 
-    if (is.ios && (cfg[type] === void 0 || cfg[type].iosStatusBarPadding)) {
+    if (is.ios && (mobileCfg === void 0 || mobileCfg.iosStatusBarPadding)) {
       cls.push('q-ios-padding')
+    } else if (
+      is.android &&
+      (mobileCfg === void 0 || mobileCfg.androidSafeAreaPadding !== false)
+    ) {
+      cls.push('q-safe-area-padding')
     }
   } else if (is.electron) {
     cls.push('electron')

--- a/ui/src/plugins/private.body/Body.test.js
+++ b/ui/src/plugins/private.body/Body.test.js
@@ -1,11 +1,67 @@
 import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
-import Body from './Body.js'
+import Body, { getBodyClasses } from './Body.js'
 
 const mountPlugin = () => mount({ template: '<div />' })
 
+function getNativeMobilePlatform(
+  is,
+  config = {},
+  nativeMobileWrapper = 'capacitor'
+) {
+  return getBodyClasses(
+    {
+      is: {
+        desktop: false,
+        mobile: true,
+        ios: false,
+        android: false,
+        nativeMobile: true,
+        nativeMobileWrapper,
+        electron: false,
+        bex: false,
+        ...is
+      },
+      has: { touch: true },
+      within: { iframe: false }
+    },
+    config
+  )
+}
+
 describe('[Body API]', () => {
+  describe('[(function)getBodyClasses]', () => {
+    test.each(['capacitor', 'cordova'])(
+      'enables safe area padding for Android %s apps',
+      nativeMobileWrapper => {
+        expect(
+          getNativeMobilePlatform(
+            { android: true },
+            { [nativeMobileWrapper]: {} },
+            nativeMobileWrapper
+          )
+        ).toContain('q-safe-area-padding')
+      }
+    )
+
+    test('allows Android native mobile safe area padding to be disabled', () => {
+      const classes = getNativeMobilePlatform(
+        { android: true },
+        { capacitor: { androidSafeAreaPadding: false } }
+      )
+
+      expect(classes).not.toContain('q-safe-area-padding')
+    })
+
+    test('preserves the existing iOS padding class', () => {
+      const classes = getNativeMobilePlatform({ ios: true })
+
+      expect(classes).toContain('q-ios-padding')
+      expect(classes).not.toContain('q-safe-area-padding')
+    })
+  })
+
   describe('[Functions]', () => {
     describe('[(function)install]', () => {
       test('should be defined correctly', () => {

--- a/ui/types/config.d.ts
+++ b/ui/types/config.d.ts
@@ -1,5 +1,6 @@
 interface NativeMobileWrapperConfiguration {
   iosStatusBarPadding?: boolean;
+  androidSafeAreaPadding?: boolean;
   backButton?: boolean;
   backButtonExit?: boolean | "*" | string[];
 }


### PR DESCRIPTION
## Summary

- enable Android safe-area handling by default for native Capacitor and Cordova apps
- normalize Capacitor 8 `--safe-area-inset-*` values with CSS `env()` fallbacks
- apply the normalized insets to QLayout headers, footers and drawers, QDialog, fullscreen content, and Notify
- preserve the existing iOS `q-ios-padding` path
- add `androidSafeAreaPadding: false` as an opt-out for applications that manage their own insets
- document and type the new configuration

## Why

Android 15 and newer edge-to-edge layouts can place a QHeader beneath the native
status bar. Capacitor exposes the correct system-bar inset, but Quasar did not
consume it for Android native wrappers. This left layout components overlapping
the clock, status icons, and display cutouts.

The new Android-only body class connects those system insets to the same Quasar
components that already account for iOS safe areas.

## Validation

- full UI regression suite: 102 files and 1,081 tests passed
- focused native-platform tests: 6 passed
- full Quasar UI production build passed
- commit hooks passed oxfmt and oxlint
- `git diff --check` passed

### BrowserStack real-device matrix

| Device | OS | Result |
| --- | --- | --- |
| Google Pixel 8 | Android 14 | Existing layout remains unchanged; zero insets do not introduce double padding |
| Google Pixel 9 | Android 15 | Baseline overlap reproduced; patched header remains below the status bar |
| Google Pixel 9 | Android 16 | Baseline overlap reproduced; patched Quasar inset matches Capacitor's reported 65px inset |
| Samsung Galaxy S24 | Android 16 | Patched header consumes the reported 30px top inset and elevated footer consumes the reported 48px bottom inset |
| iPhone 16 Pro | iOS 18.6 | Baseline and patched `q-ios-padding` paths retain identical header/footer geometry |

Top Notify and QDialog were also exercised on Android 16. Native-platform unit
coverage verifies that iOS continues to receive `q-ios-padding` and never
receives the new Android-only class. The elevated QFooter check also verifies
that its generated layout shadow does not prevent the last toolbar from
receiving bottom safe-area padding.

## BrowserStack screenshots

### Android 16 — top and bottom insets

<table>
  <thead>
    <tr>
      <th>Baseline: header and footer overlap system bars</th>
      <th>Patched: header consumes 30px and footer consumes 48px</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://gist.githubusercontent.com/hawkeye64/5b130599dd9569bd5c3c4190329883bf/raw/080353d59e5c877dfcb543d8098db5128580f49c/samsung-galaxy-s24-android-16-baseline.png" alt="Samsung Galaxy S24 Android 16 baseline with header and footer overlapping system bars" width="420"></td>
      <td><img src="https://gist.githubusercontent.com/hawkeye64/5b130599dd9569bd5c3c4190329883bf/raw/080353d59e5c877dfcb543d8098db5128580f49c/samsung-galaxy-s24-android-16-patched.png" alt="Samsung Galaxy S24 Android 16 patched with header and footer content outside system bars" width="420"></td>
    </tr>
  </tbody>
</table>

Fixes #18069.
