### PR TITLE
fix(date): escape custom locale names

### DIFF
--- a/docs/src/pages/quasar-utils/date-utils.md
+++ b/docs/src/pages/quasar-utils/date-utils.md
@@ -449,6 +449,9 @@ const date = date.extractDate('21/03/1985', 'DD/MM/YYYY')
 
 With optional custom locale:
 
+Custom day and month names are matched literally, including any regular
+expression metacharacters they contain.
+
 ```js
 import { date } from 'quasar'
 

--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -194,6 +194,7 @@ function getRegexData(mask, dateLocale) {
         if (match[0] === '[') {
           match = match.slice(1, -1)
         }
+
         return escapeRegex(match)
       }
     }

--- a/ui/src/utils/date/date.js
+++ b/ui/src/utils/date/date.js
@@ -11,13 +11,18 @@ const MILLISECONDS_IN_DAY = 86_400_000,
     /\[((?:[^\]\\]|\\]|\\)*)\]|do|d{1,4}|Mo|M{1,4}|m{1,2}|wo|w{1,2}|Qo|Do|DDDo|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]/g,
   reverseToken =
     /(\[[^\]]*\])|do|d{1,4}|Mo|M{1,4}|m{1,2}|wo|w{1,2}|Qo|Do|DDDo|D{1,4}|YY(?:YY)?|H{1,2}|h{1,2}|s{1,2}|S{1,3}|Z{1,2}|a{1,2}|[AQExX]|([.*+:?^,\s${}()|\\]+)/g,
+  escapeRegexRE = /[.*+?^${}()|[\]\\]/g,
   regexStore = new Map()
 
+function escapeRegex(str) {
+  return str.replaceAll(escapeRegexRE, String.raw`\$&`)
+}
+
 function getRegexData(mask, dateLocale) {
-  const days = '(' + dateLocale.days.join('|') + ')',
-    daysShort = '(' + dateLocale.daysShort.join('|') + ')',
-    months = '(' + dateLocale.months.join('|') + ')',
-    monthsShort = '(' + dateLocale.monthsShort.join('|') + ')'
+  const days = '(' + dateLocale.days.map(escapeRegex).join('|') + ')',
+    daysShort = '(' + dateLocale.daysShort.map(escapeRegex).join('|') + ')',
+    months = '(' + dateLocale.months.map(escapeRegex).join('|') + ')',
+    monthsShort = '(' + dateLocale.monthsShort.map(escapeRegex).join('|') + ')'
 
   const key = [mask, days, daysShort, months, monthsShort].join('|')
 
@@ -189,7 +194,7 @@ function getRegexData(mask, dateLocale) {
         if (match[0] === '[') {
           match = match.slice(1, -1)
         }
-        return match.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+        return escapeRegex(match)
       }
     }
   })

--- a/ui/src/utils/date/date.test.js
+++ b/ui/src/utils/date/date.test.js
@@ -118,6 +118,35 @@ describe('[date API]', () => {
           ).toStrictEqual(new Date(2024, 0, 1))
         }
       })
+
+      test.each([
+        ['months', 'MMMM D YYYY', ' 1 2024'],
+        ['monthsShort', 'MMM D YYYY', ' 1 2024'],
+        ['days', 'dddd YYYY-MM-DD', ' 2024-01-01'],
+        ['daysShort', 'ddd YYYY-MM-DD', ' 2024-01-01']
+      ])(
+        'treats regexp metacharacters in custom %s names as literals',
+        async (localeField, mask, suffix) => {
+          const { default: enUS } = await import('quasar/lang/en-US.js')
+          const localeNames = [...enUS.date[localeField]]
+          const localeName = [
+            localeField,
+            String.raw`.*+?^$`,
+            '{}()|[name]',
+            String.raw`\path`
+          ].join('')
+          localeNames[0] = localeName
+
+          const locale = {
+            ...enUS.date,
+            [localeField]: localeNames
+          }
+
+          expect(
+            date.extractDate(localeName + suffix, mask, locale)
+          ).toStrictEqual(new Date(2024, 0, 1))
+        }
+      )
     })
 
     describe('[(function)buildDate]', () => {


### PR DESCRIPTION
## What changed

- Escape every custom day and month name before inserting it into the date parser regular expression.
- Reuse the same escaping helper for literal mask text.
- Add behavioral coverage for regular-expression metacharacters in `days`, `daysShort`, `months`, and `monthsShort`.
- Document that custom locale names are matched literally.

## Why

The localized date parser previously joined custom locale names directly into regular-expression alternations. A locale name containing characters such as `.`, `*`, `+`, parentheses, brackets, `|`, or `\` could therefore change the parser expression instead of matching its visible text. Capturing groups in a custom name could also shift the indices used to extract later date fields.

Locale-provided names are data, not regular-expression syntax. Escaping each entry preserves the existing parser structure, cache behavior, and matching semantics for normal language packs while making custom locale values literal and predictable.

## Public API impact

No signature or type changes are required. Existing locale names without regular-expression metacharacters behave as before. Custom names containing those characters now parse as their literal text.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target utils/date/date`
- `cd ui && pnpm --filter quasar-ui-test test ../src/utils/date/date.test.js` — 98 tests passed
- `pnpm test` — 135 UI files / 1,352 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date parsing for custom locale day and month names containing regular-expression characters.
  * Ensured these names are interpreted as literal text, enabling reliable date extraction.

* **Documentation**
  * Clarified how custom locale names are matched during date parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->