### PR TITLE
fix(BottomSheet): apply action.classes in grid mode (was action.class)

### DIFF
--- a/ui/src/plugins/bottom-sheet/component/BottomSheetComponent.js
+++ b/ui/src/plugins/bottom-sheet/component/BottomSheetComponent.js
@@ -71,7 +71,7 @@ export default createComponent({
               {
                 class: [
                   'q-bottom-sheet__item q-hoverable q-focusable cursor-pointer relative-position',
-                  action.class
+                  action.classes
                 ],
                 style: action.style,
                 tabindex: 0,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

A **grid** bottom-sheet drops the `classes` set on an action. The grid renderer reads `action.class`, but the documented action prop is **`classes`** — so the class never applies.

| source | reads | line |
|---|---|---|
| grid renderer | `action.class` ❌ | `BottomSheetComponent.js:74` |
| list renderer (sibling) | `action.classes` ✅ | `BottomSheetComponent.js:113` |
| documented API | `classes` | `BottomSheet.json:34` |

Grid is the lone outlier (`style` is already `action.style` in both). Fix aligns it:

```js
- action.class
+ action.classes
```

<details><summary>Empirical (screenshot)</summary>

Both grid items built with the exact class array from the code, for `{ label:'Share', classes:'my-custom' }` (`.my-custom` = red border). DOM `className`: dev `q-bottom-sheet__item`, fix `q-bottom-sheet__item my-custom`.

![BottomSheet grid classes](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/bottomsheet-classes.png)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected styling for bottom-sheet action items by applying the configured action classes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->