### PR TITLE
test(ui): cover form and panel components

### DIFF
--- a/ui/src/components/form/QForm.test.js
+++ b/ui/src/components/form/QForm.test.js
@@ -1,0 +1,268 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import QForm from './QForm.js'
+
+function createValidationComponent(overrides = {}) {
+  return {
+    $: {},
+    validate: vi.fn(() => true),
+    resetValidation: vi.fn(),
+    focus: vi.fn(),
+    ...overrides
+  }
+}
+
+function register(wrapper, ...components) {
+  wrapper.vm.getValidationComponents().push(...components)
+}
+
+describe('[QForm API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)autofocus]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QForm, {
+          props: { autofocus: true },
+          slots: {
+            default: '<input data-autofocus tabindex="0">'
+          },
+          attachTo: document.body
+        })
+
+        expect(document.activeElement).toBe(wrapper.get('input').element)
+
+        wrapper.unmount()
+      })
+    })
+
+    describe('[(prop)no-error-focus]', () => {
+      test('type Boolean has effect', async () => {
+        const invalid = createValidationComponent({
+          validate: vi.fn(() => false)
+        })
+        const wrapper = mount(QForm, {
+          props: { noErrorFocus: true }
+        })
+        register(wrapper, invalid)
+
+        expect(await wrapper.vm.validate()).toBe(false)
+        expect(invalid.focus).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('[(prop)no-reset-focus]', () => {
+      test('type Boolean has effect', async () => {
+        const outside = document.createElement('button')
+        document.body.append(outside)
+
+        const wrapper = mount(QForm, {
+          props: {
+            autofocus: true,
+            noResetFocus: true
+          },
+          slots: {
+            default: '<input data-autofocus tabindex="0">'
+          },
+          attachTo: document.body
+        })
+
+        outside.focus()
+        await wrapper.trigger('reset')
+        await flushPromises()
+
+        expect(document.activeElement).toBe(outside)
+
+        wrapper.unmount()
+        outside.remove()
+      })
+    })
+
+    describe('[(prop)greedy]', () => {
+      test('type Boolean has effect', async () => {
+        const first = createValidationComponent({
+          validate: vi.fn(() => false)
+        })
+        const second = createValidationComponent()
+        const wrapper = mount(QForm)
+        register(wrapper, first, second)
+
+        expect(await wrapper.vm.validate(false)).toBe(false)
+        expect(second.validate).not.toHaveBeenCalled()
+
+        await wrapper.setProps({ greedy: true })
+
+        expect(await wrapper.vm.validate(false)).toBe(false)
+        expect(second.validate).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QForm, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)submit]', () => {
+      test('is emitting', async () => {
+        const wrapper = mount(QForm, {
+          props: { onSubmit: vi.fn() }
+        })
+        const event = new Event('submit', { cancelable: true })
+
+        wrapper.vm.submit(event)
+        await flushPromises()
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('submit')
+        expect(eventList.submit).toHaveLength(1)
+
+        const [evt] = eventList.submit[0]
+        expect(evt).toBe(event)
+        expect(event.defaultPrevented).toBe(true)
+      })
+    })
+
+    describe('[(event)reset]', () => {
+      test('is emitting', async () => {
+        const wrapper = mount(QForm)
+
+        await wrapper.trigger('reset')
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('reset')
+        expect(eventList.reset).toHaveLength(1)
+        expect(eventList.reset[0]).toHaveLength(0)
+      })
+    })
+
+    describe('[(event)validation-success]', () => {
+      test('is emitting', async () => {
+        const wrapper = mount(QForm)
+
+        expect(await wrapper.vm.validate()).toBe(true)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('validationSuccess')
+        expect(eventList.validationSuccess).toHaveLength(1)
+        expect(eventList.validationSuccess[0]).toHaveLength(1)
+        expect(eventList.validationSuccess[0][0]).toBeUndefined()
+      })
+    })
+
+    describe('[(event)validation-error]', () => {
+      test('is emitting', async () => {
+        const invalid = createValidationComponent({
+          validate: vi.fn(() => false)
+        })
+        const wrapper = mount(QForm)
+        register(wrapper, invalid)
+
+        expect(await wrapper.vm.validate(false)).toBe(false)
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('validationError')
+        expect(eventList.validationError).toHaveLength(1)
+
+        const [ref] = eventList.validationError[0]
+        expect(ref).toBe(invalid)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)focus]', () => {
+      test('should be callable', () => {
+        const wrapper = mount(QForm, {
+          slots: {
+            default: '<button data-autofocus>Focus target</button>'
+          },
+          attachTo: document.body
+        })
+
+        expect(wrapper.vm.focus()).toBeUndefined()
+        expect(document.activeElement).toBe(wrapper.get('button').element)
+
+        wrapper.unmount()
+      })
+    })
+
+    describe('[(method)validate]', () => {
+      test('should be callable', async () => {
+        const component = createValidationComponent()
+        const wrapper = mount(QForm)
+        register(wrapper, component)
+
+        const result = wrapper.vm.validate(true)
+
+        expect(result).toBeInstanceOf(Promise)
+        await expect(result).resolves.toBe(true)
+        expect(component.validate).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('[(method)resetValidation]', () => {
+      test('should be callable', () => {
+        const component = createValidationComponent()
+        const wrapper = mount(QForm)
+        register(wrapper, component)
+
+        expect(wrapper.vm.resetValidation()).toBeUndefined()
+        expect(component.resetValidation).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('[(method)submit]', () => {
+      test('should be callable', async () => {
+        const onSubmit = vi.fn()
+        const wrapper = mount(QForm, {
+          props: { onSubmit }
+        })
+        const event = new Event('submit', { cancelable: true })
+
+        expect(wrapper.vm.submit(event)).toBeUndefined()
+        await flushPromises()
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(onSubmit).toHaveBeenCalledWith(event)
+      })
+    })
+
+    describe('[(method)reset]', () => {
+      test('should be callable', async () => {
+        const component = createValidationComponent()
+        const wrapper = mount(QForm)
+        register(wrapper, component)
+        const event = new Event('reset', { cancelable: true })
+
+        expect(wrapper.vm.reset(event)).toBeUndefined()
+        await flushPromises()
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(wrapper.emitted('reset')).toHaveLength(1)
+        expect(component.resetValidation).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('[(method)getValidationComponents]', () => {
+      test('should be callable', () => {
+        const component = createValidationComponent()
+        const wrapper = mount(QForm)
+        register(wrapper, component)
+
+        expect(Array.isArray(wrapper.vm.getValidationComponents())).toBe(true)
+        expect(wrapper.vm.getValidationComponents()).toStrictEqual([component])
+      })
+    })
+  })
+})

--- a/ui/src/components/form/QFormChildMixin.test.js
+++ b/ui/src/components/form/QFormChildMixin.test.js
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, expect, test, vi } from 'vitest'
+
+import { formKey } from '../../utils/private.symbols/symbols.js'
+import QFormChildMixin from './QFormChildMixin.js'
+
+function mountFormChild(form) {
+  return mount(
+    defineComponent({
+      mixins: [QFormChildMixin],
+      props: {
+        disable: Boolean
+      },
+      template: '<div />'
+    }),
+    {
+      global: {
+        provide: {
+          [formKey]: form
+        }
+      }
+    }
+  )
+}
+
+describe('[QFormChildMixin API]', () => {
+  describe('[Methods]', () => {
+    describe('[(method)validate]', () => {
+      test('should be callable', async () => {
+        const form = {
+          bindComponent: vi.fn(),
+          unbindComponent: vi.fn()
+        }
+        const wrapper = mountFormChild(form)
+
+        expect(wrapper.vm.validate()).toBeUndefined()
+        expect(form.bindComponent.mock.calls[0][0]).toBe(wrapper.vm)
+
+        await wrapper.setProps({ disable: true })
+        expect(form.unbindComponent.mock.calls[0][0]).toBe(wrapper.vm)
+
+        await wrapper.setProps({ disable: false })
+        expect(form.bindComponent).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('[(method)resetValidation]', () => {
+      test('should be callable', async () => {
+        const form = {
+          bindComponent: vi.fn(),
+          unbindComponent: vi.fn()
+        }
+        const wrapper = mountFormChild(form)
+        const resetValidation = vi.spyOn(wrapper.vm, 'resetValidation')
+
+        expect(wrapper.vm.resetValidation()).toBeUndefined()
+
+        await wrapper.setProps({ disable: true })
+        expect(resetValidation).toHaveBeenCalledTimes(2)
+
+        await wrapper.setProps({ disable: false })
+        wrapper.unmount()
+
+        expect(form.unbindComponent.mock.calls.at(-1)[0]).toBe(wrapper.vm)
+      })
+    })
+  })
+})

--- a/ui/src/components/item/QItem.test.js
+++ b/ui/src/components/item/QItem.test.js
@@ -1,0 +1,369 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import { getRouter } from 'testing/runtime/router.js'
+import QItem from './QItem.js'
+
+describe('[QItem API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)to]', () => {
+      test('type String has effect', async () => {
+        const propVal = '/home/dashboard'
+        const router = await getRouter(propVal)
+        const wrapper = mount(QItem, {
+          props: { to: propVal },
+          global: { plugins: [router] }
+        })
+
+        expect(wrapper.get('a').attributes('href')).toBe(propVal)
+
+        await wrapper.trigger('click')
+        await flushPromises()
+
+        expect(router.currentRoute.value.path).toBe(propVal)
+      })
+
+      test('type Object has effect', async () => {
+        const path = '/my-route-name'
+        const propVal = { path }
+        const router = await getRouter(path)
+        const wrapper = mount(QItem, {
+          props: { to: propVal },
+          global: { plugins: [router] }
+        })
+
+        expect(wrapper.get('a').attributes('href')).toBe(path)
+
+        await wrapper.trigger('click')
+        await flushPromises()
+
+        expect(router.currentRoute.value.path).toBe(path)
+      })
+    })
+
+    describe('[(prop)exact]', () => {
+      test('type Boolean has effect', async () => {
+        const router = await getRouter({ '/route': 'child' })
+        await router.push('/route/child')
+        const wrapper = mount(QItem, {
+          props: {
+            to: '/route',
+            exact: true
+          },
+          global: { plugins: [router] }
+        })
+
+        expect(wrapper.get('a').classes()).not.toContain(
+          'q-router-link--active'
+        )
+
+        await wrapper.setProps({ exact: false })
+
+        expect(wrapper.get('a').classes()).toContain('q-router-link--active')
+      })
+    })
+
+    describe('[(prop)replace]', () => {
+      test('type Boolean has effect', async () => {
+        const propVal = '/replacement'
+        const router = await getRouter(propVal)
+        const replace = vi.spyOn(router, 'replace')
+        const wrapper = mount(QItem, {
+          props: {
+            to: propVal,
+            replace: true
+          },
+          global: { plugins: [router] }
+        })
+
+        await wrapper.trigger('click')
+        await flushPromises()
+
+        expect(replace).toHaveBeenCalledWith(propVal)
+      })
+    })
+
+    describe('[(prop)active-class]', () => {
+      test('type String has effect', async () => {
+        const propVal = 'item-is-active'
+        const router = await getRouter('/active')
+        const wrapper = mount(QItem, {
+          props: {
+            to: '/active',
+            activeClass: propVal
+          },
+          global: { plugins: [router] }
+        })
+
+        await router.push('/active')
+
+        expect(wrapper.get('a').classes()).toContain(propVal)
+      })
+    })
+
+    describe('[(prop)exact-active-class]', () => {
+      test('type String has effect', async () => {
+        const propVal = 'item-is-exact-active'
+        const router = await getRouter('/active')
+        const wrapper = mount(QItem, {
+          props: {
+            to: '/active',
+            exactActiveClass: propVal
+          },
+          global: { plugins: [router] }
+        })
+
+        await router.push('/active')
+
+        expect(wrapper.get('a').classes()).toContain(propVal)
+      })
+    })
+
+    describe('[(prop)href]', () => {
+      test('type String has effect', () => {
+        const propVal = 'https://quasar.dev'
+        const wrapper = mount(QItem, {
+          props: { href: propVal }
+        })
+
+        expect(wrapper.get('a').attributes('href')).toBe(propVal)
+      })
+    })
+
+    describe('[(prop)target]', () => {
+      test('type String has effect', () => {
+        const propVal = '_blank'
+        const wrapper = mount(QItem, {
+          props: {
+            href: 'https://quasar.dev',
+            target: propVal
+          }
+        })
+
+        expect(wrapper.get('a').attributes('target')).toBe(propVal)
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem, {
+          props: { clickable: true }
+        })
+        const target = wrapper.get('.q-item')
+
+        expect(target.attributes('tabindex')).toBe('0')
+
+        await wrapper.setProps({ disable: true })
+
+        expect(target.classes()).toContain('disabled')
+        expect(target.attributes('aria-disabled')).toBe('true')
+        expect(target.attributes('tabindex')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)active]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QItem, {
+          props: {
+            active: true,
+            activeClass: 'selected'
+          }
+        })
+
+        expect(wrapper.get('.q-item').classes()).toEqual(
+          expect.arrayContaining(['q-item--active', 'selected'])
+        )
+      })
+
+      test('type null has effect', async () => {
+        const router = await getRouter('/active')
+        const wrapper = mount(QItem, {
+          props: {
+            to: '/active',
+            active: null
+          },
+          global: { plugins: [router] }
+        })
+
+        await router.push('/active')
+
+        expect(wrapper.get('a').classes()).toContain('q-router-link--active')
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem)
+        const target = wrapper.get('.q-item')
+
+        expect(target.classes()).not.toContain('q-item--dark')
+
+        await wrapper.setProps({ dark: true })
+
+        expect(target.classes()).toContain('q-item--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mount(QItem, {
+          props: { dark: null }
+        })
+        await wrapper.vm.$q.dark.set(false)
+
+        expect(wrapper.get('.q-item').classes()).not.toContain('q-item--dark')
+
+        await wrapper.vm.$q.dark.set(true)
+
+        expect(wrapper.get('.q-item').classes()).toContain('q-item--dark')
+
+        await wrapper.vm.$q.dark.set(false)
+      })
+    })
+
+    describe('[(prop)clickable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem)
+        const target = wrapper.get('.q-item')
+
+        expect(target.attributes('role')).toBe('listitem')
+
+        await wrapper.setProps({ clickable: true })
+
+        expect(target.classes()).toContain('q-item--clickable')
+        expect(target.attributes('role')).toBe('button')
+        expect(target.attributes('tabindex')).toBe('0')
+        expect(wrapper.find('.q-focus-helper').exists()).toBe(true)
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem)
+        const target = wrapper.get('.q-item')
+
+        expect(target.classes()).not.toContain('q-item--dense')
+
+        await wrapper.setProps({ dense: true })
+
+        expect(target.classes()).toContain('q-item--dense')
+      })
+    })
+
+    describe('[(prop)inset-level]', () => {
+      test('type Number has effect', async () => {
+        const wrapper = mount(QItem)
+        const target = wrapper.get('.q-item')
+
+        expect(target.$style('padding-left')).toBe('')
+
+        await wrapper.setProps({ insetLevel: 1 })
+
+        expect(target.$style('padding-left')).toBe('72px')
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mount(QItem, {
+          props: {
+            clickable: true,
+            tabindex: 100
+          }
+        })
+
+        expect(wrapper.get('.q-item').attributes('tabindex')).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mount(QItem, {
+          props: {
+            clickable: true,
+            tabindex: '-1'
+          }
+        })
+
+        expect(wrapper.get('.q-item').attributes('tabindex')).toBe('-1')
+      })
+    })
+
+    describe('[(prop)tag]', () => {
+      test('type String has effect', () => {
+        const wrapper = mount(QItem, {
+          props: { tag: 'section' }
+        })
+
+        expect(wrapper.get('.q-item').element.tagName).toBe('SECTION')
+      })
+    })
+
+    describe('[(prop)manual-focus]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem, {
+          props: { clickable: true }
+        })
+        const target = wrapper.get('.q-item')
+
+        expect(target.classes()).toContain('q-focusable')
+
+        await wrapper.setProps({ manualFocus: true })
+
+        expect(target.classes()).toContain('q-manual-focusable')
+        expect(target.classes()).not.toContain('q-focusable')
+      })
+    })
+
+    describe('[(prop)focused]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mount(QItem, {
+          props: {
+            clickable: true,
+            manualFocus: true
+          }
+        })
+        const target = wrapper.get('.q-item')
+
+        expect(target.classes()).not.toContain('q-manual-focusable--focused')
+
+        await wrapper.setProps({ focused: true })
+
+        expect(target.classes()).toContain('q-manual-focusable--focused')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QItem, {
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)click]', () => {
+      test('is emitting', async () => {
+        const router = await getRouter('/destination')
+        const wrapper = mount(QItem, {
+          props: { to: '/destination' },
+          global: { plugins: [router] }
+        })
+
+        await wrapper.trigger('click')
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('click')
+        expect(eventList.click).toHaveLength(1)
+
+        const [evt, go] = eventList.click[0]
+        expect(evt).toBeInstanceOf(Event)
+        expect(go).toBeTypeOf('function')
+      })
+    })
+  })
+})

