### PR TITLE
fix(QToggle): #18242 keep track and thumb visible in forced-colors mode

### DIFF
--- a/ui/src/components/toggle/QToggle.forced-colors.test.js
+++ b/ui/src/components/toggle/QToggle.forced-colors.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import 'quasar/src/css/index.sass'
+
+const checkedSelector = '.q-toggle__inner--truthy .q-toggle__track'
+const specificity = selector => (selector.match(/\.[\w-]+/g) || []).length
+const topRules = () =>
+  [...document.styleSheets].flatMap(sheet => [...sheet.cssRules])
+
+function forcedColors(selectorRE) {
+  const rules = topRules()
+  const index = rules.findIndex(
+    rule =>
+      rule.media !== void 0 &&
+      /forced-colors/.test(rule.media.mediaText) === true &&
+      [...rule.cssRules].some(
+        inner => selectorRE.test(inner.selectorText) === true
+      )
+  )
+
+  return index === -1
+    ? null
+    : {
+        index,
+        rule: [...rules[index].cssRules].find(
+          inner => selectorRE.test(inner.selectorText) === true
+        )
+      }
+}
+
+describe('[QToggle forced-colors]', () => {
+  test('outlines the track and the thumb', () => {
+    const track = forcedColors(/\.q-toggle__track$/)
+    const thumb = forcedColors(/\.q-toggle__thumb:after$/)
+
+    expect(track).not.toBeNull()
+    expect(thumb).not.toBeNull()
+    expect(track.rule.style.border).toBe('1px solid')
+    expect(thumb.rule.style.border).toBe('1px solid')
+  })
+
+  test('restores full track opacity over the checked-state override', () => {
+    const track = forcedColors(/\.q-toggle__track$/)
+
+    expect(track.rule.style.opacity).toBe('1')
+    expect(specificity(track.rule.selectorText)).toBeGreaterThanOrEqual(
+      specificity(checkedSelector)
+    )
+    expect(track.index).toBeGreaterThan(
+      topRules().findIndex(rule => rule.selectorText === checkedSelector)
+    )
+  })
+})

--- a/ui/src/components/toggle/QToggle.sass
+++ b/ui/src/components/toggle/QToggle.sass
@@ -66,6 +66,13 @@ $toggle-transition: .22s cubic-bezier(.4,0,.2,1)
           color: #fff
           opacity: 1
 
+  @media (forced-colors: active)
+    &__inner &__track
+      opacity: 1
+      border: 1px solid
+    &__thumb:after
+      border: 1px solid
+
   &.disabled
     opacity: .75 !important
 


### PR DESCRIPTION
Closes #18242

**TL;DR — in forced-colors mode a QToggle renders literally zero pixels. The track's entire visual is `background: currentColor` and the thumb's is `background: #fff` + `box-shadow`; forced-colors overrides `background-color` to `Canvas` and strips `box-shadow` to `none`, so both collapse into the page background. The fix gives each a 1px border — the one property forced-colors maps to `CanvasText` — inside a `@media (forced-colors: active)` block.**

Verified against a locally rebuilt `quasar.prod.css`, not a CDN copy: the unpatched build reproduces the bug first, the patched build fixes it, and normal (non-forced) rendering is screenshot-identical across Chromium, Firefox and WebKit.

```diff
--- a/ui/src/components/toggle/QToggle.sass
+++ b/ui/src/components/toggle/QToggle.sass
@@ -66,6 +66,13 @@ $toggle-transition: .22s cubic-bezier(.4,0,.2,1)
           color: #fff
           opacity: 1
 
+  @media (forced-colors: active)
+    &__inner &__track
+      opacity: 1
+      border: 1px solid
+    &__thumb:after
+      border: 1px solid
+
   &.disabled
     opacity: .75 !important
```

Plus `ui/src/components/toggle/QToggle.forced-colors.test.js` (new, 53 lines).

---

## Verify it in 30 seconds

**In forced-colors mode QToggle paints nothing at all — the label is there, the control is gone.**

