### PR TITLE
fix(app-vite): preserve Electron app identity in dev

### DIFF
--- a/app-vite/lib/modes/electron/electron-devserver.js
+++ b/app-vite/lib/modes/electron/electron-devserver.js
@@ -1,13 +1,23 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createServer } from 'vite'
 
 import { AppDevserver } from '../../app-devserver.js'
 import { fatal, log, warn } from '../../utils/logger.js'
+import { onShutdown } from '../../utils/on-shutdown.js'
 import { spawn } from '../../utils/spawn.js'
 import { getPackagePath } from '../../utils/get-package-path.js'
 import { updateHtmlVariables } from '../../plugins/vite.html.js'
 import { quasarElectronConfig } from './electron-config.js'
+
+const linuxDesktopEntryMarker = 'X-Quasar-Dev-Entry=true'
 
 function delay(time) {
   const { promise, resolve } = Promise.withResolvers()
@@ -15,11 +25,47 @@ function delay(time) {
   return promise
 }
 
+function getLinuxDesktopName({ desktopName, productName, name }) {
+  if (typeof desktopName === 'string' && desktopName.trim() !== '') {
+    const configuredName = desktopName.trim().replace(/\.desktop$/i, '')
+
+    // A desktop file ID cannot contain a path separator. Preserve unusual
+    // explicit values for Electron itself, but do not use them as file paths.
+    return /^[a-zA-Z0-9_.-]+$/.test(configuredName) ? configuredName : null
+  }
+
+  for (const appName of [productName, name]) {
+    if (typeof appName === 'string') {
+      const normalizedName = appName
+        .normalize('NFKD')
+        .replaceAll(/\p{M}/gu, '')
+        .toLowerCase()
+        .replaceAll(/[^a-z0-9]+/g, '-')
+        .replaceAll(/^-+|-+$/g, '')
+
+      if (normalizedName !== '') {
+        return normalizedName
+      }
+    }
+  }
+
+  return null
+}
+
+function escapeDesktopEntryValue(value) {
+  return String(value)
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('\n', String.raw`\n`)
+    .replaceAll('\r', '')
+}
+
 export class QuasarModeDevserver extends AppDevserver {
   #pid = 0
   #watcherList = []
   #killedPid = false
   #electronExecutable
+  #linuxDesktopEntryPath
+  #linuxDesktopEntryContent
 
   constructor(opts) {
     super(opts)
@@ -34,6 +80,10 @@ export class QuasarModeDevserver extends AppDevserver {
       dirname(electronPkgPath),
       electronPkg.bin.electron
     )
+
+    onShutdown(() => {
+      this.#removeLinuxDesktopEntry()
+    })
 
     this.registerDiff('electron', (quasarConf, diffMap) => [
       quasarConf.devServer,
@@ -125,6 +175,16 @@ export class QuasarModeDevserver extends AppDevserver {
 
     const electronEntryDir = this.ctx.appPaths.resolve.entry('electron')
     const { name, productName, version, desktopName } = this.ctx.pkg.appPkg
+    const linuxDesktopName =
+      process.platform === 'linux'
+        ? getLinuxDesktopName({ name, productName, desktopName })
+        : null
+
+    this.#createLinuxDesktopEntry({
+      name,
+      productName,
+      desktopName: linuxDesktopName
+    })
 
     // Electron only loads application metadata when launched with an app
     // directory. Passing the compiled main file directly makes development
@@ -135,7 +195,7 @@ export class QuasarModeDevserver extends AppDevserver {
         name,
         productName,
         version,
-        desktopName,
+        desktopName: linuxDesktopName || desktopName,
         main: './electron-main.js',
         type: 'module'
       })
@@ -163,5 +223,115 @@ export class QuasarModeDevserver extends AppDevserver {
         )
       }
     )
+  }
+
+  #createLinuxDesktopEntry({ name, productName, desktopName }) {
+    this.#removeLinuxDesktopEntry()
+
+    if (
+      process.platform !== 'linux' ||
+      desktopName === null ||
+      (process.env.DISPLAY === void 0 && process.env.WAYLAND_DISPLAY === void 0)
+    ) {
+      return
+    }
+
+    const appPaths = this.ctx.appPaths
+    const iconPathList = [
+      appPaths.resolve.electron('electron-assets/icons/icon.png'),
+      appPaths.resolve.electron('electron-assets/icons/linux-512x512.png')
+    ]
+    const iconPath = iconPathList.find(existsSync)
+
+    if (iconPath === void 0) {
+      return
+    }
+
+    const filename = `${desktopName}.desktop`
+    const appDir = escapeDesktopEntryValue(appPaths.appDir)
+    const appDirMarker = `X-Quasar-Dev-AppDir=${appDir}`
+    const dataHome =
+      process.env.XDG_DATA_HOME || join(homedir(), '.local', 'share')
+    const dataDirList = (
+      process.env.XDG_DATA_DIRS || '/usr/local/share:/usr/share'
+    )
+      .split(':')
+      .filter(Boolean)
+
+    const desktopEntryPath = join(dataHome, 'applications', filename)
+    const existingDesktopEntryPath = [dataHome, ...dataDirList]
+      .map(dir => join(dir, 'applications', filename))
+      .find(existsSync)
+
+    if (existingDesktopEntryPath !== void 0) {
+      if (existingDesktopEntryPath === desktopEntryPath) {
+        try {
+          const content = readFileSync(desktopEntryPath, 'utf8')
+
+          // Adopt an entry left by an interrupted Quasar process so that a
+          // later graceful shutdown can remove it.
+          if (
+            content.includes(linuxDesktopEntryMarker) &&
+            content.includes(appDirMarker)
+          ) {
+            this.#linuxDesktopEntryPath = desktopEntryPath
+            this.#linuxDesktopEntryContent = content
+          }
+        } catch {}
+      }
+
+      return
+    }
+
+    const appDisplayName = escapeDesktopEntryValue(
+      productName || name || 'Quasar App'
+    )
+    const content = `[Desktop Entry]
+Type=Application
+Name=${appDisplayName} (Development)
+Comment=Temporary launcher metadata for Quasar Electron development
+Exec=/bin/false
+Icon=${escapeDesktopEntryValue(iconPath)}
+NoDisplay=true
+StartupNotify=false
+StartupWMClass=${desktopName}
+${linuxDesktopEntryMarker}
+${appDirMarker}
+`
+
+    try {
+      mkdirSync(dirname(desktopEntryPath), { recursive: true })
+      writeFileSync(desktopEntryPath, content, {
+        flag: 'wx',
+        mode: 0o600
+      })
+
+      this.#linuxDesktopEntryPath = desktopEntryPath
+      this.#linuxDesktopEntryContent = content
+    } catch {
+      // Desktop integration is best-effort and must not prevent development.
+    }
+  }
+
+  #removeLinuxDesktopEntry() {
+    if (this.#linuxDesktopEntryPath === void 0) {
+      return
+    }
+
+    try {
+      // Never delete a desktop entry that another process replaced while the
+      // development server was running.
+      if (
+        readFileSync(this.#linuxDesktopEntryPath, 'utf8') ===
+        this.#linuxDesktopEntryContent
+      ) {
+        unlinkSync(this.#linuxDesktopEntryPath)
+      }
+    } catch {
+      // The entry may already have been removed by the user or the OS.
+    }
+
+    this.#linuxDesktopEntryPath = void 0
+    this.#linuxDesktopEntryContent = void 0
   }
 }

