### PR TITLE
fix(QInfiniteScroll): #17848 reverse mode double-compensates scroll position against CSS scroll anchoring

### DIFF
--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
@@ -295,7 +295,9 @@ export default createComponent({
       return h(
         'div',
         {
-          class: 'q-infinite-scroll',
+          class:
+            'q-infinite-scroll' +
+            (props.reverse ? ' q-infinite-scroll--reverse' : ''),
           ref: rootRef
         },
         child

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.sass
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.sass
@@ -1,0 +1,2 @@
+.q-infinite-scroll--reverse
+  overflow-anchor: none

--- a/ui/src/css/index.sass
+++ b/ui/src/css/index.sass
@@ -36,6 +36,7 @@
 @import '../components/file/QFile.sass'
 @import '../components/form/QForm.sass'
 @import '../components/img/QImg.sass'
+@import '../components/infinite-scroll/QInfiniteScroll.sass'
 @import '../components/inner-loading/QInnerLoading.sass'
 @import '../components/input/QInput.sass'
 @import '../components/intersection/QIntersection.sass'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — **not tested, see "Not verified" below**
- [ ] It's been tested on an Electron app — **not tested, see "Not verified" below**
- [x] Any necessary documentation has been added or updated — none needed; this adds one internal modifier class, no public API surface

---

**TL;DR — in reverse mode `trigger()` reads `scrollTop` inside a `nextTick`, i.e. *after* Vue has patched the DOM, then adds the prepended height to it. When the list has stable `:key`s the browser's CSS scroll anchoring has already moved `scrollTop` by exactly that amount, so the correction lands twice and the list jumps by the full height of the prepended batch.**

Opting the reverse-mode subtree out of scroll anchoring stops the browser from doing the half the component is already doing itself.

Resolves #17848 (open since Feb 2025). The reporter diagnosed it correctly in the original write-up, `overflow-anchor` included; what this PR adds is the measurement, the scoping, and the reason the docs demo never showed it.

```diff
--- /dev/null
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.sass
+.q-infinite-scroll--reverse
+  overflow-anchor: none

--- a/ui/src/css/index.sass
+++ b/ui/src/css/index.sass
 @import '../components/img/QImg.sass'
+@import '../components/infinite-scroll/QInfiniteScroll.sass'
 @import '../components/inner-loading/QInnerLoading.sass'

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.js
       return h(
         'div',
         {
-          class: 'q-infinite-scroll',
+          class:
+            'q-infinite-scroll' +
+            (props.reverse ? ' q-infinite-scroll--reverse' : ''),
           ref: rootRef
         },
```

## Verify it in 30 seconds

**Each reverse-mode load prepends 500px and moves the scroll position by 1000 — the correction is applied twice.**

📄 **[`mre/17848.html`](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/mre/17848.html)** — one self-contained file, no build, no deps. Open it in a browser or paste it into a CodePen; it loads Quasar 2.23.3 from the CDN and **self-reports a pass/fail verdict on the page**.

|  | scrollTop after a 500px prepend | anchor item moved |
|---|---|---|
| **unpatched 2.23.3**, chromium | ❌ 40 → **1040** (expected 540) | ❌ −500px |
| **patched build**, chromium | ✅ 40 → **540** | ✅ 0px |
| **unpatched 2.23.3**, firefox | ❌ 40 → **1040** | ❌ −500px |
| **patched build**, firefox | ✅ 40 → **540** | ✅ 0px |

**Two things mask this bug completely, and both are easy to fall into.** (1) Scrolling straight to `scrollTop = 0`: CSS scroll anchoring only engages when there is content *above* the viewport, so landing exactly on 0 means there is no first correction to double up and everything reads green. The MRE starts scrolled down and approaches the top without reaching it. (2) `:key="index"` — which is what Quasar's own docs example uses. A re-keyed node cannot be anchored to, so the bug vanishes. Stable keys are load-bearing here, and a regression test written the documented way would pass against unfixed code.

Both rows run byte-identical HTML; the patched row only swaps the locally built dist in for the CDN response.

<details>
<summary><b>Before / after screenshots</b></summary>

**unpatched — every load overshoots by 500px**

![17848-base-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/17848-base-chromium.png)

**patched — scrollTop grows by exactly the prepended height**

![17848-fix-chromium.png](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots/17848-fix-chromium.png)

</details>

---

<details>
<summary><b>Root cause</b></summary>

`ui/src/components/infinite-scroll/QInfiniteScroll.js`, inside `trigger()`:

```js
const heightBefore = getScrollHeight(localScrollTarget)

emit('load', index, isDone => {
  if (isWorking.value) {
    isFetching.value = false
    nextTick(() => {
      if (props.reverse) {
        const heightAfter = getScrollHeight(localScrollTarget),
          scrollPosition = getVerticalScrollPosition(localScrollTarget),
          heightDifference = heightAfter - heightBefore

        setVerticalScrollPosition(
          localScrollTarget,
          scrollPosition + heightDifference
        )
      }
```

`heightBefore` is sampled before the prepend. `scrollPosition` is sampled **inside `nextTick`**, i.e. after Vue has patched the DOM. The component then writes `scrollPosition + heightDifference`.

That arithmetic is only correct if `scrollTop` still holds its pre-prepend value at the moment it is read. Usually it does not. CSS scroll anchoring — [css-scroll-anchoring](https://drafts.csswg.org/css-scroll-anchoring/), on by default in Chromium, Gecko and WebKit — picks a DOM node near the top of the viewport before a mutation and, when content is inserted *above* it, silently adjusts `scrollTop` to keep that node visually still. That adjustment is exactly `heightDifference`. The component then adds it a second time and the list overshoots by one full batch.

**Why it depends on `:key`.** Anchoring can only fire if the anchor node survives the patch. With `:key="index"` Vue reuses the elements and rewrites their contents, so there is no preserved node to anchor to and the browser does nothing — the component's arithmetic is then correct. With stable keys (`:key="item.id"`) the old nodes are preserved and pushed down, anchoring fires, and the component double-counts.

The matrix below splits cleanly along exactly that axis: **0 of 120 index-keyed configs reproduce the bug; 98 of 180 stable-keyed ones do.** This is what the reporter described as *"only if the displayed content has not changed"*.

It is also, I think, why this sat open for 17 months: `docs/src/examples/QInfiniteScroll/Reverse.vue` uses `:key="index"`, so the official demo is in the one keying mode that cannot reproduce — which matches the reporter's *"the scroll behaves as shown in the documentation"*.

**Why CSS rather than fixing the arithmetic.** The obvious JS fix — capture `scrollTop` *before* the patch — was built and measured, and it trades this bug for a different one. Numbers in "Alternatives". Removing the browser's contribution is what makes the component's existing arithmetic true again, and it mirrors what `ui/src/components/virtual-scroll/QVirtualScroll.sass` already does for the same class of problem.

**Why scoped to reverse.** `overflow-anchor: none` on the root disables anchoring for the whole subtree. Forward mode has no compensating write, so disabling it there is pure loss. Measured on all three engines; that fold is next, and it is the reason this PR has a JS line at all.

</details>

<details>
<summary><b>Forward mode keeps its anchoring — why this is 6 lines and not 3</b></summary>

The first version of this patch put `overflow-anchor: none` on `.q-infinite-scroll` unconditionally. Smaller, and wrong: it disables scroll anchoring for every `QInfiniteScroll` including forward mode, where nothing compensates. Content growth above the viewport — a late-loading image, a webfont swap, an expansion panel opening — would then shove the reading position down by the growth.

The forward-mode row in the main matrix cannot catch this: it appends *below* the viewport, and scroll anchoring only fires for changes *above* the anchor node. So that control is silent on this by construction, and it needed a separate probe.

**Probe:** 30 × 100 px rows in a 400 px scroller, parked at `scrollTop 1500`; the row at `y = 300`, far above the viewport, grows by 200 px. `drift` = how far the content the user was looking at moved. **0 = anchoring protected it; +200 = it jumped.** `plaindiv` is a control with the same DOM and box shape and no `q-infinite-scroll` class.

| build | variant | computed `overflow-anchor` | drift — chromium / firefox / webkit |
|---|---|---|---|
| baseline | `plaindiv` | `auto` | 0 / 0 / 0 |
| baseline | forward, live | `auto` | 0 / 0 / 0 |
| baseline | forward, `disable` | `auto` | 0 / 0 / 0 |
| baseline | reverse | `auto` | 0 / 0 / 0 |
| unscoped `.q-infinite-scroll` | `plaindiv` | `auto` | 0 / 0 / 0 |
| unscoped `.q-infinite-scroll` | forward, live | `none` | **200 / 200 / 200** ← regression |
| unscoped `.q-infinite-scroll` | forward, `disable` | `none` | **200 / 200 / 200** ← regression |
| unscoped `.q-infinite-scroll` | reverse | `none` | 200 / 200 / 200 |
| **this PR** | `plaindiv` | `auto` | 0 / 0 / 0 |
| **this PR** | forward, live | `auto` | **0 / 0 / 0** |
| **this PR** | forward, `disable` | `auto` | **0 / 0 / 0** |
| **this PR** | reverse | `none` | 200 / 200 / 200 |

`plaindiv` stays at 0 in every build on every engine, so the class rule is the only variable and all three engines demonstrably do anchor here.

Reverse mode still reads 200. That is the intended cost — it is precisely the browser adjustment the component's own `setVerticalScrollPosition()` replaces. Confining it to reverse is the whole job of the extra JS line.

The 110-config matrix was then re-run against the scoped build: **0 differences from the unscoped build across all 330 config × engine cells.** The scoping removes the forward-mode regression and costs nothing on the fix itself.

For what it's worth, `QVirtualScroll.sass` already prefers precise over blanket, which is the in-repo precedent I'd rather follow:

```sass
    > *
      overflow-anchor: none

    > [data-q-vs-anchor]
      overflow-anchor: auto
```

</details>

<details>
<summary><b>Validation — A/B matrix, 110 configs × 3 engines</b></summary>

Everything below was run against **locally built `ui/dist/quasar.umd.prod.js` + `quasar.prod.css`**, not a CDN. Baseline = `dev` at `be971f329`.

Build integrity, established before any behavioural number was trusted:

| check | result |
|---|---|
| `git revert --no-commit HEAD` + rebuild, vs the stored baseline artifact | `cmp`-identical, both files — the baseline really is unpatched `dev` |
| patched `dist/` vs the artifact actually under test | `cmp`-identical — the measured bytes are this commit's bytes |
| only JS delta vs baseline, from a byte diff of the minified UMD | `` `q-infinite-scroll` `` → `` `q-infinite-scroll`+(t.reverse?` q-infinite-scroll--reverse`:``) ``, and nothing else anywhere in the bundle |
| CSS | 198 526 → 198 575 bytes; rule present in `quasar.prod.css`, `quasar.rtl.prod.css`, `quasar.css`, `quasar.sass`; absent from `quasar.addon.*`, which carries no `overflow-anchor` rules at all |

**Harness.** Plain Vue 3 app, Quasar UMD, no framework wrapper. Playwright drives Chromium 151.0.7922.34, Firefox 153.0, WebKit 26.5. Each config mounts a reverse `QInfiniteScroll`, parks the scroller, lets exactly one load fire, and records `scrollTop` at the moment of prepend and after settling.

**Metric: `overshoot = scrollTopAfter − (scrollTopAtPrepend + prependedHeight)`. 0 is correct; 500 is one whole prepended batch — the reported jump.** Every config prepends exactly 500 px and is asserted to have fired exactly one load; rows failing that assertion are counted as invalid rather than silently used as data.

The 110 configs are the cross product of **keying** (`index`, stable) × **`done()` timing** (`sync`, `nextTick`, `raf`, `async`, and an `asyncScroll` variant where the user keeps scrolling during the fetch) × **scroll target** (`selector`, `window`, an inner `QScrollArea`, an `ancestor` overflow div, inside a `QMenu`) × **surrounding layout** (bare, sibling above visible, sibling above off-screen, sibling below visible, parked at `scrollTop 0`) × **direction** (a forward-mode control).

Cell = configs with non-zero overshoot, before → after:

| config family | n/engine | chromium | firefox | webkit |
|---|---|---|---|---|
| `plain` | 40 | 16/40 → **0/40** | 20/40 → **0/40** | 20/40 → **0/40** |
| `sibAbove300-visible` | 40 | 0/40 → **0/40** | 0/40 → **0/40** | 0/40 → **0/40** |
| `sibAbove30-offscreen` | 5 | 4/5 → **0/5** | 5/5 → **0/5** | 5/5 → **0/5** |
| `sibBelow300-visible` | 5 | 4/5 → **3/5** | 5/5 → **4/5** | 5/5 → **4/5** |
| `startPos0` | 5 | 0/5 → **0/5** | 0/5 → **0/5** | 0/5 → **0/5** |
| `userScrollsDuringFetch` | 5 | 4/5 → **0/5** | 5/5 → **0/5** | 5/5 → **0/5** |
| `FORWARD` (control) | 10 | 0/10 → **0/10** | 0/10 → **0/10** | 0/10 → **0/10** |
| **all** | **110** | **28/110 → 3/110** | **35/110 → 4/110** | **35/110 → 4/110** |

**No cell that was 0 became non-zero.** The bar is not "still works" but *numerically identical except where it was broken*, and 330 of 330 config × engine cells meet it.

Split along the axis the reporter identified:

| `:key` | n per engine | non-zero before (ch / ff / wk) | non-zero after |
|---|---|---|---|
| `index` | 40 | 0 / 0 / 0 | 0 / 0 / 0 |
| stable | 60 | 28 / 35 / 35 | 3 / 4 / 4 |

**Cross-engine note worth having on record:** inside a `QMenu`, Chromium does **not** apply scroll anchoring while Firefox and WebKit do — the `…|menu` configs read `chromium 0, firefox 500, webkit 500` on the unpatched build. A page can therefore be broken in Firefox and fine in Chrome, which is a plausible source of "can't reproduce" traffic on this issue.

**Residual, disclosed rather than buried.** The `sibBelow300-visible` family keeps 3–4 non-zero cells after the fix, at 85/140/142 px — not 500, and **numerically unchanged from the unpatched build for those same cells** (142 → 142, 140 → 140, 85 → 85). The one cell in that family that *was* this bug — `window` target, overshoot 340 on all three engines — goes to 0. So this PR never makes that family worse, but it does not fully resolve it either; the JS alternative does, at a cost described below. I did not chase it further and I am not claiming it is unrelated — I don't know that.

</details>

<details>
<summary><b>Regression test — failing without the fix, passing with it</b></summary>

Browser-level, because the bug is layout behaviour and jsdom does not implement scroll anchoring. 5 cases per engine × 3 engines: four programmatically-scrolled variants across `done()` timings and scroll targets, plus one driven by **real `mouse.wheel` events** rather than a programmatic `scrollTop` write, since a synthetic scroll is not obviously equivalent to a user scroll for anchor selection.

Run against a build produced by `git revert --no-commit HEAD` on this branch and rebuilding — not a cached baseline:

```
$ node regression.mjs mine-reverted
REGRESSION quasar#17848 — build under test: mine-reverted
expectation: after one reverse load, scrollTop must equal (scrollTop at prepend + prepended height); overshoot must be 0

  FAIL    chromium  scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    chromium  scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    chromium  scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    chromium  scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    chromium  scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 27 -> 1027 (expected 527) overshoot=500
  FAIL    firefox   scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    firefox   scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    firefox   scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    firefox   scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    firefox   scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 27 -> 1027 (expected 527) overshoot=500
  FAIL    webkit    scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    webkit    scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    webkit    scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    webkit    scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 1020 (expected 520) overshoot=500
  FAIL    webkit    scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 52 -> 1052 (expected 552) overshoot=500

15 FAILURE(S) — build mine-reverted

$ echo $?
1
```

Same test, same command, against this branch's build:

```
$ node regression.mjs scoped-fix
REGRESSION quasar#17848 — build under test: scoped-fix
expectation: after one reverse load, scrollTop must equal (scrollTop at prepend + prepended height); overshoot must be 0

  PASS    chromium  scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    chromium  scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    chromium  scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    chromium  scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    chromium  scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 52 -> 552 (expected 552) overshoot=0
  PASS    firefox   scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    firefox   scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    firefox   scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    firefox   scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    firefox   scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 27 -> 527 (expected 527) overshoot=0
  PASS    webkit    scrolled=programmatic target=selector   done=sync     prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    webkit    scrolled=programmatic target=window     done=nextTick prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    webkit    scrolled=programmatic target=scrollarea done=async    prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    webkit    scrolled=programmatic target=ancestor   done=raf      prepended=500 scrollTop 20 -> 520 (expected 520) overshoot=0
  PASS    webkit    scrolled=mouse.wheel target=selector   done=sync     prepended=500 scrollTop 52 -> 552 (expected 552) overshoot=0

ALL PASS — build scoped-fix

$ echo $?
0
```

**Repo checks**, run on this branch:

| check | result |
|---|---|
| `node ./testing/specs/script.js --ci` (from `/ui`) | exit 0 — 103 ✅, 0 ❌ |
| vitest (from `/ui/testing`) | 104 files / 1179 tests passed, exit 0 |
| `node build/script.build.js` | ok |
| `oxfmt --check ./ui` | "All matched files use the correct format" |
| `oxlint ./ui` | exit 0; one pre-existing `ui/playground/jsconfig.json` tsconfig error, present before the change and unrelated |
| `git diff --check` | clean |

</details>

<details>
<summary><b>Alternatives considered, and what is NOT verified</b></summary>

**Alternatives rejected — both were built and measured, not merely reasoned about.**

***Capture `scrollTop` before the DOM patch*** and write `capturedPosition + heightDifference` instead of reading it inside `nextTick`. This is the pure-JS fix and it is the one I expected to ship. Measured across the same 110 × 3 matrix, it is a genuine trade rather than a clean loss, and the maintainer should see both halves:

| | this PR (CSS, reverse-scoped) | JS capture-before |
|---|---|---|
| the 500 px jump | fixed everywhere | fixed everywhere |
| `sibBelow300-visible` residual (85/140/142) | **left as-is**, 11 cells, unchanged from baseline | **fixed**, 0 cells |
| `userScrollsDuringFetch` | 0 cells non-zero | **regresses: −150 px on all 15 cells, all 3 engines** |

The decisive part is the last row. `userScrollsDuringFetch|stable|asyncScroll|menu` on Chromium reads **0 on the unpatched build** — Chromium does not anchor inside a `QMenu`, so the bug never existed there — and the JS fix takes it to **−150**. That is a configuration that works today and would stop working, on an engine where there was nothing to fix. The mechanism is straightforward: if the user keeps scrolling during an async fetch, a position captured before the fetch is stale by however far they scrolled, and the component would now write that stale value. Trading a jump the user causes by scrolling *to* the top for a jump caused by scrolling *while* loading is not an improvement.

***Do both*** (CSS opt-out plus captured position). Measured identically to the JS fix alone — same 15 × −150 cells — because the JS write dominates once anchoring is off. It buys the `sibBelow300` improvement at the same regression, and keeps the more fragile of the two mechanisms.

***`overflow-anchor: none` on the scroll container instead of the component root.*** The scroll target is frequently *not* the component root — the `scroll-target` prop, a `QScrollArea`, `window` — so there is no reliable element to put it on from inside the component. Putting it on the root works because anchor *selection* walks the subtree: an element opted out cannot be chosen as the anchor, whichever ancestor is doing the scrolling.

***`overflow-anchor: none` on `.q-infinite-scroll` unconditionally*** — 3 lines instead of 6, and it regresses forward mode on all three engines. Measured; see the fold above.

**Not verified — stated plainly:**

- **Not tested on Cordova or Electron.** No such app set up here. The change is engine-level CSS plus one class string; the Chromium/WebKit results are the closest proxy I can offer.
- **No in-repo test added.** jsdom does not implement scroll anchoring, so a unit test could only assert that the modifier class is emitted — it would not have caught this bug and would not catch its return. `QInfiniteScroll` also has no `.test.js` today (37 of 79 components do), so adding one means generating the full spec-mandated file, a much larger diff than the fix. I'd rather you choose: happy to add the class-presence test, the full generated spec, or neither.
- **The browser-level harness is not wired into CI.** It lives outside the repo and was run by hand. I did not want to smuggle a new test infrastructure into a bugfix PR, but I'll propose a home for it if you want it upstreamed.
- **I did not ship a paste-and-run reproduction, because I could not get one to behave.** Three attempts at a small standalone demo either failed to discriminate patched from unpatched or measured something other than the bug — the failure modes being that engines suppress anchoring at `scrollTop 0`, and that continuing to wheel during an async fetch produces a *different* offset. Rather than paste a snippet I hadn't verified, I'm pointing at the reporter's own CodePen (`https://codepen.io/martynoff/pen/XJWdVOm`, not re-run by me — it targets an older release via CDN) and at the measured conditions instead: **reverse mode, stable `:key`s, and a load that fires while `scrollTop` is still clear of 0.** All three are necessary; the matrix above is where I actually established that.
- **Browsers are Playwright's bundled builds** — Chromium 151.0.7922.34, Firefox 153.0, WebKit 26.5. Not real Safari, not real Chrome, no mobile engines, no Android WebView, despite the issue listing Android.
- **The `:key` explanation is an inference** from the measured 0/120 vs 98/180 split plus the spec's anchor-selection rules. I did not instrument the browsers' anchor node choice directly. The fix does not depend on the explanation being right.
- **A user-supplied `overflow-anchor: auto` on their own list content will re-arm the bug.** The rule is a single class selector with no `!important` and is trivially overridden. `!important` felt like the wrong trade for a component-level opt-out, but that's a judgement call I'd rather flag than make silently.
- **Engines without `overflow-anchor` support** are unaffected in both directions — an engine that lacks the property also lacks scroll anchoring, so the bug cannot occur there. That is reasoning, not measurement: `CSS.supports('overflow-anchor','none')` was true on all three engines tested and no such engine was available to me.
- **SSR/hydration not specifically exercised** beyond the suites above. The class is computed in the render function so it is present in SSR output, but I did not render server-side and diff the markup.
- **RTL** was checked only to the extent that the rule is present in `quasar.rtl.prod.css`; no RTL behavioural run.
- **2 of 990 matrix datapoints were discarded as harness-invalid**, not counted as data: a `FORWARD|…|scrollarea` config on Firefox intermittently fails to fire its load. It occurs on baseline and patched builds alike, in the forward-mode control, which this PR does not touch.

</details>

<sub>Investigated and drafted by Claude Code on evnchn's behalf; every number above was measured against a locally built `dist/`, not reasoned about. The forward-mode regression described in the second fold was in the first draft of this patch and was caught by an adversarial review pass before this was written.</sub>


---