📄 **[`mre/18242.html`](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/mre/18242.html)** — one self-contained file, no build, no deps. Open it in a browser or paste it into a CodePen; it loads Quasar 2.23.3 from the CDN and **self-reports a pass/fail verdict on the page**.

|  | QToggle track fill | border | verdict |
|---|---|---|---|
| **unpatched**, forced-colors | `rgb(255,255,255)` = Canvas | `0px` | ❌ invisible |
| **patched**, forced-colors | `rgb(255,255,255)` = Canvas | `1px` | ✅ visible |
| **unpatched**, normal mode | `rgb(0,0,0)` / `rgb(25,118,210)` | `0px` | ✅ visible |

The fill stays Canvas in both states — the fix works by restoring an *edge*, not a fill, which is why it costs nothing in normal mode. QCheckbox sits beside it as the passing control: same family, still visible, because its box already has a border that forced-colors keeps. The normal-mode row is the no-false-alarm check.

Both rows run byte-identical HTML; the patched row only swaps the locally built dist in for the CDN response.

<details>
<summary><b>Before / after screenshots</b></summary>

**unpatched — the toggles are simply absent**

![18242-base-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/18242-base-chromium.png)

**patched — outlined pill + thumb, checked state distinguishable**

![18242-fix-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/18242-fix-chromium.png)

</details>

---

<details>
<summary><b>Root cause</b> — why this component in particular vanishes</summary>

The compiled unpatched CSS for the two visible parts:

```css
.q-toggle__track       { opacity:.38; background:currentColor; border-radius:.175em; height:.35em }
.q-toggle__thumb:after { content:""; background:#fff; border-radius:50%; position:absolute; inset:0;
                         box-shadow:0 3px 1px -2px #0003, 0 2px 2px #00000024, 0 1px 5px #0000001f }
.q-toggle__inner--truthy .q-toggle__track { opacity:.54 }
```

Neither element has a border. The track is a coloured rectangle; the thumb is a white circle held apart from the track by a shadow. Under `forced-color-adjust: auto` the UA overrides `background-color` to a system colour and forces `box-shadow` to `none`. Both parts therefore become exactly the page background, with nothing left to outline them.

Computed styles taken from the running page (Chromium, `forcedColors: 'active'`, light palette, `Canvas` = `rgb(255,255,255)`):

| build | `__track` opacity | `__track` border-top | `__thumb:after` border-top | `__thumb:after` box-shadow |
|---|---|---|---|---|
| unpatched | `0.38` (unchecked) / `0.54` (checked) | `0px` | `0px` | `none` ← stripped by the UA |
| patched | `1` | `1px` | `1px` | `none` |

`box-shadow: none` in the unpatched column is the smoking gun: the author wrote three shadows and the engine deleted all of them.

`border-color` is one of the properties forced-colors *does* map (to `CanvasText`), so a border is the correct affordance — it is drawn in the user's chosen foreground colour rather than fighting the palette.

**Why `opacity: 1` is in the patch.** `opacity` is not a forced property, so the decorative `.38`/`.54` alpha survives and would modulate the new outline — and it differs between unchecked and checked, so the two states would render at different weights for no semantic reason. Measured cost of leaving it out is small (see the mutation table below); I kept it because a user in High Contrast Mode has explicitly asked for maximum contrast, and a 38%-alpha outline is not that. **Happy to drop that one line if you'd rather keep the diff at two declarations** — it is the only judgement call in here.

**Why only QToggle.** QCheckbox draws its box with `border: 2px solid currentColor` and QRadio draws its dot with SVG `fill: currentColor`; `border-color` is forced and SVG fill follows the forced `color`, so both survive. QToggle is the only one of the three whose whole appearance is built from the two properties forced-colors overrides. (This is a reading of their `.sass` sources — I did not pixel-test QCheckbox or QRadio, see the not-verified list.)

</details>

