### PR TITLE
test(ui): cover plugins

### DIFF
--- a/ui/src/plugins/bottom-sheet/BottomSheet.test.js
+++ b/ui/src/plugins/bottom-sheet/BottomSheet.test.js
@@ -1,0 +1,62 @@
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import BottomSheet from './BottomSheet.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { BottomSheet } })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.runAllTimers()
+  vi.useRealTimers()
+})
+
+describe('[BottomSheet API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(BottomSheet.create).toBe(wrapper.vm.$q.bottomSheet)
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)create]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        const api = BottomSheet.create({
+          title: 'Share',
+          message: 'Please select how to share',
+          actions: [{ label: 'Facebook', icon: 'share' }],
+          grid: true
+        })
+
+        expect(api).toBeTypeOf('object')
+        expect(Object.values(api)).not.toHaveLength(0)
+        expect(api).$objectValues(expect.any(Function))
+
+        await nextTick()
+        await nextTick()
+
+        expect(document.querySelector('.q-bottom-sheet--grid')).not.toBe(null)
+        expect(document.body.textContent).toContain('Facebook')
+
+        api.hide()
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(document.querySelector('.q-bottom-sheet--grid')).toBe(null)
+      })
+    })
+  })
+})

--- a/ui/src/plugins/bottom-sheet/component/BottomSheetComponent.test.js
+++ b/ui/src/plugins/bottom-sheet/component/BottomSheetComponent.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+
+import BottomSheetComponent from './BottomSheetComponent.js'
+
+describe('[BottomSheetComponent API]', () => {
+  describe('[Variables]', () => {
+    describe('[(variable)default]', () => {
+      test('is defined correctly', () => {
+        expect(BottomSheetComponent).toBeTypeOf('object')
+        expect(BottomSheetComponent.name).toBeTypeOf('string')
+        expect(BottomSheetComponent.props).$props()
+        expect(BottomSheetComponent.emits).$emits()
+      })
+    })
+  })
+})

--- a/ui/src/plugins/cookies/Cookies.test.js
+++ b/ui/src/plugins/cookies/Cookies.test.js
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import Cookies, { getObject } from './Cookies.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { Cookies } })
+
+const cookieNames = [
+  'q-test-get',
+  'q-test-get-all',
+  'q-test-set',
+  'q-test-has',
+  'q-test-remove'
+]
+
+afterEach(() => {
+  cookieNames.forEach(name => {
+    Cookies.remove(name)
+  })
+})
+
+describe('[Cookies API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(wrapper.vm.$q.cookies).toBe(Cookies)
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)get]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        Cookies.set('q-test-get', { user: 'john' })
+
+        expect(Cookies.get('q-test-get')).toStrictEqual({ user: 'john' })
+        expect(Cookies.get('q-test-missing')).toBe(null)
+      })
+    })
+
+    describe('[(method)getAll]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        Cookies.set('q-test-get-all', 'value')
+
+        expect(Cookies.getAll()).toMatchObject({
+          'q-test-get-all': 'value'
+        })
+      })
+    })
+
+    describe('[(method)set]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        expect(
+          Cookies.set('q-test-set', ['one', 'two'], {
+            sameSite: 'Lax'
+          })
+        ).toBeUndefined()
+
+        expect(Cookies.get('q-test-set')).toStrictEqual(['one', 'two'])
+      })
+    })
+
+    describe('[(method)has]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        expect(Cookies.has('q-test-has')).toBe(false)
+
+        Cookies.set('q-test-has', 'present')
+
+        expect(Cookies.has('q-test-has')).toBe(true)
+      })
+    })
+
+    describe('[(method)remove]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        Cookies.set('q-test-remove', 'present')
+        expect(Cookies.has('q-test-remove')).toBe(true)
+
+        expect(Cookies.remove('q-test-remove')).toBeUndefined()
+        expect(Cookies.has('q-test-remove')).toBe(false)
+      })
+    })
+
+    describe('[(method)parseSSR]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+        const ssrContext = {
+          req: {
+            headers: {
+              cookie: 'userId=john12'
+            }
+          },
+          res: {
+            setHeader: vi.fn()
+          }
+        }
+        // parseSSR() delegates to getObject() and is only attached to the
+        // public plugin in SSR builds.
+        const cookies = getObject(ssrContext)
+
+        expect(cookies.get('userId')).toBe('john12')
+
+        cookies.set('theme', 'dark')
+
+        expect(ssrContext.res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+          'theme=dark'
+        ])
+        expect(ssrContext.req.headers.cookie).toBe('theme=dark; userId=john12')
+      })
+
+      test('ignores malformed cookie encoding', () => {
+        const cookies = getObject({
+          req: {
+            headers: {
+              cookie: 'broken=%E0%A4%A'
+            }
+          },
+          res: {
+            setHeader: vi.fn()
+          }
+        })
+
+        expect(cookies.get('broken')).toBe(null)
+      })
+    })
+  })
+})

