### PR TITLE
fix(TouchPan): reference bindings.value in updated hook, not undeclared value

### DIFF
--- a/ui/src/directives/touch-pan/TouchPan.js
+++ b/ui/src/directives/touch-pan/TouchPan.js
@@ -426,7 +426,7 @@ export default createDirective(
 
           if (ctx !== void 0) {
             if (bindings.oldValue !== bindings.value) {
-              if (typeof value !== 'function') ctx.end()
+              if (typeof bindings.value !== 'function') ctx.end()
               ctx.handler = bindings.value
             }
 

--- a/ui/src/directives/touch-pan/TouchPan.test.js
+++ b/ui/src/directives/touch-pan/TouchPan.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import TouchPan from './TouchPan.js'
+
+describe('[TouchPan API]', () => {
+  describe('[Functions]', () => {
+    describe('[(hook)updated]', () => {
+      test('does not end an active pan when the handler reference changes to another function', () => {
+        const end = vi.fn()
+        const fnA = () => {}
+        const fnB = () => {}
+        const el = { __qtouchpan: { end, handler: fnA, direction: {} } }
+
+        TouchPan.updated(el, { oldValue: fnA, value: fnB, modifiers: {} })
+
+        expect(end).not.toHaveBeenCalled()
+        expect(el.__qtouchpan.handler).toBe(fnB)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

The `v-touch-pan` `updated` hook references an **undeclared** variable `value`:

```js
updated(el, bindings) {
  const ctx = el.__qtouchpan
  if (ctx !== void 0) {
    if (bindings.oldValue !== bindings.value) {
      if (typeof value !== 'function') ctx.end()   // <-- `value` is undeclared
      ctx.handler = bindings.value
    }
    ...
```

`typeof value` on an undeclared identifier is always `'undefined'` (no ReferenceError, and `no-undef` skips the `typeof` operand), so `typeof value !== 'function'` is **always true**. Every time the bound handler's reference changes (e.g. an inline arrow re-created each render), `ctx.end()` runs — aborting an in-progress pan gesture. The intent was to abort only when the *new* binding is not a function.

**Fix:**

```js
if (typeof bindings.value !== 'function') ctx.end()
```

<details><summary>Verification — fail-first triple-check</summary>

New `TouchPan.test.js` calls the `updated` hook directly with a mock `__qtouchpan` and a handler reference that changes from one function to another; asserts `ctx.end()` is **not** called and `ctx.handler` is updated.

| step | state | result |
|---|---|---|
| 1 | with the fix | ✅ `1 passed` |
| 2 | reverted to `dev` (buggy) | ❌ `1 failed` — `ctx.end()` is called |
| 3 | fix restored | ✅ `1 passed` |

Full `quasar-ui-test` suite green; fork CI (build + tests) green.
</details>
