### PR TITLE
fix(runSequentialPromises): normalize invalid concurrency

### DIFF
--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -332,7 +332,6 @@ runSequentialPromises(
 })
 ```
 
-`threadsNumber` must be a positive integer. Invalid values fall back to `1`.
 When configuring threadsNumber (`opts > threadsNumber`) AND using http
 requests, be aware of the maximum threads that the hosting browser supports
 (usually 5). Any number of threads above that won't add any real benefits.

--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -332,9 +332,7 @@ runSequentialPromises(
 })
 ```
 
-When configuring threadsNumber (`opts > threadsNumber`) AND using http
-requests, be aware of the maximum threads that the hosting browser supports
-(usually 5). Any number of threads above that won't add any real benefits.
+When configuring threadsNumber (`opts > threadsNumber`) AND using http requests, be aware of the maximum threads that the hosting browser supports (usually 5). Any number of threads above that won't add any real benefits.
 
 ```js
 import { runSequentialPromises } from 'quasar'

--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -147,6 +147,8 @@ The following is a helper to run multiple Promises sequentially. **Optionally, o
  * @param {*} opts - Optional options Object
  *                   Object form: { threadsNumber?: number, abortOnFail?: boolean }
  *                   Default: { threadsNumber: 1, abortOnFail: true }
+ *                   threadsNumber must be a positive integer; invalid values
+ *                       fall back to 1
  *                   When configuring threadsNumber AND using http requests, be
  *                       aware of the maximum threads that the hosting browser
  *                       supports (usually 5); any number of threads above that
@@ -330,7 +332,10 @@ runSequentialPromises(
 })
 ```
 
