### PR TITLE
test(ui): cover progress and observer components

### DIFF
--- a/ui/src/components/ajax-bar/QAjaxBar.test.js
+++ b/ui/src/components/ajax-bar/QAjaxBar.test.js
@@ -1,0 +1,169 @@
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import QAjaxBar from './QAjaxBar.js'
+
+function mountAjaxBar(props = {}) {
+  return mount(QAjaxBar, {
+    props: {
+      skipHijack: true,
+      ...props
+    }
+  })
+}
+
+function expectPosition(position) {
+  const wrapper = mountAjaxBar({ position })
+
+  expect(wrapper.classes()).toContain(`q-loading-bar--${position}`)
+}
+
+describe('[QAjaxBar API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)position]', () => {
+      test('value "top" has effect', () => {
+        expectPosition('top')
+      })
+
+      test('value "right" has effect', () => {
+        expectPosition('right')
+      })
+
+      test('value "bottom" has effect', () => {
+        expectPosition('bottom')
+      })
+
+      test('value "left" has effect', () => {
+        expectPosition('left')
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountAjaxBar({
+          position: 'right',
+          size: '4px'
+        })
+
+        expect(wrapper.attributes('style')).toContain('width: 4px')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountAjaxBar({ color: 'primary' })
+
+        expect(wrapper.classes()).toContain('bg-primary')
+      })
+    })
+
+    describe('[(prop)reverse]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountAjaxBar({ reverse: true })
+
+        expect(wrapper.attributes('style')).toContain(
+          'translate3d(100%,-200%,0)'
+        )
+      })
+    })
+
+    describe('[(prop)skip-hijack]', () => {
+      test('type Boolean has effect', () => {
+        const originalOpen = XMLHttpRequest.prototype.open
+        const wrapper = mount(QAjaxBar, {
+          props: { skipHijack: true }
+        })
+
+        expect(XMLHttpRequest.prototype.open).toBe(originalOpen)
+        wrapper.unmount()
+      })
+    })
+
+    describe('[(prop)hijack-filter]', () => {
+      test('type Function has effect', () => {
+        const hijackFilter = vi.fn(() => false)
+        const wrapper = mount(QAjaxBar, {
+          props: { hijackFilter }
+        })
+        const request = new XMLHttpRequest()
+
+        request.open('GET', '/ignored')
+        request.dispatchEvent(new Event('loadstart'))
+
+        expect(hijackFilter).toHaveBeenCalledWith('/ignored')
+        expect(wrapper.emitted()).not.toHaveProperty('start')
+
+        wrapper.unmount()
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)start]', () => {
+      test('is emitting', () => {
+        const wrapper = mountAjaxBar()
+
+        wrapper.vm.start(0)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('start')
+        expect(eventList.start).toHaveLength(1)
+        expect(eventList.start[0]).toHaveLength(0)
+      })
+    })
+
+    describe('[(event)stop]', () => {
+      test('is emitting', () => {
+        const wrapper = mountAjaxBar()
+
+        wrapper.vm.start(0)
+        wrapper.vm.stop()
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('stop')
+        expect(eventList.stop).toHaveLength(1)
+        expect(eventList.stop[0]).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)start]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountAjaxBar()
+
+        expect(wrapper.vm.start(0)).toBe(1)
+        await nextTick()
+
+        expect(wrapper.attributes('role')).toBe('progressbar')
+        expect(wrapper.attributes('aria-valuenow')).toBe('0')
+      })
+    })
+
+    describe('[(method)increment]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountAjaxBar()
+
+        wrapper.vm.start(0)
+        expect(wrapper.vm.increment(10)).toBe(1)
+        await nextTick()
+
+        expect(wrapper.attributes('aria-valuenow')).toBe('10')
+      })
+    })
+
+    describe('[(method)stop]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountAjaxBar()
+
+        wrapper.vm.start(0)
+        wrapper.vm.increment(10)
+        expect(wrapper.vm.stop()).toBe(0)
+        await nextTick()
+
+        expect(wrapper.attributes('aria-valuenow')).toBe('100')
+      })
+    })
+  })
+})

