### PR TITLE
fix(QDialog): #13395 keep focus inside a child moved out by fullscreen

### DIFF
--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -20,6 +20,7 @@ import useTransition, {
 } from '../../composables/private.use-transition/use-transition.js'
 import usePortal from '../../composables/private.use-portal/use-portal.js'
 import usePreventScroll from '../../composables/private.use-prevent-scroll/use-prevent-scroll.js'
+import { focusIsInDetachedFullscreen } from '../../composables/private.use-fullscreen/use-fullscreen.js'
 
 import { createComponent } from '../../utils/private.create/create.js'
 import { childHasFocus } from '../../utils/dom/dom.js'
@@ -406,7 +407,8 @@ export default createComponent({
       if (
         !props.allowFocusOutside &&
         portalIsAccessible.value &&
-        !childHasFocus(innerRef.value, evt.target)
+        !childHasFocus(innerRef.value, evt.target) &&
+        !focusIsInDetachedFullscreen(innerRef.value, evt.target)
       ) {
         focus('[tabindex]:not([tabindex="-1"])')
       }

--- a/ui/src/components/dialog/QDialog.test.js
+++ b/ui/src/components/dialog/QDialog.test.js
@@ -14,9 +14,26 @@ import {
   vi
 } from 'vitest'
 
+import { defineComponent, h } from 'vue'
+
 import QDialog from './QDialog.js'
+import useFullscreen, {
+  useFullscreenProps
+} from '../../composables/private.use-fullscreen/use-fullscreen.js'
 import { getRouter } from 'testing/runtime/router.js'
 import DialogWrapper from './test/DialogWrapper.vue'
+
+const FullscreenChild = defineComponent({
+  name: 'FullscreenChild',
+  props: useFullscreenProps,
+
+  setup() {
+    useFullscreen()
+
+    return () =>
+      h('section', null, [h('input', { 'data-test': 'fullscreen-input' })])
+  }
+})
 
 let wrapper = null
 
@@ -667,6 +684,27 @@ describe('[QDialog API]', () => {
 
         await wrapper.setProps({ allowFocusOutside: true })
         await flushPromises()
+
+        el.focus()
+
+        await flushPromises()
+        await vi.runAllTimers()
+
+        expect(document.activeElement).toBe(el)
+      })
+
+      test('does not trap focus away from a fullscreen child', async () => {
+        wrapper = mount(QDialog, {
+          props: { modelValue: true },
+          slots: { default: () => h(FullscreenChild, { fullscreen: true }) }
+        })
+
+        await flushPromises()
+        await vi.runAllTimers()
+
+        const el = document.body.querySelector('[data-test="fullscreen-input"]')
+
+        expect(el.closest('.q-dialog__inner')).toBeNull()
 
         el.focus()
 

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.js
@@ -21,6 +21,26 @@ import {
 let counter = 0
 let restoreState = null
 
+const fillerMap = new Map()
+
+function fillerNodeFor(el) {
+  for (const [fillerNode, movedVm] of fillerMap) {
+    if (movedVm.$el.contains(el)) return fillerNode
+  }
+}
+
+export function focusIsInDetachedFullscreen(rootEl, focusedEl) {
+  for (
+    let node = fillerNodeFor(focusedEl);
+    node !== void 0;
+    node = fillerNodeFor(node)
+  ) {
+    if (rootEl.contains(node)) return true
+  }
+
+  return false
+}
+
 export const useFullscreenProps = {
   fullscreen: Boolean,
   noRouteFullscreenExit: Boolean
@@ -85,6 +105,7 @@ export default function useFullscreen() {
     inFullscreen.value = true
     proxy.$el.replaceWith(fullscreenFillerNode)
     document.body.append(proxy.$el)
+    fillerMap.set(fullscreenFillerNode, proxy)
 
     counter++
     if (counter === 1) {
@@ -104,6 +125,8 @@ export default function useFullscreen() {
       History.remove(historyEntry)
       historyEntry = void 0
     }
+
+    fillerMap.delete(fullscreenFillerNode)
 
     if (shouldRestoreElement === true) {
       fullscreenFillerNode.replaceWith(proxy.$el)

--- a/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
+++ b/ui/src/composables/private.use-fullscreen/use-fullscreen.test.js
@@ -3,6 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { KeepAlive, defineComponent, h, ref } from 'vue'
 
 import useFullscreen, {
+  focusIsInDetachedFullscreen,
   useFullscreenEmits,
   useFullscreenProps
 } from './use-fullscreen.js'
@@ -40,6 +41,19 @@ const OtherComponent = defineComponent({
   setup: () => () => h('section', { 'data-test': 'other-component' })
 })
 
+const NestedFullscreenComponent = defineComponent({
+  name: 'NestedFullscreenComponent',
+  props: useFullscreenProps,
+  emits: useFullscreenEmits,
+
+  setup() {
+    useFullscreen()
+
+    return () =>
+      h('section', null, [h(FullscreenComponent, { fullscreen: true })])
+  }
+})
+
 describe('[useFullscreen API]', () => {
   describe('[Variables]', () => {
     describe('[(variable)useFullscreenProps]', () => {
@@ -58,6 +72,58 @@ describe('[useFullscreen API]', () => {
   })
 
   describe('[Functions]', () => {
+    describe('[(function)focusIsInDetachedFullscreen]', () => {
+      test('has correct return value', async () => {
+        mountTarget = document.createElement('div')
+        document.body.append(mountTarget)
+
+        wrapper = mount(FullscreenComponent, {
+          props: { fullscreen: true },
+          attachTo: mountTarget
+        })
+
+        await flushPromises()
+
+        const el = document.body.querySelector(
+          '[data-test="fullscreen-component"]'
+        )
+
+        expect(el.parentElement).toBe(document.body)
+        expect(focusIsInDetachedFullscreen(mountTarget, el)).toBe(true)
+        expect(
+          focusIsInDetachedFullscreen(document.createElement('div'), el)
+        ).toBe(false)
+        expect(focusIsInDetachedFullscreen(mountTarget, mountTarget)).toBe(
+          false
+        )
+
+        await wrapper.setProps({ fullscreen: false })
+        await flushPromises()
+
+        expect(focusIsInDetachedFullscreen(mountTarget, el)).toBe(false)
+      })
+
+      test('follows a chain of nested fullscreen elements', async () => {
+        mountTarget = document.createElement('div')
+        document.body.append(mountTarget)
+
+        wrapper = mount(NestedFullscreenComponent, {
+          props: { fullscreen: true },
+          attachTo: mountTarget
+        })
+
+        await flushPromises()
+
+        const el = document.body.querySelector(
+          '[data-test="fullscreen-component"]'
+        )
+
+        expect(mountTarget.contains(el)).toBe(false)
+        expect(wrapper.vm.$el.contains(el)).toBe(false)
+        expect(focusIsInDetachedFullscreen(mountTarget, el)).toBe(true)
+      })
+    })
+
     describe('[(function)default]', () => {
       test('does not move a deactivated root back into the live DOM', async () => {
         const showFullscreen = ref(true)


### PR DESCRIPTION
## fix(QDialog): keep focus inside a child moved out by fullscreen

**`useFullscreen()` detaches the component root to `document.body`, so QDialog's focus trap sees every focus inside that child as "outside the dialog" and yanks it straight back — making any QTable / QEditor / QCarousel unusable the moment it goes fullscreen inside a dialog.**

Closes #13395 (2022, QTable filter input). Refs #17843 (2025, QEditor) — the focus-trap half of it; deliberately NOT auto-closed, see the scope note at the bottom. One root cause, two costumes — see the scope note at the bottom for what #17843 still has left over.

---

### The fix

`useFullscreen()` already leaves a filler `<span>` behind at the element's original position so it can be put back on exit. That filler is the missing link: it is still *inside* the dialog, and it identifies which dialog logically owns the detached element. Record the pairing, and let QDialog ask.

```diff
       if (
         !props.allowFocusOutside &&
         portalIsAccessible.value &&
-        !childHasFocus(innerRef.value, evt.target)
+        !childHasFocus(innerRef.value, evt.target) &&
+        !focusIsInDetachedFullscreen(innerRef.value, evt.target)
       ) {
```

`focusIsInDetachedFullscreen()` is a new export from `use-fullscreen.js`: it walks the filler-node
chain that the composable already leaves behind at the element's original position, so it resolves a
fullscreen child *of* a fullscreen child too. Full diff in the Files tab.

+26 / −1 production lines across 2 files. No new prop, no public API surface (the composable is `private.`-prefixed, so no `.json` API file, no docs or types regen). **Zero CSS delta** — the compiled `quasar.prod.css` is byte-identical before and after (`ae5bd183a91890824433e763007f3ba3` both ways).

The loop walks the filler chain rather than testing a single hop, so a fullscreen child *of* a fullscreen child resolves too. That is not hypothetical — it was measured broken with the single-hop version; details in the refuted-alternatives fold.

---

## Verify it in 30 seconds

**Put a component into fullscreen inside a QDialog, click its text field, type — the keystrokes go nowhere.**

📄 **[`mre/13395.html`](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/mre/13395.html)** — one self-contained file, no build, no deps. Open it in a browser or paste it into a CodePen; it loads Quasar 2.23.3 from the CDN and **self-reports a pass/fail verdict on the page**.

|  | printable keys pressed | characters the field received | focus landed on |
|---|---|---|---|
| **unpatched 2.23.3** | 3 | ❌ **0** (`""`) | `button.q-btn` |
| **patched build** | 3 | ✅ **3** (`"abc"`) | `input.q-field__native` |

The invariant is keys-pressed vs characters-received, which needs no knowledge of where focus *should* be. Verified that fullscreen really does detach the component: after toggling, the table's `parentElement` is `document.body` (`class="… q-body--fullscreen-mixin"`), which is precisely why `childHasFocus(innerRef.value, …)` returns false and the trap fires.

Both rows run byte-identical HTML; the patched row only swaps the locally built dist in for the CDN response.

<details>
<summary><b>Before / after screenshots</b></summary>

**unpatched — 3 keys in, 0 received**

![13395-base-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/13395-base-chromium.png)

**patched — 3 keys in, 3 received**

![13395-fix-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/13395-fix-chromium.png)

</details>

---

<details>
<summary><b>Root cause — why it looks like a QDialog bug but is a shared-DOM-ownership bug</b></summary>

`QDialog` traps focus by testing physical containment:

```js
!childHasFocus(innerRef.value, evt.target)   // → refocus the dialog
```

`useFullscreen()` breaks that test by design. On entering fullscreen it does:

```js
proxy.$el.replaceWith(fullscreenFillerNode)   // leave a <span> marker behind
document.body.append(proxy.$el)               // move the real element to <body>
```

The element is now a sibling of the dialog's portal, not a descendant. So on the next `focusin`, `childHasFocus(innerRef, target)` is `false`, the trap concludes focus escaped the modal, and calls `focus('[tabindex]:not([tabindex="-1"])')` — pulling focus back to `.q-dialog__inner`. Every keystroke the user types then goes to the dialog wrapper instead of the input. That is exactly the reported symptom: the QTable filter accepts no text, the QEditor caret will not stay.

The important part is that **neither component is wrong**. QDialog's containment test is correct for every other case; `useFullscreen`'s detach is required for the fullscreen mixin to escape ancestor `overflow`/`transform` contexts. What is missing is a way to express *logical* ownership across the move — and `useFullscreen` was already creating exactly that token (the filler node) for its own restore path. The fix reuses it instead of inventing new state.

This also explains why it reads as two different bugs: #13395 filed it against QTable's filter input, #17843 filed it against QEditor three years later. Both are just "a `useFullscreen` consumer inside a QDialog". Any of the three (QTable, QEditor, QCarousel) reproduces it — measured below.

**Why the map is keyed on the filler node and stores the vm proxy:** the filler is the only stable handle to the *original* position (the vm's `$el` has moved away), and storing the proxy rather than a captured `$el` means the check reads the component's current root at test time rather than a possibly-stale reference. The entry is deleted in `exitFullscreenImpl` *before* any DOM restoration and before `vmIsDestroyed(vm)` can return early, so route exit, History back, prop toggle, KeepAlive deactivate and unmount all clear it on the same path.

</details>

<details>
<summary><b>A/B matrix — 10 shapes × 3 engines × 2 locally-built artifacts (60 cells)</b></summary>

Both artifacts are real `pnpm --filter quasar build` outputs from this branch, served over `http://127.0.0.1` — no CDN, no page-level shim, no `focus()` stub. The harness drives real Playwright browsers: open the dialog, enter fullscreen, click the target, type, then read `document.activeElement` and the input's value.

Build provenance (`md5`):

| artifact | `quasar.umd.prod.js` | `quasar.prod.css` |
|---|---|---|
| base (this branch, 2 production files reverted to `dev`) | `2ce999b45a76ffca8fabdd1b6d6e4930` | `ae5bd183a91890824433e763007f3ba3` |
| fix (this branch as committed) | `cb0cb3318ef92321948fe2592fc2c193` | `ae5bd183a91890824433e763007f3ba3` |

Rebuilding from the committed source reproduces `cb0cb331…` exactly. **The baseline was proven to reproduce the bug before the fix was written** — the three broken rows below are the unpatched local build failing, not a remembered symptom.

Values are identical across chromium / firefox / webkit for every row, so engines are collapsed; per-engine divergence is called out where it exists.

| shape | base: `activeElement` / typed | fix: `activeElement` / typed | |
|---|---|---|---|
| `table-in-dialog` | `div.q-dialog__inner` / `""` | `input[filter]` / `"abc"` | **DIFF** ✅ |
| `editor-in-dialog` | `div.q-dialog__inner` / `""` | `div.q-editor__content` / `"abc"` | **DIFF** ✅ |
| `carousel-in-dialog` | `div.q-dialog__inner` / `""` | `input[filter]` / `"abc"` | **DIFF** ✅ |
| `table-standalone` | `input[filter]` / `"abc"` | `input[filter]` / `"abc"` | SAME |
| `dialog-plain` | `input[filter]` / `"abc"` | `input[filter]` / `"abc"` | SAME |
| `trap-outside-plain` | `input[filter]` / `"xyz"` | `input[filter]` / `"xyz"` | SAME |
| `trap-outside-fs` | `div.q-dialog__inner` / `""` | `div.q-dialog__inner` / `""` | SAME |
| `afo-table-in-dialog` | `input[filter]` / `"abc"` | `input[filter]` / `"abc"` | SAME |
| `table-in-menu` | `body` / `null` | `body` / `null` | SAME¹ |
| `exit-fs-restore` | `input[filter]` / `"abc"` | `input[filter]` / `"abc"` | SAME |

**9 DIFF / 20 SAME / 1 could-not-test**, across 30 base-vs-fix pairs. Every DIFF is a broken cell becoming a working one; no cell went the other way.

The three SAME rows that matter most are the negative controls:

- **`trap-outside-fs`** — dialog open, child fullscreen, then click a plain `<input>` that is genuinely outside the dialog. Focus is still yanked back to `.q-dialog__inner` and the outside input stays empty (`outsideVal: ""`) in **both** builds. The modality guarantee is intact; the fix did not turn the trap into a no-op.
- **`afo-table-in-dialog`** — same shape with `allow-focus-outside`. Already worked before, still works. The existing escape hatch is untouched.
- **`exit-fs-restore`** — enter fullscreen, exit again, then type. Works in both. The map delete does not disturb the restore path.

¹ `table-in-menu` (QMenu instead of QDialog) — on chromium and webkit the menu *closes outright* on entering fullscreen (`menuOpen: false`, `dialogOpen: false`), so there is no filter input left to type into (`typed: null`). Identical in both builds. That is a different failure mode with a different cause and is deliberately out of scope here. On **firefox this cell could not be tested at all**: `waitForSelector('.q-menu')` timed out after 30 s in *both* builds identically, which makes it a harness failure, not a product datapoint. It is counted as could-not-test above, not as a pass.

</details>

<details>
<summary><b>Regression tests — seen to fail without the fix, quoted both ways</b></summary>

Three assertions were added: one integration test in `QDialog.test.js` (does the trap leave a fullscreen child alone?) and two unit tests in `use-fullscreen.test.js` (does the predicate return the right thing, including through a nested chain?).

**Against the unpatched build** — the two production files reverted to `dev`, the new tests kept:

```
 FAIL  ../src/components/dialog/QDialog.test.js > [QDialog API] > [Props] > [(prop)allow-focus-outside] > does not trap focus away from a fullscreen child
AssertionError: expected <div …(3)><span></span></div> to be <input …(1)></input> // Object.is equality

- Expected
+ Received

- <input
-   data-test="fullscreen-input"
- />
+ <div
+   class="q-dialog__inner flex no-pointer-events q-dialog__inner--minimized q-dialog__inner--standard fixed-full flex-center"
+   style="--q-transition-duration: 300ms;"
+   tabindex="-1"
+ >
+   <span />
+ </div>

 FAIL  ../src/composables/private.use-fullscreen/use-fullscreen.test.js > [useFullscreen API] > [Functions] > [(function)focusIsInDetachedFullscreen] > follows a chain of nested fullscreen elements
TypeError: focusIsInDetachedFullscreen is not a function

 Test Files  2 failed (2)
      Tests  3 failed | 40 passed (43)
```

Note the received DOM: `<div class="q-dialog__inner …"><span /></div>` — that lone `<span>` *is* the filler node, sitting in the dialog with the real element gone to `<body>`, and focus parked on the dialog wrapper. The failure output is a picture of the bug.

**Against the patched build** — same tests, production files restored:

```
 Test Files  2 passed (2)
      Tests  43 passed (43)
```

Full UI suite on the patched tree, with no skips hiding anything:

```
 Test Files  104 passed (104)
      Tests  1182 passed (1182)
   Duration  21.02s
```

Spec-structure validation passes: `node ./testing/specs/script.js --target composables/private.use-fullscreen/use-fullscreen --ci` → `✅ src/composables/private.use-fullscreen/use-fullscreen.test.js`.

Lint/format on all four touched files: `oxlint --deny-warnings` silent, `oxfmt --check` reports "All matched files use the correct format", `git diff --check` clean.

</details>

<details>
<summary><b>Refuted alternatives — including one refuted by measurement after it was already written</b></summary>

**1. A single-hop predicate (this was the first implementation, and it was wrong).**
The obvious version tests one level: *is the filler in the dialog, and is the focus in the moved element?*

```js
for (const [fillerNode, movedVm] of fillerMap) {
  if (rootEl.contains(fillerNode) && movedVm.$el.contains(focusedEl)) return true
}
```

That passes every shape in the matrix above. It still fails for **nested fullscreen** — a fullscreen QCarousel inside a fullscreen QTable inside a dialog — because the inner filler lives inside the *outer* moved element, which is in `<body>`, so `rootEl.contains(fillerNode)` is false and neither hop matches. `useFullscreen` explicitly supports multiple simultaneous users (the module-level `counter`), so this is a reachable state, not a contrived one.

Measured against a separately built single-hop artifact (`17708b7dc602231345860f38c483c0e3`) versus the shipped one:

| shape | base | single-hop | shipped (chain walk) |
|---|---|---|---|
| `nested-fs-dialog` (fullscreen carousel inside fullscreen table, inside a dialog) | `div.q-dialog__inner` / `""` | `div.q-dialog__inner` / `""` ❌ | `input[filter]` / `"abc"` ✅ |
| `two-fs-dialog` (two sibling fullscreen tables, same dialog) | `div.q-dialog__inner` / `""` | `input[filter]` / `"abc"` ✅ | `input[filter]` / `"abc"` ✅ |

All 3 engines agree on every cell. The disambiguating control matters: **`nested-fs-standalone`** — the identical nesting with no dialog at all — types `"abc"` successfully on all 3 engines in *both* builds. So nested fullscreen is a working configuration generally, and the single-hop version would have left it broken specifically inside a dialog. The loop in the shipped diff is 4 lines longer and closes that.

Termination is structural rather than guarded: each hop moves from a filler to the filler of a strictly *outer* fullscreen element, and a moved element can never contain its own filler (the filler is left at the position the element vacated), so the chain cannot cycle in a DOM tree.

**2. Use `allow-focus-outside`.** This is the existing workaround suggested in the issue threads, and it does work — `afo-table-in-dialog` types `"abc"` in both builds. But it is a blunt instrument: it disables the focus trap for the *entire* dialog, including genuinely-outside elements, costing the modality guarantee to fix a case where focus never actually left the dialog's logical subtree. A fix should not require users to opt out of a correctness feature.

**3. Change `childHasFocus` in `utils/dom/dom.js`.** Rejected on blast radius, not measured: that helper is shared by QMenu, QPopupProxy and others, so widening its notion of containment would change focus behaviour for components this issue says nothing about. Keeping the new predicate in `use-fullscreen.js` confines the change to the two parties that actually participate in the move. It is worth noting the two rules are now adjacent but not identical — `childHasFocus` also treats sibling portal nodes as owned by the dialog, which this predicate does not. That asymmetry cannot cause a focus *escape*, because the new clause is `&&`-ed in and can only ever make the trap fire *less*; a false negative just means the pre-existing behaviour.

**4. Stop detaching the element in `useFullscreen`.** Not viable: the move to `<body>` is what lets the fullscreen mixin escape ancestor `overflow`, `transform` and stacking contexts. Removing it would break fullscreen everywhere to fix focus in one container.

</details>

<details>
<summary><b>Cross-engine notes</b></summary>

chromium 151.0.7922.34, firefox 153.0, webkit 26.5 (Playwright), all headless at 1280×900 on macOS.

The three engines agreed on **every** cell of the main matrix — no engine-specific divergence in either direction. That is expected here: the mechanism is DOM containment plus a `focusin` handler, with no engine-specific focus heuristics involved.

Two harness limitations, both symmetric across base and fix and therefore reported as could-not-test rather than as results:

- **firefox, `table-in-menu`** — `waitForSelector('.q-menu')` timed out after 30 s in both builds.
- **firefox and webkit, `select-in-fs-dialog`** — `page.click('[data-t="sel"]')` timed out after 30 s in both builds. On chromium this shape is a clean SAME: the QSelect menu opens inside the detached fullscreen content and an option can be clicked in both builds (`menuOpenedAfterClick: true`, `picked: "clicked"`), i.e. popups nested inside the moved element are unaffected. I have that result for chromium only and am not extrapolating it to the other two.

Total real-browser cells actually executed for this PR: **126** — 60 main matrix (base/fix) + 24 adversarial shapes (base/fix) + 24 adversarial shapes against the intermediate single-hop artifact + 6 nested-standalone control + 12 caret probes.

</details>

<details>
<summary><b>Not verified — read this before trusting the rest</b></summary>

Honest list of what this PR does *not* establish:

- **SSR / hydration.** The `fillerMap` is module-scope, like the existing `counter` and `restoreState` next to it, so it inherits whatever server-side sharing characteristics those already have. Entries are only ever created from `setFullscreen()`, which runs from `onMounted`/`onActivated` — client-only — so no entry should exist on a server render. **Not measured**; no SSR build was run.
- **Memory retention.** The map holds a strong reference to the component proxy. Reading the code, every exit path (`exitFullscreen`, route change, History back, prop toggle, `onDeactivated`, `onBeforeUnmount`) reaches `fillerMap.delete()` before any early return. The `close-while-fs` shape (close the dialog while the child is still fullscreen) measures clean on all 3 engines — `strayFullscreenNodes: 0`, `bodyFsMixin: false`, and the page stays usable afterwards (typing into an outside input yields `"xyz"`). But that is a behavioural check, **not a heap measurement**; no profiler was attached and no long-run leak test was done.
- **`allowFocusOutside` interaction beyond the single shape measured.** Only the fullscreen-table case was exercised.
- **Real user input devices.** All input is synthetic Playwright `click` + `keyboard.type`. No touch, no IME, no screen reader, no physical Tab-key traversal of the trap.
- **Accessibility.** Whether a screen reader announces the detached fullscreen element as part of the dialog is unaddressed — this PR fixes programmatic focus retention only, and the underlying DOM relationship (element outside the dialog's subtree, no `aria-owns`) is unchanged.
- **QMenu / QPopupProxy.** Unchanged by this PR and still exhibits its own, different fullscreen failure (the popup closes outright). Not fixed, not attempted.
- **Nesting depth beyond 2.** The chain walk is written to be depth-agnostic and the unit test covers a 2-level chain; 3+ levels were reasoned about, not measured.
- **Old browsers.** Only current chromium/firefox/webkit were tested.

**Scope note on #17843.** That report is a genuine duplicate of this root cause for its main symptom — the `editor-in-dialog` row above is the QEditor case, broken in base and fixed here. But it *also* separately alleges that placing the caret in the QEditor *before* entering fullscreen loses the caret. That is measured as **still reproducing after this fix**, on all 3 engines: caret in editor → type `pre` → enter fullscreen → type `post` without re-clicking, and the text stays `"pre"` with `activeElement` on `body`. The control defuses half of it — the identical caret loss happens with **no dialog at all** (`editor-standalone`, all 3 engines, both builds), so it is generic `useFullscreen` blur from the DOM move, not a dialog focus-trap problem and arguably a separate issue. For that reason the commit says `Closes` for #13395 only and carries #17843 as a `Ref`, so merging this does not auto-close a report that still has a live symptom.

</details>

---

<sub>Validation run: full UI suite 104 files / 1182 tests passed (0 skipped); `test:specs --ci` green for the touched composable; `oxlint --deny-warnings` + `oxfmt --check` + `git diff --check` clean. Local run; CI on this PR is the authoritative check.</sub>


---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog focus handling when interacting with detached fullscreen content.
  * Fullscreen inputs can now retain focus without being redirected back into the dialog.
  * Added support for nested fullscreen focus scenarios.

* **Tests**
  * Added coverage for focus behavior in simple and nested fullscreen contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->