### PR TITLE
fix(use-panel): terminate goToPanelByOffset when walking below index 0

### DIFF
--- a/ui/src/composables/private.use-panel/use-panel.js
+++ b/ui/src/composables/private.use-panel/use-panel.js
@@ -201,7 +201,7 @@ export default function usePanel() {
   function goToPanelByOffset(direction, startIndex = panelIndex.value) {
     let index = startIndex + direction
 
-    while (index !== -1 && index < panels.length) {
+    while (index >= 0 && index < panels.length) {
       const opt = panels[index]
 
       if (


### PR DESCRIPTION
### `goToPanelByOffset` never terminates when it walks backwards from index `-1`

Reachable through the documented public `previous()` on QTabPanels / QCarousel / QStepper. The tab freezes.

```vue
<!-- 'nope' matches no panel, so panelIndex is -1 -->
<q-tab-panels v-model="name" ref="panels">
  <q-tab-panel name="a">a</q-tab-panel>
  <q-tab-panel name="b">b</q-tab-panel>
</q-tab-panels>
```
```js
name.value = 'nope'
panels.value.previous()   // never returns
```

The backwards walk terminated on the **exact** sentinel:

```js
let index = startIndex + direction
while (index !== -1 && index < panels.length) {
```

Starting at `startIndex = -1` with `direction = -1` makes `index` begin at `-2`. It never *equals* `-1`, and a negative index is always `< panels.length`, so it decrements forever. The forward direction is fine — bounded by the range check.

That `-1` was meant as "walked off the start", and the `props.infinite` recursion at the bottom of the same function already treats it that way (`startIndex !== -1`). The loop condition simply cannot catch an index that **steps over** the sentinel rather than landing on it.

`panelIndex` is `-1` whenever the model names a panel that does not exist, names one that is currently `disable`d, or the panel list is still empty while loading asynchronously.

![previous() freeze](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/use-panel-previous-freeze.png)

A freeze cannot be screenshotted directly, so the left pane runs a build **instrumented to abort the loop at 200,000 iterations** — that abort is the only artificial part. dev: `200,001+` iterations, never terminates. Patched: `2` iterations, returns normally.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

`index >= 0` accepts strictly fewer indices than `index !== -1`, and every index it excludes is negative — which `panels[index]` could never resolve anyway. The `props.infinite` wrap-around is unaffected: it re-enters with `startIndex = panels.length` going backwards and `startIndex = -1` going forwards, so the first wrapped indices remain `length - 1` and `0`.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification — note the failure mode is a HANG, not an assertion failure</b></summary>

A probe mounting `QTabPanels` with `model-value="nope"` and calling `previous()`:

| # | State | Result |
|---|---|---|
| 1 | With fix | ✅ PASS in **1.29 s** |
| 2 | `use-panel.js` reverted to `dev` | ❌ **killed at 45 s** by an external timeout — never completed |
| 3 | Fix re-applied | ✅ PASS in **1.29 s** |

Step 2 needs a *process-level* timeout because the loop is synchronous and blocks the event loop, so vitest's own `testTimeout` never fires. Instrumented output on dev: `index=-200002 startIndex=-1 direction=-1 panels.length=3`, reproducing on QTabPanels, QCarousel and QStepper.

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`use-panel.js` has no `use-panel.test.js` today, and `testing/specs` validates any new test file against the full `use-panel.json` API — so adding one means a complete generated scaffold (a `describe` per declared prop, emit and method) wrapped around a one-word fix. That seemed like the wrong trade, so the verification above ran against a scratch probe that is not part of this diff. Say the word and I will run `specs -t composables/private.use-panel` and fill it in.

</details>

<details>
<summary><b>Two reachability claims deliberately NOT made</b></summary>

Both were checked and do **not** hold, noting them so they are not repeated:

- **QCarousel's prev arrow** — the arrow render is guarded by `panelIndex.value >= 0`, so it cannot be clicked in the `-1` state.
- **Negative `autoplay`** — `duration = Math.abs(props.autoplay)` makes the reverse branch dead.

The swipe path looks plausible but was not verified, so it is not claimed either. The confirmed trigger is `previous()`.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panel navigation so moving backward stops correctly at the first available panel.
  * Prevented navigation from continuing indefinitely when no earlier enabled panel exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->