### PR TITLE
fix(Notify): use notif.multiLine (not multiline) in the auto-group key

### DIFF
--- a/ui/src/plugins/notify/Notify.js
+++ b/ui/src/plugins/notify/Notify.js
@@ -201,7 +201,7 @@ function addNotification(config, $q, originalApi) {
       notif.group = [
         notif.message,
         notif.caption,
-        notif.multiline,
+        notif.multiLine,
         ...notif.actions.map(props => `${props.label}*${props.icon}`)
       ].join('|')
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

The Notify auto-group key references `notif.multiline`, but the property is **`multiLine`** (capital L). The value is therefore always `undefined` in the key, so two otherwise-identical notifications that differ only in an explicit `multiLine` collapse into the same group (one replaces the other).

`multiLine` is the canonical name everywhere else — `Notify.js:167,168,174,181,185,217` and the API `Notify.json`. Line 204 is the lone lowercase outlier, and the API documents the default group as *"message + caption + multiline + actions labels + position"* — i.e. `multiLine` is intended to be in the key.

```js
- notif.multiline,
+ notif.multiLine,
```

<details><summary>Empirical (faithful replica of the group-key array)</summary>

Two notifications identical except an explicit `multiLine`:

| | dev (`notif.multiline`) | fix (`notif.multiLine`) |
|---|---|---|
| key(a=`multiLine:true`) | `"Saved\|\|"` | `"Saved\|\|true"` |
| key(b=`multiLine:false`) | `"Saved\|\|"` | `"Saved\|\|false"` |
| **collide?** | **true** (b replaces a) | **false** (distinct) |

Low practical impact — when `multiLine` is auto-derived from `actions.length`, the actions (also in the key) already distinguish them; the typo only bites on an *explicit* differing `multiLine`. No notify unit harness exists (plugin + global state), so the evidence is this exact-logic replica. Full suite green.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed grouped notifications so multiline settings are handled consistently.
  - Improved notification matching and replacement when messages, captions, and buttons are identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->