--- a/ui/src/components/chat/QChatMessage.test.js
+++ b/ui/src/components/chat/QChatMessage.test.js
@@ -1,0 +1,255 @@
+import { h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QChatMessage from './QChatMessage.js'
+
+describe('[QChatMessage API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)sent]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            sent: true,
+            text: ['Message content']
+          }
+        })
+
+        expect(wrapper.classes()).toContain('q-message-sent')
+        expect(wrapper.get('.q-message-container').classes()).toContain(
+          'reverse'
+        )
+        expect(wrapper.get('.q-message-text').classes()).toContain(
+          'q-message-text--sent'
+        )
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: { label: 'Friday, 18th' }
+        })
+
+        expect(wrapper.get('.q-message-label').text()).toBe('Friday, 18th')
+      })
+    })
+
+    describe('[(prop)bg-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            bgColor: 'primary',
+            text: ['Message content']
+          }
+        })
+
+        expect(wrapper.get('.q-message-text').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)text-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            textColor: 'primary',
+            text: ['Message content']
+          }
+        })
+
+        expect(wrapper.get('.q-message-text-content').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: { name: 'John Doe' }
+        })
+
+        expect(wrapper.get('.q-message-name').text()).toBe('John Doe')
+      })
+    })
+
+    describe('[(prop)avatar]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: { avatar: 'https://example.test/avatar.png' }
+        })
+        const avatar = wrapper.get('.q-message-avatar')
+
+        expect(avatar.attributes('src')).toBe('https://example.test/avatar.png')
+        expect(avatar.attributes('aria-hidden')).toBe('true')
+      })
+    })
+
+    describe('[(prop)text]', () => {
+      test('type Array has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: { text: ['How are you?', 'Are you free later?'] }
+        })
+        const messages = wrapper.findAll('.q-message-text-content')
+
+        expect(messages).toHaveLength(2)
+        expect(messages.map(message => message.text())).toStrictEqual([
+          'How are you?',
+          'Are you free later?'
+        ])
+      })
+    })
+
+    describe('[(prop)stamp]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            stamp: '13:55',
+            text: ['Message content']
+          }
+        })
+
+        expect(wrapper.get('.q-message-stamp').text()).toBe('13:55')
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: { size: '4' }
+        })
+
+        expect(wrapper.get('.q-message-container > div').classes()).toContain(
+          'col-4'
+        )
+      })
+    })
+
+    describe('[(prop)label-html]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            label: '<strong>Friday</strong>',
+            labelHtml: true
+          }
+        })
+
+        expect(wrapper.get('.q-message-label strong').text()).toBe('Friday')
+      })
+    })
+
+    describe('[(prop)name-html]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            name: '<strong>John</strong>',
+            nameHtml: true
+          }
+        })
+
+        expect(wrapper.get('.q-message-name strong').text()).toBe('John')
+      })
+    })
+
+    describe('[(prop)text-html]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            text: ['<strong>Message</strong>'],
+            textHtml: true
+          }
+        })
+
+        expect(wrapper.get('.q-message-text-content strong').text()).toBe(
+          'Message'
+        )
+      })
+    })
+
+    describe('[(prop)stamp-html]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QChatMessage, {
+          props: {
+            stamp: '<strong>13:55</strong>',
+            stampHtml: true,
+            text: ['Message content']
+          }
+        })
+
+        expect(wrapper.get('.q-message-stamp strong').text()).toBe('13:55')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Message slot content'
+        const wrapper = mount(QChatMessage, {
+          slots: {
+            default: () => h('span', slotContent)
+          }
+        })
+
+        expect(wrapper.get('.q-message-text-content').text()).toBe(slotContent)
+      })
+    })
+
+    describe('[(slot)avatar]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Avatar slot content'
+        const wrapper = mount(QChatMessage, {
+          slots: {
+            avatar: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-message-container').text()).toContain(
+          slotContent
+        )
+      })
+    })
+
+    describe('[(slot)name]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Name slot content'
+        const wrapper = mount(QChatMessage, {
+          slots: {
+            name: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-message-name').text()).toBe(slotContent)
+      })
+    })
+
+    describe('[(slot)stamp]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Stamp slot content'
+        const wrapper = mount(QChatMessage, {
+          slots: {
+            default: () => h('span', 'Message content'),
+            stamp: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-message-stamp').text()).toBe(slotContent)
+      })
+    })
+
+    describe('[(slot)label]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Label slot content'
+        const wrapper = mount(QChatMessage, {
+          slots: {
+            label: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-message-label').text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/circular-progress/QCircularProgress.test.js
+++ b/ui/src/components/circular-progress/QCircularProgress.test.js
@@ -1,0 +1,242 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCircularProgress from './QCircularProgress.js'
+
+describe('[QCircularProgress API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { size: '16px' }
+        })
+
+        expect(wrapper.attributes('style')).toContain('font-size: 16px')
+      })
+    })
+
+    describe('[(prop)value]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { value: 40 }
+        })
+
+        expect(wrapper.attributes('aria-valuenow')).toBe('40')
+      })
+    })
+
+    describe('[(prop)min]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: {
+            min: 10,
+            value: 25
+          }
+        })
+
+        expect(wrapper.attributes('aria-valuemin')).toBe('10')
+        expect(wrapper.attributes('aria-valuenow')).toBe('25')
+      })
+    })
+
+    describe('[(prop)max]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: {
+            max: 200,
+            value: 150
+          }
+        })
+
+        expect(wrapper.attributes('aria-valuemax')).toBe('200')
+        expect(wrapper.attributes('aria-valuenow')).toBe('150')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { color: 'primary' }
+        })
+
+        expect(wrapper.get('.q-circular-progress__circle').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)center-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { centerColor: 'primary' }
+        })
+
+        expect(wrapper.get('.q-circular-progress__center').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)track-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { trackColor: 'primary' }
+        })
+
+        expect(wrapper.get('.q-circular-progress__track').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)font-size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: {
+            fontSize: '1em',
+            showValue: true
+          }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__text').attributes('style')
+        ).toContain('font-size: 1em')
+      })
+    })
+
+    describe('[(prop)rounded]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { rounded: true }
+        })
+
+        expect(
+          wrapper
+            .get('.q-circular-progress__circle')
+            .attributes('stroke-linecap')
+        ).toBe('round')
+      })
+    })
+
+    describe('[(prop)thickness]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { thickness: 0.4 }
+        })
+
+        expect(
+          Number(
+            wrapper
+              .get('.q-circular-progress__circle')
+              .attributes('stroke-width')
+          )
+        ).toBeGreaterThan(20)
+      })
+    })
+
+    describe('[(prop)angle]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { angle: 45 }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__svg').attributes('style')
+        ).toContain('rotate3d(0, 0, 1, -45deg)')
+      })
+    })
+
+    describe('[(prop)indeterminate]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: {
+            indeterminate: true,
+            value: 40
+          }
+        })
+
+        expect(wrapper.classes()).toContain(
+          'q-circular-progress--indeterminate'
+        )
+        expect(wrapper.attributes()).not.toHaveProperty('aria-valuenow')
+      })
+    })
+
+    describe('[(prop)show-value]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: {
+            showValue: true,
+            value: 40
+          }
+        })
+
+        expect(wrapper.get('.q-circular-progress__text').text()).toBe('40')
+      })
+    })
+
+    describe('[(prop)reverse]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { reverse: true }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__svg').attributes('style')
+        ).toContain('scale3d(-1, 1, 1)')
+      })
+    })
+
+    describe('[(prop)instant-feedback]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { instantFeedback: true }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__circle').attributes('style')
+        ).toBe('')
+      })
+    })
+
+    describe('[(prop)animation-speed]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { animationSpeed: '1200' }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__circle').attributes('style')
+        ).toContain('1200ms')
+      })
+
+      test('type Number has effect', () => {
+        const wrapper = mount(QCircularProgress, {
+          props: { animationSpeed: 750 }
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__circle').attributes('style')
+        ).toContain('750ms')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Progress value'
+        const wrapper = mount(QCircularProgress, {
+          props: { showValue: true },
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-circular-progress__text').text()).toBe(
+          slotContent
+        )
+      })
+    })
+  })
+})

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.test.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.test.js
@@ -1,0 +1,297 @@
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import QInfiniteScroll from './QInfiniteScroll.js'
+
+const targets = []
+const wrappers = []
+
+afterEach(() => {
+  wrappers.splice(0).forEach(wrapper => wrapper.unmount())
+  targets.splice(0).forEach(target => target.remove())
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+function createScrollTarget(id) {
+  const target = document.createElement('div')
+  if (id !== void 0) target.id = id
+
+  Object.defineProperty(target, 'scrollHeight', {
+    configurable: true,
+    value: 1000
+  })
+  target.getBoundingClientRect = () => ({
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100
+  })
+
+  document.body.append(target)
+  targets.push(target)
+  return target
+}
+
+function mountInfiniteScroll(
+  props = {},
+  slots = {},
+  target = createScrollTarget()
+) {
+  const wrapper = mount(QInfiniteScroll, {
+    props: {
+      debounce: 0,
+      scrollTarget: target,
+      ...props
+    },
+    slots,
+    attachTo: document.body
+  })
+
+  wrappers.push(wrapper)
+  return { target, wrapper }
+}
+
+describe('[QInfiniteScroll API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)offset]', () => {
+      test('type Number has effect', () => {
+        const target = createScrollTarget()
+        target.scrollTop = 350
+
+        const { wrapper } = mountInfiniteScroll({ offset: 550 }, {}, target)
+
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)debounce]', () => {
+      test('type String has effect', () => {
+        vi.useFakeTimers()
+        const { target, wrapper } = mountInfiniteScroll({ debounce: '50' })
+
+        target.scrollTop = 450
+        target.dispatchEvent(new Event('scroll'))
+
+        expect(wrapper.emitted()).not.toHaveProperty('load')
+
+        vi.advanceTimersByTime(50)
+
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+
+      test('type Number has effect', () => {
+        const { target, wrapper } = mountInfiniteScroll({ debounce: 0 })
+
+        target.scrollTop = 450
+        target.dispatchEvent(new Event('scroll'))
+
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)initial-index]', () => {
+      test('type Number has effect', () => {
+        const { wrapper } = mountInfiniteScroll({ initialIndex: 4 })
+
+        wrapper.vm.trigger()
+
+        expect(wrapper.emitted('load')[0][0]).toBe(5)
+      })
+    })
+
+    describe('[(prop)scroll-target]', () => {
+      test('type Element has effect', () => {
+        const target = createScrollTarget()
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+
+        mountInfiniteScroll({}, {}, target)
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+
+      test('type String has effect', () => {
+        const target = createScrollTarget('infinite-scroll-target')
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+        const wrapper = mount(QInfiniteScroll, {
+          props: {
+            debounce: 0,
+            scrollTarget: '#infinite-scroll-target'
+          },
+          attachTo: document.body
+        })
+        wrappers.push(wrapper)
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', () => {
+        const { wrapper } = mountInfiniteScroll({ disable: true })
+
+        wrapper.vm.trigger()
+
+        expect(wrapper.emitted()).not.toHaveProperty('load')
+        expect(wrapper.find('.q-infinite-scroll__loading').exists()).toBe(false)
+      })
+    })
+
+    describe('[(prop)reverse]', () => {
+      test('type Boolean has effect', () => {
+        const { target, wrapper } = mountInfiniteScroll(
+          { reverse: true },
+          {
+            default: () => 'Content',
+            loading: () => 'Loading'
+          }
+        )
+
+        target.scrollTop = 100
+        wrapper.vm.poll()
+
+        expect(wrapper.emitted('load')).toHaveLength(1)
+        expect(wrapper.text()).toBe('LoadingContent')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const { wrapper } = mountInfiniteScroll(
+          {},
+          { default: () => 'Infinite scroll content' }
+        )
+
+        expect(wrapper.text()).toContain('Infinite scroll content')
+      })
+    })
+
+    describe('[(slot)loading]', () => {
+      test('renders the content', () => {
+        const { wrapper } = mountInfiniteScroll(
+          {},
+          { loading: () => 'Loading content' }
+        )
+
+        expect(wrapper.get('.q-infinite-scroll__loading').text()).toBe(
+          'Loading content'
+        )
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)load]', () => {
+      test('is emitting', () => {
+        const { wrapper } = mountInfiniteScroll()
+
+        wrapper.vm.trigger()
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('load')
+        expect(eventList.load).toHaveLength(1)
+
+        const [index, done] = eventList.load[0]
+        expect(index).toBe(1)
+        expect(done).toBeTypeOf('function')
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)poll]', () => {
+      test('should be callable', () => {
+        const { target, wrapper } = mountInfiniteScroll()
+        target.scrollTop = 450
+
+        expect(wrapper.vm.poll()).toBeUndefined()
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+    })
+
+    describe('[(method)trigger]', () => {
+      test('should be callable', () => {
+        const { wrapper } = mountInfiniteScroll()
+
+        expect(wrapper.vm.trigger()).toBeUndefined()
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+    })
+
+    describe('[(method)reset]', () => {
+      test('should be callable', () => {
+        const { wrapper } = mountInfiniteScroll()
+
+        wrapper.vm.setIndex(8)
+        expect(wrapper.vm.reset()).toBeUndefined()
+        wrapper.vm.trigger()
+
+        expect(wrapper.emitted('load')[0][0]).toBe(1)
+      })
+    })
+
+    describe('[(method)stop]', () => {
+      test('should be callable', async () => {
+        const { wrapper } = mountInfiniteScroll()
+
+        expect(wrapper.vm.stop()).toBeUndefined()
+        wrapper.vm.trigger()
+        await nextTick()
+
+        expect(wrapper.emitted()).not.toHaveProperty('load')
+        expect(wrapper.find('.q-infinite-scroll__loading').exists()).toBe(false)
+      })
+    })
+
+    describe('[(method)resume]', () => {
+      test('should be callable', () => {
+        const { target, wrapper } = mountInfiniteScroll()
+        wrapper.vm.stop()
+        target.scrollTop = 450
+
+        expect(wrapper.vm.resume()).toBeUndefined()
+        expect(wrapper.emitted('load')).toHaveLength(1)
+      })
+    })
+
+    describe('[(method)setIndex]', () => {
+      test('should be callable', () => {
+        const { wrapper } = mountInfiniteScroll()
+
+        expect(wrapper.vm.setIndex(10)).toBeUndefined()
+        wrapper.vm.trigger()
+
+        expect(wrapper.emitted('load')[0][0]).toBe(11)
+      })
+    })
+
+    describe('[(method)updateScrollTarget]', () => {
+      test('should be callable', () => {
+        const target = createScrollTarget()
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+        const { wrapper } = mountInfiniteScroll({}, {}, target)
+        addEventListener.mockClear()
+
+        expect(wrapper.vm.updateScrollTarget()).toBeUndefined()
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+    })
+  })
+})

--- a/ui/src/components/intersection/QIntersection.test.js
+++ b/ui/src/components/intersection/QIntersection.test.js
@@ -1,0 +1,231 @@
+import { Transition, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import QIntersection from './QIntersection.js'
+
+let observers
+
+beforeEach(() => {
+  observers = []
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback, options) {
+        this.callback = callback
+        this.options = options
+        this.observe = vi.fn()
+        this.unobserve = vi.fn()
+        this.disconnect = vi.fn()
+        observers.push(this)
+      }
+    }
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function show(observer = observers[0]) {
+  observer.callback([
+    {
+      isIntersecting: true,
+      rootBounds: {}
+    }
+  ])
+}
+
+describe('[QIntersection API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: {
+            disable: true,
+            tag: 'section'
+          }
+        })
+
+        expect(wrapper.element.tagName).toBe('SECTION')
+      })
+    })
+
+    describe('[(prop)once]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QIntersection, {
+          props: { once: true },
+          slots: { default: () => 'Visible content' }
+        })
+
+        show()
+        await nextTick()
+
+        expect(wrapper.text()).toBe('Visible content')
+        expect(observers[0].disconnect).toHaveBeenCalledOnce()
+      })
+    })
+
+    describe('[(prop)ssr-prerender]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: { ssrPrerender: true },
+          slots: { hidden: () => 'Hydrated hidden content' }
+        })
+
+        expect(wrapper.text()).toBe('Hydrated hidden content')
+        expect(observers).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)root]', () => {
+      test('type Element has effect', () => {
+        const root = document.createElement('div')
+
+        mount(QIntersection, {
+          props: { root }
+        })
+
+        expect(observers[0].options.root).toBe(root)
+      })
+
+      test('type null has effect', () => {
+        mount(QIntersection, {
+          props: { root: null }
+        })
+
+        expect(observers[0].options.root).toBeNull()
+      })
+    })
+
+    describe('[(prop)margin]', () => {
+      test('type String has effect', () => {
+        mount(QIntersection, {
+          props: { margin: '-20px 0px' }
+        })
+
+        expect(observers[0].options.rootMargin).toBe('-20px 0px')
+      })
+    })
+
+    describe('[(prop)threshold]', () => {
+      test('type Array has effect', () => {
+        const threshold = [0, 0.25, 0.5, 0.75, 1]
+
+        mount(QIntersection, {
+          props: { threshold }
+        })
+
+        expect(observers[0].options.threshold).toStrictEqual(threshold)
+      })
+
+      test('type Number has effect', () => {
+        mount(QIntersection, {
+          props: { threshold: 1 }
+        })
+
+        expect(observers[0].options.threshold).toBe(1)
+      })
+    })
+
+    describe('[(prop)transition]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: { transition: 'fade' },
+          slots: { hidden: () => 'Hidden content' }
+        })
+
+        expect(wrapper.getComponent(Transition).props('name')).toBe(
+          'q-transition--fade'
+        )
+      })
+    })
+
+    describe('[(prop)transition-duration]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: {
+            disable: true,
+            transitionDuration: '450'
+          },
+          slots: { hidden: () => 'Hidden content' }
+        })
+
+        expect(
+          wrapper.get('.q-intersection > div').attributes('style')
+        ).toContain('--q-transition-duration: 450ms')
+      })
+
+      test('type Number has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: {
+            disable: true,
+            transitionDuration: 300
+          },
+          slots: { hidden: () => 'Hidden content' }
+        })
+
+        expect(
+          wrapper.get('.q-intersection > div').attributes('style')
+        ).toContain('--q-transition-duration: 300ms')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QIntersection, {
+          props: { disable: true },
+          slots: { hidden: () => 'Hidden content' }
+        })
+
+        expect(wrapper.text()).toBe('Hidden content')
+        expect(observers).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', async () => {
+        const wrapper = mount(QIntersection, {
+          slots: { default: () => 'Visible content' }
+        })
+
+        show()
+        await nextTick()
+
+        expect(wrapper.text()).toBe('Visible content')
+      })
+    })
+
+    describe('[(slot)hidden]', () => {
+      test('renders the content', () => {
+        const wrapper = mount(QIntersection, {
+          slots: { hidden: () => 'Hidden content' }
+        })
+
+        expect(wrapper.text()).toBe('Hidden content')
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)visibility]', () => {
+      test('is emitting', () => {
+        const wrapper = mount(QIntersection, {
+          props: { onVisibility: () => {} }
+        })
+
+        show()
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('visibility')
+        expect(eventList.visibility).toHaveLength(1)
+
+        const [isVisible] = eventList.visibility[0]
+        expect(isVisible).toBe(true)
+      })
+    })
+  })
+})

