### PR TITLE
test(ui): align createDialog specs

### DIFF
--- a/ui/src/utils/private.dialog/create-dialog.test.js
+++ b/ui/src/utils/private.dialog/create-dialog.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest'
 
-import { merge } from './create-dialog.js'
+import { createDialog, merge } from './create-dialog.js'
 
-describe('[create-dialog API]', () => {
+describe('[createDialog API]', () => {
   describe('[Functions]', () => {
     describe('[(function)merge]', () => {
       test('replaces an array-valued prop instead of spreading it into an object', () => {
@@ -12,6 +12,14 @@ describe('[create-dialog API]', () => {
 
         expect(Array.isArray(target.options.items)).toBe(true)
         expect(target.options.items).toEqual(['x'])
+      })
+    })
+
+    describe('[(function)createDialog]', () => {
+      test('returns a dialog factory', () => {
+        const result = createDialog({}, false, {})
+
+        expect(result).toBeTypeOf('function')
       })
     })
   })


### PR DESCRIPTION
## Summary

- rename the root test suite to the specs validator's expected
  `[createDialog API]` identifier
- add the missing test section for the exported `createDialog()` function
- verify that `createDialog()` returns a dialog factory

## Root cause

The test added with #18434 used the kebab-cased source filename in its root
`describe()` statement. The specs analyzer derives the API identifier as
`createDialog`, so `test:specs` rejected `[create-dialog API]`.

The source also exports both `merge()` and `createDialog()`, but the test only
contained the `merge()` section. Once the root identifier was corrected, the
analyzer correctly reported the missing `createDialog()` test case.

## Impact

The UI specs validator and the root test workflow pass again. This changes tests
only; Dialog runtime behavior is unchanged.

## Validation

- `pnpm run test:specs --target utils/private.dialog/create-dialog` — passed
- `pnpm --filter quasar test:specs:ci` — passed
- focused `create-dialog.test.js` suite — 2 tests passed
- full `pnpm test` from the repository root — passed
  - Quasar and Vite plugin builds passed
  - 104 UI test files / 1,179 tests passed
  - Vite plugin usage tests: 10 passed
  - Vite plugin runtime tests: 75 passed
- commit hooks passed `oxfmt` and `oxlint`
- `git diff --check` passed

Follow-up to #18434.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming the dialog creation API returns a usable dialog factory.
  * Updated test organization to clearly identify the dialog API under test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->