<details>
<summary><b>A/B matrix</b> — unpatched vs patched, locally built, 8 shapes × 3 engines</summary>

**Method.** `node build/script.build.js` twice from the same worktree (once with the `@media` block, once without) into `base/` and `fix/`. A static page mounts eight QToggle configurations against the Vue 3 UMD + the locally built `quasar.umd.prod.js` / `quasar.prod.css`. Playwright screenshots each toggle's `__inner` bounding box + 4px margin, decodes the PNG to raw RGBA, and reports:

- **ink** = pixels differing from the sampled page background,
- **contrast** = highest WCAG ratio of any pixel in the box against that background,
- **sha** = SHA-256 of the clipped PNG.

A fixed `background-color: rgb(1,2,3)` probe element confirms whether the engine is genuinely forcing colours or merely matching the media query.

**Normal rendering (`forced-colors` off) — the no-regression bar.**

| engine | shapes | screenshots identical unpatched vs patched |
|---|---|---|
| chromium | 8 | 8 / 8 |
| firefox | 8 | 8 / 8 |
| webkit | 8 | 8 / 8 |

**24 / 24 byte-identical PNGs.** Geometry is untouched too — e.g. the track box stays `32x14@52,53` in every build. The `@media` block is inert outside forced-colors, as intended.

**Forced-colors, Chromium** (`Canvas` = white; the control disappears completely):

| shape | unpatched ink | unpatched contrast | patched ink | patched contrast |
|---|---|---|---|---|
| unchecked | **0** | 1.00 | 164 | 21.00 |
| checked | **0** | 1.00 | 164 | 21.00 |
| indeterminate | **0** | 1.00 | 188 | 21.00 |
| disabled | **0** | 1.00 | 164 | 10.53 |
| dense-unchecked | **0** | 1.00 | 160 | 21.00 |
| dense-checked | **0** | 1.00 | 160 | 21.00 |
| dark-unchecked | **0** | 1.00 | 164 | 21.00 |
| icons-checked | 25 | 20.75 | 189 | 21.00 |

Seven of eight shapes render **one single colour** across the whole box — the toggle is not faint, it is absent. `icons-checked` is the exception only because the optional `check` glyph is text and text keeps its forced foreground colour: the user sees a floating tick with no control around it.

**Forced-colors, Firefox** (a different failure: unchecked states survive but sit under the 3:1 non-text minimum):

| shape | unpatched ink | unpatched contrast | patched ink | patched contrast |
|---|---|---|---|---|
| unchecked | 207 | **2.71** | 314 | 21.00 |
| checked | 526 | 21.00 | 530 | 21.00 |
| indeterminate | 190 | **2.71** | 280 | 21.00 |
| disabled | 207 | **2.03** | 314 | 10.53 |
| dense-unchecked | 189 | **2.71** | 286 | 21.00 |
| dense-checked | 498 | 21.00 | 502 | 21.00 |
| dark-unchecked | 207 | **2.71** | 314 | 21.00 |
| icons-checked | 383 | 21.00 | 387 | 21.00 |

The patched `disabled` row lands at 10.53 rather than 21.00 because `.q-toggle.disabled { opacity: .75 }` still applies — deliberate, and still far above the 3:1 floor.

**Dark forced-colors palette, Chromium** (`Canvas` = `rgb(0,0,0)`, `CanvasText` = `rgb(255,255,255)`), all eight shapes:

| build | `__track` border-top-width | border-top-color | background-color |
|---|---|---|---|
| unpatched | `0px` | — | `rgb(0,0,0)` = Canvas → invisible |
| patched | `1px` | `rgb(255,255,255)` | `rgb(0,0,0)` |

The fix is palette-symmetric: it never hard-codes a colour, so the outline inverts with the user's theme.

**Build provenance.**

```
base/quasar.prod.css  198526 bytes
fix/quasar.prod.css   198658 bytes   (+132)
```

The entire diff in the 198 KB bundle is one inserted string, byte-for-byte:

