### PR TITLE
fix(escape-key): keep ESC armed across interleaved key events while held

### DIFF
--- a/ui/src/utils/private.keyboard/escape-key.js
+++ b/ui/src/utils/private.keyboard/escape-key.js
@@ -15,12 +15,9 @@ function onBlur() {
 }
 
 function onKeyup(evt) {
-  if (escDown) {
+  if (escDown && isKeyCode(evt, 27)) {
     escDown = false
-
-    if (isKeyCode(evt, 27)) {
-      handlers.at(-1)(evt)
-    }
+    handlers.at(-1)(evt)
   }
 }
 

--- a/ui/src/utils/private.keyboard/escape-key.js
+++ b/ui/src/utils/private.keyboard/escape-key.js
@@ -5,7 +5,9 @@ const handlers = []
 let escDown
 
 function onKeydown(evt) {
-  escDown = evt.keyCode === 27
+  if (evt.keyCode === 27) {
+    escDown = true
+  }
 }
 
 function onBlur() {

--- a/ui/src/utils/private.keyboard/escape-key.test.js
+++ b/ui/src/utils/private.keyboard/escape-key.test.js
@@ -100,6 +100,19 @@ describe('[escapeKey API]', () => {
 
         expect(removeEscapeKey(fn)).toBeUndefined()
       })
+      test('does not swallow ESC when another key is released while ESC is held', () => {
+        const fn = createTestFn()
+        addEscapeKey(fn)
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 16 })) // Shift down
+        window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 })) // Esc down
+        window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: 16 })) // Shift released first
+        const escUp = new KeyboardEvent('keyup', { keyCode: 27 })
+        window.dispatchEvent(escUp) // Esc released
+
+        expect(fn).toHaveBeenCalledTimes(1)
+        expect(fn).toHaveBeenCalledWith(escUp)
+      })
     })
   })
 })

--- a/ui/src/utils/private.keyboard/escape-key.test.js
+++ b/ui/src/utils/private.keyboard/escape-key.test.js
@@ -113,6 +113,18 @@ describe('[escapeKey API]', () => {
         expect(fn).toHaveBeenCalledTimes(1)
         expect(fn).toHaveBeenCalledWith(escUp)
       })
+      test('does not swallow ESC when another key is pressed while ESC is held', () => {
+        const fn = createTestFn()
+        addEscapeKey(fn)
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 27 })) // Esc down
+        window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 65 })) // 'a' down while Esc held
+        const escUp = new KeyboardEvent('keyup', { keyCode: 27 })
+        window.dispatchEvent(escUp) // Esc released
+
+        expect(fn).toHaveBeenCalledTimes(1)
+        expect(fn).toHaveBeenCalledWith(escUp)
+      })
     })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

The window-level ESC tracker (`escape-key.js`, used by QDialog / QMenu / QTooltip via `addEscapeKey`) drops a legitimate Escape when **any other key event is interleaved while ESC is held**. Two defects:

1. `onKeydown` did `escDown = evt.keyCode === 27`, so *any* non-ESC keydown reset `escDown` to `false`.
2. `onKeyup` cleared `escDown` on *any* keyup (only firing when it was ESC), so releasing another key first consumed the pending ESC.

Sequences that fail on `dev` (an open dialog does **not** close):

```
Shift↓  Esc↓  Shift↑  Esc↑     // Shift+Esc, release Shift first   -> defect #2
Esc↓    A↓    Esc↑             // another key pressed while Esc held -> defect #1
```

**Fix:** `onKeydown` only **sets** `escDown` on ESC (never clears it on other keys); `onKeyup` only clears + fires when the keyup **is** ESC. `escDown` is still cleared by `onBlur` / `update`.

<details><summary>Verification — fail-first triple-check</summary>

Two `escape-key.test.js` cases, one per sequence above.

| step | state | result |
|---|---|---|
| 1 | complete fix | ✅ `7 passed` |
| 2 | revert `onKeydown` only (keep `onKeyup` fix) | ❌ the "other key pressed while held" test fails |
| 3 | restore | ✅ `7 passed` |

Also verified in a real browser (real key events on the actual handler): `dev` leaves the dialog stuck open on both sequences; the fix closes it on all. Full `quasar-ui-test` suite + fork CI green.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape key handling to reliably trigger registered actions when other keys are pressed or released while Escape is held.
  * Prevented unrelated keyboard events from interfering with Escape key release behavior.

* **Tests**
  * Added coverage for Escape key interactions with other keyboard actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->