### PR TITLE
test(ui): cover toggle and portal composables

### DIFF
--- a/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
+++ b/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, reactive, ref } from 'vue'
+
+import useModelToggle, {
+  useModelToggleEmits,
+  useModelToggleProps
+} from './use-model-toggle.js'
+
+let wrapper
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+  vi.restoreAllMocks()
+})
+
+function mountModelToggle({ componentProps = {}, global, options = {} } = {}) {
+  const { showing = ref(false), ...toggleOptions } = options
+  let controls
+
+  wrapper = mount(
+    defineComponent({
+      props: {
+        ...useModelToggleProps,
+        disable: Boolean
+      },
+      emits: [...useModelToggleEmits, 'update:modelValue'],
+
+      setup() {
+        controls = useModelToggle({
+          showing,
+          ...toggleOptions
+        })
+
+        return () => h('div')
+      }
+    }),
+    {
+      global,
+      props: componentProps
+    }
+  )
+
+  return { controls, showing }
+}
+
+describe('[useModelToggle API]', () => {
+  describe('[Variables]', () => {
+    describe('[(variable)useModelToggleProps]', () => {
+      test('is defined correctly', () => {
+        expect(Object.keys(useModelToggleProps)).toStrictEqual([
+          'modelValue',
+          'onUpdate:modelValue'
+        ])
+        expect(useModelToggleProps.modelValue).toMatchObject({
+          type: Boolean,
+          default: null
+        })
+      })
+    })
+
+    describe('[(variable)useModelToggleEmits]', () => {
+      test('is defined correctly', () => {
+        expect(useModelToggleEmits).toStrictEqual([
+          'beforeShow',
+          'show',
+          'beforeHide',
+          'hide'
+        ])
+      })
+    })
+  })
+
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('shows, hides, and toggles an uncontrolled component', () => {
+        const { controls, showing } = mountModelToggle()
+        const showEvent = { type: 'show' }
+        const hideEvent = { type: 'hide' }
+
+        expect(controls).toStrictEqual({
+          show: expect.any(Function),
+          hide: expect.any(Function),
+          toggle: expect.any(Function)
+        })
+        expect(wrapper.vm.show).toBe(controls.show)
+        expect(wrapper.vm.hide).toBe(controls.hide)
+        expect(wrapper.vm.toggle).toBe(controls.toggle)
+
+        controls.show(showEvent)
+
+        expect(showing.value).toBe(true)
+        expect(wrapper.emitted('beforeShow')).toStrictEqual([[showEvent]])
+        expect(wrapper.emitted('show')).toStrictEqual([[showEvent]])
+
+        controls.hide(hideEvent)
+
+        expect(showing.value).toBe(false)
+        expect(wrapper.emitted('beforeHide')).toStrictEqual([[hideEvent]])
+        expect(wrapper.emitted('hide')).toStrictEqual([[hideEvent]])
+
+        controls.toggle()
+        expect(showing.value).toBe(true)
+      })
+
+      test('waits for a controlled model to change', async () => {
+        const onUpdateModelValue = vi.fn()
+        const { controls, showing } = mountModelToggle({
+          componentProps: {
+            modelValue: false,
+            'onUpdate:modelValue': onUpdateModelValue
+          }
+        })
+
+        controls.show()
+
+        expect(onUpdateModelValue).toHaveBeenCalledExactlyOnceWith(true)
+        expect(showing.value).toBe(false)
+
+        await wrapper.setProps({ modelValue: true })
+
+        expect(showing.value).toBe(true)
+
+        controls.hide()
+
+        expect(onUpdateModelValue).toHaveBeenLastCalledWith(false)
+        expect(showing.value).toBe(true)
+
+        await wrapper.setProps({ modelValue: false })
+
+        expect(showing.value).toBe(false)
+      })
+
+      test('honors show guards and delegates transition handling', async () => {
+        const canShow = vi.fn(() => false)
+        const handleShow = vi.fn()
+        const handleHide = vi.fn()
+        const { controls, showing } = mountModelToggle({
+          options: {
+            canShow,
+            handleShow,
+            handleHide
+          }
+        })
+        const event = { type: 'pointerdown' }
+
+        controls.show(event)
+
+        expect(showing.value).toBe(false)
+        expect(canShow).toHaveBeenCalledExactlyOnceWith(event)
+
+        canShow.mockReturnValue(true)
+        controls.show({ qAnchorHandled: true })
+
+        expect(showing.value).toBe(false)
+        expect(canShow).toHaveBeenCalledOnce()
+
+        await wrapper.setProps({ disable: true })
+        controls.show(event)
+
+        expect(showing.value).toBe(false)
+
+        await wrapper.setProps({ disable: false })
+        controls.show(event)
+
+        expect(showing.value).toBe(true)
+        expect(handleShow).toHaveBeenCalledExactlyOnceWith(event)
+        expect(wrapper.emitted('show')).toBeUndefined()
+
+        controls.hide(event)
+
+        expect(showing.value).toBe(false)
+        expect(handleHide).toHaveBeenCalledExactlyOnceWith(event)
+        expect(wrapper.emitted('hide')).toBeUndefined()
+      })
+
+      test('processes the initial model when requested', () => {
+        const { showing } = mountModelToggle({
+          componentProps: { modelValue: true },
+          options: { processOnMount: true }
+        })
+
+        expect(showing.value).toBe(true)
+        expect(wrapper.emitted('beforeShow')).toStrictEqual([[void 0]])
+        expect(wrapper.emitted('show')).toStrictEqual([[void 0]])
+      })
+
+      test('hides on route changes when configured', async () => {
+        const route = reactive({ fullPath: '/first' })
+        const showing = ref(true)
+        const hideOnRouteChange = ref(true)
+        const handleRouteChange = vi.fn()
+
+        mountModelToggle({
+          global: {
+            config: {
+              globalProperties: {
+                $route: route,
+                $router: {}
+              }
+            }
+          },
+          options: {
+            showing,
+            hideOnRouteChange,
+            handleRouteChange
+          }
+        })
+
+        route.fullPath = '/second'
+        await nextTick()
+
+        expect(handleRouteChange).toHaveBeenCalledOnce()
+        expect(showing.value).toBe(false)
+        expect(wrapper.emitted('beforeHide')).toStrictEqual([[void 0]])
+        expect(wrapper.emitted('hide')).toStrictEqual([[void 0]])
+      })
+
+      test('repairs an enabled controlled model when disabled', async () => {
+        const onUpdateModelValue = vi.fn()
+
+        mountModelToggle({
+          componentProps: {
+            modelValue: false,
+            'onUpdate:modelValue': onUpdateModelValue
+          }
+        })
+
+        await wrapper.setProps({
+          disable: true,
+          modelValue: true
+        })
+
+        expect(onUpdateModelValue).toHaveBeenCalledExactlyOnceWith(false)
+      })
+    })
+  })
+})