--- a/ui/src/components/knob/QKnob.test.js
+++ b/ui/src/components/knob/QKnob.test.js
@@ -1,0 +1,307 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QKnob from './QKnob.js'
+
+function mountKnob(props = {}, options = {}) {
+  return mount(QKnob, {
+    ...options,
+    props: {
+      modelValue: 10,
+      ...props
+    }
+  })
+}
+
+describe('[QKnob API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountKnob({ name: 'car_id' })
+        const input = wrapper.get('input[type="hidden"]')
+
+        expect(input.attributes()).toMatchObject({
+          name: 'car_id',
+          value: '10'
+        })
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mountKnob()
+        const target = wrapper.get('.q-knob')
+
+        await wrapper.setProps({ size: '16px' })
+
+        expect(target.$style('font-size')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ modelValue: 42 })
+
+        expect(wrapper.get('.q-knob').attributes('aria-valuenow')).toBe('42')
+      })
+    })
+
+    describe('[(prop)min]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ min: 5 })
+
+        expect(wrapper.get('.q-knob').attributes('aria-valuemin')).toBe('5')
+      })
+    })
+
+    describe('[(prop)max]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ max: 50 })
+
+        expect(wrapper.get('.q-knob').attributes('aria-valuemax')).toBe('50')
+      })
+    })
+
+    describe('[(prop)inner-min]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ innerMin: 8 })
+
+        expect(wrapper.get('.q-knob').attributes('aria-valuemin')).toBe('8')
+      })
+    })
+
+    describe('[(prop)inner-max]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ innerMax: 80 })
+
+        expect(wrapper.get('.q-knob').attributes('aria-valuemax')).toBe('80')
+      })
+    })
+
+    describe('[(prop)step]', () => {
+      test('type Number has effect', async () => {
+        const wrapper = mountKnob({ step: 5 })
+
+        await wrapper.trigger('keydown', { keyCode: 39 })
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([[15]])
+      })
+    })
+
+    describe('[(prop)reverse]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountKnob()
+        const svg = wrapper.get('svg')
+
+        expect(svg.$style('transform')).not.toContain('scale3d')
+
+        await wrapper.setProps({ reverse: true })
+
+        expect(svg.$style('transform')).toContain('scale3d(-1, 1, 1)')
+      })
+    })
+
+    describe('[(prop)instant-feedback]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountKnob()
+        const circle = wrapper.get('.q-circular-progress__circle')
+
+        expect(circle.$style('transition')).toContain('stroke-dashoffset')
+
+        await wrapper.setProps({ instantFeedback: true })
+
+        expect(circle.$style('transition')).toBe('')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountKnob({ color: 'primary' })
+
+        expect(wrapper.get('.q-circular-progress__circle').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)center-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountKnob({ centerColor: 'primary' })
+
+        expect(wrapper.get('.q-circular-progress__center').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)track-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountKnob({ trackColor: 'primary' })
+
+        expect(wrapper.get('.q-circular-progress__track').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)font-size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountKnob({
+          showValue: true,
+          fontSize: '1em'
+        })
+
+        expect(
+          wrapper.get('.q-circular-progress__text').$style('font-size')
+        ).toBe('1em')
+      })
+    })
+
+    describe('[(prop)rounded]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountKnob({ rounded: true })
+
+        expect(
+          wrapper
+            .get('.q-circular-progress__circle')
+            .attributes('stroke-linecap')
+        ).toBe('round')
+      })
+    })
+
+    describe('[(prop)thickness]', () => {
+      test('type Number has effect', async () => {
+        const wrapper = mountKnob()
+        const circle = wrapper.get('.q-circular-progress__circle')
+        const initial = circle.attributes('stroke-width')
+
+        await wrapper.setProps({ thickness: 0.4 })
+
+        expect(circle.attributes('stroke-width')).not.toBe(initial)
+      })
+    })
+
+    describe('[(prop)angle]', () => {
+      test('type Number has effect', async () => {
+        const wrapper = mountKnob()
+        const svg = wrapper.get('svg')
+        const initial = svg.$style('transform')
+
+        await wrapper.setProps({ angle: 45 })
+
+        expect(svg.$style('transform')).not.toBe(initial)
+        expect(svg.$style('transform')).toContain('-45deg')
+      })
+    })
+
+    describe('[(prop)show-value]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountKnob()
+
+        expect(wrapper.find('.q-circular-progress__text').exists()).toBe(false)
+
+        await wrapper.setProps({ showValue: true })
+
+        expect(wrapper.get('.q-circular-progress__text').text()).toBe('10')
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountKnob({ tabindex: 2 })
+
+        expect(wrapper.get('.q-knob').attributes('tabindex')).toBe('2')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountKnob({ tabindex: '-1' })
+
+        expect(wrapper.get('.q-knob').attributes('tabindex')).toBe('-1')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountKnob({ disable: true })
+        const target = wrapper.get('.q-knob')
+
+        expect(target.classes()).toContain('disabled')
+        expect(target.attributes('aria-disabled')).toBe('true')
+        expect(target.attributes('tabindex')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)readonly]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountKnob({ readonly: true })
+        const target = wrapper.get('.q-knob')
+
+        expect(target.classes()).not.toContain('disabled')
+        expect(target.attributes('aria-readonly')).toBe('true')
+        expect(target.attributes('tabindex')).toBeUndefined()
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mountKnob(
+          { showValue: true },
+          {
+            slots: {
+              default: () => slotContent
+            }
+          }
+        )
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountKnob()
+
+        await wrapper.trigger('keydown', { keyCode: 39 })
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([[11]])
+      })
+    })
+
+    describe('[(event)change]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountKnob()
+        const initialCount = wrapper.emitted('change').length
+
+        await wrapper.trigger('keydown', { keyCode: 39 })
+        await wrapper.trigger('keyup', { keyCode: 39 })
+
+        const changes = wrapper.emitted('change')
+        expect(changes).toHaveLength(initialCount + 1)
+        expect(changes.at(-1)).toStrictEqual([11])
+      })
+    })
+
+    describe('[(event)drag-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountKnob()
+
+        await wrapper.trigger('click', {
+          clientX: 10,
+          clientY: 0
+        })
+
+        const eventList = wrapper.emitted()
+        expect(eventList).toHaveProperty('dragValue')
+        expect(eventList.dragValue).toHaveLength(1)
+
+        const [value] = eventList.dragValue[0]
+        expect(value).toBeTypeOf('number')
+      })
+    })
+  })
+})