-When configuring threadsNumber (`opts > threadsNumber`) AND using http requests, be aware of the maximum threads that the hosting browser supports (usually 5). Any number of threads above that won't add any real benefits.
+`threadsNumber` must be a positive integer. Invalid values fall back to `1`.
+When configuring threadsNumber (`opts > threadsNumber`) AND using http
+requests, be aware of the maximum threads that the hosting browser supports
+(usually 5). Any number of threads above that won't add any real benefits.
 
 ```js
 import { runSequentialPromises } from 'quasar'

--- a/ui/src/utils/run-sequential-promises/run-sequential-promises.js
+++ b/ui/src/utils/run-sequential-promises/run-sequential-promises.js
@@ -13,7 +13,7 @@ function parsePromises(sequentialPromises) {
   const resultAggregator = resultKeys.reduce((acc, key) => {
     acc[key] = null
     return acc
-  }, {})
+  }, Object.create(null))
 
   return {
     isList: false,
@@ -32,6 +32,8 @@ function parsePromises(sequentialPromises) {
  * @param {*} opts - Optional options Object
  *                   Object form: { threadsNumber?: number, abortOnFail?: boolean }
  *                   Default: { threadsNumber: 1, abortOnFail: true }
+ *                   threadsNumber must be a positive integer; invalid values
+ *                       fall back to 1
  *                   When configuring threadsNumber AND using http requests, be
  *                       aware of the maximum threads that the hosting browser
  *                       supports (usually 5); any number of threads above that
@@ -102,7 +104,10 @@ export default function runSequentialPromises(
       })
   }
 
-  const concurrencyLimit = Math.min(totalJobs, Math.max(1, threadsNumber))
+  const concurrencyLimit = Math.min(
+    totalJobs,
+    Number.isInteger(threadsNumber) && threadsNumber > 0 ? threadsNumber : 1
+  )
   const threads = Array.from({ length: concurrencyLimit }, () => {
     const threadCtx = Promise.withResolvers()
     runNextPromise(threadCtx)

--- a/ui/src/utils/run-sequential-promises/run-sequential-promises.test.js
+++ b/ui/src/utils/run-sequential-promises/run-sequential-promises.test.js
@@ -73,6 +73,25 @@ describe('[runSequentialPromises API]', () => {
 
           expect(result.taskB.value).toBe(150)
         })
+
+        test('supports object jobs with reserved property names', async () => {
+          const names = ['__proto__', 'constructor', 'toString']
+          const tasks = Object.fromEntries(
+            names.map(name => [name, () => Promise.resolve(name)])
+          )
+
+          const result = await runSequentialPromises(tasks)
+
+          expect(Object.getPrototypeOf(result)).toBeNull()
+
+          for (const name of names) {
+            expect(result[name]).toStrictEqual({
+              key: name,
+              status: 'fulfilled',
+              value: name
+            })
+          }
+        })
       })
 
       describe('Error Handling (abortOnFail)', () => {
@@ -156,6 +175,34 @@ describe('[runSequentialPromises API]', () => {
           // If they ran sequentially, maxConcurrency would be 1.
           // If threading worked, it should hit exactly 3.
           expect(maxConcurrency).toBe(3)
+        })
+
+        test.each([
+          Number.NaN,
+          Number.POSITIVE_INFINITY,
+          Number.NEGATIVE_INFINITY,
+          0,
+          -1,
+          1.5,
+          '2'
+        ])('falls back to one thread for %o', async threadsNumber => {
+          let runningTasks = 0
+          let maxConcurrency = 0
+
+          const trackConcurrency = async () => {
+            runningTasks++
+            maxConcurrency = Math.max(maxConcurrency, runningTasks)
+            await Promise.resolve()
+            runningTasks--
+          }
+
+          const result = await runSequentialPromises(
+            [trackConcurrency, trackConcurrency, trackConcurrency],
+            { threadsNumber }
+          )
+
+          expect(result).toHaveLength(3)
+          expect(maxConcurrency).toBe(1)
         })
       })
 

--- a/ui/types/utils/run-sequential-promises.d.ts
+++ b/ui/types/utils/run-sequential-promises.d.ts
@@ -42,6 +42,8 @@ export type RunSequentialPromisesResult<TKey extends number | string, TValue> =
 
 export interface RunSequentialPromisesOptions {
   /**
+   * Must be a positive integer. Invalid runtime values fall back to `1`.
+   *
    * When making HTTP requests, be aware of the maximum threads that
    * the hosting browser supports (usually 5). Any number of threads
    * above that won't add any real benefits.


### PR DESCRIPTION
## What changed

- Normalize invalid `threadsNumber` values to one worker.
- Use null-prototype storage for object-form result aggregators.
- Add behavioral coverage for non-finite, non-positive, fractional, and non-number concurrency values, plus reserved object keys.
- Document the runtime fallback in source JSDoc, public docs, and TypeScript declarations.

## Why

`Math.min(totalJobs, Math.max(1, threadsNumber))` allowed JavaScript coercion to define runtime behavior. In particular, `NaN` produced a `NaN` concurrency limit, created zero workers, and resolved with untouched `null` results. Fractional and string values were also silently coerced.

Object-form aggregation also used a normal object, exposing inherited-property collisions for dictionary-style result keys.

Invalid concurrency now falls back to the documented safe default of one worker, while valid positive integers retain existing behavior and remain capped by the number of jobs.

## Public API impact

No signatures change. Valid positive integer values behave as before. Invalid runtime values now complete sequentially with one worker instead of being coerced inconsistently or, for `NaN`, skipping every job. Object-form results remain objects but no longer inherit from `Object.prototype`.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target utils/run-sequential-promises/run-sequential-promises`
- `cd ui && pnpm --filter quasar-ui-test test ../src/utils/run-sequential-promises/run-sequential-promises.test.js` — 18 tests passed
- `pnpm test` — 135 UI files / 1,356 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of jobs using reserved property names, ensuring results are returned correctly.
  * Invalid concurrency settings—including zero, negative, fractional, non-numeric, and non-finite values—now safely fall back to a single thread.

* **Documentation**
  * Clarified that the concurrency setting must be a positive integer.
  * Updated TypeScript documentation to reflect the fallback behavior for invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->