--- a/ui/src/plugins/dialog/Dialog.test.js
+++ b/ui/src/plugins/dialog/Dialog.test.js
@@ -1,0 +1,63 @@
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import Dialog from './Dialog.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { Dialog } })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.runAllTimers()
+  vi.useRealTimers()
+})
+
+describe('[Dialog API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(Dialog.create).toBe(wrapper.vm.$q.dialog)
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)create]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        const api = Dialog.create({
+          title: 'Continue?',
+          message: 'Are you certain you want to continue?',
+          progress: false,
+          ok: 'Continue',
+          cancel: 'Cancel'
+        })
+
+        expect(api).toBeTypeOf('object')
+        expect(Object.values(api)).not.toHaveLength(0)
+        expect(api).$objectValues(expect.any(Function))
+
+        await nextTick()
+        await nextTick()
+
+        expect(document.querySelector('.q-dialog-plugin')).not.toBe(null)
+        expect(document.body.textContent).toContain('Continue?')
+
+        api.hide()
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(document.querySelector('.q-dialog-plugin')).toBe(null)
+      })
+    })
+  })
+})

--- a/ui/src/plugins/dialog/component/DialogPluginComponent.test.js
+++ b/ui/src/plugins/dialog/component/DialogPluginComponent.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+
+import DialogPluginComponent from './DialogPluginComponent.js'
+
+describe('[DialogPluginComponent API]', () => {
+  describe('[Variables]', () => {
+    describe('[(variable)default]', () => {
+      test('is defined correctly', () => {
+        expect(DialogPluginComponent).toBeTypeOf('object')
+        expect(DialogPluginComponent.name).toBeTypeOf('string')
+        expect(DialogPluginComponent.props).$props()
+        expect(DialogPluginComponent.emits).$emits()
+      })
+    })
+  })
+})

--- a/ui/src/plugins/loading-bar/LoadingBar.test.js
+++ b/ui/src/plugins/loading-bar/LoadingBar.test.js
@@ -1,0 +1,114 @@
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import LoadingBar from './LoadingBar.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { LoadingBar } })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  if (LoadingBar.isActive) {
+    LoadingBar.stop()
+  }
+  vi.runAllTimers()
+  vi.useRealTimers()
+})
+
+describe('[LoadingBar API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(LoadingBar).toBe(wrapper.vm.$q.loadingBar)
+    })
+  })
+
+  describe('[Props]', () => {
+    describe('[(prop)isActive]', () => {
+      test('is correct type', () => {
+        mountPlugin()
+        expect(LoadingBar.isActive).toBeTypeOf('boolean')
+      })
+
+      test('is reactive', () => {
+        mountPlugin()
+
+        expect(LoadingBar.isActive).toBe(false)
+
+        LoadingBar.start(0)
+        expect(LoadingBar.isActive).toBe(true)
+
+        LoadingBar.stop()
+        expect(LoadingBar.isActive).toBe(false)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)start]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        expect(LoadingBar.start(300)).toBeUndefined()
+        expect(LoadingBar.isActive).toBe(true)
+
+        LoadingBar.stop()
+      })
+    })
+
+    describe('[(method)stop]', () => {
+      test('should be callable', () => {
+        mountPlugin()
+
+        LoadingBar.start(0)
+        expect(LoadingBar.isActive).toBe(true)
+
+        expect(LoadingBar.stop()).toBeUndefined()
+        expect(LoadingBar.isActive).toBe(false)
+      })
+    })
+
+    describe('[(method)increment]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+
+        LoadingBar.start(0)
+        await nextTick()
+
+        const bar = document.querySelector('.q-loading-bar')
+        expect(bar.getAttribute('aria-valuenow')).toBe('0')
+
+        expect(LoadingBar.increment(10)).toBeUndefined()
+        await nextTick()
+
+        expect(Number(bar.getAttribute('aria-valuenow'))).toBeGreaterThan(0)
+
+        LoadingBar.stop()
+      })
+    })
+
+    describe('[(method)setDefaults]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+
+        expect(
+          LoadingBar.setDefaults({ position: 'bottom', reverse: true })
+        ).toBeUndefined()
+
+        await nextTick()
+
+        expect(document.querySelector('.q-loading-bar--bottom')).not.toBe(null)
+      })
+    })
+  })
+})

