### PR TITLE
fix(app-vite): harden Electron dev desktop entries

### DIFF
--- a/app-vite/lib/modes/electron/electron-devserver.js
+++ b/app-vite/lib/modes/electron/electron-devserver.js
@@ -33,11 +33,14 @@ function getLinuxDesktopName({ desktopName, productName, name }) {
       const configuredName = trimmedName.replace(/\.desktop$/i, '')
 
       /**
-       * A desktop file ID cannot contain a path separator.
-       * Preserve unusual explicit values for Electron itself,
-       * but do not use them as file paths.
+       * The value becomes a desktop-entry filename, so reject path separators
+       * and the special dot-only path segments.
        */
-      return /^[a-zA-Z0-9_.-]+$/.test(configuredName) ? configuredName : null
+      return configuredName !== '.' &&
+        configuredName !== '..' &&
+        /^[a-zA-Z0-9_.-]+$/.test(configuredName)
+        ? configuredName
+        : null
     }
   }
 
@@ -62,6 +65,7 @@ function getLinuxDesktopName({ desktopName, productName, name }) {
 function escapeDesktopEntryValue(value) {
   return String(value)
     .replaceAll('\\', String.raw`\\`)
+    .replaceAll('\t', String.raw`\t`)
     .replaceAll('\n', String.raw`\n`)
     .replaceAll('\r', '')
 }


### PR DESCRIPTION
## Summary

- escape tab characters in generated Linux desktop-entry values
- reject `.` and `..` as explicit Electron desktop names
- update the nearby comment to describe the filename-safety contract accurately

## Motivation

This is a focused follow-up to #18467 based on the post-merge CodeRabbit review.

The Desktop Entry specification does not allow literal control characters in
string values and defines `\t` as the tab escape sequence. Explicit dot-only
desktop names are also not useful desktop-entry identifiers and would produce
hidden filenames.

Electron defines `desktopName` as the Linux `.desktop` filename used for the
XDG application ID and X11 `WM_CLASS`. For that reason, the existing
`QuasarApp` fallback remains unchanged: `Quasar App` is suitable for the
desktop entry's display `Name`, but a space is not suitable for its filename
identifier.

Valid configured desktop names and normalized names derived from
`productName`/`name` are unchanged.

## Validation

- `pnpm exec oxfmt --check app-vite/lib/modes/electron/electron-devserver.js`
- `pnpm exec oxlint --no-error-on-unmatched-pattern app-vite/lib/modes/electron/electron-devserver.js`
- `node --check app-vite/lib/modes/electron/electron-devserver.js`
- direct helper assertions for tabs, dot-only names, explicit `.desktop`
  suffixes, and derived names
- `git diff --check`
- local Electron development launch on Ubuntu GNOME/X11 using the File Explorer
  example and App Vite directly from this checkout
- verified generated package metadata, desktop entry, taskbar icon, window
  title, and `WM_CLASS`
- verified graceful shutdown removes the temporary desktop entry

References:

- https://www.electronjs.org/docs/latest/api/app#appsetdesktopnamename-linux
- https://specifications.freedesktop.org/desktop-entry/latest/value-types.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux desktop entry validation by rejecting invalid dot-only names.
  * Enhanced desktop entry value handling to safely escape tab characters, along with existing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->