### PR TITLE
test(ui): cover item, table, and timeline components

### DIFF
--- a/ui/src/components/icon/QIcon.test.js
+++ b/ui/src/components/icon/QIcon.test.js
@@ -33,6 +33,7 @@ describe('[QIcon API]', () => {
 
         expect(wrapper.classes()).toContain('material-icons')
         expect(wrapper.text()).toBe('map')
+        expect(wrapper.attributes('aria-hidden')).toBe('true')
       })
     })
 
@@ -77,6 +78,20 @@ describe('[QIcon API]', () => {
           }
         })
 
+        expect(wrapper.text()).toContain(slotContent)
+      })
+
+      test('renders the content alongside the icon', () => {
+        const slotContent = 'Custom icon content'
+        const wrapper = mount(QIcon, {
+          props: { name: 'map' },
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.classes()).toContain('material-icons')
+        expect(wrapper.text()).toContain('map')
         expect(wrapper.text()).toContain(slotContent)
       })
     })

--- a/ui/src/components/icon/QIcon.test.js
+++ b/ui/src/components/icon/QIcon.test.js
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QIcon from './QIcon.js'
+
+describe('[QIcon API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { size: '16px' }
+        })
+
+        expect(wrapper.attributes('style')).toContain('font-size: 16px')
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { tag: 'span' }
+        })
+
+        expect(wrapper.element.tagName).toBe('SPAN')
+      })
+    })
+
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { name: 'map' }
+        })
+
+        expect(wrapper.classes()).toContain('material-icons')
+        expect(wrapper.text()).toBe('map')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { color: 'primary' }
+        })
+
+        expect(wrapper.classes()).toContain('text-primary')
+      })
+    })
+
+    describe('[(prop)left]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { left: true }
+        })
+
+        expect(wrapper.classes()).toContain('on-left')
+      })
+    })
+
+    describe('[(prop)right]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QIcon, {
+          props: { right: true }
+        })
+
+        expect(wrapper.classes()).toContain('on-right')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Custom icon content'
+        const wrapper = mount(QIcon, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/item/QItemLabel.test.js
+++ b/ui/src/components/item/QItemLabel.test.js
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QItemLabel from './QItemLabel.js'
+
+describe('[QItemLabel API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)overline]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemLabel, {
+          props: { overline: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__label--overline')
+        expect(wrapper.classes()).toContain('text-overline')
+      })
+    })
+
+    describe('[(prop)caption]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemLabel, {
+          props: { caption: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__label--caption')
+        expect(wrapper.classes()).toContain('text-caption')
+      })
+    })
+
+    describe('[(prop)header]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemLabel, {
+          props: { header: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__label--header')
+      })
+    })
+
+    describe('[(prop)lines]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QItemLabel, {
+          props: { lines: 3 }
+        })
+
+        expect(wrapper.attributes('style')).toContain('overflow: hidden')
+        expect(wrapper.attributes('style')).toContain('display: -webkit-box')
+        expect(wrapper.attributes('style')).toContain('-webkit-line-clamp: 3')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mount(QItemLabel, {
+          props: { lines: '1' }
+        })
+
+        expect(wrapper.classes()).toContain('ellipsis')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Item label content'
+        const wrapper = mount(QItemLabel, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/item/QItemLabel.test.js
+++ b/ui/src/components/item/QItemLabel.test.js
@@ -45,6 +45,9 @@ describe('[QItemLabel API]', () => {
 
         expect(wrapper.attributes('style')).toContain('overflow: hidden')
         expect(wrapper.attributes('style')).toContain('display: -webkit-box')
+        expect(wrapper.attributes('style')).toContain(
+          '-webkit-box-orient: vertical'
+        )
         expect(wrapper.attributes('style')).toContain('-webkit-line-clamp: 3')
       })
 

--- a/ui/src/components/item/QItemSection.test.js
+++ b/ui/src/components/item/QItemSection.test.js
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QItemSection from './QItemSection.js'
+
+describe('[QItemSection API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)avatar]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemSection, {
+          props: { avatar: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__section--side')
+        expect(wrapper.classes()).toContain('q-item__section--avatar')
+      })
+    })
+
+    describe('[(prop)thumbnail]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemSection, {
+          props: { thumbnail: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__section--side')
+        expect(wrapper.classes()).toContain('q-item__section--thumbnail')
+      })
+    })
+
+    describe('[(prop)side]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemSection, {
+          props: { side: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__section--side')
+        expect(wrapper.classes()).not.toContain('q-item__section--main')
+      })
+    })
+
+    describe('[(prop)top]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemSection, {
+          props: { top: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__section--top')
+        expect(wrapper.classes()).toContain('justify-start')
+        expect(wrapper.classes()).not.toContain('justify-center')
+      })
+    })
+
+    describe('[(prop)no-wrap]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItemSection, {
+          props: { noWrap: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-item__section--nowrap')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Item section content'
+        const wrapper = mount(QItemSection, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/skeleton/QSkeleton.test.js
+++ b/ui/src/components/skeleton/QSkeleton.test.js
@@ -1,0 +1,235 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QSkeleton from './QSkeleton.js'
+
+function expectType(type) {
+  const wrapper = mount(QSkeleton, {
+    props: { type }
+  })
+
+  expect(wrapper.classes()).toContain(`q-skeleton--type-${type}`)
+}
+
+function expectAnimation(animation) {
+  const wrapper = mount(QSkeleton, {
+    props: { animation }
+  })
+
+  if (animation === 'none') {
+    expect(wrapper.classes()).not.toContain('q-skeleton--anim')
+  } else {
+    expect(wrapper.classes()).toContain('q-skeleton--anim')
+    expect(wrapper.classes()).toContain(`q-skeleton--anim-${animation}`)
+  }
+}
+
+describe('[QSkeleton API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { dark: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-skeleton--dark')
+        expect(wrapper.classes()).not.toContain('q-skeleton--light')
+      })
+
+      test('type null has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { dark: null }
+        })
+
+        expect(wrapper.classes()).toContain('q-skeleton--light')
+        expect(wrapper.classes()).not.toContain('q-skeleton--dark')
+      })
+    })
+
+    describe('[(prop)type]', () => {
+      test('value "text" has effect', () => {
+        expectType('text')
+      })
+
+      test('value "rect" has effect', () => {
+        expectType('rect')
+      })
+
+      test('value "circle" has effect', () => {
+        expectType('circle')
+      })
+
+      test('value "QBtn" has effect', () => {
+        expectType('QBtn')
+      })
+
+      test('value "QBadge" has effect', () => {
+        expectType('QBadge')
+      })
+
+      test('value "QChip" has effect', () => {
+        expectType('QChip')
+      })
+
+      test('value "QToolbar" has effect', () => {
+        expectType('QToolbar')
+      })
+
+      test('value "QCheckbox" has effect', () => {
+        expectType('QCheckbox')
+      })
+
+      test('value "QRadio" has effect', () => {
+        expectType('QRadio')
+      })
+
+      test('value "QToggle" has effect', () => {
+        expectType('QToggle')
+      })
+
+      test('value "QSlider" has effect', () => {
+        expectType('QSlider')
+      })
+
+      test('value "QRange" has effect', () => {
+        expectType('QRange')
+      })
+
+      test('value "QInput" has effect', () => {
+        expectType('QInput')
+      })
+
+      test('value "QAvatar" has effect', () => {
+        expectType('QAvatar')
+      })
+    })
+
+    describe('[(prop)animation]', () => {
+      test('value "wave" has effect', () => {
+        expectAnimation('wave')
+      })
+
+      test('value "pulse" has effect', () => {
+        expectAnimation('pulse')
+      })
+
+      test('value "pulse-x" has effect', () => {
+        expectAnimation('pulse-x')
+      })
+
+      test('value "pulse-y" has effect', () => {
+        expectAnimation('pulse-y')
+      })
+
+      test('value "fade" has effect', () => {
+        expectAnimation('fade')
+      })
+
+      test('value "blink" has effect', () => {
+        expectAnimation('blink')
+      })
+
+      test('value "none" has effect', () => {
+        expectAnimation('none')
+      })
+    })
+
+    describe('[(prop)animation-speed]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { animationSpeed: '750' }
+        })
+
+        expect(wrapper.attributes('style')).toContain(
+          '--q-skeleton-speed: 750ms'
+        )
+      })
+
+      test('type Number has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { animationSpeed: 900 }
+        })
+
+        expect(wrapper.attributes('style')).toContain(
+          '--q-skeleton-speed: 900ms'
+        )
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { square: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-skeleton--square')
+      })
+    })
+
+    describe('[(prop)bordered]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { bordered: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-skeleton--bordered')
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { size: '48px' }
+        })
+
+        expect(wrapper.attributes('style')).toContain('width: 48px')
+        expect(wrapper.attributes('style')).toContain('height: 48px')
+      })
+    })
+
+    describe('[(prop)width]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { width: '160px' }
+        })
+
+        expect(wrapper.attributes('style')).toContain('width: 160px')
+      })
+    })
+
+    describe('[(prop)height]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { height: '32px' }
+        })
+
+        expect(wrapper.attributes('style')).toContain('height: 32px')
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QSkeleton, {
+          props: { tag: 'span' }
+        })
+
+        expect(wrapper.element.tagName).toBe('SPAN')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Skeleton fallback content'
+        const wrapper = mount(QSkeleton, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/table/QTd.test.js
+++ b/ui/src/components/table/QTd.test.js
@@ -1,0 +1,65 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QTd from './QTd.js'
+
+describe('[QTd API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)props]', () => {
+      test('type Object has effect', () => {
+        const row = { status: 'active' }
+        const wrapper = mount(QTd, {
+          props: {
+            props: {
+              row,
+              col: {
+                __tdClass: value => `status-${value.status}`,
+                __tdStyle: value => ({
+                  opacity: value.status === 'active' ? 1 : 0
+                })
+              }
+            }
+          }
+        })
+
+        expect(wrapper.classes()).toContain('status-active')
+        expect(wrapper.attributes('style')).toContain('opacity: 1')
+      })
+    })
+
+    describe('[(prop)auto-width]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTd, {
+          props: { autoWidth: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-table--col-auto-width')
+      })
+    })
+
+    describe('[(prop)no-hover]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTd, {
+          props: { noHover: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-td--no-hover')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Table cell content'
+        const wrapper = mount(QTd, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/table/QTh.test.js
+++ b/ui/src/components/table/QTh.test.js
@@ -30,6 +30,17 @@ describe('[QTh API]', () => {
 
         await wrapper.trigger('click')
         expect(sort).toHaveBeenCalledWith(col)
+
+        sort.mockClear()
+        await wrapper.trigger('keyup', { key: 'Enter' })
+        expect(sort).toHaveBeenCalledOnce()
+        expect(sort).toHaveBeenCalledWith(col)
+
+        sort.mockClear()
+        await wrapper.trigger('keydown', { key: ' ' })
+        await wrapper.trigger('keyup', { key: ' ' })
+        expect(sort).toHaveBeenCalledOnce()
+        expect(sort).toHaveBeenCalledWith(col)
       })
     })
 

--- a/ui/src/components/table/QTh.test.js
+++ b/ui/src/components/table/QTh.test.js
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import QTh from './QTh.js'
+
+describe('[QTh API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)props]', () => {
+      test('type Object has effect', async () => {
+        const col = {
+          sortable: true,
+          align: 'right',
+          __iconClass: 'sort-icon',
+          __thClass: 'sortable-header',
+          __ariaSort: 'ascending',
+          headerStyle: { width: '120px' }
+        }
+        const sort = vi.fn()
+        const wrapper = mount(QTh, {
+          props: {
+            props: { col, sort }
+          }
+        })
+
+        expect(wrapper.classes()).toContain('sortable-header')
+        expect(wrapper.attributes('style')).toContain('width: 120px')
+        expect(wrapper.attributes('tabindex')).toBe('0')
+        expect(wrapper.attributes('aria-sort')).toBe('ascending')
+        expect(wrapper.get('.q-icon').classes()).toContain('sort-icon')
+
+        await wrapper.trigger('click')
+        expect(sort).toHaveBeenCalledWith(col)
+      })
+    })
+
+    describe('[(prop)auto-width]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTh, {
+          props: { autoWidth: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-table--col-auto-width')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Table heading content'
+        const wrapper = mount(QTh, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/table/QTr.test.js
+++ b/ui/src/components/table/QTr.test.js
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QTr from './QTr.js'
+
+describe('[QTr API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)props]', () => {
+      test('type Object has effect', () => {
+        const wrapper = mount(QTr, {
+          props: {
+            props: {
+              header: false,
+              __trClass: 'selected-row',
+              __trStyle: { height: '40px' }
+            }
+          }
+        })
+
+        expect(wrapper.classes()).toContain('selected-row')
+        expect(wrapper.attributes('style')).toContain('height: 40px')
+      })
+    })
+
+    describe('[(prop)no-hover]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTr, {
+          props: { noHover: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-tr--no-hover')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Table row content'
+        const wrapper = mount(QTr, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/timeline/QTimeline.test.js
+++ b/ui/src/components/timeline/QTimeline.test.js
@@ -1,0 +1,102 @@
+import { h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QTimeline from './QTimeline.js'
+import QTimelineEntry from './QTimelineEntry.js'
+
+describe('[QTimeline API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { color: 'secondary' },
+          slots: {
+            default: () => h(QTimelineEntry)
+          }
+        })
+
+        expect(wrapper.get('.q-timeline__dot').classes()).toContain(
+          'text-secondary'
+        )
+      })
+    })
+
+    describe('[(prop)side]', () => {
+      test('value "left" has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { side: 'left' }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--dense--left')
+      })
+
+      test('value "right" has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { side: 'right' }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--dense--right')
+      })
+    })
+
+    describe('[(prop)layout]', () => {
+      test('value "dense" has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { layout: 'dense' }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--dense')
+      })
+
+      test('value "comfortable" has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { layout: 'comfortable' }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--comfortable')
+      })
+
+      test('value "loose" has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { layout: 'loose' }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--loose')
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { dark: true }
+        })
+
+        expect(wrapper.classes()).toContain('q-timeline--dark')
+      })
+
+      test('type null has effect', () => {
+        const wrapper = mount(QTimeline, {
+          props: { dark: null }
+        })
+
+        expect(wrapper.classes()).not.toContain('q-timeline--dark')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Timeline content'
+        const wrapper = mount(QTimeline, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/timeline/QTimelineEntry.test.js
+++ b/ui/src/components/timeline/QTimelineEntry.test.js
@@ -1,0 +1,149 @@
+import { h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QTimeline from './QTimeline.js'
+import QTimelineEntry from './QTimelineEntry.js'
+
+function mountTimelineEntry(props = {}, slots = {}) {
+  return mount(QTimeline, {
+    slots: {
+      default: () => h(QTimelineEntry, props, slots)
+    }
+  })
+}
+
+describe('[QTimelineEntry API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)heading]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountTimelineEntry({ heading: true })
+
+        expect(wrapper.find('.q-timeline__entry').exists()).toBe(false)
+        expect(wrapper.get('.q-timeline__heading').exists()).toBe(true)
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountTimelineEntry({
+          heading: true,
+          tag: 'h4'
+        })
+
+        expect(wrapper.get('.q-timeline__heading-title').element.tagName).toBe(
+          'H4'
+        )
+      })
+    })
+
+    describe('[(prop)side]', () => {
+      test('value "left" has effect', () => {
+        const wrapper = mountTimelineEntry({ side: 'left' })
+
+        expect(wrapper.get('.q-timeline__entry').classes()).toContain(
+          'q-timeline__entry--left'
+        )
+      })
+
+      test('value "right" has effect', () => {
+        const wrapper = mountTimelineEntry({ side: 'right' })
+
+        expect(wrapper.get('.q-timeline__entry').classes()).toContain(
+          'q-timeline__entry--right'
+        )
+      })
+    })
+
+    describe('[(prop)icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountTimelineEntry({ icon: 'map' })
+
+        expect(wrapper.get('.q-timeline__entry').classes()).toContain(
+          'q-timeline__entry--icon'
+        )
+        expect(wrapper.get('.q-timeline__dot .q-icon').text()).toBe('map')
+      })
+    })
+
+    describe('[(prop)avatar]', () => {
+      test('type String has effect', () => {
+        const avatar = 'https://example.test/avatar.png'
+        const wrapper = mountTimelineEntry({ avatar })
+
+        expect(wrapper.get('.q-timeline__entry').classes()).toContain(
+          'q-timeline__entry--icon'
+        )
+        expect(wrapper.get('.q-timeline__dot-img').attributes('src')).toBe(
+          avatar
+        )
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountTimelineEntry({ color: 'accent' })
+
+        expect(wrapper.get('.q-timeline__dot').classes()).toContain(
+          'text-accent'
+        )
+      })
+    })
+
+    describe('[(prop)title]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountTimelineEntry({ title: 'December party' })
+
+        expect(wrapper.get('.q-timeline__title').text()).toBe('December party')
+      })
+    })
+
+    describe('[(prop)subtitle]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountTimelineEntry({ subtitle: 'All invited' })
+
+        expect(wrapper.get('.q-timeline__subtitle').text()).toBe('All invited')
+      })
+    })
+
+    describe('[(prop)body]', () => {
+      test('type String has effect', () => {
+        const body = 'Timeline body content'
+        const wrapper = mountTimelineEntry({ body })
+
+        expect(wrapper.get('.q-timeline__content').text()).toContain(body)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Default timeline content'
+        const wrapper = mountTimelineEntry({}, { default: () => slotContent })
+
+        expect(wrapper.get('.q-timeline__content').text()).toContain(
+          slotContent
+        )
+      })
+    })
+
+    describe('[(slot)title]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Custom timeline title'
+        const wrapper = mountTimelineEntry({}, { title: () => slotContent })
+
+        expect(wrapper.get('.q-timeline__title').text()).toBe(slotContent)
+      })
+    })
+
+    describe('[(slot)subtitle]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Custom timeline subtitle'
+        const wrapper = mountTimelineEntry({}, { subtitle: () => slotContent })
+
+        expect(wrapper.get('.q-timeline__subtitle').text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/timeline/QTimelineEntry.test.js
+++ b/ui/src/components/timeline/QTimelineEntry.test.js
@@ -5,8 +5,9 @@ import { describe, expect, test } from 'vitest'
 import QTimeline from './QTimeline.js'
 import QTimelineEntry from './QTimelineEntry.js'
 
-function mountTimelineEntry(props = {}, slots = {}) {
+function mountTimelineEntry(props = {}, slots = {}, timelineProps = {}) {
   return mount(QTimeline, {
+    props: timelineProps,
     slots: {
       default: () => h(QTimelineEntry, props, slots)
     }
@@ -52,6 +53,32 @@ describe('[QTimelineEntry API]', () => {
         expect(wrapper.get('.q-timeline__entry').classes()).toContain(
           'q-timeline__entry--right'
         )
+      })
+
+      test('comfortable left timeline reverses the entry content order', () => {
+        const wrapper = mountTimelineEntry(
+          {
+            title: 'December party',
+            subtitle: 'All invited',
+            body: 'Timeline body content'
+          },
+          {},
+          {
+            layout: 'comfortable',
+            side: 'left'
+          }
+        )
+
+        expect(
+          Array.from(
+            wrapper.get('.q-timeline__entry').element.children,
+            element => element.classList[0]
+          )
+        ).toStrictEqual([
+          'q-timeline__content',
+          'q-timeline__dot',
+          'q-timeline__subtitle'
+        ])
       })
     })
 


### PR DESCRIPTION
## What changed

- add generated-spec-compliant component tests for `QIcon`, `QItemLabel`, `QItemSection`, and `QSkeleton`
- add component tests for the table primitives `QTd`, `QTh`, and `QTr`
- add parent-aware coverage for `QTimeline` and `QTimelineEntry`
- cover observable classes, styles, rendered tags and content, slots, timeline injection, and sortable table-header behavior
- cover icon accessibility and slot merging, multiline label clamping, keyboard-triggered sorting, and comfortable-left timeline ordering

## Why

This is the second small batch in the component-test coverage series. It adds real behavioral assertions for nine previously uncovered components while keeping the PR below the requested maximum of 10 test files.

The assertions validate each public prop or slot through rendered behavior. They avoid fixed snapshots of component prop declarations, so normal API evolution does not make unrelated tests stale.

## Developer impact

There is no production or public API change. These tests provide regression coverage for commonly reused item, icon, skeleton, table, and timeline primitives.

## Validation

- built Quasar UI before generating the test specifications
- ran `pnpm test:specs --target <component path>` for every component; all passed
- ran focused tests for the four files changed during review
  - 4 files / 31 tests passed
- ran the complete root `pnpm test`
  - 144 UI test files / 1,433 UI tests passed
  - 10 Vite usage tests passed
  - 75 Vite runtime tests passed
- ran `pnpm lint:check`
- ran `git diff --check`
- confirmed no `.todo()` or `.skip()` tests remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new automated test coverage for icon, item, skeleton, table, and timeline components.
  * Validated prop-driven rendering, including dynamic classes, inline styles, tag/element selection, accessibility attributes, and text/icon output.
  * Expanded interaction and behavior checks, including keyboard-triggered sorting for table headers.
  * Confirmed default and named slot rendering across skeletons, timeline entries, and table cells/rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
