### PR TITLE
test(ui): cover directives

### DIFF
--- a/ui/src/directives/close-popup/ClosePopup.test.js
+++ b/ui/src/directives/close-popup/ClosePopup.test.js
@@ -1,0 +1,99 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import ClosePopup from './ClosePopup.js'
+
+const portalMocks = vi.hoisted(() => ({
+  closePortals: vi.fn(),
+  getPortalProxy: vi.fn()
+}))
+
+vi.mock('../../utils/private.portal/portal.js', () => portalMocks)
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  portalMocks.closePortals.mockReset()
+  portalMocks.getPortalProxy.mockReset()
+  portalMocks.getPortalProxy.mockReturnValue({ name: 'portal' })
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('[ClosePopup API]', () => {
+  describe('[Value]', () => {
+    test('as Boolean', async () => {
+      const TestComponent = defineComponent({
+        template: '<div v-close-popup="val" />',
+        directives: { ClosePopup },
+        setup() {
+          return {
+            val: true
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qclosepopup.depth).toBe(1)
+
+      await wrapper.trigger('click')
+      vi.runAllTimers()
+
+      expect(portalMocks.closePortals).toHaveBeenCalledWith(
+        { name: 'portal' },
+        expect.any(Event),
+        1
+      )
+    })
+
+    test('as Number', async () => {
+      const TestComponent = defineComponent({
+        template: '<div v-close-popup="val" />',
+        directives: { ClosePopup },
+        setup() {
+          return {
+            val: 10
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qclosepopup.depth).toBe(10)
+
+      await wrapper.trigger('keyup', { keyCode: 13 })
+      vi.runAllTimers()
+
+      expect(portalMocks.closePortals).toHaveBeenCalledWith(
+        { name: 'portal' },
+        expect.any(Event),
+        10
+      )
+    })
+
+    test('as String', async () => {
+      const TestComponent = defineComponent({
+        template: '<div v-close-popup="val" />',
+        directives: { ClosePopup },
+        setup() {
+          return {
+            val: 'some-string'
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qclosepopup.depth).toBe(0)
+
+      await wrapper.trigger('click')
+      vi.runAllTimers()
+
+      expect(portalMocks.closePortals).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/ui/src/directives/intersection/Intersection.test.js
+++ b/ui/src/directives/intersection/Intersection.test.js
@@ -1,0 +1,130 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import Intersection from './Intersection.js'
+
+let observers
+
+beforeEach(() => {
+  observers = []
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback, options) {
+        this.callback = callback
+        this.options = options
+        this.observe = vi.fn()
+        this.unobserve = vi.fn()
+        this.disconnect = vi.fn()
+        observers.push(this)
+      }
+    }
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('[Intersection API]', () => {
+  describe('[Value]', () => {
+    test('as Object', () => {
+      const handler = vi.fn(() => true)
+      const root = document.createElement('div')
+      const TestComponent = defineComponent({
+        template: '<div v-intersection="val" />',
+        directives: { Intersection },
+        setup() {
+          return {
+            val: {
+              handler,
+              cfg: {
+                root,
+                rootMargin: '10px 20px 30px 40px',
+                threshold: [0, 0.25, 0.5, 0.75, 1]
+              }
+            }
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const observer = observers[0]
+      const entry = {
+        isIntersecting: false,
+        rootBounds: {}
+      }
+
+      expect(observer.options).toStrictEqual({
+        root,
+        rootMargin: '10px 20px 30px 40px',
+        threshold: [0, 0.25, 0.5, 0.75, 1]
+      })
+      expect(observer.observe).toHaveBeenCalledWith(wrapper.element)
+
+      observer.callback([entry])
+
+      expect(handler).toHaveBeenCalledWith(entry, observer)
+    })
+
+    test('as Function', () => {
+      const handler = vi.fn(() => true)
+      const TestComponent = defineComponent({
+        template: '<div v-intersection="handler" />',
+        directives: { Intersection },
+        setup() {
+          return { handler }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const observer = observers[0]
+      const entry = {
+        isIntersecting: false,
+        rootBounds: {}
+      }
+
+      expect(observer.options).toStrictEqual({
+        root: null,
+        rootMargin: '0px',
+        threshold: 0
+      })
+
+      observer.callback([entry])
+
+      expect(handler).toHaveBeenCalledWith(entry, observer)
+      expect(wrapper.element.__qvisible).toBeDefined()
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)once]', () => {
+      test('has effect', () => {
+        const handler = vi.fn(() => true)
+        const TestComponent = defineComponent({
+          template: '<div v-intersection.once="handler" />',
+          directives: { Intersection },
+          setup() {
+            return { handler }
+          }
+        })
+
+        const wrapper = mount(TestComponent)
+        const observer = observers[0]
+
+        observer.callback([
+          {
+            isIntersecting: true,
+            rootBounds: {}
+          }
+        ])
+
+        expect(handler).toHaveBeenCalledOnce()
+        expect(observer.disconnect).toHaveBeenCalledOnce()
+        expect(wrapper.element.__qvisible).toBeUndefined()
+      })
+    })
+  })
+})

--- a/ui/src/directives/morph/Morph.test.js
+++ b/ui/src/directives/morph/Morph.test.js
@@ -1,0 +1,171 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import Morph from './Morph.js'
+
+function mountModifier(modifier) {
+  const group = `modifier-${modifier.toLowerCase()}`
+  const TestComponent = defineComponent({
+    template: `<div v-morph:item:${group}.${modifier}="model" />`,
+    directives: { Morph },
+    setup() {
+      return {
+        model: 'item'
+      }
+    }
+  })
+
+  return mount(TestComponent)
+}
+
+function expectModifier(modifier) {
+  const wrapper = mountModifier(modifier)
+
+  expect(wrapper.element.__qmorph.opts[modifier]).toBe(true)
+
+  wrapper.unmount()
+}
+
+describe('[Morph API]', () => {
+  describe('[Value]', () => {
+    test('as Object', () => {
+      const onEnd = vi.fn()
+      const TestComponent = defineComponent({
+        template: '<div v-morph:item="val" />',
+        directives: { Morph },
+        setup() {
+          return {
+            val: {
+              group: 'dialogGroup',
+              name: 'btn',
+              model: 'btn',
+              duration: 300,
+              delay: 0,
+              easing: 'ease-in-out',
+              fill: 'none',
+              classes: 'bg-grey-2',
+              style: 'border-radius: 20px',
+              resize: true,
+              useCSS: true,
+              hideFromClone: true,
+              keepToClone: true,
+              tween: true,
+              tweenFromOpacity: 0.6,
+              tweenToOpacity: 0.5,
+              waitFor: 0,
+              onEnd
+            }
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const ctx = wrapper.element.__qmorph
+
+      expect(ctx.name).toBe('btn')
+      expect(ctx.group).toBe('dialogGroup')
+      expect(ctx.model).toBe('btn')
+      expect(ctx.opts).toMatchObject({
+        duration: 300,
+        delay: 0,
+        easing: 'ease-in-out',
+        fill: 'none',
+        classes: 'bg-grey-2',
+        style: 'border-radius: 20px',
+        resize: true,
+        useCSS: true,
+        hideFromClone: true,
+        keepToClone: true,
+        tween: true,
+        tweenFromOpacity: 0.6,
+        tweenToOpacity: 0.5,
+        waitFor: 0,
+        onEnd
+      })
+      expect(wrapper.classes()).not.toContain('q-morph--invisible')
+
+      wrapper.unmount()
+    })
+
+    test('as Any', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-morph:any-value:primitive-group="val" />',
+        directives: { Morph },
+        setup() {
+          return {
+            val: 'any-value'
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const ctx = wrapper.element.__qmorph
+
+      expect(ctx.name).toBe('any-value')
+      expect(ctx.group).toBe('primitive-group')
+      expect(ctx.model).toBe('any-value')
+      expect(wrapper.classes()).not.toContain('q-morph--invisible')
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('[Argument]', () => {
+    test('has effect', () => {
+      const TestComponent = defineComponent({
+        template:
+          '<div v-morph:item:argument-group:450:transitionend="model" />',
+        directives: { Morph },
+        setup() {
+          return {
+            model: 'other'
+          }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const ctx = wrapper.element.__qmorph
+
+      expect(ctx.name).toBe('item')
+      expect(ctx.group).toBe('argument-group')
+      expect(ctx.opts.duration).toBe(450)
+      expect(ctx.opts.waitFor).toBe('transitionend')
+      expect(wrapper.classes()).toContain('q-morph--invisible')
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)resize]', () => {
+      test('has effect', () => {
+        expectModifier('resize')
+      })
+    })
+
+    describe('[(modifier)useCSS]', () => {
+      test('has effect', () => {
+        expectModifier('useCSS')
+      })
+    })
+
+    describe('[(modifier)hideFromClone]', () => {
+      test('has effect', () => {
+        expectModifier('hideFromClone')
+      })
+    })
+
+    describe('[(modifier)keepToClone]', () => {
+      test('has effect', () => {
+        expectModifier('keepToClone')
+      })
+    })
+
+    describe('[(modifier)tween]', () => {
+      test('has effect', () => {
+        expectModifier('tween')
+      })
+    })
+  })
+})

--- a/ui/src/directives/mutation/Mutation.test.js
+++ b/ui/src/directives/mutation/Mutation.test.js
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import Mutation from './Mutation.js'
+
+let observers
+
+beforeEach(() => {
+  observers = []
+
+  vi.stubGlobal(
+    'MutationObserver',
+    class {
+      constructor(callback) {
+        this.callback = callback
+        this.observe = vi.fn((_el, options) => {
+          this.options = options
+        })
+        this.disconnect = vi.fn()
+        observers.push(this)
+      }
+    }
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function mountModifier(modifier) {
+  const handler = vi.fn(() => true)
+  const TestComponent = defineComponent({
+    template: `<div v-mutation.${modifier}="handler" />`,
+    directives: { Mutation },
+    setup() {
+      return { handler }
+    }
+  })
+
+  return {
+    handler,
+    wrapper: mount(TestComponent)
+  }
+}
+
+function expectModifier(modifier) {
+  const { wrapper } = mountModifier(modifier)
+
+  expect(observers[0].options).toStrictEqual({
+    [modifier]: true
+  })
+
+  wrapper.unmount()
+}
+
+describe('[Mutation API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const handler = vi.fn(() => true)
+      const TestComponent = defineComponent({
+        template: '<div v-mutation="handler" />',
+        directives: { Mutation },
+        setup() {
+          return { handler }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      const observer = observers[0]
+      const mutations = [{ type: 'attributes' }]
+
+      expect(observer.observe).toHaveBeenCalledWith(wrapper.element, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+        attributeOldValue: true,
+        characterDataOldValue: true
+      })
+
+      observer.callback(mutations)
+
+      expect(handler).toHaveBeenCalledWith(mutations)
+      expect(wrapper.element.__qmutation).toBeDefined()
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)once]', () => {
+      test('has effect', () => {
+        const { handler, wrapper } = mountModifier('once')
+        const observer = observers[0]
+
+        observer.callback([{ type: 'childList' }])
+
+        expect(handler).toHaveBeenCalledOnce()
+        expect(observer.disconnect).toHaveBeenCalledOnce()
+        expect(wrapper.element.__qmutation).toBeUndefined()
+      })
+    })
+
+    describe('[(modifier)childList]', () => {
+      test('has effect', () => {
+        expectModifier('childList')
+      })
+    })
+
+    describe('[(modifier)subtree]', () => {
+      test('has effect', () => {
+        expectModifier('subtree')
+      })
+    })
+
+    describe('[(modifier)attributes]', () => {
+      test('has effect', () => {
+        expectModifier('attributes')
+      })
+    })
+
+    describe('[(modifier)characterData]', () => {
+      test('has effect', () => {
+        expectModifier('characterData')
+      })
+    })
+
+    describe('[(modifier)attributeOldValue]', () => {
+      test('has effect', () => {
+        expectModifier('attributeOldValue')
+      })
+    })
+
+    describe('[(modifier)characterDataOldValue]', () => {
+      test('has effect', () => {
+        expectModifier('characterDataOldValue')
+      })
+    })
+  })
+})

--- a/ui/src/directives/scroll-fire/ScrollFire.test.js
+++ b/ui/src/directives/scroll-fire/ScrollFire.test.js
@@ -1,0 +1,65 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import ScrollFire from './ScrollFire.js'
+
+let removeEventListener
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  removeEventListener = vi.spyOn(window, 'removeEventListener')
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('[ScrollFire API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const handler = vi.fn()
+      const TestComponent = defineComponent({
+        template: '<div v-scroll-fire="handler" />',
+        directives: { ScrollFire },
+        setup() {
+          return { handler }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+      wrapper.element.getBoundingClientRect = () => ({
+        bottom: 100
+      })
+
+      vi.advanceTimersByTime(25)
+
+      expect(handler).toHaveBeenCalledWith(wrapper.element)
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'scroll',
+        wrapper.element.__qscrollfire.scroll,
+        expect.anything()
+      )
+    })
+
+    test('as undefined', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-scroll-fire />',
+        directives: { ScrollFire }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qscrollfire.handler).toBeUndefined()
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'scroll',
+        wrapper.element.__qscrollfire.scroll,
+        expect.anything()
+      )
+
+      vi.runAllTimers()
+    })
+  })
+})

--- a/ui/src/directives/scroll/Scroll.test.js
+++ b/ui/src/directives/scroll/Scroll.test.js
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import Scroll from './Scroll.js'
+
+let addEventListener
+let removeEventListener
+
+beforeEach(() => {
+  addEventListener = vi.spyOn(window, 'addEventListener')
+  removeEventListener = vi.spyOn(window, 'removeEventListener')
+
+  Object.defineProperties(window, {
+    pageXOffset: {
+      configurable: true,
+      value: 12
+    },
+    pageYOffset: {
+      configurable: true,
+      value: 45
+    }
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('[Scroll API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const handler = vi.fn()
+      const TestComponent = defineComponent({
+        template: '<div v-scroll="handler" />',
+        directives: { Scroll },
+        setup() {
+          return { handler }
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(addEventListener).toHaveBeenCalledWith(
+        'scroll',
+        wrapper.element.__qscroll.scroll,
+        expect.anything()
+      )
+
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(handler).toHaveBeenCalledWith(45, 12)
+
+      wrapper.unmount()
+
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'scroll',
+        expect.any(Function),
+        expect.anything()
+      )
+    })
+
+    test('as undefined', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-scroll />',
+        directives: { Scroll }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qscroll.handler).toBeUndefined()
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'scroll',
+        wrapper.element.__qscroll.scroll,
+        expect.anything()
+      )
+    })
+  })
+})

--- a/ui/src/directives/touch-hold/TouchHold.test.js
+++ b/ui/src/directives/touch-hold/TouchHold.test.js
@@ -1,0 +1,138 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { client } from '../../plugins/platform/Platform.js'
+import TouchHold from './TouchHold.js'
+
+let originalHasTouch
+
+beforeEach(() => {
+  originalHasTouch = client.has.touch
+  client.has.touch = false
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  client.has.touch = originalHasTouch
+  document.body.classList.remove('non-selectable')
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+function mountTouchHold(template, handler = vi.fn()) {
+  const TestComponent = defineComponent({
+    template,
+    directives: { TouchHold },
+    setup() {
+      return { handler }
+    }
+  })
+
+  return {
+    handler,
+    wrapper: mount(TestComponent)
+  }
+}
+
+function getMainEvent(ctx, name) {
+  return ctx.__q_main_evt.find(event => event[1] === name)
+}
+
+describe('[TouchHold API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const { handler, wrapper } = mountTouchHold(
+        '<div v-touch-hold.mouse="handler" />'
+      )
+
+      wrapper.element.dispatchEvent(
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          button: 0,
+          clientX: 10,
+          clientY: 20
+        })
+      )
+      vi.advanceTimersByTime(600)
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mouse: true,
+          touch: false,
+          position: {
+            left: 10,
+            top: 20
+          },
+          duration: 600
+        })
+      )
+    })
+
+    test('as undefined', () => {
+      const { wrapper } = mountTouchHold('<div v-touch-hold.mouse />')
+
+      wrapper.element.dispatchEvent(
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          button: 0
+        })
+      )
+
+      expect(wrapper.element.__qtouchhold.handler).toBeUndefined()
+      expect(wrapper.element.__qtouchhold.timer).toBeUndefined()
+    })
+  })
+
+  describe('[Argument]', () => {
+    test('has effect', () => {
+      const { wrapper } = mountTouchHold(
+        '<div v-touch-hold:25:11:13.mouse="handler" />'
+      )
+      const ctx = wrapper.element.__qtouchhold
+
+      expect(ctx.duration).toBe(25)
+      expect(ctx.touchSensitivity).toBe(11)
+      expect(ctx.mouseSensitivity).toBe(13)
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)capture]', () => {
+      test('has effect', () => {
+        client.has.touch = true
+        const { wrapper } = mountTouchHold(
+          '<div v-touch-hold.capture="handler" />'
+        )
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchhold, 'touchstart')[3]
+        ).toBe('passiveCapture')
+      })
+    })
+
+    describe('[(modifier)mouse]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchHold(
+          '<div v-touch-hold.mouse="handler" />'
+        )
+
+        expect(getMainEvent(wrapper.element.__qtouchhold, 'mousedown')[3]).toBe(
+          'passive'
+        )
+      })
+    })
+
+    describe('[(modifier)mouseCapture]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchHold(
+          '<div v-touch-hold.mouse.mouseCapture="handler" />'
+        )
+
+        expect(getMainEvent(wrapper.element.__qtouchhold, 'mousedown')[3]).toBe(
+          'passiveCapture'
+        )
+      })
+    })
+  })
+})

