### PR TITLE
fix(lang): encode SSR language attributes

### DIFF
--- a/ui/src/plugins/lang/Lang.js
+++ b/ui/src/plugins/lang/Lang.js
@@ -3,6 +3,18 @@ import { createReactivePlugin } from '../../utils/private.create/create.js'
 // oxlint-disable-next-line unicorn/prefer-export-from
 import defaultLang from '../../../lang/en-US.js'
 
+const htmlChars = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+}
+
+function encodeHtmlAttribute(value) {
+  return String(value).replaceAll(/[&<>"']/g, char => htmlChars[char])
+}
+
 function getLocale() {
   if (__QUASAR_SSR_SERVER__) return
 
@@ -58,7 +70,7 @@ const Plugin = createReactivePlugin(
           !ssrContext.$q.config.lang.noHtmlAttrs
         ) {
           const dir = lang.rtl ? 'rtl' : 'ltr'
-          const attrs = `lang=${lang.isoName} dir=${dir}`
+          const attrs = `lang="${encodeHtmlAttribute(lang.isoName)}" dir="${dir}"`
 
           ssrContext._meta.htmlAttrs =
             ssrContext.__qPrevLang !== void 0

--- a/ui/src/plugins/lang/Lang.test.js
+++ b/ui/src/plugins/lang/Lang.test.js
@@ -307,6 +307,34 @@ describe('[Lang API]', () => {
         expect(Lang.props.nativeName).toBe(itLang.nativeName)
         expect($q.lang.nativeName).toBe(itLang.nativeName)
       })
+
+      test('quotes and encodes SSR language attributes', async () => {
+        const { Lang: SsrLang } =
+          await import('quasar/dist/quasar.server.prod.js')
+        const ssrContext = {
+          $q: {
+            config: {},
+            lang: { set() {} }
+          },
+          _meta: { htmlAttrs: '' }
+        }
+
+        SsrLang.set(
+          {
+            isoName: `en" onload="<script>'&`,
+            rtl: false
+          },
+          ssrContext
+        )
+
+        expect(ssrContext._meta.htmlAttrs).toBe(
+          'lang="en&quot; onload=&quot;&lt;script&gt;&#39;&amp;" dir="ltr"'
+        )
+
+        SsrLang.set({ isoName: 'ar', rtl: true }, ssrContext)
+
+        expect(ssrContext._meta.htmlAttrs).toBe('lang="ar" dir="rtl"')
+      })
     })
 
     describe('[(method)getLocale]', () => {


### PR DESCRIPTION
## What changed

- Quote the SSR-generated `lang` and `dir` attributes.
- HTML-attribute-encode custom language-pack `isoName` values before adding them to SSR metadata.
- Test the actual built server bundle with markup characters and repeated language changes.

## Why

The SSR Lang plugin interpolated `isoName` into an unquoted raw attribute string. Built-in packs use trusted identifiers, but a custom language pack containing spaces, quotes, or markup could change the server-rendered `<html>` attributes.

The client path already uses `setAttribute()`. This change gives SSR equivalent output safety while preserving the supplied identifier and existing language-pack compatibility.

## Public API and SSR impact

No API, type, or configuration signatures change. Normal language packs produce semantically identical quoted attributes. Custom values are preserved as text but HTML-encoded, so they cannot escape the `lang` attribute. Repeated SSR language changes continue replacing the prior Quasar-generated attributes, including RTL direction changes.

A strict language-tag validator was intentionally not added because it rejects existing Quasar identifiers such as `sr-CYR` and `kur-CKB` and could break valid custom/private tags. Output encoding fully addresses the HTML injection sink without introducing that compatibility risk.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target plugins/lang/Lang`
- `cd ui && pnpm --filter quasar-ui-test test ../src/plugins/lang/Lang.test.js` — 7 tests passed
- `pnpm test` — 135 UI files / 1,349 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered language metadata by safely escaping special characters in HTML attributes.
  * Prevented malformed or unsafe language attributes from being generated.

* **Tests**
  * Added coverage for malicious language values and verified correct handling of right-to-left language metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->