### PR TITLE
test(ui): cover file composable

### DIFF
--- a/ui/src/composables/private.use-file/use-file-dom-props.test.js
+++ b/ui/src/composables/private.use-file/use-file-dom-props.test.js
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { reactive } from 'vue'
+
+import useFileDomProps from './use-file-dom-props.js'
+
+const dataTransferDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  'DataTransfer'
+)
+const clipboardEventDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  'ClipboardEvent'
+)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+
+  if (dataTransferDescriptor === void 0) {
+    Reflect.deleteProperty(window, 'DataTransfer')
+  } else {
+    Object.defineProperty(window, 'DataTransfer', dataTransferDescriptor)
+  }
+
+  if (clipboardEventDescriptor === void 0) {
+    Reflect.deleteProperty(window, 'ClipboardEvent')
+  } else {
+    Object.defineProperty(window, 'ClipboardEvent', clipboardEventDescriptor)
+  }
+})
+
+function installDataTransferMock() {
+  vi.stubGlobal(
+    'DataTransfer',
+    class {
+      constructor() {
+        this.files = []
+        this.items = {
+          add: file => {
+            this.files.push(file)
+          }
+        }
+      }
+    }
+  )
+}
+
+describe('[useFileDomProps API]', () => {
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('has correct return value', () => {
+        installDataTransferMock()
+
+        const file = new File(['content'], 'example.txt')
+        const result = useFileDomProps({ modelValue: file })
+
+        expect(result).$ref({ files: [file] })
+      })
+
+      test('adds every file from an array-like model', () => {
+        installDataTransferMock()
+
+        const files = [
+          new File(['first'], 'first.txt'),
+          new File(['second'], 'second.txt')
+        ]
+        const result = useFileDomProps({ modelValue: files })
+
+        expect(result.value.files).toStrictEqual(files)
+      })
+
+      test('uses the ClipboardEvent fallback when DataTransfer is unavailable', () => {
+        Reflect.deleteProperty(window, 'DataTransfer')
+
+        vi.stubGlobal(
+          'ClipboardEvent',
+          class {
+            constructor() {
+              this.clipboardData = {
+                files: [],
+                items: {
+                  add: file => {
+                    this.clipboardData.files.push(file)
+                  }
+                }
+              }
+            }
+          }
+        )
+
+        const file = new File(['content'], 'example.txt')
+        const result = useFileDomProps({ modelValue: file })
+
+        expect(result).$ref({ files: [file] })
+      })
+
+      test('returns an undefined files value when browser file-transfer APIs are unavailable', () => {
+        Reflect.deleteProperty(window, 'DataTransfer')
+        Reflect.deleteProperty(window, 'ClipboardEvent')
+
+        const result = useFileDomProps({
+          modelValue: new File(['content'], 'example.txt')
+        })
+
+        expect(result).$ref({ files: void 0 })
+      })
+
+      test('only supplies files for file inputs when guarded', () => {
+        installDataTransferMock()
+
+        const file = new File(['content'], 'example.txt')
+        const props = reactive({
+          modelValue: file,
+          type: 'text'
+        })
+        const result = useFileDomProps(props, true)
+
+        expect(result).$ref(void 0)
+
+        props.type = 'file'
+        expect(result).$ref({ files: [file] })
+      })
+
+      test('returns an undefined files value when the browser API fails', () => {
+        vi.stubGlobal(
+          'DataTransfer',
+          class {
+            constructor() {
+              throw new Error('DataTransfer is unavailable')
+            }
+          }
+        )
+
+        const result = useFileDomProps({
+          modelValue: new File(['content'], 'example.txt')
+        })
+
+        expect(result).$ref({ files: void 0 })
+      })
+    })
+  })
+})

