### PR TITLE
fix(debounce): re-arm the leading edge after cancel() in immediate mode

### DIFF
--- a/ui/src/utils/debounce/debounce.js
+++ b/ui/src/utils/debounce/debounce.js
@@ -18,7 +18,10 @@ export default function debounce(fn, wait = 250, immediate) {
   }
 
   debounced.cancel = () => {
-    if (timer !== null) clearTimeout(timer)
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
   }
 
   return debounced

--- a/ui/src/utils/debounce/debounce.test.js
+++ b/ui/src/utils/debounce/debounce.test.js
@@ -176,6 +176,17 @@ describe('[debounce API]', () => {
 
         expect(callback).not.toHaveBeenCalled()
       })
+      test('cancel() re-arms the leading edge in immediate mode', () => {
+        const callback = vi.fn()
+        const fn = debounce(callback, 100, true)
+
+        fn()
+        expect(callback).toHaveBeenCalledTimes(1)
+
+        fn.cancel()
+        fn()
+        expect(callback).toHaveBeenCalledTimes(2)
+      })
     })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

`debounce(fn, wait, immediate)` in `immediate` (leading-edge) mode swallows the next call after `.cancel()`. `cancel()` clears the pending timeout but leaves the internal `timer` reference non-null, so the next `debounced()` sees `timer !== null` and takes the trailing-clear branch instead of firing the leading edge.

Minimal reproduction:

```js
import debounce from 'quasar/src/utils/debounce/debounce.js'

let calls = 0
const d = debounce(() => { calls++ }, 100, true) // immediate = true

d()          // leading edge fires               -> calls === 1
d.cancel()   // cancel the pending trailing window
d()          // should fire a fresh leading edge -> expected calls === 2
// actual on dev: calls === 1 (the leading edge is swallowed)
```

**Fix:** reset `timer = null` after clearing in `cancel()`, returning the debouncer to its initial state so the next call is treated as a fresh leading edge.

<details><summary>Verification</summary>

- Standalone repro: `dev` → `calls === 1`; fixed → `calls === 2`.
- Added `debounce.test.js` case *"cancel() re-arms the leading edge in immediate mode"* — fails on `dev`, passes with the fix.
- Full `quasar-ui-test` suite green (1055 tests).
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed debounce cancellation so subsequent calls correctly trigger the callback again in immediate mode.
  * Improved cancellation state handling to prevent callbacks from remaining blocked unexpectedly.

* **Tests**
  * Added coverage verifying that canceling a debounced action re-enables the next invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->