### PR TITLE
fix(EventBus): prevent once() firing twice on a re-entrant emit

### DIFF
--- a/ui/src/utils/EventBus/EventBus.js
+++ b/ui/src/utils/EventBus/EventBus.js
@@ -18,7 +18,10 @@ export default class EventBus {
   }
 
   once(name, callback, ctx) {
+    let fired = false
     const listener = (...args) => {
+      if (fired === true) return
+      fired = true
       this.off(name, listener)
       callback.apply(ctx, args)
     }

--- a/ui/src/utils/EventBus/EventBus.test.js
+++ b/ui/src/utils/EventBus/EventBus.test.js
@@ -103,6 +103,16 @@ describe('[EventBus API]', () => {
         expect(callback).toHaveBeenCalledTimes(1)
         expect(callback).toHaveBeenCalledWith(1, 2, 'testing')
       })
+      test('a once listener does not fire twice on a re-entrant emit', () => {
+        const instance = new EventBus()
+        const second = vi.fn()
+
+        instance.once('e', () => instance.emit('e')) // re-emits during dispatch
+        instance.once('e', second)
+        instance.emit('e')
+
+        expect(second).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

An `EventBus.once()` listener can fire **twice** when its own callback re-emits the same event. `emit()` iterates a snapshot of the listener array; a re-entrant `emit()` from inside the callback re-invokes the same once-listener, so it runs a second time.

Minimal reproduction:

```js
const bus = new EventBus()
let count = 0
bus.once('e', () => bus.emit('e')) // re-emits during its own dispatch
bus.once('e', () => { count++ })
bus.emit('e')
// expected count === 1 (a once listener fires at most once)
// actual on dev: count === 2
```

**Fix:** latch each `once` listener with a `fired` flag so it is a no-op after its first invocation, regardless of re-entrancy.

<details><summary>Verification</summary>

- Added `EventBus.test.js` case *"a once listener does not fire twice on a re-entrant emit"* — fails on `dev` (fires twice), passes with the fix.
- Full `quasar-ui-test` suite green.
</details>
