### PR TITLE
test(ui): cover private composable helpers

### DIFF
--- a/ui/src/composables/private.use-key-composition/use-key-composition.test.js
+++ b/ui/src/composables/private.use-key-composition/use-key-composition.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import useKeyComposition from './use-key-composition.js'
+
+describe('[useKeyComposition API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('tracks composition and forwards its terminal event', () => {
+        const onInput = vi.fn()
+        const onComposition = useKeyComposition(onInput)
+        const target = {}
+
+        onComposition({
+          type: 'compositionupdate',
+          data: '日',
+          target
+        })
+
+        expect(target.qComposing).toBe(true)
+
+        const compositionEndEvent = {
+          type: 'compositionend',
+          target
+        }
+
+        onComposition(compositionEndEvent)
+
+        expect(target.qComposing).toBe(false)
+        expect(onInput).toHaveBeenCalledExactlyOnceWith(compositionEndEvent)
+      })
+
+      test('ignores terminal events when composition is inactive', () => {
+        const onInput = vi.fn()
+        const onComposition = useKeyComposition(onInput)
+        const target = {}
+
+        onComposition({
+          type: 'compositionupdate',
+          data: 'a',
+          target
+        })
+        onComposition({
+          type: 'change',
+          target
+        })
+
+        expect(target.qComposing).toBeUndefined()
+        expect(onInput).not.toHaveBeenCalled()
+      })
+
+      test('forwards a change event that terminates composition', () => {
+        const onInput = vi.fn()
+        const onComposition = useKeyComposition(onInput)
+        const target = { qComposing: true }
+        const changeEvent = {
+          type: 'change',
+          target
+        }
+
+        onComposition(changeEvent)
+
+        expect(target.qComposing).toBe(false)
+        expect(onInput).toHaveBeenCalledExactlyOnceWith(changeEvent)
+      })
+    })
+  })
+})

--- a/ui/src/composables/private.use-prevent-scroll/use-prevent-scroll.test.js
+++ b/ui/src/composables/private.use-prevent-scroll/use-prevent-scroll.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import preventScroll from '../../utils/scroll/prevent-scroll.js'
+import usePreventScroll from './use-prevent-scroll.js'
+
+vi.mock('../../utils/scroll/prevent-scroll.js', () => ({
+  default: vi.fn()
+}))
+
+describe('[usePreventScroll API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      beforeEach(() => {
+        vi.clearAllMocks()
+      })
+
+      test('updates scroll prevention only when its state changes', () => {
+        const { preventBodyScroll } = usePreventScroll()
+
+        preventBodyScroll(false)
+        expect(preventScroll).not.toHaveBeenCalled()
+
+        preventBodyScroll(true)
+        preventBodyScroll(true)
+        preventBodyScroll(false)
+        preventBodyScroll(false)
+
+        expect(preventScroll.mock.calls).toStrictEqual([[true], [false]])
+      })
+    })
+  })
+})

--- a/ui/src/composables/private.use-refocus-target/use-refocus-target.test.js
+++ b/ui/src/composables/private.use-refocus-target/use-refocus-target.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, reactive, ref } from 'vue'
+
+import useRefocusTarget from './use-refocus-target.js'
+
+describe('[useRefocusTarget API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('renders and focuses the appropriate refocus target', async () => {
+        const props = reactive({ disable: false })
+        const rootRef = ref(null)
+        const mountTarget = document.createElement('div')
+        let result
+
+        document.body.append(mountTarget)
+
+        const wrapper = mount(
+          defineComponent({
+            setup() {
+              result = useRefocusTarget(props, rootRef)
+
+              return () =>
+                h(
+                  'div',
+                  {
+                    ref: rootRef,
+                    tabindex: -1
+                  },
+                  [result.refocusTargetEl.value]
+                )
+            }
+          }),
+          { attachTo: mountTarget }
+        )
+
+        const root = wrapper.element
+        const target = wrapper.get('span').element
+        const rootFocus = vi.spyOn(root, 'focus')
+        const targetFocus = vi.spyOn(target, 'focus')
+
+        target.focus()
+        rootFocus.mockClear()
+        targetFocus.mockClear()
+
+        result.refocusTarget({ type: 'keydown' })
+
+        expect(rootFocus).toHaveBeenCalledOnce()
+        expect(targetFocus).not.toHaveBeenCalled()
+
+        result.refocusTarget({
+          type: 'click',
+          target: root
+        })
+
+        expect(targetFocus).toHaveBeenCalledOnce()
+
+        targetFocus.mockClear()
+
+        result.refocusTarget({
+          type: 'click',
+          target: mountTarget
+        })
+
+        expect(targetFocus).not.toHaveBeenCalled()
+
+        rootFocus.mockClear()
+        targetFocus.mockClear()
+
+        result.refocusTarget({
+          type: 'keydown',
+          qAvoidFocus: true
+        })
+
+        expect(rootFocus).not.toHaveBeenCalled()
+        expect(targetFocus).not.toHaveBeenCalled()
+
+        props.disable = true
+        await nextTick()
+
+        expect(result.refocusTargetEl.value).toBeNull()
+        expect(wrapper.find('span').exists()).toBe(false)
+
+        wrapper.unmount()
+        mountTarget.remove()
+      })
+    })
+  })
+})

