### PR TITLE
test(ui): cover component primitives

### DIFF
--- a/ui/src/components/btn-group/QBtnGroup.test.js
+++ b/ui/src/components/btn-group/QBtnGroup.test.js
@@ -1,0 +1,97 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QBtnGroup from './QBtnGroup.js'
+
+async function expectBooleanClass(prop, className) {
+  const wrapper = mount(QBtnGroup)
+  const target = wrapper.get('.q-btn-group')
+
+  expect(target.classes()).not.toContain(className)
+
+  await wrapper.setProps({ [prop]: true })
+
+  expect(target.classes()).toContain(className)
+}
+
+describe('[QBtnGroup API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)spread]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QBtnGroup)
+        const target = wrapper.get('.q-btn-group')
+
+        expect(target.classes()).toContain('inline')
+        expect(target.classes()).not.toContain('q-btn-group--spread')
+
+        await wrapper.setProps({ spread: true })
+
+        expect(target.classes()).not.toContain('inline')
+        expect(target.classes()).toContain('q-btn-group--spread')
+      })
+    })
+
+    describe('[(prop)outline]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('outline', 'q-btn-group--outline')
+      })
+    })
+
+    describe('[(prop)flat]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('flat', 'q-btn-group--flat')
+      })
+    })
+
+    describe('[(prop)unelevated]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('unelevated', 'q-btn-group--unelevated')
+      })
+    })
+
+    describe('[(prop)rounded]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('rounded', 'q-btn-group--rounded')
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('square', 'q-btn-group--square')
+      })
+    })
+
+    describe('[(prop)push]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('push', 'q-btn-group--push')
+      })
+    })
+
+    describe('[(prop)stretch]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('stretch', 'q-btn-group--stretch')
+      })
+    })
+
+    describe('[(prop)glossy]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('glossy', 'q-btn-group--glossy')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QBtnGroup, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-btn-group').text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/card/QCard.test.js
+++ b/ui/src/components/card/QCard.test.js
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCard from './QCard.js'
+
+async function expectBooleanClass(prop, className) {
+  const wrapper = mount(QCard)
+  const target = wrapper.get('.q-card')
+
+  expect(target.classes()).not.toContain(className)
+
+  await wrapper.setProps({ [prop]: true })
+
+  expect(target.classes()).toContain(className)
+}
+
+describe('[QCard API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QCard)
+        const target = wrapper.get('.q-card')
+
+        expect(target.classes()).not.toContain('q-card--dark')
+        expect(target.classes()).not.toContain('q-dark')
+
+        await wrapper.setProps({ dark: true })
+
+        expect(target.classes()).toContain('q-card--dark')
+        expect(target.classes()).toContain('q-dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mount(QCard, {
+          props: {
+            dark: true
+          }
+        })
+        const target = wrapper.get('.q-card')
+
+        expect(target.classes()).toContain('q-card--dark')
+
+        await wrapper.setProps({ dark: null })
+
+        expect(target.classes()).not.toContain('q-card--dark')
+        expect(target.classes()).not.toContain('q-dark')
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('square', 'q-card--square')
+      })
+    })
+
+    describe('[(prop)flat]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('flat', 'q-card--flat')
+      })
+    })
+
+    describe('[(prop)bordered]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('bordered', 'q-card--bordered')
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCard, {
+          props: {
+            tag: 'section'
+          }
+        })
+
+        expect(wrapper.element.tagName).toBe('SECTION')
+        expect(wrapper.classes()).toContain('q-card')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QCard, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-card').text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/card/QCardActions.test.js
+++ b/ui/src/components/card/QCardActions.test.js
@@ -1,0 +1,87 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCardActions from './QCardActions.js'
+
+function expectAlignment(align, className) {
+  const wrapper = mount(QCardActions, {
+    props: { align }
+  })
+
+  expect(wrapper.get('.q-card__actions').classes()).toContain(className)
+}
+
+describe('[QCardActions API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)align]', () => {
+      test('value "left" has effect', () => {
+        expectAlignment('left', 'justify-start')
+      })
+
+      test('value "center" has effect', () => {
+        expectAlignment('center', 'justify-center')
+      })
+
+      test('value "right" has effect', () => {
+        expectAlignment('right', 'justify-end')
+      })
+
+      test('value "between" has effect', () => {
+        expectAlignment('between', 'justify-between')
+      })
+
+      test('value "around" has effect', () => {
+        expectAlignment('around', 'justify-around')
+      })
+
+      test('value "evenly" has effect', () => {
+        expectAlignment('evenly', 'justify-evenly')
+      })
+
+      test('value "stretch" has effect', () => {
+        expectAlignment('stretch', 'justify-stretch')
+      })
+    })
+
+    describe('[(prop)vertical]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QCardActions)
+        const target = wrapper.get('.q-card__actions')
+
+        expect(target.classes()).toEqual(
+          expect.arrayContaining([
+            'q-card__actions--horiz',
+            'row',
+            'justify-start'
+          ])
+        )
+
+        await wrapper.setProps({ vertical: true })
+
+        expect(target.classes()).toEqual(
+          expect.arrayContaining([
+            'q-card__actions--vert',
+            'column',
+            'items-stretch'
+          ])
+        )
+        expect(target.classes()).not.toContain('q-card__actions--horiz')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QCardActions, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-card__actions').text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/card/QCardSection.test.js
+++ b/ui/src/components/card/QCardSection.test.js
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCardSection from './QCardSection.js'
+
+describe('[QCardSection API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)horizontal]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QCardSection)
+        const target = wrapper.get('.q-card__section')
+
+        expect(target.classes()).toContain('q-card__section--vert')
+        expect(target.classes()).not.toContain('row')
+
+        await wrapper.setProps({ horizontal: true })
+
+        expect(target.classes()).not.toContain('q-card__section--vert')
+        expect(target.classes()).toEqual(
+          expect.arrayContaining(['q-card__section--horiz', 'row', 'no-wrap'])
+        )
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCardSection, {
+          props: {
+            tag: 'section'
+          }
+        })
+
+        expect(wrapper.element.tagName).toBe('SECTION')
+        expect(wrapper.classes()).toContain('q-card__section')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QCardSection, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-card__section').text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/carousel/QCarouselControl.test.js
+++ b/ui/src/components/carousel/QCarouselControl.test.js
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCarouselControl from './QCarouselControl.js'
+
+function expectPosition(position) {
+  const wrapper = mount(QCarouselControl, {
+    props: { position }
+  })
+
+  expect(wrapper.get('.q-carousel__control').classes()).toContain(
+    `absolute-${position}`
+  )
+}
+
+describe('[QCarouselControl API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)position]', () => {
+      test('value "top-right" has effect', () => {
+        expectPosition('top-right')
+      })
+
+      test('value "top-left" has effect', () => {
+        expectPosition('top-left')
+      })
+
+      test('value "bottom-right" has effect', () => {
+        expectPosition('bottom-right')
+      })
+
+      test('value "bottom-left" has effect', () => {
+        expectPosition('bottom-left')
+      })
+
+      test('value "top" has effect', () => {
+        expectPosition('top')
+      })
+
+      test('value "right" has effect', () => {
+        expectPosition('right')
+      })
+
+      test('value "bottom" has effect', () => {
+        expectPosition('bottom')
+      })
+
+      test('value "left" has effect', () => {
+        expectPosition('left')
+      })
+    })
+
+    describe('[(prop)offset]', () => {
+      test('type Array has effect', async () => {
+        const wrapper = mount(QCarouselControl)
+        const target = wrapper.get('.q-carousel__control')
+
+        expect(target.$style('margin')).toBe('18px')
+
+        await wrapper.setProps({ offset: [5, 10] })
+
+        expect(target.$style('margin')).toBe('10px 5px')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QCarouselControl, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-carousel__control').text()).toContain(
+          slotContent
+        )
+      })
+    })
+  })
+})

