### PR TITLE
test(ui): cover anchor composable

### DIFF
--- a/ui/src/composables/private.use-anchor/use-anchor.test.js
+++ b/ui/src/composables/private.use-anchor/use-anchor.test.js
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, getCurrentInstance, h, nextTick, ref } from 'vue'
+
+import useAnchor, {
+  useAnchorProps,
+  useAnchorStaticProps
+} from './use-anchor.js'
+
+let wrapper
+const createdElements = []
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+  createdElements.forEach(el => el.remove())
+  createdElements.length = 0
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+function createElement(tag = 'div') {
+  const el = document.createElement(tag)
+  document.body.append(el)
+  createdElements.push(el)
+  return el
+}
+
+function mountAnchor({
+  avoidEmit = false,
+  componentProps = {},
+  configureAnchorEl,
+  showing = ref(false)
+} = {}) {
+  const hide = vi.fn()
+  const show = vi.fn()
+  const toggle = vi.fn()
+  let anchor
+
+  wrapper = mount(
+    defineComponent({
+      props: {
+        ...useAnchorProps,
+        modelValue: Boolean
+      },
+      emits: ['update:modelValue'],
+
+      setup() {
+        const vm = getCurrentInstance()
+
+        Object.assign(vm.proxy, {
+          hide,
+          show,
+          toggle
+        })
+
+        anchor = useAnchor({
+          showing,
+          avoidEmit,
+          configureAnchorEl
+        })
+
+        return () => h('button', { 'data-test': 'anchor-child' })
+      }
+    }),
+    {
+      props: componentProps
+    }
+  )
+
+  return {
+    anchor,
+    anchorElement: anchor.anchorEl.value,
+    hide,
+    show,
+    showing,
+    toggle
+  }
+}
+
+describe('[useAnchor API]', () => {
+  describe('[Variables]', () => {
+    describe('[(variable)useAnchorStaticProps]', () => {
+      test('is defined correctly', () => {
+        expect(Object.keys(useAnchorStaticProps)).toStrictEqual([
+          'target',
+          'noParentEvent'
+        ])
+        expect(useAnchorStaticProps.target).toMatchObject({
+          type: [Boolean, String, Element],
+          default: true
+        })
+        expect(useAnchorStaticProps.noParentEvent).toBe(Boolean)
+      })
+    })
+
+    describe('[(variable)useAnchorProps]', () => {
+      test('is defined correctly', () => {
+        expect(Object.keys(useAnchorProps)).toStrictEqual([
+          'target',
+          'noParentEvent',
+          'contextMenu'
+        ])
+        expect(useAnchorProps.contextMenu).toBe(Boolean)
+      })
+    })
+  })
+
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('configures parent click and keyboard events', () => {
+        const { anchor, anchorElement, toggle } = mountAnchor()
+
+        expect(anchor).toStrictEqual({
+          anchorEl: expect.$ref(anchorElement),
+          canShow: expect.any(Function),
+          anchorEvents: expect.any(Object)
+        })
+        expect(anchor.canShow()).toBe(true)
+        expect(
+          anchor.canShow({
+            touches: [{}, {}]
+          })
+        ).toBe(false)
+
+        const clickEvent = new MouseEvent('click')
+        anchorElement.dispatchEvent(clickEvent)
+
+        expect(toggle).toHaveBeenCalledExactlyOnceWith(clickEvent)
+        expect(clickEvent.qAnchorHandled).toBe(true)
+
+        const enterEvent = new KeyboardEvent('keyup', { keyCode: 13 })
+        anchorElement.dispatchEvent(enterEvent)
+
+        expect(toggle).toHaveBeenLastCalledWith(enterEvent)
+        expect(enterEvent.qAnchorHandled).toBe(true)
+
+        anchorElement.dispatchEvent(new KeyboardEvent('keyup', { keyCode: 32 }))
+
+        expect(toggle).toHaveBeenCalledTimes(2)
+      })
+
+      test('reconfigures parent events when props change', async () => {
+        const { anchorElement, hide, show, toggle } = mountAnchor()
+
+        await wrapper.setProps({ noParentEvent: true })
+        anchorElement.dispatchEvent(new MouseEvent('click'))
+
+        expect(toggle).not.toHaveBeenCalled()
+
+        await wrapper.setProps({
+          contextMenu: true,
+          noParentEvent: false
+        })
+
+        const downEvent = new MouseEvent('mousedown')
+        anchorElement.dispatchEvent(downEvent)
+
+        expect(hide).toHaveBeenCalledExactlyOnceWith(downEvent)
+
+        const contextEvent = new MouseEvent('contextmenu', {
+          cancelable: true
+        })
+        anchorElement.dispatchEvent(contextEvent)
+
+        expect(contextEvent.defaultPrevented).toBe(true)
+        expect(hide).toHaveBeenLastCalledWith(contextEvent)
+        expect(show).not.toHaveBeenCalled()
+
+        await nextTick()
+
+        expect(show).toHaveBeenCalledExactlyOnceWith(contextEvent)
+        expect(contextEvent.qAnchorHandled).toBe(true)
+      })
+
+      test('resolves element and selector targets', async () => {
+        const firstTarget = createElement()
+        firstTarget.id = 'first-anchor'
+        const secondTarget = createElement()
+        const { anchor } = mountAnchor({
+          componentProps: { target: '#first-anchor' }
+        })
+
+        expect(anchor.anchorEl).$ref(firstTarget)
+
+        await wrapper.setProps({ target: secondTarget })
+
+        expect(anchor.anchorEl).$ref(secondTarget)
+      })
+
+      test('reports a missing target and repairs an open model', () => {
+        const consoleError = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
+        const { anchor } = mountAnchor({
+          componentProps: {
+            modelValue: true,
+            target: '[invalid-selector'
+          }
+        })
+
+        expect(anchor.anchorEl).$ref(null)
+        expect(anchor.canShow()).toBe(false)
+        expect(consoleError).toHaveBeenCalledWith(
+          'Anchor: target "[invalid-selector" not found'
+        )
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([[false]])
+      })
+
+      test('leaves model repair to callers when emission is avoided', () => {
+        mountAnchor({
+          avoidEmit: true,
+          componentProps: {
+            modelValue: true,
+            target: false
+          }
+        })
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+
+      test('supports a custom anchor configurator', async () => {
+        const configureAnchorEl = vi.fn()
+        const { anchor } = mountAnchor({ configureAnchorEl })
+
+        expect(configureAnchorEl).toHaveBeenCalledExactlyOnceWith()
+        expect(anchor.anchorEvents).toStrictEqual({})
+
+        await wrapper.setProps({ contextMenu: true })
+
+        expect(configureAnchorEl).toHaveBeenLastCalledWith(true)
+
+        await wrapper.setProps({ noParentEvent: true })
+        await wrapper.setProps({ noParentEvent: false })
+
+        expect(configureAnchorEl).toHaveBeenCalledTimes(3)
+      })
+
+      test('opens after a sustained mobile touch', () => {
+        vi.useFakeTimers()
+
+        const { anchor, anchorElement, hide, show } = mountAnchor()
+        const touchTarget = document.createElement('span')
+        anchorElement.append(touchTarget)
+        const touchEvent = {
+          target: touchTarget,
+          touches: [{}]
+        }
+
+        anchor.anchorEvents.mobileTouch(touchEvent)
+
+        expect(hide).toHaveBeenCalledExactlyOnceWith(touchEvent)
+        expect(anchorElement.classList).toContain('non-selectable')
+
+        vi.advanceTimersByTime(299)
+        expect(show).not.toHaveBeenCalled()
+
+        vi.advanceTimersByTime(1)
+
+        expect(show).toHaveBeenCalledExactlyOnceWith(touchEvent)
+        expect(touchEvent.qAnchorHandled).toBe(true)
+
+        anchor.anchorEvents.mobileCleanup(touchEvent)
+
+        expect(anchorElement.classList).not.toContain('non-selectable')
+      })
+
+      test('cancels a pending mobile touch when unmounted', () => {
+        vi.useFakeTimers()
+
+        const { anchor, anchorElement, show } = mountAnchor()
+        const touchTarget = document.createElement('span')
+        anchorElement.append(touchTarget)
+
+        anchor.anchorEvents.mobileTouch({
+          target: touchTarget,
+          touches: [{}]
+        })
+
+        wrapper.unmount()
+        wrapper = void 0
+        vi.advanceTimersByTime(300)
+
+        expect(show).not.toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?** <!-- Check at least one -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Generated unit-test coverage

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

Adds generated Specs-compliant behavioral coverage for the private `useAnchor` composable:

- exported prop contracts
- parent click and keyboard activation
- event reconfiguration for `noParentEvent` and context menus
- selector and element target resolution
- missing-target model repair and `avoidEmit`
- custom anchor configuration
- sustained mobile-touch activation and cancellation during unmount

There are no runtime or documentation changes. Cordova and Electron testing is not applicable to this test-only PR.

Validation:

- The exact `pnpm test:specs --target composables/private.use-anchor/use-anchor` check passes.
- Focused Vitest run: 1 file, 10 tests passed.
- Complete `pnpm test`: 105 UI files / 1,192 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed.
- `pnpm lint:check` passed across 2,934 files.
- `git diff --check` passed.
