### PR TITLE
fix(EventBus): support reserved event names

### DIFF
--- a/ui/src/utils/EventBus/EventBus.js
+++ b/ui/src/utils/EventBus/EventBus.js
@@ -5,7 +5,8 @@
 
 export default class EventBus {
   constructor() {
-    this.__stack = {}
+    // Event names can match properties inherited from Object.prototype.
+    this.__stack = Object.create(null)
   }
 
   on(name, callback, ctx) {

--- a/ui/src/utils/EventBus/EventBus.test.js
+++ b/ui/src/utils/EventBus/EventBus.test.js
@@ -81,6 +81,31 @@ describe('[EventBus API]', () => {
         expect(callback2).toHaveBeenCalledWith('testing2')
       })
 
+      test.each(['__proto__', 'constructor', 'toString'])(
+        'supports the reserved event name %s',
+        name => {
+          const instance = new EventBus()
+          const callback = vi.fn()
+          const onceCallback = vi.fn()
+
+          instance.on(name, callback).once(name, onceCallback)
+          instance.emit(name, 'first')
+          instance.off(name, callback)
+          instance.emit(name, 'second')
+
+          expect(callback).toHaveBeenCalledTimes(1)
+          expect(callback).toHaveBeenCalledWith('first')
+          expect(onceCallback).toHaveBeenCalledTimes(1)
+          expect(onceCallback).toHaveBeenCalledWith('first')
+
+          instance.on(name, callback)
+          instance.off(name)
+          instance.emit(name, 'third')
+
+          expect(callback).toHaveBeenCalledTimes(1)
+        }
+      )
+
       test('arguments preservation', () => {
         const instance = new EventBus()
         const callback = vi.fn()


### PR DESCRIPTION
## What changed

- Store EventBus listeners in a null-prototype object.
- Add behavioral coverage for `__proto__`, `constructor`, and `toString` through `on()`, `once()`, `emit()`, callback-specific `off()`, and full-event `off()`.

## Why

EventBus used a normal object as its listener registry. Event names matching inherited `Object.prototype` properties resolved to functions or objects instead of an empty listener slot, so subscribing attempted to call `.push()` on a non-array and threw a `TypeError`.

A null-prototype registry preserves the existing object-based lookup behavior while allowing every string event name supported by the public API.

## Public API impact

No signatures or types change. Event names that previously collided with inherited object properties now work like any other event name.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target utils/EventBus/EventBus`
- `cd ui && pnpm --filter quasar-ui-test test ../src/utils/EventBus/EventBus.test.js` — 12 tests passed
- `pnpm test`
  - generated Specs CI passed
  - 135 UI files / 1,351 UI tests passed
  - 10 Vite usage tests passed
  - 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handling for reserved event names such as `__proto__`, `constructor`, and `toString`.
  * Ensured event listeners can be registered, triggered, and removed consistently without name collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->