### PR TITLE
fix(slider): ignore a non-positive markers prop

### DIFF
--- a/ui/src/components/slider/use-slider.js
+++ b/ui/src/components/slider/use-slider.js
@@ -304,7 +304,7 @@ export default function useSlider({
   }
 
   const markerStep = computed(() =>
-    isNumber(props.markers) ? props.markers : keyStep.value
+    isNumber(props.markers) && props.markers > 0 ? props.markers : keyStep.value
   )
 
   const markerTicks = computed(() => {


### PR DESCRIPTION
### A `markers` value of `0` (or negative) drives an unbounded `do/while`, killing the component on first render

```vue
<q-slider v-model="v" :min="0" :max="10" :markers="0" marker-labels />
```

```js
const markerStep = computed(() =>
  isNumber(props.markers) ? props.markers : keyStep.value
)

const markerTicks = computed(() => {
  const acc = []
  const step = markerStep.value        // 0 or negative
  let value = props.min
  do {
    acc.push(value)
    value += step                      // never advances toward max
  } while (value < max)
```

`markers: [Boolean, Number]` has **no validator**, so `isNumber(0)` is `true` and `0` passes straight through as the step.

The telling part: the **analogous `step` prop is guarded twice in this same file** — at the prop (`validator: v => v >= 0`) and at the point of use (`keyStep = props.step === 0 ? 1 : props.step`). `markers` feeds the same kind of loop and is guarded in neither place. Falling back to `keyStep` on a non-positive value matches what `markers: true` already does.

![markers=0](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/slider-markers-zero.png)

dev throws `RangeError: Invalid array length` and the component never renders; patched renders normally.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Only affects values that previously killed the render. Every `markers` value that rendered before renders identically. `markers: false` still skips markers entirely.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

Probe mounts `<QSlider :min="0" :max="10" :markers="0" marker-labels />`:

| # | State | Result |
|---|---|---|
| 1 | With fix | ✅ `Tests 1 passed (1)` — 2.05 s |
| 2 | `use-slider.js` reverted to `dev` | ❌ `Tests 1 failed (1)` — `RangeError: Invalid array length` |
| 3 | Fix re-applied | ✅ `Tests 1 passed (1)` — 1.02 s |

Verbatim stack from step 2 — note this is the **plain render path**, not an interaction:

```
RangeError: Invalid array length
 ❯ ComputedRefImpl.fn      use-slider.js:317:11
 ❯ getMarkerList           use-slider.js:374:26
 ❯ getMarkerLabelsContent  use-slider.js:423:29
 ❯ Object.getContent       use-slider.js:696:11
```

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>Exact symptom depends on heap headroom</b></summary>

Under Node 22 + jsdom and in Chromium, the array hits the `2^32-1` length limit first, so it throws `RangeError` in under a second. With less headroom it exhausts memory instead — an earlier run under `--max-old-space-size=300` aborted with `FATAL ERROR: Reached heap limit`, rc=134. Either way the component never renders; only the console symptom differs.

</details>

<details>
<summary><b>Scope: <code>markers="0"</code> alone is harmless</b></summary>

`markerTicks` is only evaluated when marker **labels** are being built, so the failure needs `marker-labels` to be `true` or a Function. With `marker-labels` as an Array or Object, `markers: 0` is inert.

The realistic path is a **bound** `:markers="n"` that transiently reaches `0` — which reads to the author as "no markers" and instead takes the page down.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`use-slider.js` has no test file today, and `testing/specs` validates any new one against the full `use-slider.json` API, which would mean a complete generated scaffold around a one-clause fix. The probe above is not part of this diff.

</details>

