### PR TITLE
fix(date): correct UTC month ends and locale cache

### DIFF
--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -11,17 +11,23 @@ const MILLISECONDS_IN_DAY = 86_400_000,
     /\[((?:[^\]\\]|\\]|\\)*)\]|do|d{1,4}|Mo|M{1,4}|m{1,2}|wo|w{1,2}|Qo|Do|DDDo|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]/g,
   reverseToken =
     /(\[[^\]]*\])|do|d{1,4}|Mo|M{1,4}|m{1,2}|wo|w{1,2}|Qo|Do|DDDo|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]|([.*+:?^,\s${}()|\\]+)/g,
-  regexStore = {}
+  regexStore = new Map()
 
 function getRegexData(mask, dateLocale) {
-  const days = '(' + dateLocale.days.join('|') + ')',
-    key = mask + days
+  const key = JSON.stringify([
+    mask,
+    dateLocale.days,
+    dateLocale.daysShort,
+    dateLocale.months,
+    dateLocale.monthsShort
+  ])
 
-  if (regexStore[key] !== void 0) {
-    return regexStore[key]
+  if (regexStore.has(key)) {
+    return regexStore.get(key)
   }
 
-  const daysShort = '(' + dateLocale.daysShort.join('|') + ')',
+  const days = '(' + dateLocale.days.join('|') + ')',
+    daysShort = '(' + dateLocale.daysShort.join('|') + ')',
     months = '(' + dateLocale.months.join('|') + ')',
     monthsShort = '(' + dateLocale.monthsShort.join('|') + ')'
 
@@ -195,7 +201,7 @@ function getRegexData(mask, dateLocale) {
   })
 
   const res = { map, regex: new RegExp('^' + regexText) }
-  regexStore[key] = res
+  regexStore.set(key, res)
 
   return res
 }
@@ -603,7 +609,7 @@ export function endOfDate(date, unit, utc) {
     }
     case 'month': // oxlint-disable-line no-fallthrough
     case 'months': {
-      t[`${prefix}Date`](daysInMonth(t))
+      t[`${prefix}Date`](getDaysInMonth(t, utc))
     }
     case 'day': // oxlint-disable-line no-fallthrough
     case 'days':
@@ -790,8 +796,19 @@ export function isSameDate(date, date2, unit) {
   return true
 }
 
+function getDaysInMonth(date, utc) {
+  const prefix = utc ? 'UTC' : '',
+    t = new Date(date)
+
+  t[`set${prefix}Date`](1)
+  t[`set${prefix}Month`](t[`get${prefix}Month`]() + 1)
+  t[`set${prefix}Date`](0)
+
+  return t[`get${prefix}Date`]()
+}
+
 export function daysInMonth(date) {
-  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+  return getDaysInMonth(date, false)
 }
 
 function getOrdinal(n) {

--- a/ui/src/utils/date/date.test.js
+++ b/ui/src/utils/date/date.test.js
@@ -85,6 +85,39 @@ describe('[date API]', () => {
           ).toBe(value.getTime())
         }
       )
+
+      test('keeps localized parsers isolated by all embedded locale names', async () => {
+        const { default: enUS } = await import('quasar/lang/en-US.js')
+        const cases = [
+          ['MMMM D YYYY', 'months', 'Alpha 1 2024', 'Beta 1 2024'],
+          ['MMM D YYYY', 'monthsShort', 'Alp 1 2024', 'Bet 1 2024'],
+          ['ddd YYYY-MM-DD', 'daysShort', 'Alp 2024-01-01', 'Bet 2024-01-01'],
+          ['dddd YYYY-MM-DD', 'days', 'Alpha 2024-01-01', 'Beta 2024-01-01']
+        ]
+
+        for (const [mask, localeField, firstValue, secondValue] of cases) {
+          const firstNames = [...enUS.date[localeField]]
+          const secondNames = [...firstNames]
+          firstNames[0] = firstValue.split(' ')[0]
+          secondNames[0] = secondValue.split(' ')[0]
+
+          const firstLocale = {
+            ...enUS.date,
+            [localeField]: firstNames
+          }
+          const secondLocale = {
+            ...enUS.date,
+            [localeField]: secondNames
+          }
+
+          expect(date.extractDate(firstValue, mask, firstLocale)).toStrictEqual(
+            new Date(2024, 0, 1)
+          )
+          expect(
+            date.extractDate(secondValue, mask, secondLocale)
+          ).toStrictEqual(new Date(2024, 0, 1))
+        }
+      })
     })
 
     describe('[(function)buildDate]', () => {
@@ -245,6 +278,12 @@ describe('[date API]', () => {
 
     describe('[(function)endOfDate]', () => {
       const original = new Date('2024-07-14T13:14:15.678Z')
+      const originalTZ = process.env.TZ
+
+      afterEach(() => {
+        if (originalTZ === void 0) delete process.env.TZ
+        else process.env.TZ = originalTZ
+      })
 
       test.each([
         ['year', '2024-12-31T23:59:59.999Z'],
@@ -258,6 +297,25 @@ describe('[date API]', () => {
           expected
         )
         expect(original.toISOString()).toBe('2024-07-14T13:14:15.678Z')
+      })
+
+      test.each([
+        [
+          'America/Los_Angeles',
+          '2024-03-01T00:30:00.000Z',
+          '2024-03-31T23:59:59.999Z'
+        ],
+        [
+          'Pacific/Kiritimati',
+          '2024-01-31T23:30:00.000Z',
+          '2024-01-31T23:59:59.999Z'
+        ]
+      ])('uses the UTC month length in %s', (timezone, value, expected) => {
+        process.env.TZ = timezone
+
+        expect(date.endOfDate(value, 'month', true).toISOString()).toBe(
+          expected
+        )
       })
     })
 


### PR DESCRIPTION
## Summary

- calculate month length with UTC getters/setters when `endOfDate()` operates in UTC
- key localized parsing regexes with every locale array embedded in the expression
- add regressions for UTC/local month-boundary mismatches in positive and negative offsets
- verify parser isolation when full and abbreviated weekday/month names differ

## Root cause and impact

`endOfDate(date, 'month', true)` used UTC setters but called the local-time `daysInMonth()` helper. Near a local/UTC month boundary, it could select the local month's length and return the wrong UTC day.

The localized parser cache keyed expressions with only the mask and full weekday names even though each expression also embeds abbreviated weekdays and full/abbreviated month names. Parsing with a second locale could therefore reuse an incompatible expression and return a wrong date.

This keeps the existing public API intact while making UTC calculations and custom/built-in locale parsing deterministic.

## Validation

- `pnpm test:specs --target utils/date/date` — passed
- focused date suite — 94 tests passed
- `pnpm test` — build and generated Specs validation passed; 104 UI files / 1,185 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed
- `pnpm lint:check` — passed
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized date parsing to prevent locale-specific values from interfering with one another.
  * Corrected month-end calculations across local and UTC time zones.
  * Improved date-format caching for more reliable parsing behavior.

* **Tests**
  * Added coverage for localized date parsing and UTC month-end calculations across multiple time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->