--- a/ui/src/components/markup-table/QMarkupTable.test.js
+++ b/ui/src/components/markup-table/QMarkupTable.test.js
@@ -1,0 +1,134 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QMarkupTable from './QMarkupTable.js'
+
+async function expectBooleanClass(prop, className) {
+  const wrapper = mount(QMarkupTable)
+  const target = wrapper.get('.q-markup-table')
+
+  expect(target.classes()).not.toContain(className)
+
+  await wrapper.setProps({ [prop]: true })
+
+  expect(target.classes()).toContain(className)
+}
+
+function expectSeparator(separator) {
+  const wrapper = mount(QMarkupTable, {
+    props: { separator }
+  })
+
+  expect(wrapper.get('.q-markup-table').classes()).toContain(
+    `q-table--${separator}-separator`
+  )
+}
+
+describe('[QMarkupTable API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('dense', 'q-table--dense')
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QMarkupTable)
+        const target = wrapper.get('.q-markup-table')
+
+        expect(target.classes()).not.toContain('q-table--dark')
+
+        await wrapper.setProps({ dark: true })
+
+        expect(target.classes()).toEqual(
+          expect.arrayContaining([
+            'q-table--dark',
+            'q-table__card--dark',
+            'q-dark'
+          ])
+        )
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mount(QMarkupTable, {
+          props: {
+            dark: true
+          }
+        })
+        const target = wrapper.get('.q-markup-table')
+
+        expect(target.classes()).toContain('q-table--dark')
+
+        await wrapper.setProps({ dark: null })
+
+        expect(target.classes()).not.toContain('q-table--dark')
+        expect(target.classes()).not.toContain('q-dark')
+      })
+    })
+
+    describe('[(prop)flat]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('flat', 'q-table--flat')
+      })
+    })
+
+    describe('[(prop)bordered]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('bordered', 'q-table--bordered')
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', async () => {
+        await expectBooleanClass('square', 'q-table--square')
+      })
+    })
+
+    describe('[(prop)separator]', () => {
+      test('value "horizontal" has effect', () => {
+        expectSeparator('horizontal')
+      })
+
+      test('value "vertical" has effect', () => {
+        expectSeparator('vertical')
+      })
+
+      test('value "cell" has effect', () => {
+        expectSeparator('cell')
+      })
+
+      test('value "none" has effect', () => {
+        expectSeparator('none')
+      })
+    })
+
+    describe('[(prop)wrap-cells]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QMarkupTable)
+        const target = wrapper.get('.q-markup-table')
+
+        expect(target.classes()).toContain('q-table--no-wrap')
+
+        await wrapper.setProps({ wrapCells: true })
+
+        expect(target.classes()).not.toContain('q-table--no-wrap')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QMarkupTable, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('table.q-table').text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/responsive/QResponsive.test.js
+++ b/ui/src/components/responsive/QResponsive.test.js
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QResponsive from './QResponsive.js'
+
+function getRatioPadding(wrapper) {
+  return wrapper
+    .get('.q-responsive__filler')
+    .get('div')
+    .$style('padding-bottom')
+}
+
+describe('[QResponsive API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)ratio]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mount(QResponsive)
+
+        expect(getRatioPadding(wrapper)).toBe('')
+
+        await wrapper.setProps({ ratio: '1.7778' })
+
+        expect(Number.parseFloat(getRatioPadding(wrapper))).toBeCloseTo(56.25)
+      })
+
+      test('type Number has effect', async () => {
+        const wrapper = mount(QResponsive)
+
+        expect(getRatioPadding(wrapper)).toBe('')
+
+        await wrapper.setProps({ ratio: 2 })
+
+        expect(getRatioPadding(wrapper)).toBe('50%')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QResponsive, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-responsive__content').text()).toContain(
+          slotContent
+        )
+      })
+    })
+  })
+})

