### PR TITLE
fix(use-panel): do not apply the RTL swipe flip when vertical

### DIFF
--- a/ui/src/composables/private.use-panel/use-panel.js
+++ b/ui/src/composables/private.use-panel/use-panel.js
@@ -90,7 +90,8 @@ export default function usePanel() {
   function onSwipe(evt) {
     const dir = props.vertical ? 'up' : 'left'
     goToPanelByOffset(
-      (proxy.$q.lang.rtl ? -1 : 1) * (evt.direction === dir ? 1 : -1)
+      (!props.vertical && proxy.$q.lang.rtl ? -1 : 1) *
+        (evt.direction === dir ? 1 : -1)
     )
   }
 


### PR DESCRIPTION
### A vertical panel set navigates backwards when swiped under RTL

```js
function onSwipe (evt) {
  const dir = props.vertical ? 'up' : 'left'
  goToPanelByOffset(
    (proxy.$q.lang.rtl ? -1 : 1) * (evt.direction === dir ? 1 : -1)
  )
}
```

`dir` is already `'up'` for a vertical set, so the swipe is measured on the **vertical** axis — which RTL does not mirror. The `rtl` sign flip is nevertheless applied unconditionally.

Every sibling making the same decision gates on `vertical` first. Two of them are **eleven lines below, in this same file**:

```js
`slide-${props.vertical ? 'down' : proxy.$q.lang.rtl ? 'left' : 'right'}`   // transitionPrev
`slide-${props.vertical ? 'up'   : proxy.$q.lang.rtl ? 'right' : 'left'}`   // transitionNext
```

The same shape appears in `QCarousel.js:135` and `QTabs.js:183`. `onSwipe` was the only place the guard was missing.

![vertical RTL swipe](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/use-panel-vertical-rtl-swipe.png)

Starting on panel B and swiping **UP**: dev lands on **A (previous)**, patched lands on **C (next)** — matching what the identical LTR carousel does. Content currently slides against the user's finger.

Affects `QCarousel`, `QTabPanels` and `QStepper` with `vertical` + `swipeable` under an RTL language. For `QStepper`, `vertical` is the prop that selects its primary layout.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Horizontal behaviour is untouched in both directions; only vertical + RTL changes, and only to match vertical + LTR.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification, with the horizontal control</b></summary>

Probe mounts `QTabPanels` (panels `a`,`b`,`c`, model `b`, `swipeable`) and invokes the **real bound `onSwipe`** via `el.__qtouchswipe.handler`, in all four vertical × rtl combinations. The horizontal rows are the control — the RTL flip **is** load-bearing there and must keep working.

| # | State | vertical, swipe up | horizontal, swipe left | Result |
|---|---|---|---|---|
| 1 | With fix | LTR → `c`, RTL → `c` ✅ same | LTR → `c`, RTL → `a` ✅ differs | ✅ `Tests 1 passed (1)` |
| 2 | Reverted to `dev` | LTR → `c`, RTL → **`a`** ❌ | LTR → `c`, RTL → `a` ✅ | ❌ `AssertionError: expected 'a' to be 'c'` |
| 3 | Fix re-applied | LTR → `c`, RTL → `c` ✅ | LTR → `c`, RTL → `a` ✅ | ✅ `Tests 1 passed (1)` |

The horizontal control passing in **both** states is what proves this is a missing `vertical` guard rather than an over-broad removal of the RTL flip.

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>TouchSwipe is not implicated</b></summary>

`el.__qtouchswipe.event.dir` is `'up'` in both LTR and RTL — TouchSwipe reports direction purely geometrically and does no mirroring of its own, so there is no compensating flip upstream that this change would double up on. That is also why the probe drives `onSwipe` directly: the geometry is not what is under test, the sign mapping is.

</details>

<details>
<summary><b>Precision note</b></summary>

One tempting description is wrong and worth stating: the animation does **not** disagree with the destination. Measured, an RTL vertical swipe-up selects `q-transition--slide-down` and lands on the previous panel — internally self-consistent. The actual symptom is simply that both are backwards.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`use-panel.js` has no test file today, and `testing/specs` validates any new one against the full `use-panel.json` API — a complete generated scaffold around a one-line guard.

</details>