--- a/ui/src/directives/touch-hold/TouchHold.test.js
+++ b/ui/src/directives/touch-hold/TouchHold.test.js
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
+import { getMainEvent } from 'testing/runtime/directive.js'
+
 import { client } from '../../plugins/platform/Platform.js'
 import TouchHold from './TouchHold.js'
 
@@ -35,10 +37,6 @@ function mountTouchHold(template, handler = vi.fn()) {
   }
 }
 
-function getMainEvent(ctx, name) {
-  return ctx.__q_main_evt.find(event => event[1] === name)
-}
-
 describe('[TouchHold API]', () => {
   describe('[Value]', () => {
     test('as Function', () => {
@@ -67,6 +65,8 @@ describe('[TouchHold API]', () => {
           duration: 600
         })
       )
+
+      wrapper.unmount()
     })
 
     test('as undefined', () => {

--- a/ui/src/directives/touch-pan/TouchPan.test.js
+++ b/ui/src/directives/touch-pan/TouchPan.test.js
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
+import { getMainEvent } from 'testing/runtime/directive.js'
+
 import { client } from '../../plugins/platform/Platform.js'
 import TouchPan from './TouchPan.js'
 
@@ -39,10 +41,6 @@ function mountTouchPan(modifiers = 'mouse', handler = vi.fn(() => true)) {
   }
 }
 
-function getMainEvent(ctx, name) {
-  return ctx.__q_main_evt.find(event => event[1] === name)
-}
-
 function dispatchMousePan(wrapper, x, y) {
   wrapper.element.dispatchEvent(
     new MouseEvent('mousedown', {
@@ -57,6 +55,13 @@ function dispatchMousePan(wrapper, x, y) {
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
+      clientX: x,
+      clientY: y
+    })
+  )
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
       clientX: x,
       clientY: y
     })
@@ -178,9 +183,25 @@ describe('[TouchPan API]', () => {
 
     describe('[(modifier)mouseAllDir]', () => {
       test('has effect', () => {
-        const { wrapper } = mountTouchPan('right.mouse.mouseAllDir')
+        const strict = mountTouchPan('right.mouse')
 
-        expect(wrapper.element.__qtouchpan.modifiers.mouseAllDir).toBe(true)
+        dispatchMousePan(strict.wrapper, 5, 40)
+
+        expect(strict.handler).not.toHaveBeenCalled()
+
+        const mouseAllDir = mountTouchPan('right.mouse.mouseAllDir')
+
+        dispatchMousePan(mouseAllDir.wrapper, 5, 40)
+
+        expect(mouseAllDir.handler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            direction: 'right',
+            distance: {
+              x: 5,
+              y: 40
+            }
+          })
+        )
       })
     })
 

--- a/ui/src/directives/touch-pan/TouchPan.test.js
+++ b/ui/src/directives/touch-pan/TouchPan.test.js
@@ -1,0 +1,242 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { client } from '../../plugins/platform/Platform.js'
+import TouchPan from './TouchPan.js'
+
+let originalHasTouch
+
+beforeEach(() => {
+  originalHasTouch = client.has.touch
+  client.has.touch = false
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  client.has.touch = originalHasTouch
+  document.body.classList.remove(
+    'no-pointer-events--children',
+    'non-selectable'
+  )
+  document.documentElement.style.cursor = ''
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+function mountTouchPan(modifiers = 'mouse', handler = vi.fn(() => true)) {
+  const TestComponent = defineComponent({
+    template: `<div v-touch-pan.${modifiers}="handler" />`,
+    directives: { TouchPan },
+    setup() {
+      return { handler }
+    }
+  })
+
+  return {
+    handler,
+    wrapper: mount(TestComponent)
+  }
+}
+
+function getMainEvent(ctx, name) {
+  return ctx.__q_main_evt.find(event => event[1] === name)
+}
+
+function dispatchMousePan(wrapper, x, y) {
+  wrapper.element.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 0,
+      clientY: 0
+    })
+  )
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y
+    })
+  )
+}
+
+function expectDirection(modifier, expected) {
+  const { wrapper } = mountTouchPan(`${modifier}.mouse`)
+
+  expect(wrapper.element.__qtouchpan.direction).toMatchObject(expected)
+
+  wrapper.unmount()
+}
+
+describe('[TouchPan API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const { handler, wrapper } = mountTouchPan()
+
+      dispatchMousePan(wrapper, 40, 5)
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'right',
+          isFirst: true,
+          mouse: true,
+          touch: false
+        })
+      )
+    })
+
+    test('as undefined', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-touch-pan.mouse />',
+        directives: { TouchPan }
+      })
+      const wrapper = mount(TestComponent)
+
+      wrapper.element.dispatchEvent(
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          button: 0
+        })
+      )
+
+      expect(wrapper.element.__qtouchpan.handler).toBeUndefined()
+      expect(wrapper.element.__qtouchpan.event).toBeUndefined()
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)stop]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan('stop.mouse')
+        const event = new MouseEvent('touchstart', {
+          cancelable: true,
+          clientX: 0,
+          clientY: 0
+        })
+
+        wrapper.element.__qtouchpan.start(event, false)
+
+        expect(event.cancelBubble).toBe(true)
+      })
+    })
+
+    describe('[(modifier)prevent]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan('prevent.mouse')
+        const ctx = wrapper.element.__qtouchpan
+        const startEvent = new MouseEvent('touchstart', {
+          cancelable: true,
+          clientX: 0,
+          clientY: 0
+        })
+        const moveEvent = new MouseEvent('touchmove', {
+          cancelable: true,
+          clientX: 20,
+          clientY: 5
+        })
+
+        ctx.start(startEvent, false)
+        ctx.move(moveEvent)
+
+        expect(moveEvent.defaultPrevented).toBe(true)
+      })
+    })
+
+    describe('[(modifier)capture]', () => {
+      test('has effect', () => {
+        client.has.touch = true
+        const { wrapper } = mountTouchPan('capture')
+
+        expect(getMainEvent(wrapper.element.__qtouchpan, 'touchstart')[3]).toBe(
+          'passiveCapture'
+        )
+      })
+    })
+
+    describe('[(modifier)mouse]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan()
+
+        expect(getMainEvent(wrapper.element.__qtouchpan, 'mousedown')[3]).toBe(
+          'passive'
+        )
+      })
+    })
+
+    describe('[(modifier)mouseCapture]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan('mouse.mouseCapture')
+
+        expect(getMainEvent(wrapper.element.__qtouchpan, 'mousedown')[3]).toBe(
+          'passiveCapture'
+        )
+      })
+    })
+
+    describe('[(modifier)mouseAllDir]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan('right.mouse.mouseAllDir')
+
+        expect(wrapper.element.__qtouchpan.modifiers.mouseAllDir).toBe(true)
+      })
+    })
+
+    describe('[(modifier)preserveCursor]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchPan('mouse.preserveCursor')
+        document.documentElement.style.cursor = 'crosshair'
+
+        dispatchMousePan(wrapper, 40, 5)
+
+        expect(document.documentElement.style.cursor).toBe('crosshair')
+      })
+    })
+
+    describe('[(modifier)horizontal]', () => {
+      test('has effect', () => {
+        expectDirection('horizontal', {
+          horizontal: true,
+          left: true,
+          right: true
+        })
+      })
+    })
+
+    describe('[(modifier)vertical]', () => {
+      test('has effect', () => {
+        expectDirection('vertical', {
+          down: true,
+          up: true,
+          vertical: true
+        })
+      })
+    })
+
+    describe('[(modifier)up]', () => {
+      test('has effect', () => {
+        expectDirection('up', { up: true })
+      })
+    })
+
+    describe('[(modifier)right]', () => {
+      test('has effect', () => {
+        expectDirection('right', { right: true })
+      })
+    })
+
+    describe('[(modifier)down]', () => {
+      test('has effect', () => {
+        expectDirection('down', { down: true })
+      })
+    })
+
+    describe('[(modifier)left]', () => {
+      test('has effect', () => {
+        expectDirection('left', { left: true })
+      })
+    })
+  })
+})