--- a/ui/src/components/separator/QSeparator.test.js
+++ b/ui/src/components/separator/QSeparator.test.js
@@ -1,0 +1,140 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QSeparator from './QSeparator.js'
+
+function expectInsetClass(inset, className) {
+  const wrapper = mount(QSeparator, {
+    props: { inset }
+  })
+
+  expect(wrapper.get('.q-separator').classes()).toContain(className)
+}
+
+describe('[QSeparator API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        expect(target.classes()).not.toContain('q-separator--dark')
+
+        await wrapper.setProps({ dark: true })
+
+        expect(target.classes()).toContain('q-separator--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mount(QSeparator, {
+          props: {
+            dark: true
+          }
+        })
+        const target = wrapper.get('.q-separator')
+
+        expect(target.classes()).toContain('q-separator--dark')
+
+        await wrapper.setProps({ dark: null })
+
+        expect(target.classes()).not.toContain('q-separator--dark')
+      })
+    })
+
+    describe('[(prop)spaced]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        expect(target.$style('margin-top')).toBe('')
+        expect(target.$style('margin-bottom')).toBe('')
+
+        await wrapper.setProps({ spaced: true })
+
+        expect(target.$style('margin-top')).toBe('8px')
+        expect(target.$style('margin-bottom')).toBe('8px')
+      })
+
+      test('type String has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        await wrapper.setProps({ spaced: '12px' })
+
+        expect(target.$style('margin-top')).toBe('12px')
+        expect(target.$style('margin-bottom')).toBe('12px')
+      })
+    })
+
+    describe('[(prop)inset]', () => {
+      test('value true has effect', () => {
+        expectInsetClass(true, 'q-separator--horizontal-inset')
+      })
+
+      test('value false has effect', () => {
+        const wrapper = mount(QSeparator, {
+          props: {
+            inset: false
+          }
+        })
+
+        expect(wrapper.get('.q-separator').classes()).not.toContain(
+          'q-separator--horizontal-inset'
+        )
+      })
+
+      test('value "item" has effect', () => {
+        expectInsetClass('item', 'q-separator--horizontal-item-inset')
+      })
+
+      test('value "item-thumbnail" has effect', () => {
+        expectInsetClass(
+          'item-thumbnail',
+          'q-separator--horizontal-item-thumbnail-inset'
+        )
+      })
+    })
+
+    describe('[(prop)vertical]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        expect(target.attributes('aria-orientation')).toBe('horizontal')
+        expect(target.classes()).toContain('q-separator--horizontal')
+
+        await wrapper.setProps({ vertical: true })
+
+        expect(target.attributes('aria-orientation')).toBe('vertical')
+        expect(target.classes()).toContain('q-separator--vertical')
+        expect(target.classes()).not.toContain('q-separator--horizontal')
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        expect(target.$style('height')).toBe('')
+
+        await wrapper.setProps({ size: '16px' })
+
+        expect(target.$style('height')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mount(QSeparator)
+        const target = wrapper.get('.q-separator')
+
+        expect(target.classes()).not.toContain('bg-primary')
+
+        await wrapper.setProps({ color: 'primary' })
+
+        expect(target.classes()).toContain('bg-primary')
+      })
+    })
+  })
+})

