### PR TITLE
test(ui): validate Vue prop definitions generically

### DIFF
--- a/ui/src/composables/private.use-anchor/use-anchor.test.js
+++ b/ui/src/composables/private.use-anchor/use-anchor.test.js
@@ -82,26 +82,13 @@ describe('[useAnchor API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useAnchorStaticProps]', () => {
       test('is defined correctly', () => {
-        expect(Object.keys(useAnchorStaticProps)).toStrictEqual([
-          'target',
-          'noParentEvent'
-        ])
-        expect(useAnchorStaticProps.target).toMatchObject({
-          type: [Boolean, String, Element],
-          default: true
-        })
-        expect(useAnchorStaticProps.noParentEvent).toBe(Boolean)
+        expect(useAnchorStaticProps).$props()
       })
     })
 
     describe('[(variable)useAnchorProps]', () => {
       test('is defined correctly', () => {
-        expect(Object.keys(useAnchorProps)).toStrictEqual([
-          'target',
-          'noParentEvent',
-          'contextMenu'
-        ])
-        expect(useAnchorProps.contextMenu).toBe(Boolean)
+        expect(useAnchorProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
+++ b/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
@@ -49,14 +49,7 @@ describe('[useModelToggle API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useModelToggleProps]', () => {
       test('is defined correctly', () => {
-        expect(Object.keys(useModelToggleProps)).toStrictEqual([
-          'modelValue',
-          'onUpdate:modelValue'
-        ])
-        expect(useModelToggleProps.modelValue).toMatchObject({
-          type: Boolean,
-          default: null
-        })
+        expect(useModelToggleProps).$props()
       })
     })
 

--- a/ui/testing/README.md
+++ b/ui/testing/README.md
@@ -173,7 +173,7 @@ $ pnpm test:specs --target <target_file>
 - Watch for `$computedStyle()` calls as these get cached, so you only get one chance per node to get the expected result. Usually leave this as the last expect() call.
 - Test the effect while not duplicating the implementation of what you are testing. Where you can, use `$computedStyle()`.
 - Be aware of the common formulas (below).
-- There are some custom matchers that you can use (`$any`, `$arrayValues`, `$objectValues`, `$ref`, `$reactive`) and also some extra @vue/test-utils mount() additions (`$style`, `$computedStyle`): [code](https://github.com/quasarframework/quasar/blob/dev/ui/testing/setup.js)
+- There are some custom matchers that you can use (`$any`, `$props`, `$arrayValues`, `$objectValues`, `$ref`, `$reactive`) and also some extra @vue/test-utils mount() additions (`$style`, `$computedStyle`): [code](https://github.com/quasarframework/quasar/blob/dev/ui/testing/vitest.setup.js)
 - Use of Copilot when writing the tests is allowed ;)
 
 Important reading list:

--- a/ui/testing/vitest.setup.js
+++ b/ui/testing/vitest.setup.js
@@ -58,6 +58,68 @@ function $any(received, expectedList) {
   }
 }
 
+const vuePropOptionKeys = new Set(['type', 'required', 'default', 'validator'])
+
+function isVuePropType(value, allowTrue = false) {
+  return (
+    value === null ||
+    typeof value === 'function' ||
+    (allowTrue === true && value === true) ||
+    (Array.isArray(value) &&
+      value.every(type => type === null || typeof type === 'function'))
+  )
+}
+
+function isVuePropDefinition(value) {
+  if (isVuePropType(value)) {
+    return true
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const keys = Object.keys(value)
+
+  return (
+    keys.every(key => vuePropOptionKeys.has(key)) &&
+    (value.type === void 0 || isVuePropType(value.type, true)) &&
+    (value.required === void 0 || typeof value.required === 'boolean') &&
+    (value.validator === void 0 || typeof value.validator === 'function')
+  )
+}
+
+/**
+ * Examples:
+ *   expect(component.props).$props()
+ *   expect(composableProps).$props()
+ */
+export function $props(received) {
+  const isObject =
+    received !== null &&
+    typeof received === 'object' &&
+    Array.isArray(received) === false
+  const invalidKeys = isObject
+    ? Object.keys(received).filter(
+        key =>
+          key.startsWith('$') || isVuePropDefinition(received[key]) === false
+      )
+    : []
+  const pass = isObject && invalidKeys.length === 0
+
+  return {
+    pass,
+    message: () =>
+      `expected ${this.utils.printReceived(
+        received
+      )} to${this.isNot ? ' not' : ''} be an object containing valid Vue prop definitions${
+        invalidKeys.length !== 0
+          ? `; invalid prop keys: ${this.utils.printReceived(invalidKeys)}`
+          : ''
+      }`
+  }
+}
+
 /**
  * Examples:
  *   expect(arr).$arrayValues({ ... })
@@ -148,6 +210,7 @@ export function $reactive(received, expected) {
 
 expect.extend({
   $any,
+  $props,
   $objectValues,
   $arrayValues,
   $ref,


### PR DESCRIPTION
## What changed

- add a reusable `$props()` Vitest matcher for Vue object prop definitions
- validate constructor shorthand, constructor arrays, `null`, and Vue prop option objects
- replace the merged `useAnchorProps` and `useModelToggleProps` snapshots with structural validation
- document the matcher and correct the setup-file link

## Why

The generated composable tests were asserting exact prop names, types, and defaults. Those assertions become stale whenever a valid prop is added, removed, or changed, without testing meaningful behavior.

The matcher now verifies that the export is an object and that every value has a valid Vue prop-definition shape, while deliberately remaining independent of the current prop list.

This PR provides the shared foundation for correcting the same pattern in the still-open UI coverage PRs.

## Validation

- `pnpm build` from `ui/`
- `pnpm test:specs --target composables/private.use-anchor/use-anchor`
- `pnpm test:specs --target composables/private.use-model-toggle/use-model-toggle`
- focused Vitest: 2 files, 18 tests passed
- `pnpm test`: 107 UI files / 1,216 tests, 10 Vite usage tests, 75 Vite runtime tests
- `quasar prepare` in all four apps requiring generated `.quasar/tsconfig.json`
- `pnpm lint:check`
- `git diff --check`

No production behavior or public API is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated validation of Vue component prop definitions.
  - Added clearer checks for valid prop options while ignoring framework-generated properties.
  - Updated related tests to use the standardized prop validation matcher.

- **Documentation**
  - Updated testing guidelines to reference the current test setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->