### PR TITLE
fix(portal): guard removeGlobalNode against untracked elements

### DIFF
--- a/ui/src/utils/private.config/nodes.js
+++ b/ui/src/utils/private.config/nodes.js
@@ -29,8 +29,10 @@ export function createGlobalNode(id, portalType) {
 export function removeGlobalNode(el) {
   const nodeIndex = nodesList.indexOf(el)
 
-  nodesList.splice(nodeIndex, 1)
-  portalTypeList.splice(nodeIndex, 1)
+  if (nodeIndex !== -1) {
+    nodesList.splice(nodeIndex, 1)
+    portalTypeList.splice(nodeIndex, 1)
+  }
 
   el.remove()
 }

--- a/ui/src/utils/private.config/nodes.test.js
+++ b/ui/src/utils/private.config/nodes.test.js
@@ -99,6 +99,21 @@ describe('[nodes API]', () => {
           expect(node.parentElement).toBe(newTargetEl)
         })
       })
+      test('removeGlobalNode ignores an untracked element', () => {
+        const tracked = createGlobalNode('tracked-node')
+        const stray = document.createElement('div')
+
+        removeGlobalNode(stray) // untracked -> must not evict a tracked node
+
+        const newTarget = document.createElement('div')
+        document.body.append(newTarget)
+        changeGlobalNodesTarget(newTarget)
+        expect(tracked.parentElement).toBe(newTarget)
+
+        removeGlobalNode(tracked)
+        changeGlobalNodesTarget(document.body)
+        newTarget.remove()
+      })
     })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

`removeGlobalNode(el)` computes `nodesList.indexOf(el)` and splices unconditionally. If `el` is not in the registry, `indexOf` returns `-1`, and `splice(-1, 1)` removes the **last** element instead — evicting an unrelated tracked global node from `nodesList` and `portalTypeList`.

Minimal reproduction:

```js
// nodesList holds one tracked global node A (e.g. a portal target)
removeGlobalNode(someUntrackedEl) // indexOf === -1 -> splice(-1, 1) drops A
// A is now untracked: changeGlobalNodesTarget() no longer relocates it
```

**Fix:** guard the splice with `if (nodeIndex !== -1)` so an untracked element is a no-op (the trailing `el.remove()` still runs unchanged).

<details><summary>Verification</summary>

- Added `nodes.test.js` case *"removeGlobalNode ignores an untracked element"* — on `dev` the untracked call evicts the tracked node; with the fix the tracked node survives.
- Full `quasar-ui-test` suite green.
</details>
