### PR TITLE
fix(useSplitAttrs): read the current vnode each update, not a stale setup capture

### DIFF
--- a/ui/src/composables/use-split-attrs/use-split-attrs.js
+++ b/ui/src/composables/use-split-attrs/use-split-attrs.js
@@ -3,7 +3,8 @@ import { getCurrentInstance, onBeforeUpdate, ref } from 'vue'
 const listenerRE = /^on[A-Z]/
 
 export default function useSplitAttrs() {
-  const { attrs, vnode } = getCurrentInstance()
+  const vm = getCurrentInstance()
+  const { attrs } = vm
 
   const acc = {
     listeners: ref({}),
@@ -20,9 +21,9 @@ export default function useSplitAttrs() {
       }
     }
 
-    for (const key in vnode.props) {
+    for (const key in vm.vnode.props) {
       if (listenerRE.test(key)) {
-        listeners[key] = vnode.props[key]
+        listeners[key] = vm.vnode.props[key]
       }
     }
 

--- a/ui/src/composables/use-split-attrs/use-split-attrs.test.js
+++ b/ui/src/composables/use-split-attrs/use-split-attrs.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { defineComponent } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 
 import useSplitAttrs from './use-split-attrs.js'
 
@@ -51,6 +51,35 @@ describe('[useSplitAttrs API]', () => {
           attributes: expect.$ref(attrs),
           listeners: expect.$ref(fnList)
         })
+      })
+
+      test('reflects an updated event handler after re-render (not the stale setup-time one)', async () => {
+        const Child = defineComponent({
+          name: 'Child',
+          setup() {
+            return { result: useSplitAttrs() }
+          },
+          render() {
+            return h('div')
+          }
+        })
+        const handler = ref(() => 'A')
+        const wrapper = mount(
+          defineComponent({
+            setup() {
+              return () => h(Child, { onFoo: handler.value })
+            }
+          })
+        )
+        const child = wrapper.findComponent({ name: 'Child' })
+
+        expect(child.vm.result.listeners.value.onFoo()).toBe('A')
+
+        handler.value = () => 'B'
+        await nextTick()
+        await nextTick()
+
+        expect(child.vm.result.listeners.value.onFoo()).toBe('B')
       })
     })
   })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

`useSplitAttrs()` destructures `vnode` from `getCurrentInstance()` **once at setup** and reads `vnode.props` from that frozen snapshot on every `update()`. So an event handler whose reference changes on re-render (an inline arrow, or a reactively-swapped handler) never propagates — the composable keeps emitting the setup-time handler.

Minimal reproduction (real `@vue/test-utils` mount):

```js
const handler = ref(() => 'A')
// parent renders <Child :onFoo="handler" />, Child calls useSplitAttrs()
handler.value = () => 'B'         // re-render
// child.result.listeners.value.onFoo()  ->  dev: 'A' (stale)  |  fixed: 'B'
```

## Fix

Keep the instance and read the current vnode each update, instead of a stale capture (`attrs` stays destructured — it's a stable reactive proxy):

```js
const vm = getCurrentInstance()
const { attrs } = vm
...
for (const key in vm.vnode.props) { ... }   // fresh each update()
```

<details><summary>Verification — fail-first triple-check</summary>

New `use-split-attrs.test.js` case mounts a child under a parent that swaps `onFoo` from `()=>'A'` to `()=>'B'` and asserts the split listener returns `'B'` after re-render.

| step | state | result |
|---|---|---|
| 1 | fix | ✅ `6 passed` |
| 2 | reverted to `dev` | ❌ `AssertionError: expected 'A' to be 'B'` |
| 3 | restored | ✅ `6 passed` |

Full `quasar-ui-test` suite + fork CI (build + tests) green.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handler updates so components now use the latest listener after re-rendering.
  * Prevented stale event handlers from being retained when reactive values change.

* **Tests**
  * Added coverage verifying listener updates across component re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->