--- a/ui/src/directives/touch-repeat/TouchRepeat.test.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.test.js
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
+import { getMainEvent } from 'testing/runtime/directive.js'
+
 import { client } from '../../plugins/platform/Platform.js'
 import TouchRepeat from './TouchRepeat.js'
 
@@ -34,10 +36,6 @@ function mountTouchRepeat(template, handler = vi.fn()) {
     handler,
     wrapper: mount(TestComponent)
   }
-}
-
-function getMainEvent(ctx, name) {
-  return ctx.__q_main_evt.find(event => event[1] === name)
 }
 
 function dispatchMouseDown(wrapper) {
@@ -82,6 +80,8 @@ describe('[TouchRepeat API]', () => {
       vi.advanceTimersByTime(600)
 
       expect(handler).toHaveBeenCalledTimes(2)
+
+      wrapper.unmount()
     })
 
     test('as undefined', () => {
@@ -112,6 +112,8 @@ describe('[TouchRepeat API]', () => {
       vi.advanceTimersByTime(40)
 
       expect(handler).toHaveBeenCalledTimes(2)
+
+      wrapper.unmount()
     })
   })
 

--- a/ui/src/directives/touch-repeat/TouchRepeat.test.js
+++ b/ui/src/directives/touch-repeat/TouchRepeat.test.js
@@ -1,0 +1,228 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { client } from '../../plugins/platform/Platform.js'
+import TouchRepeat from './TouchRepeat.js'
+
+let originalHasTouch
+
+beforeEach(() => {
+  originalHasTouch = client.has.touch
+  client.has.touch = false
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  client.has.touch = originalHasTouch
+  document.body.classList.remove('non-selectable')
+  document.documentElement.style.cursor = ''
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+function mountTouchRepeat(template, handler = vi.fn()) {
+  const TestComponent = defineComponent({
+    template,
+    directives: { TouchRepeat },
+    setup() {
+      return { handler }
+    }
+  })
+
+  return {
+    handler,
+    wrapper: mount(TestComponent)
+  }
+}
+
+function getMainEvent(ctx, name) {
+  return ctx.__q_main_evt.find(event => event[1] === name)
+}
+
+function dispatchMouseDown(wrapper) {
+  wrapper.element.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 10,
+      clientY: 20
+    })
+  )
+}
+
+function expectKeyboard(modifier, expected) {
+  const { wrapper } = mountTouchRepeat(
+    `<div v-touch-repeat.${modifier}="handler" />`
+  )
+
+  expect(wrapper.element.__qtouchrepeat.keyboard).toStrictEqual(expected)
+
+  wrapper.unmount()
+}
+
+describe('[TouchRepeat API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const { handler, wrapper } = mountTouchRepeat(
+        '<div v-touch-repeat.mouse="handler" />'
+      )
+
+      dispatchMouseDown(wrapper)
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mouse: true,
+          repeatCount: 1,
+          touch: false
+        })
+      )
+
+      vi.advanceTimersByTime(600)
+
+      expect(handler).toHaveBeenCalledTimes(2)
+    })
+
+    test('as undefined', () => {
+      const { wrapper } = mountTouchRepeat('<div v-touch-repeat.mouse />')
+
+      dispatchMouseDown(wrapper)
+
+      expect(wrapper.element.__qtouchrepeat.handler).toBeUndefined()
+      expect(wrapper.element.__qtouchrepeat.event).toBeUndefined()
+    })
+  })
+
+  describe('[Argument]', () => {
+    test('has effect', () => {
+      const { handler, wrapper } = mountTouchRepeat(
+        '<div v-touch-repeat:100:40:20.mouse="handler" />'
+      )
+
+      dispatchMouseDown(wrapper)
+      vi.advanceTimersByTime(99)
+
+      expect(handler).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+
+      expect(handler).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(40)
+
+      expect(handler).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)capture]', () => {
+      test('has effect', () => {
+        client.has.touch = true
+        const { wrapper } = mountTouchRepeat(
+          '<div v-touch-repeat.capture="handler" />'
+        )
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchrepeat, 'touchstart')[3]
+        ).toBe('passiveCapture')
+      })
+    })
+
+    describe('[(modifier)mouse]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchRepeat(
+          '<div v-touch-repeat.mouse="handler" />'
+        )
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchrepeat, 'mousedown')[3]
+        ).toBe('passive')
+      })
+    })
+
+    describe('[(modifier)mouseCapture]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchRepeat(
+          '<div v-touch-repeat.mouse.mouseCapture="handler" />'
+        )
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchrepeat, 'mousedown')[3]
+        ).toBe('passiveCapture')
+      })
+    })
+
+    describe('[(modifier)keyCapture]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchRepeat(
+          '<div v-touch-repeat.enter.keyCapture="handler" />'
+        )
+
+        expect(getMainEvent(wrapper.element.__qtouchrepeat, 'keydown')[3]).toBe(
+          'notPassiveCapture'
+        )
+      })
+    })
+
+    describe('[(modifier)esc]', () => {
+      test('has effect', () => {
+        expectKeyboard('esc', [27])
+      })
+    })
+
+    describe('[(modifier)tab]', () => {
+      test('has effect', () => {
+        expectKeyboard('tab', [9])
+      })
+    })
+
+    describe('[(modifier)enter]', () => {
+      test('has effect', () => {
+        expectKeyboard('enter', [13])
+      })
+    })
+
+    describe('[(modifier)space]', () => {
+      test('has effect', () => {
+        expectKeyboard('space', [32])
+      })
+    })
+
+    describe('[(modifier)up]', () => {
+      test('has effect', () => {
+        expectKeyboard('up', [38])
+      })
+    })
+
+    describe('[(modifier)left]', () => {
+      test('has effect', () => {
+        expectKeyboard('left', [37])
+      })
+    })
+
+    describe('[(modifier)right]', () => {
+      test('has effect', () => {
+        expectKeyboard('right', [39])
+      })
+    })
+
+    describe('[(modifier)down]', () => {
+      test('has effect', () => {
+        expectKeyboard('down', [40])
+      })
+    })
+
+    describe('[(modifier)delete]', () => {
+      test('has effect', () => {
+        expectKeyboard('delete', [8, 46])
+      })
+    })
+
+    describe('[(modifier)[keycode]]', () => {
+      test('has effect', () => {
+        expectKeyboard('10', [10])
+      })
+    })
+  })
+})

