### PR TITLE
fix(morph directive): resolve object-form binding in getSSRProps

### DIFF
--- a/ui/src/directives/morph/Morph.js
+++ b/ui/src/directives/morph/Morph.js
@@ -165,9 +165,13 @@ export default createDirective(
         name: 'morph',
         getSSRProps: binding => {
           const name = binding.arg ? binding.arg.split(':')[0] : false
+          const model =
+            Object(binding.value) === binding.value
+              ? binding.value.model
+              : binding.value
 
           return {
-            class: name === binding.value ? '' : 'q-morph--invisible'
+            class: name === model ? '' : 'q-morph--invisible'
           }
         }
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch

## Description

The `v-morph` directive accepts an **object form** client-side — `v-morph:cardA="{ model: 'cardA' }"` (client `updateValue` does `String(value.model)`, `Morph.js:146`). But `getSSRProps` compares the arg name to the **raw** `binding.value`:

```js
class: name === binding.value ? '' : 'q-morph--invisible'
```

For the object form, `binding.value` is `{ model: 'cardA' }`, so the comparison is always false → an element that should be visible SSR-renders `q-morph--invisible` (hydration mismatch / flash). Fix resolves `.model` like the client:

```js
const model = Object(binding.value) === binding.value ? binding.value.model : binding.value
return { class: name === model ? '' : 'q-morph--invisible' }
```

<details><summary>Empirical (getSSRProps replica + screenshot)</summary>

| binding | dev | fix |
|---|---|---|
| object-form `{ model:'cardA' }` | `q-morph--invisible` (hidden) | `''` (visible) |
| bare-form `'cardA'` | `''` | `''` (unchanged) |

Active object-form card with the real `.q-morph--invisible` style applied — dev hides it off-screen, fix shows it:

![v-morph SSR object-form](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/vmorph-ssr-object-form.png)

(No unit test: `getSSRProps` is on the SSR build variant behind `__QUASAR_SSR_SERVER__`, not instantiated by the client vitest run — the replica exercises identical logic.)
</details>
