### PR TITLE
fix(QSelect): cancel a pending input-value emit when setting a new one

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -1130,6 +1130,11 @@ export default createComponent({
 
     function setInputValue(val, emitImmediately) {
       if (inputValue.value !== val) {
+        if (inputValueTimer !== null) {
+          clearTimeout(inputValueTimer)
+          inputValueTimer = null
+        }
+
         inputValue.value = val
 
         if (


### PR DESCRIPTION
### A stale `@input-value` arrives after the field has already been cleared, and nothing corrects it afterwards

`setInputValue`'s immediate branch emitted without cancelling a debounced emit scheduled by an earlier keystroke:

```js
function setInputValue (val, emitImmediately) {
  if (inputValue.value !== val) {
    inputValue.value = val
    if (emitImmediately || props.inputDebounce === 0 || props.inputDebounce === '0') {
      emit('inputValue', val)          // <- pending inputValueTimer left running
    } else {
      inputValueTimer = setTimeout(...) // <- also overwrites the handle, orphaning it
    }
  }
}
```

`onInput` clears `inputValueTimer` before it calls in, which is why ordinary typing is fine. The **internal** immediate-emit callers do not:

- `resetInputValue()` on ESC, on focusout, and on dialog hide
- the ArrowDown `fill-input` path (`QSelect.js:657` / `:910`)

![stale input-value](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/qselect-stale-input-value.png)

Type `ap`, then reset the field. dev emits `""` at t=316ms and then a stale `"ap"` at t=806ms — 490 ms *after* the field was cleared. Patched stops at `""`.

**Why this is worse than an ordinary out-of-order emit:** there is no corrective emit afterwards. By the time `"ap"` lands, `inputValue.value` is already `''`, so the next `setInputValue('')` short-circuits on `inputValue.value !== val` and emits nothing. The stale value is the **final state** userland observes, and it disagrees with both the DOM input (`value=""`) and the component's own `inputValue`.

The clear is hoisted to the top of the `if`, which also covers the debounced branch — that path overwrites `inputValueTimer` without clearing it first, orphaning the previous timer the same way. This matches the file's own idiom, already used verbatim at `QSelect.js:718` and `:1106`.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

Only suppresses an emit that contradicted the component's own state. Ordinary typing still debounces to the latest value. `filter()` reads `inputValue.value` directly and is unaffected.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

Probe mounts `<QSelect use-input>` at the **default** `input-debounce: 500`, dispatches a real `input` event carrying `ap`, triggers an immediate-emit caller, then lets the debounce elapse:

| # | State | emits before debounce | emits after debounce | Result |
|---|---|---|---|---|
| 1 | With fix | `[""]` | `[""]` | ✅ `Tests 1 passed (1)` |
| 2 | Reverted to `dev` | `[""]` | `["", "ap"]` | ❌ `AssertionError: expected 'ap' to be ''` |
| 3 | Fix re-applied | `[""]` | `[""]` | ✅ `Tests 1 passed (1)` |

Reproduces with **real** timers as well as fake ones, and with plain `use-input` — `fill-input` is not required.

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`QSelect` has no test file today and `testing/specs` validates any new one against `QSelect.json`, which is a very large generated scaffold for this component.

</details>