--- a/ui/src/components/page-scroller/QPageScroller.test.js
+++ b/ui/src/components/page-scroller/QPageScroller.test.js
@@ -1,0 +1,175 @@
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { layoutKey } from '../../utils/private.symbols/symbols.js'
+
+import QPageScroller from './QPageScroller.js'
+
+const targets = []
+
+afterEach(() => {
+  targets.splice(0).forEach(target => target.remove())
+})
+
+function mountScroller(props = {}, slots = {}, layoutOverrides = {}) {
+  const target = document.createElement('div')
+  target.classList.add('scroll')
+  target.scrollTop = 500
+  document.body.append(target)
+  targets.push(target)
+
+  const layout = {
+    header: { offset: 60 },
+    right: { offset: 24 },
+    footer: { offset: 40 },
+    left: { offset: 16 },
+    height: ref(3000),
+    containerHeight: ref(1000),
+    isContainer: ref(true),
+    rootRef: ref(target),
+    scroll: ref({
+      position: 2000,
+      direction: 'down',
+      inflectionPoint: 0
+    }),
+    ...layoutOverrides
+  }
+
+  const wrapper = mount(QPageScroller, {
+    props,
+    slots,
+    global: {
+      provide: {
+        [layoutKey]: layout
+      }
+    }
+  })
+
+  return { layout, target, wrapper }
+}
+
+function expectPosition(position) {
+  const { wrapper } = mountScroller({ position })
+
+  expect(wrapper.get('.q-page-sticky').classes()).toContain(`fixed-${position}`)
+}
+
+describe('[QPageScroller API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)position]', () => {
+      test('value "top-right" has effect', () => {
+        expectPosition('top-right')
+      })
+
+      test('value "top-left" has effect', () => {
+        expectPosition('top-left')
+      })
+
+      test('value "bottom-right" has effect', () => {
+        expectPosition('bottom-right')
+      })
+
+      test('value "bottom-left" has effect', () => {
+        expectPosition('bottom-left')
+      })
+
+      test('value "top" has effect', () => {
+        expectPosition('top')
+      })
+
+      test('value "right" has effect', () => {
+        expectPosition('right')
+      })
+
+      test('value "bottom" has effect', () => {
+        expectPosition('bottom')
+      })
+
+      test('value "left" has effect', () => {
+        expectPosition('left')
+      })
+    })
+
+    describe('[(prop)offset]', () => {
+      test('type Array has effect', () => {
+        const { wrapper } = mountScroller({ offset: [12, 8] })
+
+        expect(wrapper.get('.q-page-sticky').attributes('style')).toContain(
+          'margin: 8px 12px'
+        )
+      })
+    })
+
+    describe('[(prop)expand]', () => {
+      test('type Boolean has effect', () => {
+        const { wrapper } = mountScroller({ expand: true })
+
+        expect(wrapper.get('.q-page-sticky').classes()).toContain(
+          'q-page-sticky--expand'
+        )
+      })
+    })
+
+    describe('[(prop)scroll-offset]', () => {
+      test('type Number has effect', () => {
+        const { wrapper } = mountScroller(
+          { scrollOffset: 400 },
+          {},
+          {
+            scroll: ref({
+              position: 500,
+              direction: 'down',
+              inflectionPoint: 0
+            })
+          }
+        )
+
+        expect(wrapper.find('.q-page-scroller').exists()).toBe(true)
+      })
+    })
+
+    describe('[(prop)reverse]', () => {
+      test('type Boolean has effect', () => {
+        const { wrapper } = mountScroller(
+          { reverse: true },
+          {},
+          {
+            scroll: ref({
+              position: 100,
+              direction: 'down',
+              inflectionPoint: 0
+            })
+          }
+        )
+
+        expect(wrapper.find('.q-page-scroller').exists()).toBe(true)
+      })
+    })
+
+    describe('[(prop)duration]', () => {
+      test('type Number has effect', async () => {
+        const { target, wrapper } = mountScroller(
+          { duration: 0 },
+          {},
+          { isContainer: ref(false) }
+        )
+
+        await wrapper.get('.q-page-scroller').trigger('click')
+
+        expect(target.scrollTop).toBe(0)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Page scroller content'
+        const { wrapper } = mountScroller({}, { default: () => slotContent })
+
+        expect(wrapper.get('.q-page-sticky').text()).toBe(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/parallax/QParallax.test.js
+++ b/ui/src/components/parallax/QParallax.test.js
@@ -1,0 +1,199 @@
+import { h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import QParallax from './QParallax.js'
+
+const targets = []
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('IntersectionObserver', void 0)
+})
+
+afterEach(() => {
+  targets.splice(0).forEach(target => target.remove())
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+function createScrollTarget(id) {
+  const target = document.createElement('div')
+  if (id !== void 0) target.id = id
+  document.body.append(target)
+  targets.push(target)
+  return target
+}
+
+function updateMedia(wrapper, naturalHeight = 300) {
+  const root = wrapper.get('.q-parallax').element
+  const media = wrapper.get('.q-parallax__media > *').element
+
+  root.getBoundingClientRect = () => ({
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100
+  })
+
+  Object.defineProperty(media, 'naturalHeight', {
+    configurable: true,
+    value: naturalHeight
+  })
+
+  media.dispatchEvent(new Event('load'))
+  vi.advanceTimersToNextFrame()
+
+  return media
+}
+
+describe('[QParallax API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)src]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QParallax, {
+          props: { src: 'https://example.test/background.png' }
+        })
+
+        expect(wrapper.get('.q-parallax__media img').attributes('src')).toBe(
+          'https://example.test/background.png'
+        )
+      })
+    })
+
+    describe('[(prop)height]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QParallax, {
+          props: { height: 320 }
+        })
+
+        expect(wrapper.attributes('style')).toContain('height: 320px')
+      })
+    })
+
+    describe('[(prop)speed]', () => {
+      test('type Number has effect', () => {
+        const stationary = mount(QParallax, {
+          props: {
+            height: 100,
+            speed: 0
+          }
+        })
+        const moving = mount(QParallax, {
+          props: {
+            height: 100,
+            speed: 1
+          }
+        })
+
+        const stationaryMedia = updateMedia(stationary)
+        const movingMedia = updateMedia(moving)
+
+        expect(stationaryMedia.style.transform).toContain(',0px,0)')
+        expect(movingMedia.style.transform).not.toBe(
+          stationaryMedia.style.transform
+        )
+      })
+    })
+
+    describe('[(prop)scroll-target]', () => {
+      test('type Element has effect', () => {
+        const target = createScrollTarget()
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+
+        mount(QParallax, {
+          props: { scrollTarget: target }
+        })
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+
+      test('type String has effect', () => {
+        const target = createScrollTarget('parallax-scroll-target')
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+
+        mount(QParallax, {
+          props: { scrollTarget: '#parallax-scroll-target' }
+        })
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'Parallax content'
+        const wrapper = mount(QParallax, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.get('.q-parallax__content').text()).toBe(slotContent)
+      })
+    })
+
+    describe('[(slot)media]', () => {
+      test('renders the content', () => {
+        const wrapper = mount(QParallax, {
+          slots: {
+            media: () => h('video', { 'data-test': 'custom-media' })
+          }
+        })
+
+        expect(wrapper.find('[data-test="custom-media"]').exists()).toBe(true)
+      })
+    })
+
+    describe('[(slot)content]', () => {
+      test('renders the content', () => {
+        let slotScope
+        const slotContent = 'Scoped parallax content'
+        const wrapper = mount(QParallax, {
+          slots: {
+            content: scope => {
+              slotScope = scope
+              return slotContent
+            }
+          }
+        })
+
+        expect(wrapper.get('.q-parallax__content').text()).toBe(slotContent)
+        expect(slotScope).toStrictEqual({
+          percentScrolled: expect.any(Number)
+        })
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)scroll]', () => {
+      test('is emitting', () => {
+        const wrapper = mount(QParallax, {
+          props: { onScroll: () => {} }
+        })
+
+        updateMedia(wrapper)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('scroll')
+        expect(eventList.scroll).toHaveLength(1)
+
+        const [percentage] = eventList.scroll[0]
+        expect(percentage).toBeTypeOf('number')
+      })
+    })
+  })
+})

