### PR TITLE
docs(electron): clarify window icon platform support

### DIFF
--- a/app-vite/templates/electron/js/electron-main.js
+++ b/app-vite/templates/electron/js/electron-main.js
@@ -14,7 +14,7 @@ async function createWindow () {
    * Initial window options
    */
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath('icons/icon.png'), // linux
+    icon: resolveElectronAssetsPath('icons/icon.png'), // Windows and Linux
     width: 1000,
     height: 600,
     useContentSize: true,

--- a/app-vite/templates/electron/ts/electron-main.ts
+++ b/app-vite/templates/electron/ts/electron-main.ts
@@ -14,7 +14,7 @@ async function createWindow() {
    * Initial window options
    */
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath("icons/icon.png"), // linux
+    icon: resolveElectronAssetsPath("icons/icon.png"), // Windows and Linux
     width: 1000,
     height: 600,
     useContentSize: true,

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-accessing-files.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-accessing-files.md
@@ -35,7 +35,7 @@ import {
 
 async function createWindow() {
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath('icons/icon.png') // linux
+    icon: resolveElectronAssetsPath('icons/icon.png') // Windows and Linux
     // ...
   })
   // ...

--- a/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-with-typescript.md
+++ b/docs/src/pages/quasar-cli-vite/developing-electron-apps/electron-with-typescript.md
@@ -30,7 +30,7 @@ async function createWindow() {
    * Initial window options
    */
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath('icons/icon.png'), // linux
+    icon: resolveElectronAssetsPath('icons/icon.png'), // Windows and Linux
     width: 1000,
     height: 600,
     useContentSize: true,

--- a/docs/src/pages/quasar-cli-vite/upgrade-guide.md
+++ b/docs/src/pages/quasar-cli-vite/upgrade-guide.md
@@ -827,7 +827,7 @@ async function createWindow() { // [!code --]
     }, // [!code --]
 async function createWindow() {
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath("icons/icon.png"), // linux
+    icon: resolveElectronAssetsPath("icons/icon.png"), // Windows and Linux
     webPreferences: {
       preload: path.join(import.meta.dirname, "electron-preload.cjs")
     },
@@ -886,7 +886,7 @@ async function createWindow () {
    * Initial window options
    */
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath('icons/icon.png'), // linux
+    icon: resolveElectronAssetsPath('icons/icon.png'), // Windows and Linux
     width: 1000,
     height: 600,
     useContentSize: true,
@@ -947,7 +947,7 @@ async function createWindow() {
    * Initial window options
    */
   const mainWindow = new BrowserWindow({
-    icon: resolveElectronAssetsPath("icons/icon.png"), // linux
+    icon: resolveElectronAssetsPath("icons/icon.png"), // Windows and Linux
     width: 1000,
     height: 600,
     useContentSize: true,


### PR DESCRIPTION
## What changed

- Correct the generated JavaScript and TypeScript Electron main-process comments to state that `BrowserWindow.icon` applies to Windows and Linux.
- Apply the same correction to the Electron documentation and upgrade-guide examples.

## Why

A fresh Quasar Electron scaffold already passes the generated PNG icon to
`BrowserWindow`, which handles the application window/taskbar icon on Windows
and Linux. The existing `// linux` comment incorrectly implied that Windows
needed separate runtime handling.

macOS remains intentionally separate: Quasar sets the development Dock icon
before loading the user main process, while packaged applications use the
generated ICNS asset.

This clarification also avoids suggesting an unnecessary
`app.setAppUserModelId()` workaround, which has broader Windows shortcut,
grouping, pinning, and notification implications.

## Validation

- `pnpm lint:check`
- `git diff --check`
- Generated a fresh Quasar Electron project using the current App Vite `dev`
  checkout.
- Ran `quasar dev -m electron` natively on Linux and verified matching
  `desktopName`, temporary desktop entry, and `WM_CLASS`.
- Ran `quasar build -m electron -T all -A x64`; Linux, Windows, macOS, and MAS
  targets packaged successfully.
- Verified that the packaged macOS bundle contains the generated ICNS asset
  unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Electron window icons are supported on both Windows and Linux.
  * Updated related JavaScript and TypeScript examples and upgrade guidance for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->