--- a/ui/src/plugins/loading/Loading.test.js
+++ b/ui/src/plugins/loading/Loading.test.js
@@ -1,0 +1,123 @@
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import Loading from './Loading.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { Loading } })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  Loading.hide()
+  vi.runAllTimers()
+  vi.useRealTimers()
+})
+
+describe('[Loading API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(Loading).toBe(wrapper.vm.$q.loading)
+    })
+  })
+
+  describe('[Props]', () => {
+    describe('[(prop)isActive]', () => {
+      test('is correct type', () => {
+        mountPlugin()
+        expect(Loading.isActive).toBeTypeOf('boolean')
+      })
+
+      test('is reactive', () => {
+        mountPlugin()
+
+        expect(Loading.isActive).toBe(false)
+
+        Loading.show({ delay: 100 })
+        expect(Loading.isActive).toBe(true)
+
+        Loading.hide()
+        expect(Loading.isActive).toBe(false)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)show]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        const hide = Loading.show({
+          delay: 0,
+          message: 'Processing your request',
+          group: 'some-api-call'
+        })
+
+        expect(hide).toBeTypeOf('function')
+        expect(Loading.isActive).toBe(true)
+
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(document.querySelector('.q-loading__message').textContent).toBe(
+          'Processing your request'
+        )
+
+        hide()
+        expect(Loading.isActive).toBe(false)
+      })
+    })
+
+    describe('[(method)hide]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+
+        Loading.show({ delay: 0, group: 'some-api-call' })
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(Loading.isActive).toBe(true)
+        expect(document.querySelector('.q-loading')).not.toBe(null)
+
+        expect(Loading.hide('some-api-call')).toBeUndefined()
+        expect(Loading.isActive).toBe(false)
+
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(document.querySelector('.q-loading')).toBe(null)
+      })
+    })
+
+    describe('[(method)setDefaults]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+
+        expect(
+          Loading.setDefaults({
+            delay: 0,
+            message: 'Default loading message',
+            customClass: 'q-test-loading'
+          })
+        ).toBeUndefined()
+
+        Loading.show()
+        vi.runAllTimers()
+        await nextTick()
+
+        const loading = document.querySelector('.q-loading')
+        expect(loading.classList.contains('q-test-loading')).toBe(true)
+        expect(loading.textContent).toContain('Default loading message')
+      })
+    })
+  })
+})

--- a/ui/src/plugins/meta/Meta.test.js
+++ b/ui/src/plugins/meta/Meta.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import Meta from './Meta.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { Meta } })
+
+describe('[Meta API]', () => {
+  describe('[Generic]', () => {
+    test('should not throw error when installed', () => {
+      expect(mountPlugin).not.toThrow()
+    })
+  })
+})

--- a/ui/src/plugins/notify/Notify.test.js
+++ b/ui/src/plugins/notify/Notify.test.js
@@ -1,0 +1,92 @@
+import { nextTick } from 'vue'
+import { describe, expect, test, vi } from 'vitest'
+import { config, mount } from '@vue/test-utils'
+
+import Notify from './Notify.js'
+
+const mountPlugin = () => mount({ template: '<div />' })
+
+// We override Quasar install so it installs this plugin
+const quasarVuePlugin = config.global.plugins.find(
+  entry => entry.name === 'Quasar'
+)
+const { install } = quasarVuePlugin
+quasarVuePlugin.install = app => install(app, { plugins: { Notify } })
+
+describe('[Notify API]', () => {
+  describe('[Injection]', () => {
+    test('is injected into $q', () => {
+      const wrapper = mountPlugin()
+      expect(Notify.create).toBe(wrapper.vm.$q.notify)
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)create]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        await nextTick()
+        const onDismiss = vi.fn()
+
+        const dismiss = Notify.create({
+          message: 'John Doe pinged you',
+          group: false,
+          timeout: 0,
+          onDismiss
+        })
+
+        expect(dismiss).toBeTypeOf('function')
+
+        dismiss()
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('[(method)setDefaults]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        await nextTick()
+        const onDismiss = vi.fn()
+
+        expect(
+          Notify.setDefaults({
+            group: false,
+            timeout: 0,
+            onDismiss
+          })
+        ).toBeUndefined()
+
+        const dismiss = Notify.create({
+          message: 'Default notification'
+        })
+
+        dismiss()
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('[(method)registerType]', () => {
+      test('should be callable', async () => {
+        mountPlugin()
+        await nextTick()
+        const onDismiss = vi.fn()
+
+        expect(
+          Notify.registerType('my-type', {
+            group: false,
+            timeout: 0,
+            onDismiss
+          })
+        ).toBeUndefined()
+
+        const dismiss = Notify.create({
+          type: 'my-type',
+          message: 'Typed notification'
+        })
+
+        dismiss()
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other: generated UI plugin test coverage

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] No documentation change is needed because this only adds tests

**Other information:**

Adds the missing generated Specs coverage for the plugin scope:

- BottomSheet and BottomSheetComponent
- Cookies
- Dialog and DialogPluginComponent
- Loading
- LoadingBar
- Meta
- Notify

Every file and test case offered by `pnpm test:specs --target plugins` was
accepted. All generated `describe()` identifiers and hierarchy are preserved,
and every generated placeholder was replaced with a behavioral assertion.

This closes the plugin portion of the missing-test backlog without changing
production code or public APIs. The tests cover plugin injection, public
methods, reactive state, rendered effects, cookie mutations and the SSR cookie
backend, defaults, registered notification types, and plugin-owned component
metadata.

Validation:

- `pnpm build` from `ui`
- `pnpm test:specs --target plugins`
- focused Vitest run: 9 files, 32 tests
- root `pnpm test`: 132 UI files / 1,345 UI tests; 10 Vite usage tests; 75 Vite runtime tests
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated Vitest coverage for Bottom Sheet, Dialog (including component API), Cookies, Loading Bar, Loading, Meta, and Notify plugins.
  * Verified plugin injection into the app instance, public API shapes, and key behaviors (start/stop or show/hide, action labels/messages, DOM render/removal).
  * Confirmed callback/dismiss behavior for Notify and SSR cookie parsing (including ignoring malformed cookie encodings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->