```
@media (forced-colors:active){.q-toggle__inner .q-toggle__track{opacity:1;border:1px solid}.q-toggle__thumb:after{border:1px solid}}
```

`quasar.umd.prod.js` is SHA-256 identical between the two builds (`ad145789fcb39650…`) — this is CSS-only, no JS surface touched.

</details>

<details>
<summary><b>Regression test</b> — both outputs, failing without the fix and passing with it</summary>

The test resolves the compiled stylesheet through the CSSOM and asserts three things: the rule exists with a border on both parts, it sets `opacity: 1`, and it actually *wins* over `.q-toggle__inner--truthy .q-toggle__track` — by specificity **and** by source order, since the two selectors tie at (0,2,0) and the cascade is then decided by position.

**With the fix reverted** (`git checkout HEAD~1 -- ui/src/components/toggle/QToggle.sass`):

```
 FAIL  ../src/components/toggle/QToggle.forced-colors.test.js > [QToggle forced-colors] > outlines the track and the thumb
AssertionError: expected null not to be null
 ❯ ../src/components/toggle/QToggle.forced-colors.test.js:36:23
     36|     expect(track).not.toBeNull()
       |                       ^

 FAIL  ../src/components/toggle/QToggle.forced-colors.test.js > [QToggle forced-colors] > restores full track opacity over the checked-state override
TypeError: Cannot read properties of null (reading 'rule')
 ❯ ../src/components/toggle/QToggle.forced-colors.test.js:45:18
     45|     expect(track.rule.style.opacity).toBe('1')
       |                  ^

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

**With the fix in place:**

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  861ms
```

Full suite and the specs gate, unchanged:

```
 Test Files  105 passed (105)
      Tests  1181 passed (1181)          # 0 skipped

node ./testing/specs/script.js --ci      # exit 0
oxfmt --check ./ui                       # exit 0, "All matched files use the correct format."
oxlint ./ui                              # exit 1 — identical output with and without this patch;
                                         # the sole error is a pre-existing
                                         # ui/playground/jsconfig.json tsconfig-error.
                                         # Verified by moving the new test file aside and re-running.
```

</details>

<details>
<summary><b>Mutation testing</b> — evidence that all three declarations are load-bearing, and that the test has teeth</summary>

Each mutant is a real rebuild of `quasar.prod.css` from a modified `.sass`, then re-measured.

| mutant | change | unit test | browser result (Chromium, forced-colors) |
|---|---|---|---|
| **M1** | `&__track` instead of `&__inner &__track` | **fails** — `AssertionError: expected 1 to be greater than or equal to 2` | — |
| **M2** | correct selector, but `@media` block moved *above* the checked-state override | **fails** — `AssertionError: expected 1289 to be greater than 1293` | checked track back to `opacity: 0.54` — bug returns |
| **M5** | both borders, but no `opacity: 1` | passes | still visible: 20.26 (chromium), 20.03 (firefox), 20.62 (webkit) |

M1 and M2 are the two independent ways a future edit could silently break this, and the test catches both. M2 is worth spelling out: the two selectors have equal specificity `(0,2,0)`, so the *only* reason the forced-colors rule wins is that Sass emits the bubbled `@media` block after it. A well-meaning tidy-up that moves the block next to the `&__track` definition would reintroduce the bug with no other visible change — hence the source-order assertion rather than a specificity check alone.

**M5 is the honest one.** Dropping `opacity: 1` does **not** push any engine below the 3:1 floor — I measured 20.26 / 20.03 / 20.62 against a claim that it would fail, and the claim did not hold. What it actually costs is that the outline renders at the decorative `.38`/`.54` alpha instead of full strength, and at *different* alphas for unchecked vs checked. That is a defensible thing to trade away for a smaller diff; see the note in the root-cause section.

**Design alternatives considered but not shipped** (reasoning, not measurements):

