### PR TITLE
fix(ui): filter build sources by relative path

### DIFF
--- a/ui/build/build.transforms.js
+++ b/ui/build/build.transforms.js
@@ -28,8 +28,8 @@ function lowerCamelCase(name) {
 
 function addComponents(map, autoImport) {
   globSync('src/components/*/Q*.js', { cwd: rootFolder, absolute: true })
-    .filter(filterOutPrivateFiles)
     .map(relative)
+    .filter(filterOutPrivateFiles)
     .forEach(file => {
       const name = getWithoutExtension(path.basename(file)),
         kebab = kebabCase(name)
@@ -45,8 +45,8 @@ function addComponents(map, autoImport) {
 
 function addDirectives(map, autoImport) {
   globSync('src/directives/*/*.js', { cwd: rootFolder, absolute: true })
-    .filter(filterOutPrivateFiles)
     .map(relative)
+    .filter(filterOutPrivateFiles)
     .forEach(file => {
       const name = getWithoutExtension(path.basename(file)),
         kebab = 'v-' + kebabCase(name)
@@ -60,8 +60,8 @@ function addDirectives(map, autoImport) {
 
 function addPlugins(map) {
   globSync('src/plugins/*/*.js', { cwd: rootFolder, absolute: true })
-    .filter(filterOutPrivateFiles)
     .map(relative)
+    .filter(filterOutPrivateFiles)
     .forEach(file => {
       const name = getWithoutExtension(path.basename(file))
       map[name] = file
@@ -70,8 +70,8 @@ function addPlugins(map) {
 
 function addComposables(map) {
   globSync('src/composables/*/*.js', { cwd: rootFolder, absolute: true })
-    .filter(filterOutPrivateFiles)
     .map(relative)
+    .filter(filterOutPrivateFiles)
     .forEach(file => {
       const name = getWithoutExtension(path.basename(file))
       map[lowerCamelCase(name)] = file
@@ -80,8 +80,8 @@ function addComposables(map) {
 
 function addUtils(map) {
   globSync('src/utils/*/*.js', { cwd: rootFolder, absolute: true })
-    .filter(filterOutPrivateFiles)
     .map(relative)
+    .filter(filterOutPrivateFiles)
     .forEach(file => {
       const name = getWithoutExtension(path.basename(file))
       map[name === 'open-url' ? 'openURL' : lowerCamelCase(name)] = file


### PR DESCRIPTION
## Summary

- convert discovered UI source files to paths relative to `ui` before applying
  the existing `test|private` exclusion
- preserve the intended exclusion of test and private source files
- prevent parent checkout/worktree directory names from affecting generated
  import maps

## Why this failed for us

While preparing the type-scoped directive test PR, the worktree was named:

```text
/home/jeff/git/github/jeff/quasar-generated-tests
```

`build.transforms.js` asked `tinyglobby` for absolute paths, then passed those
paths to `filterOutPrivateFiles()`. Its existing `/test|private/` expression
therefore matched `quasar-generated-tests` in every absolute path and rejected
all public components, directives, plugins, composables, and utilities.

The UI build still completed, but `auto-import.json` was only 110 bytes and
contained empty `()` expressions. Fixture-based tests then failed because
components such as `QBreadcrumbs` and `QDialog` could not be resolved.

Mapping each result to its UI-relative path before filtering makes the filter
depend only on repository source paths.

## Validation

- moved the final worktree to a real path named
  `quasar-build-test-path` and ran `pnpm --filter quasar build`
- the test-path build produced the complete transform artifacts:
  - `auto-import.json`: 12,618 bytes
  - `import-map.json`: 9,696 bytes
- confirmed `QBreadcrumbs` and `QDialog` remained present while private/test
  sources remained excluded
- confirmed both transform files were byte-for-byte identical to artifacts
  generated from a neutral checkout path
- root `pnpm test`:
  - 104 UI files / 1,182 UI tests passed
  - 10 Vite usage tests passed
  - 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`

This does not change Quasar's public API or runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic discovery of components, directives, plugins, composables, and utilities.
  * Private files are now consistently excluded during import and transform map generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->