### PR TITLE
fix(Dialog): keep array-valued plugin options as arrays when merging on update()

### DIFF
--- a/ui/src/utils/private.dialog/create-dialog.js
+++ b/ui/src/utils/private.dialog/create-dialog.js
@@ -13,7 +13,11 @@ const ssrAPI = {
 
 export function merge(target, source) {
   for (const key in source) {
-    if (key !== 'spinner' && Object(source[key]) === source[key]) {
+    if (
+      key !== 'spinner' &&
+      Object(source[key]) === source[key] &&
+      Array.isArray(source[key]) === false
+    ) {
       target[key] =
         Object(target[key]) !== target[key] ? {} : { ...target[key] }
 

--- a/ui/src/utils/private.dialog/create-dialog.js
+++ b/ui/src/utils/private.dialog/create-dialog.js
@@ -13,14 +13,13 @@ const ssrAPI = {
 
 export function merge(target, source) {
   for (const key in source) {
-    if (key !== 'spinner' && Object(source[key]) === source[key]) {
-      target[key] = Array.isArray(source[key])
-        ? Array.isArray(target[key])
-          ? [...target[key]]
-          : []
-        : Object(target[key]) !== target[key]
-          ? {}
-          : { ...target[key] }
+    if (
+      key !== 'spinner' &&
+      Object(source[key]) === source[key] &&
+      Array.isArray(source[key]) === false
+    ) {
+      target[key] =
+        Object(target[key]) !== target[key] ? {} : { ...target[key] }
 
       merge(target[key], source[key])
     } else {

--- a/ui/src/utils/private.dialog/create-dialog.js
+++ b/ui/src/utils/private.dialog/create-dialog.js
@@ -13,13 +13,14 @@ const ssrAPI = {
 
 export function merge(target, source) {
   for (const key in source) {
-    if (
-      key !== 'spinner' &&
-      Object(source[key]) === source[key] &&
-      Array.isArray(source[key]) === false
-    ) {
-      target[key] =
-        Object(target[key]) !== target[key] ? {} : { ...target[key] }
+    if (key !== 'spinner' && Object(source[key]) === source[key]) {
+      target[key] = Array.isArray(source[key])
+        ? Array.isArray(target[key])
+          ? [...target[key]]
+          : []
+        : Object(target[key]) !== target[key]
+          ? {}
+          : { ...target[key] }
 
       merge(target[key], source[key])
     } else {

--- a/ui/src/utils/private.dialog/create-dialog.test.js
+++ b/ui/src/utils/private.dialog/create-dialog.test.js
@@ -5,13 +5,13 @@ import { merge } from './create-dialog.js'
 describe('[create-dialog API]', () => {
   describe('[Functions]', () => {
     describe('[(function)merge]', () => {
-      test('replaces an array-valued prop instead of spreading it into an object', () => {
-        const target = { options: { items: ['x'] } }
+      test('merges array-valued props by index and keeps them arrays', () => {
+        const target = { options: { items: ['a', 'b', 'c'] } }
 
-        merge(target, { options: { items: ['a', 'b'] } })
+        merge(target, { options: { items: ['x'] } })
 
         expect(Array.isArray(target.options.items)).toBe(true)
-        expect(target.options.items).toEqual(['a', 'b'])
+        expect(target.options.items).toEqual(['x', 'b', 'c'])
       })
     })
   })

--- a/ui/src/utils/private.dialog/create-dialog.test.js
+++ b/ui/src/utils/private.dialog/create-dialog.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+
+import { merge } from './create-dialog.js'
+
+describe('[create-dialog API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)merge]', () => {
+      test('replaces an array-valued prop instead of spreading it into an object', () => {
+        const target = { options: { items: ['x'] } }
+
+        merge(target, { options: { items: ['a', 'b'] } })
+
+        expect(Array.isArray(target.options.items)).toBe(true)
+        expect(target.options.items).toEqual(['a', 'b'])
+      })
+    })
+  })
+})

--- a/ui/src/utils/private.dialog/create-dialog.test.js
+++ b/ui/src/utils/private.dialog/create-dialog.test.js
@@ -5,13 +5,13 @@ import { merge } from './create-dialog.js'
 describe('[create-dialog API]', () => {
   describe('[Functions]', () => {
     describe('[(function)merge]', () => {
-      test('merges array-valued props by index and keeps them arrays', () => {
+      test('replaces an array-valued prop instead of spreading it into an object', () => {
         const target = { options: { items: ['a', 'b', 'c'] } }
 
         merge(target, { options: { items: ['x'] } })
 
         expect(Array.isArray(target.options.items)).toBe(true)
-        expect(target.options.items).toEqual(['x', 'b', 'c'])
+        expect(target.options.items).toEqual(['x'])
       })
     })
   })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

`merge()` (used by `dialog.update()` in `create-dialog.js`) recurses into any value where `Object(v) === v` — **including arrays** — so an array-valued option is spread into a plain **object** with numeric keys, silently changing its type. The built-in checkbox/radio Dialog is exactly this shape (`options.items` is an array):

```js
const d = this.$q.dialog({ title: 'Pick', options: { type: 'checkbox', items: [ { label: 'A' }, { label: 'B' } ] } })
d.update({ options: { items: [ { label: 'C' } ] } })
// dev:  options.items === { '0': {label:'C'}, '1': {label:'B'} }   // object, isArray false — QDialog then mis-renders
// fix:  options.items === [ { label: 'C' } ]                        // stays an array
```

## Fix

Exclude arrays from the recursive branch so an array value is assigned wholesale (replaced), like any other leaf:

```js
if (key !== 'spinner' && Object(source[key]) === source[key] && Array.isArray(source[key]) === false) { /* recurse */ }
else { target[key] = source[key] }   // arrays land here
```

## ⚖️ One open design choice for you (surfacing the tension)

The **corruption fix is unambiguous** — an array must not become an object. But the *leaf semantic* for an array is a judgement call, and `update()` has **no documented merge contract**, so I'm flagging it rather than deciding for you:

- **Replace (this PR):** `update({ options: { items: [C] } })` → `items === [C]`. Matches "set the new choices"; no stale elements. Also the only sane behaviour for `cardClass`/`cardStyle` arrays.
- **Index-merge (alternative):** keep recursing into arrays but preserve array type → `items === [C, B]`. Honours the original code's "recurse into everything" intent, but leaves **stale trailing elements** (the old `B`).

I went with **replace**; if you prefer index-merge, it's a one-line swap (recurse into arrays, rebuild the container as `[...]` instead of `{...}`). Object-level partial merge (`update({ options: { model } })` without clobbering `items`) is preserved either way.

<details><summary>Verification — fail-first triple-check</summary>

`merge` unit test: `items: ['a','b','c']` updated with `['x']` must yield `['x']` (array, replaced).

| step | state | result |
|---|---|---|
| 1 | replace fix | ✅ passes |
| 2 | reverted to `dev` | ❌ `items` becomes an object, `isArray` false |
| 3 | restored | ✅ passes |

Full `quasar-ui-test` suite green.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog configuration merging so array values are correctly replaced instead of incorrectly merged into existing data.

* **Tests**
  * Added coverage to verify proper handling of array-valued dialog options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->