### PR TITLE
fix(format): capitalize('') should not throw

### DIFF
--- a/ui/src/utils/format/format.js
+++ b/ui/src/utils/format/format.js
@@ -12,7 +12,7 @@ export function humanStorageSize(bytes, decimals = 1) {
 }
 
 export function capitalize(str) {
-  return str.at(0).toUpperCase() + str.slice(1)
+  return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
 export function between(v, min, max) {

--- a/ui/src/utils/format/format.test.js
+++ b/ui/src/utils/format/format.test.js
@@ -36,6 +36,10 @@ describe('[format API]', () => {
       test('has correct return value', () => {
         expect(format.capitalize('abc')).toBe('Abc')
       })
+
+      test('returns empty string for empty input', () => {
+        expect(format.capitalize('')).toBe('')
+      })
     })
 
     describe('[(function)between]', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

The public `capitalize` util throws on an empty string. `str.at(0)` returns `undefined` for `''`, so `undefined.toUpperCase()` throws a `TypeError`. `capitalize` is a documented public util (`import { capitalize } from 'quasar'`), typed `capitalize(text: string): string`, and `''` is a valid `string`.

Minimal reproduction:

```js
import { capitalize } from 'quasar'
capitalize('') // TypeError: Cannot read properties of undefined (reading 'toUpperCase')
```

**Fix:** use `str.charAt(0)`, which returns `''` for an empty string, so `capitalize('') === ''`.

<details><summary>Verification</summary>

- Added `format.test.js` case asserting `capitalize('') === ''` — throws on `dev`, passes with the fix.
- Full `quasar-ui-test` suite green.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capitalization formatting compatibility across supported environments.
  * Ensured empty text remains unchanged when processed by the capitalization utility.

* **Tests**
  * Added coverage for capitalization of empty strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->