### PR TITLE
fix(Intersection): recreate the observer when reverting to the function form

### DIFF
--- a/ui/src/directives/intersection/Intersection.js
+++ b/ui/src/directives/intersection/Intersection.js
@@ -9,17 +9,17 @@ const defaultCfg = {
 }
 
 function update(el, ctx, value) {
-  let handler, cfg, changed
+  let handler, cfg
 
   if (typeof value === 'function') {
     handler = value
     cfg = defaultCfg
-    changed = ctx.cfg === void 0
   } else {
     handler = value.handler
     cfg = { ...defaultCfg, ...value.cfg }
-    changed = ctx.cfg === void 0 || !isDeepEqual(ctx.cfg, cfg)
   }
+
+  const changed = ctx.cfg === void 0 || !isDeepEqual(ctx.cfg, cfg)
 
   if (ctx.handler !== handler) {
     ctx.handler = handler


### PR DESCRIPTION
### Switching a `v-intersection` binding from the object form back to a bare function keeps the old observer, so the previous `cfg` stays in force

```vue
<div v-intersection="binding" />
```
```js
binding = { handler: onSee, cfg: { threshold: 1 } }   // observer created, threshold 1
binding = onSee                                       // expects defaults -> still threshold 1
```

The two branches decided `changed` differently:

```js
if (typeof value === 'function') {
  handler = value
  cfg = defaultCfg
  changed = ctx.cfg === void 0                                    // <- never compares
} else {
  handler = value.handler
  cfg = { ...defaultCfg, ...value.cfg }
  changed = ctx.cfg === void 0 || !isDeepEqual(ctx.cfg, cfg)      // <- compares
}
```

The function branch only asks *"has a cfg ever been stored?"*, never *"is the stored cfg still the right one?"* — so the observer is not recreated and the stale `threshold: 1` survives.

**The clincher:** the semantically identical `{ handler: onSee }` (object form, `cfg` omitted) **does** reset to defaults, because it takes the branch that compares. The directive's two documented spellings of the same intent disagree with each other.

Hoisting the comparison out of both branches is one line shorter than duplicating it, and removes the asymmetry rather than patching one side of it.

**Practical effect:** a lazy-load or reveal-on-scroll handler that should fire as soon as the element is slightly visible only fires when it is fully visible — so content below the fold loads later than intended, or on a viewport shorter than the element, not at all.

**Honest severity:** narrow. It needs a binding whose **shape** changes at runtime, which is uncommon; nothing crashes and nothing is lost, the callback just fires later than intended. Submitted for correctness rather than urgency.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Fail-first verification</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

Probe drives the directive hooks on a real element with a recording `IntersectionObserver`, mounting with `{handler, cfg:{threshold:1}}` then updating to a bare function:

| # | State | observers created (thresholds, in order) | Result |
|---|---|---|---|
| 1 | With fix | `[1, 0]` | ✅ `Tests 1 passed (1)` |
| 2 | Reverted to `dev` | `[1]` — never recreated | ❌ `AssertionError: expected [ 1 ] to strictly equal [ 1, +0 ]` |
| 3 | Fix re-applied | `[1, 0]` | ✅ `Tests 1 passed (1)` |

Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

<details>
<summary><b>No observer churn introduced — the regression this hoist could plausibly cause</b></summary>

Hoisting makes the function branch compare where it previously did not, so the thing to rule out is over-eager recreation. Both no-op paths verified to create exactly **one** observer:

```
observers created for fn -> fn -> fn:            1  (want 1)
observers created for identical-cfg obj -> obj:  1  (want 1)
```

`fn -> fn` stays at one because `cfg` is the same `defaultCfg` object in both passes, so `isDeepEqual` is trivially true. Handler identity changes are still picked up separately by `ctx.handler !== handler`, which is untouched.

</details>

<details>
<summary><b>Real-browser confirmation</b></summary>

Driven in headless Chromium with a real `IntersectionObserver` against the shipped bundle: after the switch, a 68%-visible scroll fires nothing, and at 100% the handler receives an observer still reporting `thresholds: [1]`.

</details>

<details>
<summary><b>No test file included — happy to add one if you'd like</b></summary>

`Intersection.js` has no test file today and `testing/specs` validates any new one against `Intersection.json`.

</details>