--- a/app-vite/lib/modes/electron/electron-devserver.js
+++ b/app-vite/lib/modes/electron/electron-devserver.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { createServer } from 'vite'
 
@@ -123,11 +123,29 @@ export class QuasarModeDevserver extends AppDevserver {
       await delay(100)
     }
 
+    const electronEntryDir = this.ctx.appPaths.resolve.entry('electron')
+    const { name, productName, version, desktopName } = this.ctx.pkg.appPkg
+
+    // Electron only loads application metadata when launched with an app
+    // directory. Passing the compiled main file directly makes development
+    // builds inherit Electron's name, version and Linux desktop identity.
+    writeFileSync(
+      join(electronEntryDir, 'package.json'),
+      JSON.stringify({
+        name,
+        productName,
+        version,
+        desktopName,
+        main: './electron-main.js',
+        type: 'module'
+      })
+    )
+
     this.#pid = spawn(
       this.#electronExecutable,
       [
         '--inspect=' + quasarConf.electron.inspectPort,
-        this.ctx.appPaths.resolve.entry('electron/electron-main.js'),
+        electronEntryDir,
         ...this.argv._
       ],
       { cwd: this.ctx.appPaths.appDir },


### PR DESCRIPTION
## Summary

- generate a minimal `package.json` beside the compiled Electron development entry and launch that application directory
- preserve the application's name, product name, version, and Linux desktop name
- register a hidden, temporary Linux desktop entry when no matching installed entry exists, allowing GNOME and other desktop environments to resolve the development window's icon
- remove only the exact Quasar-owned entry on shutdown; never overwrite an existing user or system entry

## Root cause

The Electron development server passed `.quasar/dev-electron/electron/electron-main.js` directly to Electron. Because the generated directory had no package metadata, Electron treated the process as its default application. This made `app.getName()` and `app.getVersion()` report Electron's own values and produced the generic `electron` desktop identity on Linux.

Launching the generated directory corrects that metadata and `WM_CLASS`, but it is not sufficient for GNOME's dock icon. Electron's Linux desktop integration expects the effective desktop name / `WM_CLASS` to match an installed `.desktop` filename. In an unpackaged development app there is normally no such entry, and setting `BrowserWindow.icon` alone left `_NET_WM_ICON` empty on Ubuntu GNOME/X11. GNOME therefore displayed its generic gear icon.

The development server now creates a hidden, temporary desktop entry only when needed. It uses the source Electron icon, does not replace an existing entry, and removes only content it created (or a matching same-project entry left by an interrupted earlier run).

## Impact

Electron development builds now use the application's identity rather than Electron's:

- `app.getName()` and `app.getVersion()` return the app values
- Linux receives the configured or derived desktop name and matching `WM_CLASS`
- GNOME can resolve the application icon without an app-level `app.setDesktopName()` workaround

Production builds and the public API are unchanged. Desktop registration is Linux-only, display-session-only, and best-effort, so it cannot prevent the development server from starting.

## Validation

- `pnpm lint:check`
- `git diff --check`
- `pnpm test`
  - 135 UI test files / 1,348 UI tests
  - 10 Vite usage tests
  - 75 Vite runtime tests
- manual integration against a clean detached File Explorer commit with no desktop-name or native-image workaround:
  - generated metadata: `File Explorer` / `3.0.4`
  - generated `desktopName` and X11 `WM_CLASS`: `electron-quasar-file-explorer-v2`
  - generated desktop entry passed `desktop-file-validate`
  - Ubuntu GNOME/X11 dock displayed the File Explorer icon instead of the generic gear icon
  - graceful shutdown removed the temporary desktop entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Electron development launches on Linux.
  * Added temporary desktop launcher integration when a graphical environment is available.
  * Electron development apps now use project metadata such as the application name, product name, and version.

* **Bug Fixes**
  * Improved cleanup of temporary desktop launchers when development sessions end or are interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->