### PR TITLE
fix(slide-transition): do not orphan the fallback timer

### DIFF
--- a/ui/src/components/slide-transition/QSlideTransition.js
+++ b/ui/src/components/slide-transition/QSlideTransition.js
@@ -81,8 +81,6 @@ export default createComponent({
         timer = null
         el.style.height = `${el.scrollHeight}px`
         animListener = evt => {
-          timerFallback = null
-
           if (Object(evt) !== evt || evt.target === el) {
             end(el, 'show')
           }
@@ -112,8 +110,6 @@ export default createComponent({
         timer = null
         el.style.height = 0
         animListener = evt => {
-          timerFallback = null
-
           if (Object(evt) !== evt || evt.target === el) {
             end(el, 'hide')
           }


### PR DESCRIPTION
### Every completed slide transition runs `end()` twice, so `QExpansionItem` emits `@after-show` / `@after-hide` twice per toggle

The fix is a deletion of 4 lines, adding nothing.

`animListener` cleared the tracking variable **without** clearing the timer it tracks:

```js
animListener = evt => {
  timerFallback = null        // <- handle discarded, timer still scheduled
  if (Object(evt) !== evt || evt.target === el) end(el, 'show')
}
el.addEventListener('transitionend', animListener)
timerFallback = setTimeout(animListener, props.duration * 1.1)
```

On the normal path a real `transitionend` arrives, `animListener` nulls the handle, then `end()` calls `cleanup()`. But `cleanup()`'s release is guarded:

```js
if (timerFallback !== null) {
  clearTimeout(timerFallback)
  timerFallback = null
}
```

The handle is already `null`, so the guard is false and **the timer is never cleared**. It fires ~`0.1 × duration` later with `evt === undefined`, passes the `Object(evt) !== evt` fallback branch, and runs `end()` a second time. `lastEvent` is not updated after an emit, so the `event !== lastEvent` de-dup does not de-dup either.

`cleanup()` already owns the release, and `clearTimeout` on a handle whose timer has just fired is a harmless no-op — so the assignment inside `animListener` has nothing to do except break the guard.

![double emit](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/slide-transition-double-emit.png)

A userspace `@after-show` handler meant to run once per expand: dev fires it **twice** (`t=732ms`, `t=739ms`), patched fires it **once** (`t=723ms`). Real browser, real CSS transition, built bundle.

**Second effect:** if a new transition starts inside the orphan window, the stale `end()` calls `cleanup()` → `doneFn()` (Vue's `done` for the **new** transition) and `clearTimeout(timer)`, aborting it — the element snaps with no animation and its event never fires at all.

Blast radius: `QExpansionItem`, `QTree` node expansion, and vertical `QStepper` all render through this component.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Apps that de-duplicated the double emit themselves will now simply receive one event.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

Probe mounts `QSlideTransition` with `duration: 300`, advances past the inner 100 ms timer, dispatches a **real** `transitionend` on the transitioning element, then advances past the fallback window:

| # | State | `show` after transitionend | after fallback window | Result |
|---|---|---|---|---|
| 1 | With fix | 1 | 1 | ✅ `Tests 1 passed (1)` |
| 2 | Reverted to `dev` | 1 | **2** | ❌ `AssertionError: expected 2 to be 1` |
| 3 | Fix re-applied | 1 | 1 | ✅ `Tests 1 passed (1)` |

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>Real browser, and how often it actually happens</b></summary>

jsdom never dispatches a real `transitionend`, so this was also driven in headless Chromium against the built `quasar.umd.js` with a genuine CSS height transition:

```
[UNPATCHED] after-show=2  after-hide=2
   expand   : transitionend:height@775 | after-show@775 | after-show@780
   collapse : transitionend:height@2259 | after-hide@2259 | after-hide@2288
[PATCHED  ] after-show=1  after-hide=1
```

10 consecutive toggles, unpatched: `2,2,2,1,2,2,2,2,2,2`. The single `1` is where the fallback timer won the ~30 ms race against `transitionend`, which self-suppresses — so the double emit is the **dominant** case, not an edge case.

Aborted-transition case (collapse issued ~8 ms after a real `transitionend`):
```
[UNPATCHED] heights over 720ms: auto, auto, auto, auto, auto, auto ...   (no animation, no after-hide)
[PATCHED  ] heights over 720ms: 250px, 250px, 111.97px, 41.47px, 16.17px, 2.23px, auto ...
```

</details>

<details>
<summary><b>Also fixes an unflagged sibling case</b></summary>

When a `transitionend` **bubbles up from a child** (`evt.target !== el`), the old code still nulled the handle but did *not* call `end()`, so `cleanup()` never ran and the timer was orphaned with nothing to cancel it. Deleting the assignment covers that path too.

</details>

<details>
<summary><b>Precision note</b></summary>

In the aborted-transition case the stale `end()` does **not** produce a third emit — `lastEvent` suppresses that one. The damage there is purely the stale `doneFn()` + `clearTimeout(timer)` killing the new transition.

Harness note for anyone re-running the probe: `@vue/test-utils` stubs `<transition>` by default, which makes it report zero emits and look like a non-bug. `global: { stubs: { transition: false } }` is required.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`QSlideTransition` has no test file today and `testing/specs` validates any new one against `QSlideTransition.json`, which would mean a full generated scaffold around a two-line deletion.

</details>