--- a/ui/src/directives/touch-swipe/TouchSwipe.test.js
+++ b/ui/src/directives/touch-swipe/TouchSwipe.test.js
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
+import { getMainEvent } from 'testing/runtime/directive.js'
+
 import { client } from '../../plugins/platform/Platform.js'
 import TouchSwipe from './TouchSwipe.js'
 
@@ -39,10 +41,6 @@ function mountTouchSwipe(modifiers = 'mouse', handler = vi.fn()) {
   }
 }
 
-function getMainEvent(ctx, name) {
-  return ctx.__q_main_evt.find(event => event[1] === name)
-}
-
 function dispatchMouseSwipe(wrapper, x, y) {
   wrapper.element.dispatchEvent(
     new MouseEvent('mousedown', {
@@ -58,6 +56,13 @@ function dispatchMouseSwipe(wrapper, x, y) {
     new MouseEvent('mousemove', {
       bubbles: true,
       cancelable: true,
+      clientX: x,
+      clientY: y
+    })
+  )
+  document.dispatchEvent(
+    new MouseEvent('mouseup', {
+      bubbles: true,
       clientX: x,
       clientY: y
     })

--- a/ui/src/directives/touch-swipe/TouchSwipe.test.js
+++ b/ui/src/directives/touch-swipe/TouchSwipe.test.js
@@ -1,0 +1,210 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { client } from '../../plugins/platform/Platform.js'
+import TouchSwipe from './TouchSwipe.js'
+
+let originalHasTouch
+
+beforeEach(() => {
+  originalHasTouch = client.has.touch
+  client.has.touch = false
+  vi.useFakeTimers()
+  vi.setSystemTime(1000)
+})
+
+afterEach(() => {
+  client.has.touch = originalHasTouch
+  document.body.classList.remove(
+    'no-pointer-events--children',
+    'non-selectable'
+  )
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+function mountTouchSwipe(modifiers = 'mouse', handler = vi.fn()) {
+  const TestComponent = defineComponent({
+    template: `<div v-touch-swipe.${modifiers}="handler" />`,
+    directives: { TouchSwipe },
+    setup() {
+      return { handler }
+    }
+  })
+
+  return {
+    handler,
+    wrapper: mount(TestComponent)
+  }
+}
+
+function getMainEvent(ctx, name) {
+  return ctx.__q_main_evt.find(event => event[1] === name)
+}
+
+function dispatchMouseSwipe(wrapper, x, y) {
+  wrapper.element.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 0,
+      clientY: 0
+    })
+  )
+  vi.advanceTimersByTime(100)
+  document.dispatchEvent(
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y
+    })
+  )
+}
+
+function expectDirection(modifier, expected) {
+  const { wrapper } = mountTouchSwipe(`${modifier}.mouse`)
+
+  expect(wrapper.element.__qtouchswipe.direction).toMatchObject(expected)
+
+  wrapper.unmount()
+}
+
+describe('[TouchSwipe API]', () => {
+  describe('[Value]', () => {
+    test('as Function', () => {
+      const { handler, wrapper } = mountTouchSwipe()
+
+      dispatchMouseSwipe(wrapper, 100, 5)
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          direction: 'right',
+          distance: {
+            x: 100,
+            y: 5
+          },
+          duration: 100,
+          mouse: true,
+          touch: false
+        })
+      )
+    })
+
+    test('as undefined', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-touch-swipe.mouse />',
+        directives: { TouchSwipe }
+      })
+      const wrapper = mount(TestComponent)
+
+      wrapper.element.dispatchEvent(
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          button: 0
+        })
+      )
+
+      expect(wrapper.element.__qtouchswipe.handler).toBeUndefined()
+      expect(wrapper.element.__qtouchswipe.event).toBeUndefined()
+    })
+  })
+
+  describe('[Argument]', () => {
+    test('has effect', () => {
+      const TestComponent = defineComponent({
+        template: '<div v-touch-swipe:1:12:80.mouse="handler" />',
+        directives: { TouchSwipe },
+        setup() {
+          return {
+            handler: vi.fn()
+          }
+        }
+      })
+      const wrapper = mount(TestComponent)
+
+      expect(wrapper.element.__qtouchswipe.sensitivity).toStrictEqual([
+        1, 12, 80
+      ])
+    })
+  })
+
+  describe('[Modifiers]', () => {
+    describe('[(modifier)capture]', () => {
+      test('has effect', () => {
+        client.has.touch = true
+        const { wrapper } = mountTouchSwipe('capture')
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchswipe, 'touchstart')[3]
+        ).toBe('passiveCapture')
+      })
+    })
+
+    describe('[(modifier)mouse]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchSwipe()
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchswipe, 'mousedown')[3]
+        ).toBe('passive')
+      })
+    })
+
+    describe('[(modifier)mouseCapture]', () => {
+      test('has effect', () => {
+        const { wrapper } = mountTouchSwipe('mouse.mouseCapture')
+
+        expect(
+          getMainEvent(wrapper.element.__qtouchswipe, 'mousedown')[3]
+        ).toBe('passiveCapture')
+      })
+    })
+
+    describe('[(modifier)horizontal]', () => {
+      test('has effect', () => {
+        expectDirection('horizontal', {
+          horizontal: true,
+          left: true,
+          right: true
+        })
+      })
+    })
+
+    describe('[(modifier)vertical]', () => {
+      test('has effect', () => {
+        expectDirection('vertical', {
+          down: true,
+          up: true,
+          vertical: true
+        })
+      })
+    })
+
+    describe('[(modifier)up]', () => {
+      test('has effect', () => {
+        expectDirection('up', { up: true })
+      })
+    })
+
+    describe('[(modifier)right]', () => {
+      test('has effect', () => {
+        expectDirection('right', { right: true })
+      })
+    })
+
+    describe('[(modifier)down]', () => {
+      test('has effect', () => {
+        expectDirection('down', { down: true })
+      })
+    })
+
+    describe('[(modifier)left]', () => {
+      test('has effect', () => {
+        expectDirection('left', { left: true })
+      })
+    })
+  })
+})

