### PR TITLE
fix(QInput): make blur() cancel a focus() queued behind the portal wait flag

### DIFF
--- a/ui/src/components/input/QInput.js
+++ b/ui/src/components/input/QInput.js
@@ -25,7 +25,10 @@ import useKeyComposition from '../../composables/private.use-key-composition/use
 
 import { createComponent } from '../../utils/private.create/create.js'
 import { stop } from '../../utils/event/event.js'
-import { addFocusFn } from '../../utils/private.focus/focus-manager.js'
+import {
+  addFocusFn,
+  removeFocusFn
+} from '../../utils/private.focus/focus-manager.js'
 import { injectProp } from '../../utils/private.inject-obj-prop/inject-obj-prop.js'
 
 export default createComponent({
@@ -240,17 +243,27 @@ export default createComponent({
       }
     )
 
+    function focusHandler() {
+      const el = document.activeElement
+      if (
+        inputRef.value !== null &&
+        inputRef.value !== el &&
+        (el === null || el.id !== state.targetUid.value)
+      ) {
+        inputRef.value.focus({ preventScroll: true })
+      }
+    }
+
     function focus() {
-      addFocusFn(() => {
-        const el = document.activeElement
-        if (
-          inputRef.value !== null &&
-          inputRef.value !== el &&
-          (el === null || el.id !== state.targetUid.value)
-        ) {
-          inputRef.value.focus({ preventScroll: true })
-        }
-      })
+      addFocusFn(focusHandler)
+    }
+
+    function blur() {
+      removeFocusFn(focusHandler)
+      const el = document.activeElement
+      if (el !== null && state.rootRef.value.contains(el)) {
+        el.blur()
+      }
     }
 
     function select() {
@@ -529,6 +542,7 @@ export default createComponent({
     // expose public methods
     Object.assign(proxy, {
       focus,
+      blur,
       select,
       getNativeElement: () => inputRef.value // deprecated
     })


### PR DESCRIPTION
### `QInput.blur()` cannot cancel a `focus()` that is still queued behind the portal wait-flag

`QFile` can. The queued focus fires later and steals focus back — including out of a modal that has since opened.

`useField` pairs its enqueue and dequeue on **one named handler**:

```js
function focus () { addFocusFn(focusHandler) }
function blur ()  { removeFocusFn(focusHandler); /* ... */ }
```

`QInput` overrides `focus()` with a **fresh anonymous closure on every call**, and inherits `blur()` unchanged:

```js
function focus () {
  addFocusFn(() => { /* new function object every time */ })
}
```

`removeFocusFn` filters the queue by **function identity**, so it is handed a `focusHandler` that was never enqueued and removes nothing. The inherited `blur()` is a no-op against the queue.

![focus queue identity mismatch](https://raw.githubusercontent.com/evnchn/quasar/pr-evidence/.pr-evidence/wave2/upstream/qinput-focus-queue.png)

`QFile` is unaffected because it registers `state.targetRef` (`QFile.js:283`) and therefore keeps `useField`'s generic handler, leaving its add/remove pair matched. `QInput` overrode one half of a two-half contract.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

`QInput` gains a working `blur()`; the queued-focus behaviour of `focus()` is otherwise unchanged. The new `blur` mirrors `useField`'s behaviour, additionally removing QInput's own queued handler.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description

<details>
<summary><b>⚠️ A design choice I would like your call on — I deliberately took the larger option</b></summary>

There is a **smaller** fix: give `QInput` a `state.targetRef` like `QFile`, and delete the `focus()` override entirely. Much tidier diff. I did not take it because I could not convince myself it is safe:

1. `useField.focusHandler` does `if (!target.hasAttribute('tabindex')) target = target.querySelector('[tabindex]')`. On a bare `<input>` that resolves to `null` and the focus silently no-ops.
2. It would also change **which element the clear button focuses** (`use-field.js:378`).

Both are behavioural changes I cannot validate from outside the project's intent, so this PR takes the conservative route: mirror `useField`'s own named-handler pattern locally. **If you would rather have the smaller `targetRef` version, say so and I will verify those two points and reshape it** — it is clearly the nicer end state if it holds.

</details>

<details>
<summary><b>Fail-first verification, with a control</b></summary>

Probe spies on `addFocusFn` / `removeFocusFn`, calls `focus()` then `blur()`, and compares the two function identities. **QSelect is the control** — it must read `true` in every state, which is what proves the probe is not vacuous in jsdom:

| # | State | QInput `sameIdentity` | QSelect `sameIdentity` (control) | Result |
|---|---|---|---|---|
| 1 | With fix | **true** | true | ✅ `Tests 1 passed (1)` |
| 2 | `QInput.js` reverted to `dev` | **false** | true | ❌ `AssertionError: expected false to be true` |
| 3 | Fix re-applied | **true** | true | ✅ `Tests 1 passed (1)` |

Two successive `focus()` calls on unpatched `QInput` also enqueue two distinct objects (`fn1 === fn2 → false`), confirming the per-call closure.

</details>

<details>
<summary><b>Observable consequence</b></summary>

With a real `<QDialog>` show transition, a `QInput` **outside** the dialog ends up holding focus after the dialog opens — the queued focus survives the `blur()` that was meant to cancel it, and focus escapes the modal.

</details>

<details>
<summary><b>Full suite</b></summary>

```
Test Files  104 passed (104)
     Tests  1179 passed (1179)
```

Run because this component is widely depended upon and the diff is larger than the rest. There is no `QInput.test.js` today, so the probe above is not part of this diff — happy to add the generated scaffold if you prefer.

</details>