--- a/ui/src/components/resize-observer/QResizeObserver.test.js
+++ b/ui/src/components/resize-observer/QResizeObserver.test.js
@@ -1,0 +1,82 @@
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import QResizeObserver from './QResizeObserver.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('[QResizeObserver API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)debounce]', () => {
+      test('type String has effect', () => {
+        const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+        const wrapper = mount(QResizeObserver, {
+          props: { debounce: '530' }
+        })
+
+        wrapper.vm.trigger()
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), '530')
+      })
+
+      test('type Number has effect', () => {
+        const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+        const wrapper = mount(QResizeObserver, {
+          props: { debounce: 100 }
+        })
+
+        wrapper.vm.trigger()
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)resize]', () => {
+      test('is emitting', async () => {
+        const wrapper = mount(QResizeObserver)
+
+        Object.defineProperties(wrapper.element, {
+          offsetHeight: {
+            configurable: true,
+            value: 80
+          },
+          offsetWidth: {
+            configurable: true,
+            value: 120
+          }
+        })
+
+        await nextTick()
+        wrapper.vm.trigger(true)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('resize')
+        expect(eventList.resize).toHaveLength(1)
+
+        const [size] = eventList.resize[0]
+        expect(size).toStrictEqual({
+          height: 80,
+          width: 120
+        })
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)trigger]', () => {
+      test('should be callable', async () => {
+        const wrapper = mount(QResizeObserver)
+
+        await nextTick()
+
+        expect(wrapper.vm.trigger(true)).toBeUndefined()
+        expect(wrapper.emitted('resize')).toHaveLength(1)
+      })
+    })
+  })
+})

