### PR TITLE
fix(date): reject invalid extractDate input

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -447,10 +447,7 @@ const date = date.extractDate('21/03/1985', 'DD/MM/YYYY')
 // date is a new Date() object
 ```
 
-The input may contain additional text after the part described by the mask.
-When the input does not start with a matching value, or contains an impossible
-date, time, or timezone component, `extractDate()` returns an `Invalid Date`
-object:
+The input may contain additional text after the part described by the mask. When the input does not start with a matching value, or contains an impossible date, time, or timezone component, `extractDate()` returns an `Invalid Date`object:
 
 ```js
 const parsed = date.extractDate('2024-02-30', 'YYYY-MM-DD')

--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -447,6 +447,17 @@ const date = date.extractDate('21/03/1985', 'DD/MM/YYYY')
 // date is a new Date() object
 ```
 
+The input may contain additional text after the part described by the mask.
+When the input does not start with a matching value, or contains an impossible
+date, time, or timezone component, `extractDate()` returns an `Invalid Date`
+object:
+
+```js
+const parsed = date.extractDate('2024-02-30', 'YYYY-MM-DD')
+
+console.log(Number.isNaN(parsed.getTime())) // true
+```
+
 With optional custom locale:
 
 ```js

--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -451,7 +451,6 @@ The input may contain additional text after the part described by the mask. When
 
 ```js
 const parsed = date.extractDate('2024-02-30', 'YYYY-MM-DD')
-
 console.log(Number.isNaN(parsed.getTime())) // true
 ```
 

