### PR TITLE
fix(QBtn): release the submit keydown guard on cleanup

### DIFF
--- a/ui/src/components/btn/QBtn.js
+++ b/ui/src/components/btn/QBtn.js
@@ -69,7 +69,8 @@ export default createComponent({
 
     let localTouchTargetEl = null,
       avoidMouseRipple,
-      mouseTimer = null
+      mouseTimer = null,
+      clickCleanup = null
 
     const hasLabel = computed(
       () => props.label !== void 0 && props.label !== null && props.label !== ''
@@ -157,6 +158,7 @@ export default createComponent({
           if (!e.qAvoidFocus) rootRef.value.focus()
 
           const onClickCleanup = () => {
+            clickCleanup = null
             document.removeEventListener('keydown', stopAndPrevent, true)
             document.removeEventListener(
               'keyup',
@@ -170,6 +172,7 @@ export default createComponent({
             )
           }
 
+          clickCleanup = onClickCleanup
           document.addEventListener('keydown', stopAndPrevent, true)
           document.addEventListener('keyup', onClickCleanup, passiveCapture)
           rootRef.value.addEventListener('blur', onClickCleanup, passiveCapture)
@@ -281,6 +284,8 @@ export default createComponent({
     }
 
     function cleanup(destroying) {
+      clickCleanup?.()
+
       const blurTarget = blurTargetRef.value
 
       if (

--- a/ui/src/components/btn/QBtn.test.js
+++ b/ui/src/components/btn/QBtn.test.js
@@ -80,6 +80,31 @@ describe('[QBtn API]', () => {
           expect(target.attributes('type')).toBe(propVal)
         }
       )
+
+      test('type "submit" releases its keydown guard on unmount', async () => {
+        const outside = document.createElement('input')
+        document.body.append(outside)
+        outside.focus()
+
+        const wrapper = mount(QBtn, {
+          props: { type: 'submit' },
+          attachTo: document.body
+        })
+
+        await wrapper.trigger('click')
+
+        const armed = new KeyboardEvent('keydown', { cancelable: true })
+        document.dispatchEvent(armed)
+        expect(armed.defaultPrevented).toBe(true)
+
+        wrapper.unmount()
+
+        const released = new KeyboardEvent('keydown', { cancelable: true })
+        document.dispatchEvent(released)
+        expect(released.defaultPrevented).toBe(false)
+
+        outside.remove()
+      })
     })
 
     describe('[(prop)to]', () => {


### PR DESCRIPTION
### The submit-guard listener trio is not tracked, so `cleanup()` cannot release it

**Scope up front, so nothing here is oversold:** this is a listener-lifecycle correctness fix. The observable symptom is narrow, engine-dependent, and capped at exactly one swallowed keystroke. Submitted as hygiene, not as a severity claim.

When a submit QBtn is clicked while focus sits outside it, it arms a guard so a still-held ENTER cannot re-submit:

```js
const onClickCleanup = () => {
  document.removeEventListener('keydown', stopAndPrevent, true)
  document.removeEventListener('keyup', onClickCleanup, passiveCapture)
  rootRef.value?.removeEventListener('blur', onClickCleanup, passiveCapture)
}

document.addEventListener('keydown', stopAndPrevent, true)
document.addEventListener('keyup', onClickCleanup, passiveCapture)
rootRef.value.addEventListener('blur', onClickCleanup, passiveCapture)
```

Every other listener this component owns is tracked by `touchTarget` / `mouseTarget` / `keyboardTarget` and released in `cleanup()`, which `onBeforeUnmount` calls as `cleanup(true)`. This trio is tracked by none of them, so `cleanup()` has no handle on it. Its only removal paths are the guard's **own** keyup and blur handlers.

If the component unmounts before either fires, a capture-phase `keydown → stopAndPrevent` remains bound to `document` with no owner.

The fix tracks the cleanup closure in the same per-instance scope as the other targets and invokes it from `cleanup()` — where every other listener this component owns is already released.

### Observable symptom, and its real limits

![swallowed keystroke](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/qbtn-swallowed-keystroke.png)

Under WebKit: focus a text field, click a submit QBtn, unmount the button, then type — the keystroke is swallowed. Patched, it is delivered.

**This does not reproduce on Chromium**, and that is not noise: the guard also listens for `blur` on the button, and Chromium fires `blur` when a focused element is removed from the DOM, so the guard self-heals there.

| engine | fires `blur` on removal? | symptom observable? |
|---|---|---|
| Chromium | yes | no — self-heals |
| WebKit | no | yes |
| Firefox | no | yes |
| jsdom | no | yes (so the committed test is deterministic) |

The listener is structurally untracked on **every** engine; only the self-healing accident differs.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

`cleanup()` already runs at exactly the points where the guard is stale. The normal ENTER-submit flow still releases on keyup as before — the repeat `keydown` remains captured by the document guard until keyup, blur, or unmount, so the guard's actual purpose is unchanged.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>Claims I checked and had to WITHDRAW — please hold me to these limits</b></summary>

An earlier draft of this description asserted three things that empirical testing refuted. Recording them so they are not used to justify the change:

- ~~"An ordinary mouse click amplifies this."~~ **False.** The guard is never armed on a real mouse click on any engine: `cleanup()` focuses the internal `.q-focus-helper` before the click dispatches, so `rootRef.contains(el)` is true and the branch is skipped.
- ~~"The guard is armed indefinitely."~~ **False.** The leaked `keyup` listener survives too, so the damage is capped at **exactly one** swallowed keydown.
- ~~"Normal Enter-submit leaks."~~ **False.** That self-heals within the same keypress.

What actually survives: WebKit/Firefox only, via (a) a programmatic click on a submit QBtn while another element holds focus, or (b) an Enter-submit whose trailing keyup never reaches the document because focus moved to another window, tab, or OS dialog.

</details>

<details>
<summary><b>Committed regression test</b> (fix ✅ / reverted ❌ / restored ✅)</summary>

`QBtn.test.js` already exists, so the regression test ships with the fix under `[(prop)type]`:

| # | State | Result |
|---|---|---|
| 1 | With fix | ✅ `Tests 76 passed (76)` |
| 2 | `QBtn.js` reverted to `dev`, test kept | ❌ `Tests 1 failed \| 75 passed (76)` — `AssertionError: expected true to be false` |
| 3 | Fix re-applied | ✅ `Tests 76 passed (76)` |

All 75 pre-existing QBtn tests pass throughout.

`pnpm --filter quasar test:specs:ci` accepts the amended file: `✅ src/components/btn/QBtn.test.js`, exit 0.
Full UI suite on the branch: `Test Files 104 passed (104)` · `Tests 1179 passed (1179)`.

</details>