- `forced-color-adjust: none` on the track — would preserve the brand colour, but overriding the user's palette is precisely what High Contrast Mode exists to prevent. Wrong tool.
- Painting the track solid with `background: CanvasText` instead of outlining it — collapses the checked/unchecked distinction, since forced-colors gives no second background colour to distinguish them with.
- A global `@media (forced-colors: active)` block in the shared CSS — arguably the better long-term home, but a much larger change than this issue justifies. Flagged below.

</details>

<details>
<summary><b>Cross-engine notes</b> — including where the emulation cannot be trusted</summary>

All three engines are Playwright's bundled builds — Chromium 151.0.7922.34 (`chromium-1234`), Firefox 153.0 (`firefox-1538`), WebKit 26.5 (`webkit-2336`). The `rgb(1,2,3)` probe element is what separates real forcing from a media-query-only emulation:

| engine | `matchMedia('(forced-colors: active)')` | probe background under emulation | verdict |
|---|---|---|---|
| chromium | `true` | forced → `rgb(255,255,255)` light, `rgb(0,0,0)` dark | genuine; both palettes exercised |
| firefox | `true` | forced → `rgb(255,255,255)` | genuine, **light palette only** |
| webkit | `true` | **not forced** — stays `rgb(1,2,3)` | media query only |

Two caveats this produces, both worth stating plainly:

1. **WebKit does not actually force colours here.** The probe is untouched and the thumb's `box-shadow` survives as `rgba(0, 0, 0, 0.2) 0…` rather than being stripped. So the WebKit column proves only that the new rule *applies*; it is not evidence about how Safari renders High Contrast Mode. WebKit is included because dropping an engine silently would be worse than reporting its limit.
2. **Firefox ignores `colorScheme: 'dark'` while forced-colors is active.** Setting both left the probe at `rgb(255,255,255)` with a black border colour — i.e. still the light palette. Gecko's dark HCM is therefore untested.

</details>

<details>
<summary><b>Not verified</b> — the honest list</summary>

- **Real Windows High Contrast Mode on real hardware.** Every number above is Playwright's `forcedColors: 'active'` emulation. It is a good proxy for the cascade and for which properties get overridden; it is not the same as a real HCM session, and I had no Windows machine to check on.
- **Real Safari / WebKit HCM rendering** — see caveat 1 above.
- **Gecko's dark forced-colors palette** — see caveat 2 above.
- **QCheckbox and QRadio were not pixel-tested.** The claim that they are unaffected is a reading of their `.sass` (`border: 2px solid currentColor` and SVG `fill: currentColor` respectively), not a measurement. If you want them swept properly that should be its own issue.
- **The hover/focus halo is only partly characterised.** `body.desktop … .q-toggle__thumb:before` is `opacity: .12; background: currentColor` animated `transform: scale(0)` → `scale(2)`. Under forced-colors its background is forced to `Canvas`, so it washes *lighter* over the control rather than darker — inverted polarity versus normal mode. What I did measure (Chromium, forced-colors, unchecked): unpatched, hovering changes nothing at all (idle and hover screenshots hash identically, `e56c19f52286` — there is no control to give feedback about); patched, hover does change the rendering (`8e2f6fa3628a` → `6bacd79cabae`). So the fix strictly adds hover feedback where there was none. I did not measure the contrast delta the halo causes, and did not attempt to correct its polarity — that would need its own `@media` handling and belongs in a follow-up if it bothers anyone.
- **This is the first `@media (forced-colors: active)` block anywhere in the repo.** If you'd prefer the precedent set centrally — a shared forced-colors layer rather than a per-component block — say so and I'll restructure; I went per-component to keep the diff proportional to the bug.
- No visual-regression baselines were added, since the repo has no browser-based screenshot suite to add them to. The jsdom test guards the cascade; the pixel evidence above is one-off and lives in this PR, not in CI.

</details>


---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved toggle visibility and contrast when the browser’s forced-colors mode is enabled.
  * Added visible borders and full track opacity to make toggle states easier to distinguish.
* **Tests**
  * Added automated coverage verifying toggle styling and contrast behavior in forced-colors mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->