### PR TITLE
fix(icongenie): ignore no-color as profile input

### DIFF
--- a/icongenie/lib/utils/filter-argv-params.js
+++ b/icongenie/lib/utils/filter-argv-params.js
@@ -2,7 +2,7 @@ export function filterArgvParams(argv) {
   const params = {}
 
   Object.keys(argv).forEach(key => {
-    if (key.length > 1 && key !== 'help') {
+    if (key.length > 1 && key !== 'help' && key !== 'noColor') {
       // kebab to camel case
       const prop = key.replaceAll(/(-\w)/g, m => m[1].toUpperCase())
 

--- a/icongenie/test/no-color.test.js
+++ b/icongenie/test/no-color.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { after, test } from 'node:test'
+
+const cliPath = fileURLToPath(new URL('../bin/icongenie.js', import.meta.url))
+const testFolder = mkdtempSync(join(tmpdir(), 'icongenie-no-color-'))
+
+writeFileSync(join(testFolder, 'quasar.config.js'), 'export default {}')
+
+after(() => {
+  rmSync(testFolder, { recursive: true, force: true })
+})
+
+function run(command, args) {
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, command, '--no-color', ...args],
+    {
+      cwd: testFolder,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NO_UPDATE_NOTIFIER: '1'
+      }
+    }
+  )
+
+  assert.equal(
+    result.status,
+    0,
+    [result.stdout, result.stderr].filter(Boolean).join('\n')
+  )
+  assert.equal(result.stdout.includes('\u001B['), false)
+}
+
+test('generate accepts --no-color without adding it to profile params', () => {
+  run('generate', ['--mode', 'spa', '--filter', 'png'])
+})
+
+test('verify accepts --no-color without adding it to profile params', () => {
+  run('verify', ['--mode', 'spa'])
+})
+
+test('profile accepts --no-color without writing it to the profile', () => {
+  run('profile', ['--output', 'test', '--assets', 'spa'])
+
+  const profile = JSON.parse(
+    readFileSync(join(testFolder, 'icongenie-test.json'), 'utf8')
+  )
+
+  assert.equal('noColor' in profile.params, false)
+})


### PR DESCRIPTION
## Summary

- treat `--no-color` as a CLI presentation flag instead of a generation/profile parameter
- remove it centrally before `generate`, `verify`, or `profile` validates its profile object
- add real CLI regressions for all three commands
- verify generated profile JSON does not persist `noColor`

## Root cause and impact

The top-level CLI correctly used `--no-color` to disable colored output, but command argument filtering also forwarded it as `params.noColor`. Profile validation rejects that unknown property, so each documented command failed before doing its work.

Filtering the flag centrally preserves its output behavior while keeping presentation-only state out of generation profiles.

## Validation

- `node --test test/no-color.test.js` — 3 real CLI tests passed (`generate`, `verify`, and `profile`)
- focused Oxfmt and Oxlint checks — passed
- `npm pack --dry-run --json` — passed and includes the corrected runtime helper
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `--no-color` option so it is handled correctly across CLI commands.
  * Ensured command output remains free of ANSI color codes when `--no-color` is enabled.

* **Tests**
  * Added coverage for `--no-color` across generate, verify, and profile commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->