--- a/ui/src/composables/private.use-portal/use-portal.test.js
+++ b/ui/src/composables/private.use-portal/use-portal.test.js
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, getCurrentInstance, h, nextTick, ref } from 'vue'
+
+import usePortal from './use-portal.js'
+import { portalProxyList } from '../../utils/private.portal/portal.js'
+
+let wrapper
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+  portalProxyList.length = 0
+})
+
+function mountPortal({ onGlobalDialog = false, type = 'menu' } = {}) {
+  let portal, portalProxy
+
+  const PortalHarness = defineComponent({
+    name: 'PortalHarness',
+    inheritAttrs: false,
+
+    setup() {
+      const vm = getCurrentInstance()
+      const innerRef = ref(null)
+
+      portalProxy = vm.proxy
+      portal = usePortal(
+        vm,
+        innerRef,
+        () =>
+          h(
+            'div',
+            {
+              'data-test': 'portal-content'
+            },
+            'Portal content'
+          ),
+        type
+      )
+
+      return () =>
+        h(
+          'section',
+          {
+            ref: innerRef,
+            'data-test': 'portal-host'
+          },
+          portal.renderPortal()
+        )
+    }
+  })
+
+  const RootComponent =
+    onGlobalDialog === true
+      ? defineComponent({
+          name: 'QGlobalDialog',
+          setup: () => () => h(PortalHarness)
+        })
+      : PortalHarness
+
+  wrapper = mount(RootComponent)
+
+  return { portal, portalProxy }
+}
+
+describe('[usePortal API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('registers, renders, and removes teleported content', async () => {
+        const { portal, portalProxy } = mountPortal()
+
+        expect(portal.portalIsActive).$ref(false)
+        expect(portal.portalIsAccessible).$ref(false)
+        expect(portalProxy.__qPortal).toBe(true)
+        expect(portalProxy.contentEl).toBe(
+          wrapper.get('[data-test="portal-host"]').element
+        )
+        expect(portalProxyList).not.toContain(portalProxy)
+
+        portal.showPortal()
+        portal.showPortal()
+        await nextTick()
+
+        const portalNode = document.querySelector('[id^="q-portal--menu--"]')
+
+        expect(portal.portalIsActive).$ref(true)
+        expect(portal.portalIsAccessible).$ref(false)
+        expect(portalProxyList).toStrictEqual([portalProxy])
+        expect(portalNode).not.toBeNull()
+        expect(
+          portalNode.querySelector('[data-test="portal-content"]')
+        ).not.toBeNull()
+
+        portal.showPortal(true)
+
+        expect(portal.portalIsAccessible).$ref(true)
+
+        portal.hidePortal(false)
+
+        expect(portal.portalIsActive).$ref(true)
+        expect(portal.portalIsAccessible).$ref(false)
+        expect(portalProxyList).toContain(portalProxy)
+
+        portal.hidePortal(true)
+        await nextTick()
+
+        expect(portal.portalIsActive).$ref(false)
+        expect(portal.portalIsAccessible).$ref(false)
+        expect(portalProxyList).not.toContain(portalProxy)
+        expect(portalNode.isConnected).toBe(false)
+      })
+
+      test('cleans up an active portal when unmounted', async () => {
+        const { portal, portalProxy } = mountPortal({ type: 'dialog' })
+
+        portal.showPortal()
+        await nextTick()
+
+        const portalNode = document.querySelector('[id^="q-portal--dialog--"]')
+
+        expect(portalNode).not.toBeNull()
+        expect(portalProxyList).toContain(portalProxy)
+
+        wrapper.unmount()
+        wrapper = void 0
+
+        expect(portalProxyList).not.toContain(portalProxy)
+        expect(portalNode.isConnected).toBe(false)
+        expect(portal.portalIsActive).$ref(false)
+      })
+
+      test('renders dialog content in place under a global dialog', async () => {
+        const { portal, portalProxy } = mountPortal({
+          onGlobalDialog: true,
+          type: 'dialog'
+        })
+
+        portal.showPortal()
+        await nextTick()
+
+        expect(document.querySelector('[id^="q-portal--dialog--"]')).toBeNull()
+        expect(wrapper.find('[data-test="portal-content"]').exists()).toBe(true)
+        expect(portalProxyList).toStrictEqual([portalProxy])
+
+        portal.hidePortal(true)
+        await nextTick()
+
+        expect(portal.portalIsActive).$ref(false)
+        expect(portalProxyList).not.toContain(portalProxy)
+        expect(wrapper.find('[data-test="portal-content"]').exists()).toBe(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Generated unit-test coverage

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Adds generated Specs-compliant behavioral coverage for two related private lifecycle composables:

- `useModelToggle`: exported contracts, controlled and uncontrolled visibility, public methods, show guards, delegated transitions, initial-model processing, route-driven hiding, and disabled controlled-model repair
- `usePortal`: proxy registration, Teleport rendering, readiness states, duplicate activation, normal and unmount cleanup, and in-place rendering under `QGlobalDialog`

There are no runtime or documentation changes. Cordova and Electron testing is not applicable to this test-only PR.

Validation:

- Both exact `pnpm test:specs --target composables/<subpath>` checks pass.
- Focused Vitest run: 2 files, 11 tests passed.
- Complete `pnpm test`: 106 UI files / 1,193 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed.
- `pnpm lint:check` passed across 2,935 files.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for model visibility controls, including showing, hiding, toggling, controlled state, route changes, and transition handling.
  * Added coverage for portal behavior, including rendering, accessibility updates, cleanup, unmounting, and global dialog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->