### PR TITLE
fix(ui): normalize date utility failure results

### DIFF
--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -545,7 +545,7 @@ export function isBetweenDates(date, from, to, opts = {}) {
     d2 = getDateIdentifier(to, opts.onlyDate),
     cur = getDateIdentifier(date, opts.onlyDate)
 
-  return (
+  return Boolean(
     (cur > d1 || (opts.inclusiveFrom && cur === d1)) &&
     (cur < d2 || (opts.inclusiveTo && cur === d2))
   )
@@ -1051,7 +1051,7 @@ export function formatDate(
 
   const date = new Date(val)
 
-  if (Number.isNaN(date)) return
+  if (Number.isNaN(date.getTime())) return
 
   if (mask === void 0) {
     mask = defaultMask

--- a/ui/src/utils/date/date.test.js
+++ b/ui/src/utils/date/date.test.js
@@ -134,8 +134,14 @@ describe('[date API]', () => {
 
       test('excludes the boundaries by default', () => {
         expect(date.isBetweenDates(middle, from, to)).toBe(true)
-        expect(date.isBetweenDates(from, from, to)).toBeFalsy()
-        expect(date.isBetweenDates(to, from, to)).toBeFalsy()
+        expect(date.isBetweenDates(from, from, to)).toBe(false)
+        expect(date.isBetweenDates(to, from, to)).toBe(false)
+        expect(date.isBetweenDates(new Date(2024, 0, 9, 10), from, to)).toBe(
+          false
+        )
+        expect(date.isBetweenDates(new Date(2024, 0, 13, 10), from, to)).toBe(
+          false
+        )
       })
 
       test('supports inclusive boundaries', () => {
@@ -448,12 +454,16 @@ describe('[date API]', () => {
         )
       })
 
-      test.each([void 0, null, '', Number.POSITIVE_INFINITY])(
-        'returns undefined for %o',
-        value => {
-          expect(date.formatDate(value)).toBeUndefined()
-        }
-      )
+      test.each([
+        void 0,
+        null,
+        '',
+        'not a date',
+        Number.POSITIVE_INFINITY,
+        new Date('bad')
+      ])('returns undefined for %o', value => {
+        expect(date.formatDate(value)).toBeUndefined()
+      })
     })
 
     describe('[(function)clone]', () => {


### PR DESCRIPTION
## Summary

- make `isBetweenDates()` consistently return a boolean when a date is outside
  the requested range or on an excluded boundary
- make `formatDate()` return `undefined` for invalid date strings and invalid
  `Date` instances instead of formatting `NaN` components
- add strict regression coverage for both cases

## Root cause

`isBetweenDates()` allowed the optional inclusivity flags to become the value
of its boolean expression. When a comparison failed and the corresponding flag
was omitted, the expression returned `undefined`.

`formatDate()` used `Number.isNaN(date)` on a `Date` object. Because
`Number.isNaN()` does not coerce its argument, that check never detected an
invalid `Date`. Checking `date.getTime()` correctly identifies invalid values.

## User impact

These changes align both helpers with their documented contracts:

- failed range comparisons now return literal `false`
- invalid values passed to `formatDate()` now return `undefined`

Existing truthy/falsy range behavior and valid date formatting are unchanged.

## Validation

- `pnpm run test:specs --target utils/date/date` — passed
- focused date suite — 89 tests passed
- full `pnpm test` from the repository root — passed
  - Quasar and Vite plugin builds passed
  - UI specs validation passed
  - 103 UI test files / 1,174 tests passed
  - Vite plugin usage tests: 10 passed
  - Vite plugin runtime tests: 75 passed
- commit hooks passed `oxfmt` and `oxlint`
- `git diff --check` passed

Follow-up to #18439.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date validation to correctly identify invalid date values.
  * Date range checks now consistently return explicit true or false results.
  * Invalid date inputs are handled more reliably.

* **Tests**
  * Expanded coverage for boundary, out-of-range, and invalid date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->