### PR TITLE
test(ui): use props matcher in existing tests

### DIFF
--- a/ui/src/components/btn/use-btn.test.js
+++ b/ui/src/components/btn/use-btn.test.js
@@ -37,15 +37,13 @@ describe('[useBtn API]', () => {
 
     describe('[(variable)useBtnProps]', () => {
       test('is defined correctly', () => {
-        expect(useBtnProps).toBeTypeOf('object')
-        expect(Object.keys(useBtnProps)).not.toHaveLength(0)
+        expect(useBtnProps).$props()
       })
     })
 
     describe('[(variable)nonRoundBtnProps]', () => {
       test('is defined correctly', () => {
-        expect(nonRoundBtnProps).toBeTypeOf('object')
-        expect(Object.keys(nonRoundBtnProps)).not.toHaveLength(0)
+        expect(nonRoundBtnProps).$props()
       })
     })
   })

--- a/ui/src/components/circular-progress/circular-progress.test.js
+++ b/ui/src/components/circular-progress/circular-progress.test.js
@@ -6,8 +6,7 @@ describe('[circularProgress API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useCircularCommonProps]', () => {
       test('is defined correctly', () => {
-        expect(useCircularCommonProps).toBeTypeOf('object')
-        expect(Object.keys(useCircularCommonProps)).not.toHaveLength(0)
+        expect(useCircularCommonProps).$props()
       })
     })
   })

--- a/ui/src/components/spinner/use-spinner.test.js
+++ b/ui/src/components/spinner/use-spinner.test.js
@@ -7,8 +7,7 @@ describe('[useSpinner API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useSpinnerProps]', () => {
       test('is defined correctly', () => {
-        expect(useSpinnerProps).toBeTypeOf('object')
-        expect(Object.keys(useSpinnerProps)).not.toHaveLength(0)
+        expect(useSpinnerProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-align/use-align.test.js
+++ b/ui/src/composables/private.use-align/use-align.test.js
@@ -20,8 +20,7 @@ describe('[useAlign API]', () => {
 
     describe('[(variable)useAlignProps]', () => {
       test('is defined correctly', () => {
-        expect(useAlignProps).toBeTypeOf('object')
-        expect(Object.keys(useAlignProps)).not.toHaveLength(0)
+        expect(useAlignProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-dark/use-dark.test.js
+++ b/ui/src/composables/private.use-dark/use-dark.test.js
@@ -6,8 +6,7 @@ describe('[useDark API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useDarkProps]', () => {
       test('is defined correctly', () => {
-        expect(useDarkProps).toBeTypeOf('object')
-        expect(Object.keys(useDarkProps)).not.toHaveLength(0)
+        expect(useDarkProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
@@ -44,8 +44,7 @@ describe('[useFullscreen API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useFullscreenProps]', () => {
       test('is defined correctly', () => {
-        expect(useFullscreenProps).toBeTypeOf('object')
-        expect(Object.keys(useFullscreenProps)).not.toHaveLength(0)
+        expect(useFullscreenProps).$props()
       })
     })
 

--- a/ui/src/composables/private.use-ratio/use-ratio.test.js
+++ b/ui/src/composables/private.use-ratio/use-ratio.test.js
@@ -6,8 +6,7 @@ describe('[useRatio API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useRatioProps]', () => {
       test('is defined correctly', () => {
-        expect(useRatioProps).toBeTypeOf('object')
-        expect(Object.keys(useRatioProps)).not.toHaveLength(0)
+        expect(useRatioProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-size/use-size.test.js
+++ b/ui/src/composables/private.use-size/use-size.test.js
@@ -13,8 +13,7 @@ describe('[useSize API]', () => {
 
     describe('[(variable)useSizeProps]', () => {
       test('is defined correctly', () => {
-        expect(useSizeProps).toBeTypeOf('object')
-        expect(Object.keys(useSizeProps)).not.toHaveLength(0)
+        expect(useSizeProps).$props()
       })
     })
   })

--- a/ui/src/composables/private.use-transition/use-transition.test.js
+++ b/ui/src/composables/private.use-transition/use-transition.test.js
@@ -6,8 +6,7 @@ describe('[useTransition API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useTransitionProps]', () => {
       test('is defined correctly', () => {
-        expect(useTransitionProps).toBeTypeOf('object')
-        expect(Object.keys(useTransitionProps)).not.toHaveLength(0)
+        expect(useTransitionProps).$props()
       })
     })
   })

--- a/ui/src/composables/use-form/use-form.test.js
+++ b/ui/src/composables/use-form/use-form.test.js
@@ -12,8 +12,7 @@ describe('[useForm API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useFormProps]', () => {
       test('is defined correctly', () => {
-        expect(useFormProps).toBeTypeOf('object')
-        expect(Object.keys(useFormProps)).not.toHaveLength(0)
+        expect(useFormProps).$props()
       })
     })
   })


### PR DESCRIPTION
## Summary

- replace generic object/non-empty assertions for existing exported Vue props definitions with the `$props()` matcher added by #18463
- keep behavioral prop tests and non-props object/collection tests unchanged
- rename `private.use-form.test.js` to `use-form.test.js` so it follows the filename expected by the Specs generator

## Motivation

The older tests only proved that these exported values were non-empty objects. They did not verify that every entry was a valid Vue prop definition, and they provided less useful coverage than the shared matcher.

This also avoids tying tests to a fixed list of props: adding, changing, or removing a valid prop will not fail a generic props-definition test.

The `use-form` test needed a filename correction because the Specs context removes the `private.` prefix from source filenames. Without the rename, `pnpm test:specs --target composables/use-form/private.use-form` reports the existing test as missing and prompts to create a duplicate `use-form.test.js`.

## Impact

Test-only change. There is no production, public API, SSR, hydration, platform, accessibility, or security impact.

## Validation

- `cd ui && pnpm build`
- `pnpm test:specs --target <source-subpath>` for all 10 edited test targets
- focused Vitest run: 10 files, 59 tests passed
- root `pnpm test`: generated Specs validation; 107 UI files / 1,216 UI tests; 10 Vite usage tests; 75 Vite runtime tests
- `quasar prepare` for the four worktree packages whose generated tsconfigs are required by lint
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated API validation tests for UI components and composables to use the standardized `$props()` matcher.
  - Improved consistency and reliability when verifying exported property definitions.
  - No user-facing behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->