--- a/ui/src/components/scroll-observer/QScrollObserver.test.js
+++ b/ui/src/components/scroll-observer/QScrollObserver.test.js
@@ -1,0 +1,201 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import QScrollObserver from './QScrollObserver.js'
+
+const targets = []
+
+afterEach(() => {
+  targets.splice(0).forEach(target => target.remove())
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+function createScrollTarget(id) {
+  const target = document.createElement('div')
+  if (id !== void 0) target.id = id
+  document.body.append(target)
+  targets.push(target)
+  return target
+}
+
+function mountObserver(props = {}) {
+  const target = createScrollTarget()
+  const wrapper = mount(QScrollObserver, {
+    props: {
+      scrollTarget: target,
+      ...props
+    }
+  })
+
+  return { target, wrapper }
+}
+
+describe('[QScrollObserver API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)debounce]', () => {
+      test('type String has effect', () => {
+        vi.useFakeTimers()
+        const { target, wrapper } = mountObserver({ debounce: '530' })
+
+        target.scrollTop = 20
+        target.dispatchEvent(new Event('scroll'))
+
+        expect(wrapper.emitted()).not.toHaveProperty('scroll')
+
+        vi.advanceTimersByTime(530)
+
+        expect(wrapper.emitted('scroll')).toHaveLength(1)
+      })
+
+      test('type Number has effect', () => {
+        const { target, wrapper } = mountObserver({ debounce: 0 })
+
+        target.scrollTop = 20
+        target.dispatchEvent(new Event('scroll'))
+
+        expect(wrapper.emitted('scroll')).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)axis]', () => {
+      test('value "both" has effect', () => {
+        const { target, wrapper } = mountObserver({ axis: 'both' })
+
+        target.scrollTop = 20
+        target.scrollLeft = 10
+        wrapper.vm.trigger(true)
+
+        expect(wrapper.emitted('scroll').at(-1)[0].position).toStrictEqual({
+          top: 20,
+          left: 10
+        })
+      })
+
+      test('value "vertical" has effect', () => {
+        const { target, wrapper } = mountObserver({ axis: 'vertical' })
+
+        target.scrollLeft = 10
+        wrapper.vm.trigger(true)
+        expect(wrapper.emitted()).not.toHaveProperty('scroll')
+
+        target.scrollTop = 20
+        wrapper.vm.trigger(true)
+        expect(wrapper.emitted('scroll')).toHaveLength(1)
+      })
+
+      test('value "horizontal" has effect', () => {
+        const { target, wrapper } = mountObserver({ axis: 'horizontal' })
+
+        target.scrollTop = 20
+        wrapper.vm.trigger(true)
+        expect(wrapper.emitted()).not.toHaveProperty('scroll')
+
+        target.scrollLeft = 10
+        wrapper.vm.trigger(true)
+        expect(wrapper.emitted('scroll')).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)scroll-target]', () => {
+      test('type Element has effect', () => {
+        const target = createScrollTarget()
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+
+        mount(QScrollObserver, {
+          props: { scrollTarget: target }
+        })
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+
+      test('type String has effect', () => {
+        const target = createScrollTarget('scroll-observer-target')
+        const addEventListener = vi.spyOn(target, 'addEventListener')
+
+        mount(QScrollObserver, {
+          props: { scrollTarget: '#scroll-observer-target' }
+        })
+
+        expect(addEventListener).toHaveBeenCalledWith(
+          'scroll',
+          expect.any(Function),
+          expect.anything()
+        )
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)scroll]', () => {
+      test('is emitting', () => {
+        const { target, wrapper } = mountObserver({ axis: 'both' })
+
+        target.scrollTop = 20
+        target.scrollLeft = 10
+        wrapper.vm.trigger(true)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('scroll')
+        expect(eventList.scroll.length).toBeGreaterThanOrEqual(1)
+
+        const [details] = eventList.scroll.at(-1)
+        expect(details).toStrictEqual({
+          position: {
+            top: 20,
+            left: 10
+          },
+          direction: 'down',
+          directionChanged: false,
+          delta: {
+            top: 20,
+            left: 10
+          },
+          inflectionPoint: {
+            top: 0,
+            left: 0
+          }
+        })
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)trigger]', () => {
+      test('should be callable', () => {
+        const { target, wrapper } = mountObserver()
+
+        target.scrollTop = 20
+
+        expect(wrapper.vm.trigger(true)).toBeUndefined()
+        expect(wrapper.emitted('scroll')).toHaveLength(1)
+      })
+    })
+
+    describe('[(method)getPosition]', () => {
+      test('should be callable', () => {
+        const { target, wrapper } = mountObserver()
+
+        target.scrollTop = 20
+        wrapper.vm.trigger(true)
+
+        expect(wrapper.vm.getPosition()).toMatchObject({
+          position: {
+            top: 20,
+            left: 0
+          },
+          direction: 'down',
+          directionChanged: false,
+          delta: {
+            top: 20,
+            left: 0
+          }
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add generated-Specs-compatible tests for nine progress, message, scrolling,
  intersection, parallax, and observer components
- cover public props, slots, emitted events, and exposed methods through
  rendered behavior and interaction rather than snapshots of declarations
- exercise debounce timing, explicit scroll targets, axis filtering,
  observer lifecycle, progress accessibility attributes, and opt-in HTML
  rendering

This is the fourth component-test batch and remains below the requested
ten-test-file limit. It contains no production-code or public-API changes.

## Validation

- `cd ui && pnpm build`
- all nine precise `pnpm test:specs --target <component-subpath>` checks
- `cd ui && pnpm test QAjaxBar QChatMessage QCircularProgress QInfiniteScroll QIntersection QPageScroller QParallax QResizeObserver QScrollObserver`
  - 9 files and 120 tests passed
- root `pnpm test`
  - 144 UI files and 1,468 UI tests passed
  - 10 Vite usage tests passed
  - 75 Vite runtime tests passed
- `pnpm lint:check`
- `git diff --check`
