### PR TITLE
fix(position-engine): #16167 QMenu/QTooltip never appear in Firefox when their content uses flexbox

### DIFF
--- a/ui/src/css/core/positioning.sass
+++ b/ui/src/css/core/positioning.sass
@@ -103,4 +103,4 @@ body.q-safe-area-padding .fullscreen
   margin-top: var(--q-pe-top, 0) !important
   margin-left: var(--q-pe-left, 0) !important
   will-change: auto
-  visibility: collapse // needed for animation - is removed on first positioning
+  visibility: hidden // needed for animation - is removed on first positioning


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — **not tested, see "Not verified" below**
- [ ] It's been tested on an Electron app — **not tested, see "Not verified" below**
- [x] Any necessary documentation has been added or updated — none needed; this is an internal CSS class with no public API surface

---

**TL;DR — `.q-position-engine` hides popups with `visibility: collapse`, and Firefox is the only engine that gives `collapse` real layout semantics. Any QMenu/QTooltip whose content contains a flexbox is therefore measured as zero along that flex container's main axis, so `setPosition()` never clears its zero-size guard and the popup is never positioned nor shown.**

`hidden` expresses the same intent — "not visible yet" — with no layout effect in any engine.

Resolves #16167 (open since 2023). **Firefox 153 has just widened the blast radius considerably**: previously only `flex-direction: column` content was affected, now `row` is too, which is a far more common shape.

```diff
   .q-position-engine
     margin-top: var(--q-pe-top, 0) !important
     margin-left: var(--q-pe-left, 0) !important
     will-change: auto
-  visibility: collapse // needed for animation - is removed on first positioning
+  visibility: hidden // needed for animation - is removed on first positioning
```

<details>
<summary><b>Root cause</b></summary>

`ui/src/utils/private.position-engine/position-engine.js` refuses to position a zero-sized target, retrying 6 times at 10 ms and then giving up permanently:

```js
if (cfg.targetEl === null || cfg.anchorEl === null || retryNumber > 5) return
if (cfg.targetEl.offsetHeight === 0 || cfg.targetEl.offsetWidth === 0) {
  setTimeout(() => { setPosition(cfg, retryNumber + 1) }, 10)
  return
}
```

`visibility: visible` and the inline `top`/`left` are written only *after* that guard. `visibility` is an **inherited** property, so the `collapse` set on `.q-position-engine` reaches the popup's descendants.