--- a/ui/src/components/slide-transition/QSlideTransition.test.js
+++ b/ui/src/components/slide-transition/QSlideTransition.test.js
@@ -1,0 +1,114 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import QSlideTransition from './QSlideTransition.js'
+
+function mountTransition({
+  appear = false,
+  duration = 300,
+  visible = true
+} = {}) {
+  const wrapper = mount(
+    defineComponent({
+      components: { QSlideTransition },
+      props: {
+        appear: Boolean,
+        duration: Number
+      },
+      data: () => ({ visible }),
+      template: `
+        <QSlideTransition :appear :duration>
+          <div v-if="visible" class="content">content</div>
+        </QSlideTransition>
+      `
+    }),
+    {
+      props: { appear, duration },
+      global: {
+        stubs: {
+          transition: false
+        }
+      }
+    }
+  )
+
+  return {
+    wrapper,
+    transition: wrapper.getComponent(QSlideTransition)
+  }
+}
+
+describe('[QSlideTransition API]', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('[Props]', () => {
+    describe('[(prop)appear]', () => {
+      test('type Boolean has effect', async () => {
+        const { transition } = mountTransition({ appear: true })
+
+        await vi.runAllTimersAsync()
+
+        expect(transition.emitted('show')).toHaveLength(1)
+      })
+    })
+
+    describe('[(prop)duration]', () => {
+      test('type Number has effect', async () => {
+        const { wrapper } = mountTransition({
+          duration: 450,
+          visible: false
+        })
+
+        await wrapper.setData({ visible: true })
+
+        expect(wrapper.get('.content').$style('transition')).toContain('450ms')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QSlideTransition, {
+          slots: {
+            default: () => `<div>${slotContent}</div>`
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)show]', () => {
+      test('is emitting', async () => {
+        const { wrapper, transition } = mountTransition({ visible: false })
+
+        await wrapper.setData({ visible: true })
+        await vi.runAllTimersAsync()
+
+        expect(transition.emitted('show')).toStrictEqual([[]])
+      })
+    })
+
+    describe('[(event)hide]', () => {
+      test('is emitting', async () => {
+        const { wrapper, transition } = mountTransition()
+
+        await wrapper.setData({ visible: false })
+        await vi.runAllTimersAsync()
+
+        expect(transition.emitted('hide')).toStrictEqual([[]])
+      })
+    })
+  })
+})

--- a/ui/src/components/tab-panels/QTabPanel.test.js
+++ b/ui/src/components/tab-panels/QTabPanel.test.js
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import { describe, expect, test } from 'vitest'
+
+import QTabPanel from './QTabPanel.js'
+import QTabPanels from './QTabPanels.js'
+
+describe('[QTabPanel API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type Any has effect', () => {
+        const propVal = 1
+        const wrapper = mount(QTabPanels, {
+          props: { modelValue: propVal },
+          slots: {
+            default: () =>
+              h(QTabPanel, { name: propVal }, () => 'selected panel')
+          }
+        })
+
+        expect(wrapper.get('.q-panel').text()).toBe('selected panel')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mount(QTabPanels, {
+          props: { modelValue: 'disabled' },
+          slots: {
+            default: () =>
+              h(
+                QTabPanel,
+                {
+                  name: 'disabled',
+                  disable: true
+                },
+                () => 'disabled panel'
+              )
+          }
+        })
+
+        expect(wrapper.get('.q-panel').text()).toBe('')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QTabPanel, {
+          props: {
+            name: 1
+          },
+          slots: {
+            default: () => slotContent
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+})

--- a/ui/src/components/tab-panels/QTabPanels.test.js
+++ b/ui/src/components/tab-panels/QTabPanels.test.js
@@ -1,0 +1,344 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, test, vi } from 'vitest'
+
+import QTabPanel from './QTabPanel.js'
+import QTabPanels from './QTabPanels.js'
+
+function createCounter(name) {
+  return defineComponent({
+    name,
+    data: () => ({ count: 0 }),
+    template: `<button data-panel="${name}" @click="count++">{{ count }}</button>`
+  })
+}
+
+function mountPanels(props, panels) {
+  props ||= {}
+
+  const panelList = panels || [
+    ['panel-a', createCounter('PanelA')],
+    ['panel-b', createCounter('PanelB')],
+    ['panel-c', createCounter('PanelC')]
+  ]
+
+  return mount(QTabPanels, {
+    props: {
+      modelValue: 'panel-a',
+      ...props
+    },
+    slots: {
+      default: () =>
+        panelList.map(([name, component, disable = false]) =>
+          h(QTabPanel, { name, disable }, () => h(component))
+        )
+    }
+  })
+}
+
+async function expectPanelCached(filterProps) {
+  const wrapper = mountPanels({
+    keepAlive: true,
+    ...filterProps
+  })
+
+  await wrapper.get('button').trigger('click')
+  expect(wrapper.get('button').text()).toBe('1')
+
+  await wrapper.setProps({ modelValue: 'panel-b' })
+  await wrapper.setProps({ modelValue: 'panel-a' })
+
+  expect(wrapper.get('button').text()).toBe('1')
+}
+
+describe('[QTabPanels API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)model-value]', () => {
+      test('type Any has effect', async () => {
+        const wrapper = mountPanels()
+
+        expect(wrapper.get('button').attributes('data-panel')).toBe('PanelA')
+
+        await wrapper.setProps({ modelValue: 'panel-b' })
+
+        expect(wrapper.get('button').attributes('data-panel')).toBe('PanelB')
+      })
+    })
+
+    describe('[(prop)keep-alive]', () => {
+      test('type Boolean has effect', async () => {
+        await expectPanelCached({})
+      })
+    })
+
+    describe('[(prop)keep-alive-include]', () => {
+      test('type String has effect', async () => {
+        await expectPanelCached({ keepAliveInclude: 'panel-a' })
+      })
+
+      test('type Array has effect', async () => {
+        await expectPanelCached({ keepAliveInclude: ['panel-a'] })
+      })
+
+      test('type RegExp has effect', async () => {
+        await expectPanelCached({ keepAliveInclude: /^panel-a$/ })
+      })
+    })
+
+    describe('[(prop)keep-alive-exclude]', () => {
+      test('type String has effect', async () => {
+        await expectPanelCached({ keepAliveExclude: 'panel-b' })
+      })
+
+      test('type Array has effect', async () => {
+        await expectPanelCached({ keepAliveExclude: ['panel-b'] })
+      })
+
+      test('type RegExp has effect', async () => {
+        await expectPanelCached({ keepAliveExclude: /^panel-b$/ })
+      })
+    })
+
+    describe('[(prop)keep-alive-max]', () => {
+      test('type Number has effect', async () => {
+        const wrapper = mountPanels({
+          keepAlive: true,
+          keepAliveMax: 1
+        })
+
+        await wrapper.get('button').trigger('click')
+        await wrapper.setProps({ modelValue: 'panel-b' })
+        await wrapper.setProps({ modelValue: 'panel-a' })
+
+        expect(wrapper.get('button').text()).toBe('0')
+      })
+    })
+
+    describe('[(prop)animated]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountPanels({ animated: true })
+
+        await wrapper.setProps({ modelValue: 'panel-b' })
+
+        expect(wrapper.get('transition-stub').attributes('name')).toBe(
+          'q-transition--slide-left'
+        )
+      })
+    })
+
+    describe('[(prop)infinite]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountPanels({
+          modelValue: 'panel-c',
+          infinite: true
+        })
+
+        wrapper.vm.next()
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-a']
+        ])
+      })
+    })
+
+    describe('[(prop)swipeable]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountPanels({ swipeable: true })
+        const swipe = wrapper.get('.q-tab-panels').element.__qtouchswipe
+
+        expect(swipe.direction.horizontal).toBe(true)
+        swipe.handler({ direction: 'left' })
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-b']
+        ])
+      })
+    })
+
+    describe('[(prop)vertical]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountPanels({
+          swipeable: true,
+          vertical: true
+        })
+        const swipe = wrapper.get('.q-tab-panels').element.__qtouchswipe
+
+        expect(swipe.direction.vertical).toBe(true)
+        swipe.handler({ direction: 'up' })
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-b']
+        ])
+      })
+    })
+
+    describe('[(prop)transition-prev]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mountPanels({
+          modelValue: 'panel-b',
+          animated: true,
+          transitionPrev: 'fade'
+        })
+
+        await wrapper.setProps({ modelValue: 'panel-a' })
+
+        expect(wrapper.get('transition-stub').attributes('name')).toBe(
+          'q-transition--fade'
+        )
+      })
+    })
+
+    describe('[(prop)transition-next]', () => {
+      test('type String has effect', async () => {
+        const wrapper = mountPanels({
+          animated: true,
+          transitionNext: 'fade'
+        })
+
+        await wrapper.setProps({ modelValue: 'panel-b' })
+
+        expect(wrapper.get('transition-stub').attributes('name')).toBe(
+          'q-transition--fade'
+        )
+      })
+    })
+
+    describe('[(prop)transition-duration]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountPanels({ transitionDuration: '450' })
+
+        expect(wrapper.get('.q-panel').attributes('style')).toContain(
+          '--q-transition-duration: 450ms'
+        )
+      })
+
+      test('type Number has effect', () => {
+        const wrapper = mountPanels({ transitionDuration: 450 })
+
+        expect(wrapper.get('.q-panel').attributes('style')).toContain(
+          '--q-transition-duration: 450ms'
+        )
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountPanels()
+        const target = wrapper.get('.q-tab-panels')
+
+        expect(target.classes()).not.toContain('q-tab-panels--dark')
+
+        await wrapper.setProps({ dark: true })
+
+        expect(target.classes()).toContain('q-tab-panels--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mountPanels({ dark: null })
+        const target = wrapper.get('.q-tab-panels')
+        await wrapper.vm.$q.dark.set(false)
+
+        expect(target.classes()).not.toContain('q-tab-panels--dark')
+
+        await wrapper.vm.$q.dark.set(true)
+
+        await wrapper.vm.$q.dark.set(false)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mount(QTabPanels, {
+          props: {
+            modelValue: 'slot'
+          },
+          slots: {
+            default: () => h(QTabPanel, { name: 'slot' }, () => slotContent)
+          }
+        })
+
+        expect(wrapper.html()).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', () => {
+        const wrapper = mountPanels()
+
+        wrapper.vm.goTo('panel-b')
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-b']
+        ])
+      })
+    })
+
+    describe('[(event)before-transition]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountPanels()
+
+        await wrapper.setProps({ modelValue: 'panel-b' })
+
+        expect(wrapper.emitted('beforeTransition')).toStrictEqual([
+          ['panel-b', 'panel-a']
+        ])
+      })
+    })
+
+    describe('[(event)transition]', () => {
+      test('is emitting', async () => {
+        vi.useFakeTimers()
+        const wrapper = mountPanels({ transitionDuration: 25 })
+
+        await wrapper.setProps({ modelValue: 'panel-b' })
+        await vi.advanceTimersByTimeAsync(25)
+
+        expect(wrapper.emitted('transition')).toStrictEqual([
+          ['panel-b', 'panel-a']
+        ])
+
+        vi.useRealTimers()
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)next]', () => {
+      test('should be callable', () => {
+        const wrapper = mountPanels()
+
+        expect(wrapper.vm.next()).toBeUndefined()
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-b']
+        ])
+      })
+    })
+
+    describe('[(method)previous]', () => {
+      test('should be callable', () => {
+        const wrapper = mountPanels({ modelValue: 'panel-b' })
+
+        expect(wrapper.vm.previous()).toBeUndefined()
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['panel-a']
+        ])
+      })
+    })
+
+    describe('[(method)goTo]', () => {
+      test('should be callable', () => {
+        const wrapper = mountPanels()
+
+        expect(wrapper.vm.goTo('dashboard')).toBeUndefined()
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([
+          ['dashboard']
+        ])
+      })
+    })
+  })
+})

