### PR TITLE
test(ui): validate Vue emits definitions generically

### DIFF
--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
@@ -50,8 +50,7 @@ describe('[useFullscreen API]', () => {
 
     describe('[(variable)useFullscreenEmits]', () => {
       test('is defined correctly', () => {
-        expect(Array.isArray(useFullscreenEmits)).toBe(true)
-        expect(useFullscreenEmits).not.toHaveLength(0)
+        expect(useFullscreenEmits).$emits()
       })
     })
   })

--- a/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
+++ b/ui/src/composables/private.use-model-toggle/use-model-toggle.test.js
@@ -55,12 +55,7 @@ describe('[useModelToggle API]', () => {
 
     describe('[(variable)useModelToggleEmits]', () => {
       test('is defined correctly', () => {
-        expect(useModelToggleEmits).toStrictEqual([
-          'beforeShow',
-          'show',
-          'beforeHide',
-          'hide'
-        ])
+        expect(useModelToggleEmits).$emits()
       })
     })
   })

--- a/ui/testing/README.md
+++ b/ui/testing/README.md
@@ -173,7 +173,7 @@ $ pnpm test:specs --target <target_file>
 - Watch for `$computedStyle()` calls as these get cached, so you only get one chance per node to get the expected result. Usually leave this as the last expect() call.
 - Test the effect while not duplicating the implementation of what you are testing. Where you can, use `$computedStyle()`.
 - Be aware of the common formulas (below).
-- There are some custom matchers that you can use (`$any`, `$props`, `$arrayValues`, `$objectValues`, `$ref`, `$reactive`) and also some extra @vue/test-utils mount() additions (`$style`, `$computedStyle`): [code](https://github.com/quasarframework/quasar/blob/dev/ui/testing/vitest.setup.js)
+- There are some custom matchers that you can use (`$any`, `$emits`, `$props`, `$arrayValues`, `$objectValues`, `$ref`, `$reactive`) and also some extra @vue/test-utils mount() additions (`$style`, `$computedStyle`): [code](https://github.com/quasarframework/quasar/blob/dev/ui/testing/vitest.setup.js)
 - Use of Copilot when writing the tests is allowed ;)
 
 Important reading list:

--- a/ui/testing/vitest.setup.js
+++ b/ui/testing/vitest.setup.js
@@ -120,6 +120,37 @@ export function $props(received) {
   }
 }
 
+function isVueEmitsDefinition(value) {
+  if (Array.isArray(value)) {
+    return value.every(eventName => typeof eventName === 'string')
+  }
+
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    Object.values(value).every(
+      validator => validator === null || typeof validator === 'function'
+    )
+  )
+}
+
+/**
+ * Examples:
+ *   expect(component.emits).$emits()
+ *   expect(composableEmits).$emits()
+ */
+export function $emits(received) {
+  const pass = isVueEmitsDefinition(received)
+
+  return {
+    pass,
+    message: () =>
+      `expected ${this.utils.printReceived(
+        received
+      )} to${this.isNot ? ' not' : ''} be a valid Vue emits definition`
+  }
+}
+
 /**
  * Examples:
  *   expect(arr).$arrayValues({ ... })
@@ -210,6 +241,7 @@ export function $reactive(received, expected) {
 
 expect.extend({
   $any,
+  $emits,
   $props,
   $objectValues,
   $arrayValues,


### PR DESCRIPTION
## Summary

- add a `$emits()` Vitest matcher for valid Vue array and object emits declarations
- use it for the existing `useFullscreenEmits` and `useModelToggleEmits` declaration tests
- document the matcher for future generated test files

## Motivation

Follow-up to #18464. Existing generic tests either only proved that the emits
array was non-empty or hard-coded the current event list. Both approaches become
stale when valid events change.

`$emits()` checks declaration shape while leaving actual event behavior to the
existing behavioral tests. It accepts Vue's supported forms:

- arrays of event-name strings
- objects mapping event names to validator functions or `null`

Other exported `*Emits` values currently belong to source files without
generated test files; future tests can use this matcher as those files are
added.

## Impact

Test-only change. No production, public API, SSR, hydration, platform,
accessibility, or security impact.

## Validation

- `cd ui && pnpm build`
- `pnpm test:specs --target composables/private.use-fullscreen/use-fullscreen`
- `pnpm test:specs --target composables/private.use-model-toggle/use-model-toggle`
- focused Vitest: 2 files, 12 tests
- root `pnpm test`: generated Specs validation; 107 UI files and 1,216 UI
  tests; 10 Vite usage tests; 75 Vite runtime tests
- `quasar prepare` in `docs`, both App Vite playgrounds, and `ui/playground`
- `pnpm lint:check`
- `git diff --check`
