### PR TITLE
docs(date): clarify daysInMonth usage

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -362,16 +362,23 @@ const newDate = new Date(2017, 1, 9)
 const day = date.getDayOfWeek(newDate) // `day` is 4
 ```
 
-To get the number of days in the month for the specified date:
+#### Days in a month
+
+`date.daysInMonth(date, utc)` returns the number of days in the month containing
+the specified date without mutating the input.
+
+The optional `utc` Boolean defaults to `false`, which reads the input's local
+year and month. Set it to `true` to read the UTC year and month instead. This is
+useful when the input represents a UTC calendar value that could fall in a
+different month when converted to local time.
 
 ```js
 import { date } from 'quasar'
 
-const newDate = new Date()
-const days = date.daysInMonth(newDate) // e.g. 30
+const leapYearDate = new Date('2024-02-15T12:00:00.000Z')
 
-// with UTC:
-const days = date.daysInMonth(newDate, true)
+const localDays = date.daysInMonth(leapYearDate) // 29
+const utcDays = date.daysInMonth(leapYearDate, true) // 29
 ```
 
 ### Start/End of time


### PR DESCRIPTION
## What changed

- Give `date.daysInMonth()` a dedicated section in the Date Utils documentation.
- Document its return value, non-mutating behavior, and optional `utc` argument.
- Explain how local and UTC month selection differ.
- Replace the duplicate `const days` declarations with deterministic,
  copyable local and UTC examples.

## Why

The published documentation exposed both calls, but its single code block
declared the same `const` twice and therefore could not be copied and run. It
also left the optional Boolean's default and UTC semantics implicit.

This update makes the public utility easier to discover and accurately
describes the UTC support available in Quasar v2.23.3.

## Validation

- `pnpm --dir docs test` — 39 files and 228 tests passed.
- `pnpm lint:check`
- `git diff --check`
- Evaluated both examples through the built Quasar server artifact; each
  returned the documented value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `date.daysInMonth` determines the number of days in a date’s month.
  * Documented that the input date remains unchanged.
  * Explained local-time and UTC behavior, including the default setting.
  * Added leap-year examples demonstrating local versus UTC results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->