--- a/ui/src/components/uploader/QUploaderAddTrigger.test.js
+++ b/ui/src/components/uploader/QUploaderAddTrigger.test.js
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import { describe, expect, test, vi } from 'vitest'
+
+import { uploaderKey } from '../../utils/private.symbols/symbols.js'
+import QUploaderAddTrigger from './QUploaderAddTrigger.js'
+
+describe('[QUploaderAddTrigger API]', () => {
+  describe('[Generic]', () => {
+    test('should not throw error on render', () => {
+      const renderTrigger = vi.fn(() =>
+        h('button', { class: 'add-files' }, 'Add files')
+      )
+      const wrapper = mount(QUploaderAddTrigger, {
+        global: {
+          provide: {
+            [uploaderKey]: renderTrigger
+          }
+        }
+      })
+
+      expect(renderTrigger).toHaveBeenCalledTimes(1)
+      expect(wrapper.get('button.add-files').text()).toBe('Add files')
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

Continue the type-scoped UI test coverage series in reviewable batches of no
more than ten test files.

## What changed

Adds generated-Specs-compliant behavioral coverage for eight form, item,
control, transition, panel, and uploader components:

- `QForm`
- `QFormChildMixin`
- `QItem`
- `QKnob`
- `QSlideTransition`
- `QTabPanel`
- `QTabPanels`
- `QUploaderAddTrigger`

The tests cover public behavior such as form validation and focus flow, router
navigation, keyboard and pointer interaction, accessibility attributes,
transition completion, panel navigation and caching, swipe configuration, and
the uploader trigger injection contract. They avoid fixed snapshots of prop or
emit declarations so normal API evolution does not cause unrelated failures.

## Validation

- `cd ui && pnpm build`
- Precise `pnpm test:specs --target ...` validation for every included source
  file
- `cd ui && pnpm test QForm QFormChildMixin QItem QKnob QSlideTransition QTabPanel QTabPanels QUploaderAddTrigger`
  - 8 files, 101 tests passed
- Root `pnpm test`
  - 143 UI files, 1,449 UI tests passed
  - 10 Vite plugin usage tests passed
  - 75 Vite plugin runtime tests passed
- Root `pnpm lint:check`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for form validation, item navigation, knob controls, slide transitions, tab panels, and uploader triggers.
  * Verified component props, slots, events, accessibility states, keyboard interactions, navigation, transitions, and public methods.
  * Expanded coverage for disabled, readonly, dark mode, focus, validation, and dynamic rendering behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->