### PR TITLE
fix(date): accept negative epoch in extractDate X/x masks

### DIFF
--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -406,7 +406,7 @@ export function __splitDate(str, mask, dateLocale, calendar, defaultModel) {
 
   if (map.X !== void 0 || map.x !== void 0) {
     const stamp = Number.parseInt(match[map.X ?? map.x], 10)
-    if (Number.isNaN(stamp) || stamp < 0) return date
+    if (Number.isNaN(stamp)) return date
 
     const d = new Date(stamp * (map.X !== void 0 ? 1000 : 1))
 

--- a/ui/src/utils/date/date.test.js
+++ b/ui/src/utils/date/date.test.js
@@ -74,6 +74,17 @@ describe('[date API]', () => {
           date.extractDate(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ').getTime()
         ).toBe(Date.parse(value))
       })
+
+      test.each(['X', 'x'])(
+        'round-trips a pre-1970 date through the %s mask',
+        mask => {
+          const value = new Date(1950, 5, 15)
+
+          expect(
+            date.extractDate(date.formatDate(value, mask), mask).getTime()
+          ).toBe(value.getTime())
+        }
+      )
     })
 
     describe('[(function)buildDate]', () => {


### PR DESCRIPTION
### `extractDate` with an `X`/`x` mask corrupts every pre-1970 date to 1900-01-01

```js
import { date } from 'quasar'

const value = new Date(1950, 5, 15)
const stamp = date.formatDate(value, 'X')   // "-616928400"  <- negative, produced by Quasar itself
date.extractDate(stamp, 'X')                // Mon Jan 01 1900   <- expected Jun 15 1950
```

The guard at `date.js:409` rejected every negative epoch:

```js
if (Number.isNaN(stamp) || stamp < 0) return date
```

`1900-01-01` is just the generic parse-failure fallback, which is why this surfaces as a silently wrong date rather than an error.

### Pre-1970 is already supported everywhere else — the epoch path was the only holdout

This is the part worth checking before deciding the guard was protecting something. It was not: the library's date model has no 1970 floor, and every other mask path already accepts these dates on `dev`.

```
YYYY/MM/DD   1950/06/15   ->  Thu Jun 15 1950     already works on dev
YYYY-MM-DD   1950-06-15   ->  Thu Jun 15 1950     already works on dev
DD/MM/YYYY   15/06/1950   ->  Thu Jun 15 1950     already works on dev
X            -616928400   ->  Mon Jan 01 1900     <- only this path refused
```

`__splitDate` fills `year`/`month`/`day` from `d.getFullYear()` / `getMonth()` / `getDate()`, all well-defined for a negative epoch. The object produced for `1950-06-15` via the epoch path is indistinguishable from the one the `YYYY/MM/DD` path already produces for the same day.

Three further signs the guard was accidental rather than load-bearing:

1. **The regex on this same code path deliberately captures a minus sign** — `(-?\d+)` / `(-?\d{4,})`. Negative epochs are parsed with intent, then discarded on the next line.
2. **`formatDate` deliberately emits negative values** for `X`/`x`. The parser was refusing input its own serializer produces.
3. **`dateRE` already accepts negative years** (`-2024/01/21`) after the recent calendar-validity fix. Negative years are an accepted concept in this file.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Post-1970 output is byte-identical. `stamp = 0` was accepted before and still is. The only inputs whose behaviour changes are ones that previously returned the parse-failure fallback.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

`date.test.js` gains a round-trip regression test over both epoch masks. The source was reverted to `dev` with the test kept, to prove the test fails without the fix:

| # | State | Result |
|---|---|---|
| 1 | With fix | ✅ `Test Files 1 passed (1)` · `Tests 91 passed (91)` |
| 2 | `date.js` reverted to `dev`, test kept | ❌ `Test Files 1 failed (1)` · `Tests 2 failed \| 89 passed (91)` |
| 3 | Fix re-applied | ✅ `Tests 91 passed (91)` |

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>Before / after</b></summary>

```
BEFORE                                   AFTER
  -1      -> Mon Jan 01 1900               -1      -> Wed Dec 31 1969 23:59:59
  0       -> Thu Jan 01 1970  (fine)       0       -> Thu Jan 01 1970  (unchanged)
  -86400  -> Mon Jan 01 1900               -86400  -> Wed Dec 31 1969
  round-trip 1950: "-616928400" -> 1900    round-trip 1950: "-616928400" -> Jun 15 1950
```

Component level: `<q-date mask="x" :model-value="'-616885200000'"/>` renders header `— —` and navigates to the current month; with the fix it renders `1950 / Thu, Jun 15`.

Round-trip failures over a seeded sweep before the fix: 6/10 in UTC and Asia/Hong_Kong, 4/10 in America/New_York. After: 0.

</details>

<details>
<summary><b>Scope</b></summary>

- Only the `X`/`x` branch is touched; all other mask paths are untouched.
- `isValid()` is mask-agnostic and does not detect this, so it is not part of the fix.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date parsing now correctly supports dates before 1970 when using timestamp-based formats.
  * Improved round-trip consistency for formatting and extracting historical dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->