--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -352,6 +352,10 @@ export function adjustDate(date, rawMod, utc) {
 export function extractDate(str, mask, dateLocale) {
   const d = __splitDate(str, mask, dateLocale)
 
+  if (d.dateHash === null) {
+    return new Date(Number.NaN)
+  }
+
   const date = new Date(
     d.year,
     d.month === null ? null : d.month - 1,
@@ -450,9 +454,13 @@ export function __splitDate(str, mask, dateLocale, calendar, defaultModel) {
     }
 
     if (map.H !== void 0) {
-      date.hour = Number.parseInt(match[map.H], 10) % 24
+      date.hour = Number.parseInt(match[map.H], 10)
+      if (date.hour > 23) return date
     } else if (map.h !== void 0) {
-      date.hour = Number.parseInt(match[map.h], 10) % 12
+      date.hour = Number.parseInt(match[map.h], 10)
+      if (date.hour < 1 || date.hour > 12) return date
+
+      date.hour %= 12
       if (
         (map.A && match[map.A] === 'PM') ||
         (map.a && match[map.a] === 'pm') ||
@@ -465,11 +473,13 @@ export function __splitDate(str, mask, dateLocale, calendar, defaultModel) {
     }
 
     if (map.m !== void 0) {
-      date.minute = Number.parseInt(match[map.m], 10) % 60
+      date.minute = Number.parseInt(match[map.m], 10)
+      if (date.minute > 59) return date
     }
 
     if (map.s !== void 0) {
-      date.second = Number.parseInt(match[map.s], 10) % 60
+      date.second = Number.parseInt(match[map.s], 10)
+      if (date.second > 59) return date
     }
 
     if (map.S !== void 0) {
@@ -480,9 +490,18 @@ export function __splitDate(str, mask, dateLocale, calendar, defaultModel) {
     if (map.Z !== void 0 || map.ZZ !== void 0) {
       tzString =
         map.Z !== void 0 ? match[map.Z].replace(':', '') : match[map.ZZ]
-      date.timezoneOffset =
-        (tzString[0] === '+' ? -1 : 1) *
-        (60 * tzString.slice(1, 3) + Number(tzString.slice(3, 5)))
+
+      if (tzString === 'Z') {
+        date.timezoneOffset = 0
+      } else {
+        const tzHours = Number(tzString.slice(1, 3)),
+          tzMinutes = Number(tzString.slice(3, 5))
+
+        if (tzHours > 23 || tzMinutes > 59) return date
+
+        date.timezoneOffset =
+          (tzString[0] === '+' ? -1 : 1) * (60 * tzHours + tzMinutes)
+      }
     }
   }
 

--- a/ui/src/utils/date/date.test.js
+++ b/ui/src/utils/date/date.test.js
@@ -75,6 +75,31 @@ describe('[date API]', () => {
         ).toBe(Date.parse(value))
       })
 
+      test('accepts a valid prefix when the input continues beyond the mask', () => {
+        expect(
+          date.extractDate('2024-02-29T13:05:06Z', 'YYYY-MM-DD')
+        ).toStrictEqual(new Date(2024, 1, 29))
+      })
+
+      test.each([
+        [void 0, 'YYYY-MM-DD'],
+        [null, 'YYYY-MM-DD'],
+        ['', 'YYYY-MM-DD'],
+        ['not a date', 'YYYY-MM-DD'],
+        ['2024-02', 'YYYY-MM-DD'],
+        ['2024-02-30', 'YYYY-MM-DD'],
+        ['2024-02-29 24:00', 'YYYY-MM-DD HH:mm'],
+        ['2024-02-29 13:60', 'YYYY-MM-DD HH:mm'],
+        ['2024-02-29 13:05:60', 'YYYY-MM-DD HH:mm:ss'],
+        ['2024-02-29 00:05 PM', 'YYYY-MM-DD hh:mm A'],
+        ['2024-02-29 13:05 +2460', 'YYYY-MM-DD HH:mm ZZ']
+      ])('returns Invalid Date for %o with mask %s', (value, mask) => {
+        const result = date.extractDate(value, mask)
+
+        expect(result).toBeInstanceOf(Date)
+        expect(Number.isNaN(result.getTime())).toBe(true)
+      })
+
       test.each(['X', 'x'])(
         'round-trips a pre-1970 date through the %s mask',
         mask => {
@@ -598,6 +623,19 @@ describe('[date API]', () => {
 
       test('rejects an impossible calendar date', () => {
         const result = __splitDate('2023-02-29', 'YYYY-MM-DD')
+
+        expect(result.dateHash).toBeNull()
+        expect(result.timeHash).toBeNull()
+      })
+
+      test.each([
+        ['24:00', 'HH:mm'],
+        ['13:00 PM', 'hh:mm A'],
+        ['23:60', 'HH:mm'],
+        ['23:59:60', 'HH:mm:ss'],
+        ['23:59 +2460', 'HH:mm ZZ']
+      ])('rejects out-of-range time components in %s', (value, mask) => {
+        const result = __splitDate(value, mask)
 
         expect(result.dateHash).toBeNull()
         expect(result.timeHash).toBeNull()


### PR DESCRIPTION
## What changed

- Return an `Invalid Date` object when `extractDate()` cannot parse the input
  or encounters an impossible date.
- Reject out-of-range 24-hour, 12-hour, minute, second, and timezone
  components instead of wrapping them with modulo arithmetic.
- Document the invalid-input result and add behavioral regressions.
- Preserve the intentional prefix-extraction behavior introduced by #5306,
  so an input may still contain additional text after the portion described by
  the mask.

## Why

`__splitDate()` already signals failed and impossible calendar parses with null
hashes, but `extractDate()` ignored that signal and always constructed a
`Date`. The constructor then turned missing or invalid components into
valid-looking values such as January 1, 1900. Time components were also
silently wrapped, for example turning `24:00` into `00:00`.

Returning `Invalid Date` keeps the existing `Date` return type while making
failure observable through `date.isValid(result)` or
`Number.isNaN(result.getTime())`.

## Public API impact

The function signature and return type remain unchanged. Inputs that previously
produced normalized, valid-looking dates despite not matching the requested
mask now produce `Invalid Date`.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target utils/date/date`
- `cd ui && pnpm --filter quasar-ui-test test ../src/utils/date/date.test.js`
  — 111 tests passed
- `pnpm test`
  - 135 UI files / 1,365 UI tests passed
  - generated Specs CI passed
  - 10 Vite usage tests passed
  - 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date parsing validation for invalid dates, times, and timezone offsets.
  * Invalid or impossible date/time values now return an `Invalid Date` instead of producing incorrect results.
  * Date extraction now accepts valid input prefixes when extra trailing text is present.

* **Documentation**
  * Clarified `extractDate()` behavior for parsing failures and impossible date/time values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->