### PR TITLE
test(ui): cover public composables

### DIFF
--- a/ui/src/composables/use-dialog-plugin-component/use-dialog-plugin-component.test.js
+++ b/ui/src/composables/use-dialog-plugin-component/use-dialog-plugin-component.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+
+import useDialogPluginComponent from './use-dialog-plugin-component.js'
+
+describe('[useDialogPluginComponent API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('can be used in a Vue Component', () => {
+        let result
+
+        const wrapper = mount(
+          defineComponent({
+            template: '<div />',
+            emits: useDialogPluginComponent.emits,
+            setup() {
+              result = useDialogPluginComponent()
+              return result
+            }
+          })
+        )
+
+        const dialog = {
+          show: vi.fn(),
+          hide: vi.fn()
+        }
+        result.dialogRef.value = dialog
+
+        expect(wrapper.vm.show).toBeTypeOf('function')
+        expect(wrapper.vm.hide).toBeTypeOf('function')
+
+        wrapper.vm.show()
+        expect(dialog.show).toHaveBeenCalledTimes(1)
+
+        wrapper.vm.hide()
+        expect(dialog.hide).toHaveBeenCalledTimes(1)
+
+        result.onDialogOK({ accepted: true })
+        expect(wrapper.emitted('ok')).toStrictEqual([[{ accepted: true }]])
+        expect(dialog.hide).toHaveBeenCalledTimes(2)
+
+        result.onDialogCancel()
+        expect(dialog.hide).toHaveBeenCalledTimes(3)
+
+        result.onDialogHide()
+        expect(wrapper.emitted('hide')).toStrictEqual([[]])
+      })
+    })
+  })
+})

--- a/ui/src/composables/use-form/use-form-child.test.js
+++ b/ui/src/composables/use-form/use-form-child.test.js
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, getCurrentInstance, nextTick } from 'vue'
+import { describe, expect, test, vi } from 'vitest'
+
+import { formKey } from '../../utils/private.symbols/symbols.js'
+import useFormChild from './use-form-child.js'
+
+describe('[useFormChild API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('binds to QForm, reacts to disable, unbinds, and reports missing QForm', async () => {
+        const validate = vi.fn(),
+          resetValidation = vi.fn(),
+          form = {
+            bindComponent: vi.fn(),
+            unbindComponent: vi.fn()
+          }
+        let result, proxy
+
+        const wrapper = mount(
+          defineComponent({
+            props: {
+              disable: Boolean
+            },
+            setup() {
+              proxy = getCurrentInstance().proxy
+              result = useFormChild({
+                validate,
+                resetValidation,
+                requiresQForm: true
+              })
+            },
+            template: '<div />'
+          }),
+          {
+            global: {
+              provide: {
+                [formKey]: form
+              }
+            }
+          }
+        )
+
+        expect(result).toBeUndefined()
+        expect(wrapper.vm.validate).toBe(validate)
+        expect(wrapper.vm.resetValidation).toBe(resetValidation)
+        expect(form.bindComponent.mock.calls[0][0]).toBe(proxy)
+
+        await wrapper.setProps({ disable: true })
+
+        expect(resetValidation).toHaveBeenCalledTimes(1)
+        expect(form.unbindComponent.mock.calls[0][0]).toBe(proxy)
+
+        await wrapper.setProps({ disable: false })
+        expect(form.bindComponent).toHaveBeenCalledTimes(2)
+
+        wrapper.unmount()
+        expect(form.unbindComponent).toHaveBeenCalledTimes(2)
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        try {
+          mount(
+            defineComponent({
+              setup() {
+                useFormChild({
+                  validate,
+                  resetValidation,
+                  requiresQForm: true
+                })
+              },
+              template: '<div />'
+            })
+          )
+          await nextTick()
+
+          expect(errorSpy).toHaveBeenCalledWith(
+            'Parent QForm not found on useFormChild()!'
+          )
+        } finally {
+          errorSpy.mockRestore()
+        }
+      })
+    })
+  })
+})

--- a/ui/src/composables/use-meta/use-meta.test.js
+++ b/ui/src/composables/use-meta/use-meta.test.js
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import useMeta from './use-meta.js'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.runAllTimers()
+  vi.useRealTimers()
+  document.title = ''
+  document.head.querySelectorAll('[data-qmeta]').forEach(el => el.remove())
+})
+
+describe('[useMeta API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('has correct return value', async () => {
+        const title = ref('Initial title')
+        let result
+
+        const wrapper = mount(
+          defineComponent({
+            setup() {
+              result = useMeta(() => ({
+                title: title.value,
+                meta: {
+                  description: {
+                    name: 'description',
+                    content: `${title.value} description`
+                  }
+                }
+              }))
+            },
+            template: '<div />'
+          })
+        )
+
+        expect(result).toBeUndefined()
+
+        vi.runAllTimers()
+        await nextTick()
+
+        expect(document.title).toBe('Initial title')
+        expect(
+          document.head.querySelector('meta[data-qmeta="description"]').content
+        ).toBe('Initial title description')
+
+        title.value = 'Updated title'
+        await nextTick()
+        vi.runAllTimers()
+
+        expect(document.title).toBe('Updated title')
+        expect(
+          document.head.querySelector('meta[data-qmeta="description"]').content
+        ).toBe('Updated title description')
+
+        wrapper.unmount()
+        vi.runAllTimers()
+
+        expect(
+          document.head.querySelector('meta[data-qmeta="description"]')
+        ).toBe(null)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other: generated UI composable test coverage

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] No documentation change is needed because this only adds tests

**Other information:**

Adds the missing generated Specs coverage for Quasar's public composables:

- `useDialogPluginComponent`
- `useFormChild`
- `useMeta`

Every file and case offered by each precise `test:specs` target was accepted.
The generated `describe()` identifiers and hierarchy are preserved, and every
placeholder was replaced with behavioral assertions.

The tests cover dialog show/hide and emitted events, QForm registration and
disable/unmount lifecycle behavior, missing-parent diagnostics, and reactive
client meta creation, updates, and cleanup. This is test-only and does not
change production code or public APIs.

Validation:

- `pnpm build` from `ui`
- all three precise `pnpm test:specs --target ...` checks
- focused Vitest run: 3 files, 3 tests
- root `pnpm test`: 126 UI files / 1,316 UI tests; 10 Vite usage tests; 75 Vite runtime tests
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for dialog interactions, including showing, hiding, confirmation, cancellation, and emitted events.
  * Added tests for form-child validation registration, binding, unbinding, and missing parent form handling.
  * Added tests verifying reactive page titles and meta descriptions update correctly and are cleaned up when components unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->