--- a/ui/src/composables/private.use-scroll-target/use-scroll-target.test.js
+++ b/ui/src/composables/private.use-scroll-target/use-scroll-target.test.js
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, reactive } from 'vue'
+
+import { listenOpts } from '../../utils/event/event.js'
+import useScrollTarget from './use-scroll-target.js'
+
+describe('[useScrollTarget API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      afterEach(() => {
+        vi.restoreAllMocks()
+      })
+
+      test('configures, updates, and removes scroll listeners', async () => {
+        const props = reactive({ noParentEvent: false })
+        const configureScrollTarget = vi.fn()
+        let result
+
+        const wrapper = mount(
+          defineComponent({
+            template: '<div />',
+            setup() {
+              result = useScrollTarget(props, configureScrollTarget)
+            }
+          })
+        )
+
+        const scrollTarget = document.createElement('div')
+        const handler = vi.fn()
+        const targetAddEventListener = vi.spyOn(
+          scrollTarget,
+          'addEventListener'
+        )
+        const targetRemoveEventListener = vi.spyOn(
+          scrollTarget,
+          'removeEventListener'
+        )
+        const windowAddEventListener = vi.spyOn(window, 'addEventListener')
+        const windowRemoveEventListener = vi.spyOn(
+          window,
+          'removeEventListener'
+        )
+
+        result.localScrollTarget.value = scrollTarget
+        result.changeScrollEvent(scrollTarget, handler)
+
+        expect(targetAddEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(windowAddEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+
+        result.unconfigureScrollTarget()
+
+        expect(targetRemoveEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(windowRemoveEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(result.localScrollTarget.value).toBeNull()
+
+        windowAddEventListener.mockClear()
+        windowRemoveEventListener.mockClear()
+        result.localScrollTarget.value = window
+        result.changeScrollEvent(window, handler)
+
+        expect(windowAddEventListener).toHaveBeenCalledExactlyOnceWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+
+        result.unconfigureScrollTarget()
+
+        expect(windowRemoveEventListener).toHaveBeenCalledExactlyOnceWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(result.localScrollTarget.value).toBeNull()
+
+        targetRemoveEventListener.mockClear()
+        windowRemoveEventListener.mockClear()
+        result.localScrollTarget.value = scrollTarget
+        result.changeScrollEvent(scrollTarget, handler)
+
+        props.noParentEvent = true
+        await nextTick()
+
+        expect(targetRemoveEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(windowRemoveEventListener).toHaveBeenCalledWith(
+          'scroll',
+          handler,
+          listenOpts.passive
+        )
+        expect(configureScrollTarget).toHaveBeenCalledOnce()
+        expect(result.localScrollTarget.value).toBeNull()
+
+        wrapper.unmount()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- add generated Specs coverage for four small private composable helpers
- cover IME composition state and terminal input forwarding
- cover duplicate body-scroll prevention state
- cover keyboard and pointer refocus behavior, including the outside-root guard
- cover scroll-listener configuration, the special `window` target,
  reconfiguration, and cleanup

## Why

This continues the type-scoped test-file work requested for missing UI Specs.
The file DOM-props helper is intentionally excluded because its stronger
coverage is already provided by #18462.

## Impact

Tests only. There are no production-code, public API, or documentation changes.

## Validation

- `pnpm build` in `ui/`
- all four exact `pnpm test:specs --target composables/<subpath>` checks passed
- focused Vitest: 4 files, 6 tests passed
- root `pnpm test`: 123 UI files / 1,313 UI tests, 10 Vite usage tests, and 75
  Vite runtime tests passed
- root `pnpm lint:check` passed across 2,956 files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for keyboard composition handling, including composition and change events.
  * Added tests validating scroll prevention only reacts to state changes.
  * Added focus-management tests covering keyboard, click, disabled, and focus-avoidance scenarios.
  * Added scroll-target tests for listener setup, cleanup, window handling, and configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