--- a/ui/src/components/stepper/QStepperNavigation.test.js
+++ b/ui/src/components/stepper/QStepperNavigation.test.js
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QStepperNavigation from './QStepperNavigation.js'
+
+describe('[QStepperNavigation API]', () => {
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QStepperNavigation, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-stepper__nav').text()).toContain(slotContent)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What changed

Adds generated-Specs-compliant behavioral test files for nine UI component primitives:

- `QBtnGroup`
- `QCard`, `QCardActions`, and `QCardSection`
- `QCarouselControl`
- `QMarkupTable`
- `QResponsive`
- `QSeparator`
- `QStepperNavigation`

## Test design

The tests preserve the hierarchy required by the Specs generator while asserting public rendered behavior: classes, styles, semantic attributes, dynamic tags, and slot placement. Shared helpers remove repetitive setup without snapshotting complete prop definitions or other static implementation details.

This is the first component-test batch and intentionally remains below the requested limit of ten test files per PR.

## Impact

Test coverage only. There are no production, public API, type, SSR, hydration, or accessibility changes.

## Validation

- Built the UI before generating the test files.
- Ran `pnpm test:specs --target ...` for every source target — all nine files passed structural validation.
- Focused Vitest run — 9 files and 66 tests passed.
- Complete `pnpm test` — 144 UI files / 1,414 UI tests, 10 Vite usage tests, and 75 Vite runtime tests passed.
- `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for button groups, cards, carousels, tables, responsive content, separators, and stepper navigation.
  * Verified public properties such as styling, layout, orientation, spacing, sizing, dark mode, tags, responsive ratios, and positioning.
  * Added checks confirming default slot content renders correctly across components.
  * Improved confidence that visual states and property-driven behavior remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->