Firefox has implemented `visibility: collapse` on **flex items** since Firefox 29 ([bug 783470](https://bugzilla.mozilla.org/show_bug.cgi?id=783470)): a collapsed flex item is zeroed along its container's **main axis**, cross size preserved. Chromium and WebKit do not implement it and fold `collapse` to `hidden`, which is why only Firefox is affected.

That produces a deadlock: the hiding mechanism causes the zero measurement, and the zero measurement is what prevents the hiding from ever being cleared. Re-opening the popup lands in the same state, which matches the "menu simply never appears, no error" reports in #16167.

</details>

<details>
<summary><b>Validation — cross-engine A/B, 9 content shapes</b></summary>

Stock Quasar 2.18.5 (CDN), plain Vue app, no framework wrapper. Real Mozilla builds driven by geckodriver; Chromium/WebKit via Playwright. Each cell is `width×height@x,y` of the opened popup.

**The bar here is not "still works" but "geometry byte-identical to unpatched"**, except where unpatched was broken.

| case | Chromium | WebKit | FF 152 | FF 153 |
|---|---|---|---|---|
| plain div | identical | identical | identical | identical |
| `div.row` | identical | identical | identical | **BROKEN → fixed** |
| `div.column` | identical | identical | **BROKEN → fixed** | **BROKEN → fixed** |
| `q-list` / `q-item` | identical | identical | identical | identical |
| `<table>` | identical | identical | identical | identical |
| 60-line scrolling menu | identical | identical | identical | identical |
| `q-menu fit` | identical | identical | identical | **BROKEN → fixed** |
| QTooltip | identical | identical | identical | identical |
| QSelect dropdown | identical | identical | identical | identical |

- **Chromium and WebKit: all 9 cases byte-identical**, before vs after — a measurable no-op, as expected since those engines already treat `collapse` as `hidden`.
- **Firefox: every case that worked is byte-identical.** Only broken cases change.
- After the fix, **FF 153 geometry equals FF 152 geometry exactly for all 9 cases** — the patch restores pre-regression behaviour rather than introducing new behaviour.

Raw broken→fixed values, for the record:

```
FF152  column   17x0@20,120  BROKEN   ->  17x42@178,60  OK
FF153  row       0x21@20,120 BROKEN   ->  32x21@105,60  OK
FF153  column    0x0@20,120  BROKEN   ->  17x42@178,60  OK
FF153  fit       0x21@20,120 BROKEN   ->  53x21@510,60  OK
```

**No flash.** Since the comment mentions animation, I sampled the popup every animation frame for 400 ms after opening, looking for any frame where it is `visibility: visible` while still unpositioned (no inline `top`). Zero such frames in all four configurations (FF152/FF153 × before/after). With the fix the popup first becomes visible at 9 ms on FF153 and 7 ms on FF152 — already positioned.

**Blast radius.** `q-position-engine` is applied in exactly two places, both `position: fixed !important` and therefore out of flow, so they can never themselves be flex items:

```
ui/src/components/menu/QMenu.js:408       'q-menu q-position-engine scroll' + menuClass.value
ui/src/components/tooltip/QTooltip.js:445 'q-tooltip q-tooltip--style q-position-engine no-pointer-events'
```

**Repo checks**, run on this branch:

| check | baseline (`collapse`) | this branch (`hidden`) |
|---|---|---|
| `pnpm test` (vitest) | 135 files / 1348 tests passed | 135 files / 1348 tests passed |
| `pnpm build` | ok | ok |
| compiled `dist/quasar.prod.css` | `visibility:collapse` | `visibility:hidden`, zero `collapse` remaining |
| `pnpm lint:check` | format clean; 4 pre-existing `.quasar/tsconfig.json` errors | identical 4 (verified pre-existing) |
| `git diff --check` | — | clean |

</details>

<details>
<summary><b>Alternatives considered, and what is NOT verified</b></summary>

**Alternatives rejected:**

- *Move the zero-size guard to after visibility is restored.* More invasive, and risks flashing the popup at `top: 0; left: 0` during retries.
- *Scope the change to Firefox.* Backwards — Chromium/WebKit folding `collapse` into `hidden` is the accidental behaviour; `hidden` is the portable expression of the intended state.
- *`min-height`/`min-width` on `.q-menu`* (the workaround circulating in #16167). It defeats the guard but leaves the underlying reliance on `collapse` semantics in place.

**Not verified — stated plainly:**

- **Not tested on Cordova or Electron.** I have no such app set up; the change is engine-level CSS and the WebKit/Chromium results above are the closest proxy I can offer.
- **No regression test added.** The existing suite is jsdom/unit-only — `grep` across `ui/src/**/*.test.js` finds nothing that renders `.q-position-engine` or inspects QMenu/QTooltip positioning. So the green 1348/1348 above genuinely proves no unrelated logic broke, but it is **weak evidence for this specific change**; the browser matrix is the real evidence. Happy to add a test if you can point me at the right harness for browser-level positioning.
- **Not bisected to a Gecko changeset.** That Firefox 153 changed how a collapsed flex item's zero size propagates to its container's intrinsic width is an inference from measured behaviour across builds. The fix does not depend on it — it removes the reliance on `collapse` either way.
- **Firefox versions:** 152.0 and 153.0.1 were run by hand; 151.0, 152.0.6, 154.0 and 155.0a1 came from an automated sweep.
- SSR/hydration and RTL were not specifically exercised beyond the suite above.

</details>

<details>
<summary><b>Reproduction (paste into a file, open in Firefox 153)</b></summary>

Both buttons do nothing on Firefox 153. Put `.q-position-engine { visibility: hidden }` into the empty `<style>` and both work.

```html
<link href="https://cdn.jsdelivr.net/npm/quasar@2.18.5/dist/quasar.prod.css" rel="stylesheet">
<style id="fix"></style>
<div id="q-app">
  <q-btn label="ROW" color="primary">
    <q-menu><div class="row"><div>hello</div><div>world</div></div></q-menu>
  </q-btn>
  <q-btn label="COLUMN" color="primary">
    <q-menu><div class="column"><div>hello</div><div>world</div></div></q-menu>
  </q-btn>
</div>
<script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
<script src="https://cdn.jsdelivr.net/npm/quasar@2.18.5/dist/quasar.umd.prod.js"></script>
<script>Vue.createApp({}).use(Quasar).mount('#q-app')</script>
```

On Firefox 152 the `COLUMN` button already fails — that is #16167 as originally reported.

</details>

<sub>Investigated and drafted by Claude Code on evnchn's behalf; all measurements above were run rather than reasoned.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial positioning behavior for animated elements, keeping them hidden without collapsing their layout space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->