--- a/ui/testing/runtime/directive.js
+++ b/ui/testing/runtime/directive.js
@@ -1,0 +1,3 @@
+export function getMainEvent(ctx, name) {
+  return ctx.__q_main_evt.find(event => event[1] === name)
+}


### PR DESCRIPTION
## Summary

- add generated-spec-compliant behavioral tests for the 10 directives that did
  not yet have adjacent test files
- cover public values, arguments, modifiers, event options, cleanup, observer
  configuration, gesture payloads, and keyboard mappings
- preserve every `describe()` identifier and hierarchy required by the Specs
  generator, with no skipped or todo tests

## Motivation

The directive category was the smallest complete type-scoped group still
missing generated test files. Covering it separately keeps the test expansion
reviewable and avoids a monolithic generated-test PR.

This changes tests only; it does not change public API or runtime behavior.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target directives`
- focused Vitest run: 10 files, 76 tests passed
- root `pnpm test`: 114 UI files / 1,258 UI tests, 10 Vite usage tests, and 75
  Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest suites for multiple Vue directives: popup closing, intersection observation, morphing, mutation observation, scrolling, touch-hold, touch-pan, touch-repeat, and touch-swipe.
  * Validated handler invocation, keyboard/mouse/touch gesture behavior, directive configuration parsing, modifiers affecting listener options and one-time behavior, and proper observer/event cleanup.
* **Chores**
  * Added a small testing helper to retrieve registered “main” directive events for assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->