--- a/ui/src/composables/private.use-file/use-file.test.js
+++ b/ui/src/composables/private.use-file/use-file.test.js
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref } from 'vue'
+
+import useFile, { useFileEmits, useFileProps } from './use-file.js'
+
+let wrapper
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = void 0
+})
+
+function createFile(name, type, size, lastModified = 1) {
+  return new File([new Uint8Array(size)], name, { type, lastModified })
+}
+
+function mountUseFile({
+  componentProps = {},
+  editable = ref(true),
+  dnd = ref(false),
+  getFileInput = vi.fn(),
+  addFilesToQueue = vi.fn()
+} = {}) {
+  let api
+
+  wrapper = mount(
+    defineComponent({
+      props: useFileProps,
+      emits: useFileEmits,
+
+      setup() {
+        api = useFile({ editable, dnd, getFileInput, addFilesToQueue })
+
+        return () => h('div', [api.getDndNode('file')])
+      }
+    }),
+    { props: componentProps }
+  )
+
+  return { addFilesToQueue, api, dnd, editable, getFileInput }
+}
+
+function createDragEvent(dataTransfer = {}) {
+  return {
+    cancelable: true,
+    dataTransfer,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+}
+
+describe('[useFile API]', () => {
+  describe('[Variables]', () => {
+    describe('[(variable)useFileProps]', () => {
+      test('is defined correctly', () => {
+        expect(useFileProps).$props()
+      })
+    })
+
+    describe('[(variable)useFileEmits]', () => {
+      test('is defined correctly', () => {
+        expect(useFileEmits).$emits()
+      })
+    })
+  })
+
+  describe('[Functions]', () => {
+    describe('[(function)default]', () => {
+      test('can be used in a Vue Component', () => {
+        const { api } = mountUseFile({
+          componentProps: {
+            maxFiles: '3',
+            maxTotalSize: '2048'
+          }
+        })
+
+        expect(api.maxFilesNumber).$ref(3)
+        expect(api.maxTotalSizeNumber).$ref(2048)
+        expect(wrapper.vm.pickFiles).toBe(api.pickFiles)
+        expect(wrapper.vm.addFiles).toBe(api.addFiles)
+      })
+
+      test('opens the file picker and respects the editable state', () => {
+        const input = { click: vi.fn() }
+        const { addFilesToQueue, api, editable, getFileInput } = mountUseFile({
+          getFileInput: vi.fn(() => input)
+        })
+        const files = [createFile('example.txt', 'text/plain', 4)]
+
+        api.pickFiles()
+
+        expect(getFileInput).toHaveBeenCalledOnce()
+        expect(input.click).toHaveBeenCalledWith({ target: null })
+
+        const event = {
+          clientX: 0,
+          clientY: 0,
+          stopPropagation: vi.fn(),
+          target: {
+            matches: vi.fn(() => true)
+          }
+        }
+
+        api.pickFiles(event)
+
+        expect(event.stopPropagation).toHaveBeenCalledOnce()
+        expect(input.click).toHaveBeenCalledOnce()
+
+        api.addFiles(files)
+        expect(addFilesToQueue).toHaveBeenCalledWith(null, files)
+
+        editable.value = false
+        api.pickFiles()
+        api.addFiles(files)
+
+        expect(getFileInput).toHaveBeenCalledOnce()
+        expect(addFilesToQueue).toHaveBeenCalledOnce()
+      })
+
+      test('accepts matching file types and rejects non-matching files', () => {
+        const { api } = mountUseFile({
+          componentProps: {
+            accept: 'image/*, .txt',
+            multiple: true
+          }
+        })
+        const image = createFile('image.png', 'image/png', 4)
+        const text = createFile('notes.txt', 'application/octet-stream', 4)
+        const pdf = createFile('document.pdf', 'application/pdf', 4)
+
+        const result = api.processFiles(null, [image, text, pdf], [], false)
+
+        expect(result).toStrictEqual([image, text])
+        expect(image.__key).toBeTypeOf('string')
+        expect(text.__key).toBeTypeOf('string')
+        expect(wrapper.emitted('rejected')).toStrictEqual([
+          [[{ failedPropValidation: 'accept', file: pdf }]]
+        ])
+      })
+
+      test('enforces per-file and total size limits', () => {
+        const { api } = mountUseFile({
+          componentProps: {
+            maxFileSize: '5',
+            maxTotalSize: '6',
+            multiple: true
+          }
+        })
+        const accepted = createFile('accepted.txt', 'text/plain', 4)
+        const tooLarge = createFile('large.txt', 'text/plain', 6)
+        const overTotal = createFile('total.txt', 'text/plain', 3)
+
+        const result = api.processFiles(
+          null,
+          [accepted, tooLarge, overTotal],
+          [],
+          false
+        )
+
+        expect(result).toStrictEqual([accepted])
+        expect(wrapper.emitted('rejected')).toStrictEqual([
+          [
+            [
+              { failedPropValidation: 'max-file-size', file: tooLarge },
+              { failedPropValidation: 'max-total-size', file: overTotal }
+            ]
+          ]
+        ])
+      })
+
+      test('filters duplicates and observes custom and maximum-file filters', () => {
+        const { api } = mountUseFile({
+          componentProps: {
+            filter: files =>
+              files.filter(file => file.name.startsWith('blocked') === false),
+            maxFiles: '2',
+            multiple: true
+          }
+        })
+        const existing = createFile('existing.txt', 'text/plain', 1)
+        const accepted = createFile('accepted.txt', 'text/plain', 1)
+        const blocked = createFile('blocked.txt', 'text/plain', 1)
+        const overLimit = createFile('over-limit.txt', 'text/plain', 1)
+
+        expect(api.processFiles(null, [existing], [], false)).toStrictEqual([
+          existing
+        ])
+
+        const result = api.processFiles(
+          null,
+          [existing, accepted, blocked, overLimit],
+          [existing],
+          true
+        )
+
+        expect(result).toStrictEqual([accepted])
+        expect(wrapper.emitted('rejected')).toStrictEqual([
+          [
+            [
+              { failedPropValidation: 'duplicate', file: existing },
+              { failedPropValidation: 'filter', file: blocked },
+              { failedPropValidation: 'max-files', file: overLimit }
+            ]
+          ]
+        ])
+      })
+
+      test('normalizes an unbounded single-file selection', () => {
+        const { api } = mountUseFile({
+          componentProps: { accept: '*' }
+        })
+        const first = createFile('first.txt', 'text/plain', 1)
+        const second = createFile('second.txt', 'text/plain', 1)
+
+        const result = api.processFiles(
+          { target: { files: [first, second] } },
+          void 0,
+          [],
+          false
+        )
+
+        expect(result).toStrictEqual([first])
+        expect(wrapper.emitted('rejected')).toBeUndefined()
+      })
+
+      test('handles drag enter, leave, and drop', async () => {
+        const { addFilesToQueue, api, dnd } = mountUseFile()
+        const dragEvent = createDragEvent({ dropEffect: 'none' })
+
+        api.onDragover(dragEvent)
+
+        expect(dragEvent.preventDefault).toHaveBeenCalledOnce()
+        expect(dragEvent.stopPropagation).toHaveBeenCalledOnce()
+        expect(dragEvent.dataTransfer.dropEffect).toBe('copy')
+        expect(dnd.value).toBe(true)
+
+        await nextTick()
+
+        const dndElement = wrapper.find('.q-file__dnd').element
+        const leaveInsideEvent = {
+          ...createDragEvent(),
+          relatedTarget: dndElement
+        }
+
+        api.onDragleave(leaveInsideEvent)
+        expect(dnd.value).toBe(true)
+
+        const leaveEvent = {
+          ...createDragEvent(),
+          relatedTarget: null
+        }
+
+        api.onDragleave(leaveEvent)
+        expect(dnd.value).toBe(false)
+
+        dnd.value = true
+
+        const file = createFile('dropped.txt', 'text/plain', 1)
+        const dropEvent = createDragEvent({ files: [file] })
+        const dndNode = api.getDndNode('file')
+
+        dndNode.props.onDrop(dropEvent)
+
+        expect(addFilesToQueue).toHaveBeenCalledWith(null, [file])
+        expect(dropEvent.dataTransfer.dropEffect).toBe('copy')
+        expect(dnd.value).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- add generated Specs coverage for `private.use-file/use-file-dom-props.js`
- add generated Specs coverage for `private.use-file/use-file.js`
- cover DataTransfer and ClipboardEvent form-file handling, including the
  fallback when neither browser API is available
- cover guarded input types, picker exposure, editable state, file
  validation/rejection, and drag-and-drop behavior
- validate exported prop and emit declarations with the generic `$props()` and
  `$emits()` matchers instead of fixed definitions

## Why

This continues the type-scoped test-file work requested for missing UI Specs.
The targeted generator identified both private use-file modules, so both
accepted files are completed in this isolated PR.

## Impact

Tests only. There are no production-code or public API changes.

## Validation

- `pnpm build` in `ui/`
- `pnpm test:specs --target composables/private.use-file/use-file-dom-props`
- `pnpm test:specs --target composables/private.use-file/use-file`
- focused Vitest: 2 files, 15 tests passed
- root `pnpm test`: 119 UI files / 1,307 UI tests, 10 Vite usage tests, and 75
  Vite runtime tests passed
- root `pnpm lint:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new automated Vitest coverage for file input/selection and drag-and-drop handling.
  * Validated `accept` filtering with `rejected` events, per-file and total size limits, duplicate detection, and custom `filter`/`max-files` behavior.
  * Ensured `editable` gating blocks picker/queue actions as expected and normalizes unbounded single-file selections.
  * Added coverage for browser API fallbacks when `DataTransfer` is missing or throws, including `ClipboardEvent`-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
