### PR TITLE
test(ui): cover option group and rating

### DIFF
--- a/ui/src/components/option-group/QOptionGroup.test.js
+++ b/ui/src/components/option-group/QOptionGroup.test.js
@@ -1,0 +1,298 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCheckbox from '../checkbox/QCheckbox.js'
+import QRadio from '../radio/QRadio.js'
+import QToggle from '../toggle/QToggle.js'
+import QOptionGroup from './QOptionGroup.js'
+
+const options = [
+  {
+    label: 'First option',
+    value: 'first',
+    modelNumber: 1,
+    itemName: 'First custom label',
+    cannotSelect: false
+  },
+  {
+    label: 'Second option',
+    value: 'second',
+    modelNumber: 2,
+    itemName: 'Second custom label',
+    cannotSelect: true
+  }
+]
+
+function mountGroup(props, slots) {
+  props ||= {}
+
+  const type = props.type || 'radio'
+
+  return mount(QOptionGroup, {
+    props: {
+      modelValue: type === 'radio' ? 'first' : ['first'],
+      options,
+      ...props
+    },
+    slots
+  })
+}
+
+describe('[QOptionGroup API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ size: '16px' })
+
+        expect(wrapper.getComponent(QRadio).props('size')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountGroup({ modelValue: 'second' })
+        const controls = wrapper.findAllComponents(QRadio)
+
+        expect(controls[0].props('modelValue')).toBe('second')
+        expect(controls[1].props('modelValue')).toBe('second')
+        expect(controls[1].get('.q-radio').attributes('aria-checked')).toBe(
+          'true'
+        )
+      })
+    })
+
+    describe('[(prop)options]', () => {
+      test('type Array has effect', async () => {
+        const wrapper = mountGroup()
+
+        expect(wrapper.findAllComponents(QRadio)).toHaveLength(2)
+
+        await wrapper.setProps({
+          options: [{ label: 'Only option', value: 'only' }]
+        })
+
+        expect(wrapper.findAllComponents(QRadio)).toHaveLength(1)
+        expect(wrapper.text()).toContain('Only option')
+      })
+    })
+
+    describe('[(prop)option-value]', () => {
+      test('type Function has effect', () => {
+        const wrapper = mountGroup({
+          optionValue: item => item.modelNumber
+        })
+
+        expect(
+          wrapper.findAllComponents(QRadio).map(control => control.props('val'))
+        ).toStrictEqual([1, 2])
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ optionValue: 'modelNumber' })
+
+        expect(
+          wrapper.findAllComponents(QRadio).map(control => control.props('val'))
+        ).toStrictEqual([1, 2])
+      })
+    })
+
+    describe('[(prop)option-label]', () => {
+      test('type Function has effect', () => {
+        const wrapper = mountGroup({
+          optionLabel: item => item.itemName
+        })
+
+        expect(wrapper.text()).toContain('First custom label')
+        expect(wrapper.text()).toContain('Second custom label')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ optionLabel: 'itemName' })
+
+        expect(wrapper.text()).toContain('First custom label')
+        expect(wrapper.text()).toContain('Second custom label')
+      })
+    })
+
+    describe('[(prop)option-disable]', () => {
+      test('type Function has effect', () => {
+        const wrapper = mountGroup({
+          optionDisable: item => item.cannotSelect
+        })
+        const controls = wrapper.findAllComponents(QRadio)
+
+        expect(controls[0].props('disable')).toBe(false)
+        expect(controls[1].props('disable')).toBe(true)
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ optionDisable: 'cannotSelect' })
+        const controls = wrapper.findAllComponents(QRadio)
+
+        expect(controls[0].props('disable')).toBe(false)
+        expect(controls[1].props('disable')).toBe(true)
+      })
+    })
+
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ name: 'car_id' })
+        const controls = wrapper.findAllComponents(QRadio)
+
+        expect(
+          controls.every(control => control.props('name') === 'car_id')
+        ).toBe(true)
+      })
+    })
+
+    describe('[(prop)type]', () => {
+      test('value "radio" has effect', () => {
+        const wrapper = mountGroup({ type: 'radio' })
+
+        expect(wrapper.findAllComponents(QRadio)).toHaveLength(2)
+        expect(wrapper.attributes('role')).toBe('radiogroup')
+      })
+
+      test('value "checkbox" has effect', () => {
+        const wrapper = mountGroup({ type: 'checkbox' })
+
+        expect(wrapper.findAllComponents(QCheckbox)).toHaveLength(2)
+        expect(wrapper.attributes('role')).toBe('group')
+      })
+
+      test('value "toggle" has effect', () => {
+        const wrapper = mountGroup({ type: 'toggle' })
+
+        expect(wrapper.findAllComponents(QToggle)).toHaveLength(2)
+        expect(wrapper.attributes('role')).toBe('group')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountGroup({ color: 'primary' })
+
+        expect(wrapper.getComponent(QRadio).props('color')).toBe('primary')
+      })
+    })
+
+    describe('[(prop)keep-color]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ keepColor: true })
+
+        expect(wrapper.getComponent(QRadio).props('keepColor')).toBe(true)
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ dark: true })
+
+        expect(wrapper.getComponent(QRadio).props('dark')).toBe(true)
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mountGroup({ dark: null })
+        await wrapper.vm.$q.dark.set(false)
+
+        expect(wrapper.getComponent(QRadio).props('dark')).toBe(false)
+
+        await wrapper.vm.$q.dark.set(true)
+
+        expect(wrapper.getComponent(QRadio).props('dark')).toBe(true)
+
+        await wrapper.vm.$q.dark.set(false)
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ dense: true })
+
+        expect(wrapper.getComponent(QRadio).props('dense')).toBe(true)
+      })
+    })
+
+    describe('[(prop)left-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ leftLabel: true })
+
+        expect(wrapper.getComponent(QRadio).props('leftLabel')).toBe(true)
+      })
+    })
+
+    describe('[(prop)inline]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ inline: true })
+
+        expect(wrapper.classes()).toContain('q-option-group--inline')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountGroup({ disable: true })
+
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
+        expect(
+          wrapper
+            .findAllComponents(QRadio)
+            .every(control => control.props('disable') === true)
+        ).toBe(true)
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)label]', () => {
+      test('renders the content', () => {
+        const scopes = []
+        const wrapper = mountGroup(
+          {},
+          {
+            label: scope => {
+              scopes.push(scope)
+              return `Generic ${scope.label}`
+            }
+          }
+        )
+
+        expect(wrapper.text()).toContain('Generic First option')
+        expect(wrapper.text()).toContain('Generic Second option')
+        expect(scopes).toStrictEqual(options)
+      })
+    })
+
+    describe('[(slot)label-[name]]', () => {
+      test('renders the content', () => {
+        let slotScope
+        const wrapper = mountGroup(
+          {},
+          {
+            'label-0': scope => {
+              slotScope = scope
+              return 'Specific first label'
+            },
+            label: scope => `Generic ${scope.label}`
+          }
+        )
+
+        expect(wrapper.text()).toContain('Specific first label')
+        expect(wrapper.text()).toContain('Generic Second option')
+        expect(slotScope).toMatchObject(options[0])
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountGroup()
+
+        await wrapper.findAllComponents(QRadio)[1].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([['second']])
+      })
+    })
+  })
+})

--- a/ui/src/components/rating/QRating.test.js
+++ b/ui/src/components/rating/QRating.test.js
@@ -1,0 +1,318 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QIcon from '../icon/QIcon.js'
+import QRating from './QRating.js'
+
+function mountRating(props, slots) {
+  props ||= {}
+
+  return mount(QRating, {
+    props: {
+      modelValue: 2,
+      ...props
+    },
+    slots
+  })
+}
+
+function iconNames(wrapper) {
+  return wrapper.findAllComponents(QIcon).map(icon => icon.props('name'))
+}
+
+function ratingIcons(wrapper) {
+  return wrapper.findAll('.q-rating__icon')
+}
+
+describe('[QRating API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ name: 'car_id' })
+        const input = wrapper.get('input[type="hidden"]')
+
+        expect(input.attributes()).toMatchObject({
+          name: 'car_id',
+          value: '2'
+        })
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ size: '16px' })
+
+        expect(wrapper.get('.q-rating').$style('font-size')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountRating({ modelValue: 3 })
+        const containers = wrapper.findAll('.q-rating__icon-container')
+
+        expect(containers[2].attributes('aria-checked')).toBe('true')
+        expect(
+          ratingIcons(wrapper)
+            .slice(0, 3)
+            .every(icon => icon.classes().includes('q-rating__icon--active'))
+        ).toBe(true)
+      })
+    })
+
+    describe('[(prop)max]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountRating({ max: 3 })
+
+        expect(ratingIcons(wrapper)).toHaveLength(3)
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountRating({ max: '3' })
+
+        expect(ratingIcons(wrapper)).toHaveLength(3)
+      })
+    })
+
+    describe('[(prop)icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 0,
+          icon: 'map'
+        })
+
+        expect(iconNames(wrapper)).toStrictEqual([
+          'map',
+          'map',
+          'map',
+          'map',
+          'map'
+        ])
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 0,
+          max: 3,
+          icon: ['looks_one', 'looks_two', 'looks_3']
+        })
+
+        expect(iconNames(wrapper)).toStrictEqual([
+          'looks_one',
+          'looks_two',
+          'looks_3'
+        ])
+      })
+    })
+
+    describe('[(prop)icon-selected]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ iconSelected: 'star' })
+
+        expect(iconNames(wrapper).slice(0, 2)).toStrictEqual(['star', 'star'])
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          iconSelected: ['looks_one', 'looks_two']
+        })
+
+        expect(iconNames(wrapper).slice(0, 2)).toStrictEqual([
+          'looks_one',
+          'looks_two'
+        ])
+      })
+    })
+
+    describe('[(prop)icon-half]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 1.5,
+          iconHalf: 'star_half'
+        })
+
+        expect(iconNames(wrapper)[1]).toBe('star_half')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 1.5,
+          iconHalf: ['half_one', 'half_two']
+        })
+
+        expect(iconNames(wrapper)[1]).toBe('half_two')
+      })
+    })
+
+    describe('[(prop)icon-aria-label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ iconAriaLabel: 'Rating' })
+
+        expect(
+          wrapper
+            .findAll('.q-rating__icon-container')
+            .map(icon => icon.attributes('aria-label'))
+        ).toStrictEqual([
+          'Rating 1',
+          'Rating 2',
+          'Rating 3',
+          'Rating 4',
+          'Rating 5'
+        ])
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          max: 3,
+          iconAriaLabel: ['Bad', 'Normal', 'Good']
+        })
+
+        expect(
+          wrapper
+            .findAll('.q-rating__icon-container')
+            .map(icon => icon.attributes('aria-label'))
+        ).toStrictEqual(['Bad', 'Normal', 'Good'])
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ color: 'primary' })
+
+        expect(wrapper.classes()).toContain('text-primary')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 0,
+          max: 3,
+          color: ['accent', 'grey-7', 'blue']
+        })
+
+        expect(ratingIcons(wrapper).map(icon => icon.classes())).toStrictEqual([
+          expect.arrayContaining(['text-accent']),
+          expect.arrayContaining(['text-grey-7']),
+          expect.arrayContaining(['text-blue'])
+        ])
+      })
+    })
+
+    describe('[(prop)color-selected]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({ colorSelected: 'primary' })
+
+        expect(ratingIcons(wrapper)[0].classes()).toContain('text-primary')
+        expect(ratingIcons(wrapper)[1].classes()).toContain('text-primary')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          colorSelected: ['accent', 'primary']
+        })
+
+        expect(ratingIcons(wrapper)[0].classes()).toContain('text-accent')
+        expect(ratingIcons(wrapper)[1].classes()).toContain('text-primary')
+      })
+    })
+
+    describe('[(prop)color-half]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 1.5,
+          iconHalf: 'star_half',
+          colorHalf: 'primary'
+        })
+
+        expect(ratingIcons(wrapper)[1].classes()).toContain('text-primary')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountRating({
+          modelValue: 1.5,
+          iconHalf: 'star_half',
+          colorHalf: ['accent', 'primary']
+        })
+
+        expect(ratingIcons(wrapper)[1].classes()).toContain('text-primary')
+      })
+    })
+
+    describe('[(prop)no-dimming]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountRating({ noDimming: true })
+
+        expect(wrapper.classes()).toContain('q-rating--no-dimming')
+      })
+    })
+
+    describe('[(prop)no-reset]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountRating({ noReset: true })
+
+        await wrapper.findAll('.q-rating__icon-container')[1].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)readonly]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountRating({ readonly: true })
+
+        expect(wrapper.attributes('aria-readonly')).toBe('true')
+        expect(wrapper.classes()).toContain('q-rating--non-editable')
+
+        await wrapper.findAll('.q-rating__icon-container')[2].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountRating({
+          name: 'car_id',
+          disable: true
+        })
+
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
+        expect(wrapper.classes()).toContain('disabled')
+        expect(wrapper.find('input[type="hidden"]').exists()).toBe(false)
+
+        await wrapper.findAll('.q-rating__icon-container')[2].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)tip-[name]]', () => {
+      test('renders the content', () => {
+        const slotContent = 'some-slot-content'
+        const wrapper = mountRating(
+          {},
+          {
+            'tip-2': () => slotContent
+          }
+        )
+
+        expect(
+          wrapper.findAll('.q-rating__icon-container')[1].text()
+        ).toContain(slotContent)
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountRating()
+
+        await wrapper.findAll('.q-rating__icon-container')[3].trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([[4]])
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

Continue the component test-coverage series in small, independently reviewable
batches of no more than ten test files.

## What changed

Adds generated-Specs-compliant behavioral coverage for:

- `QOptionGroup`
- `QRating`

`QOptionGroup` coverage exercises option mapping through property names and
functions, radio/checkbox/toggle rendering, inherited state and presentation,
generic and option-specific label slots, disabled semantics, and model updates.

`QRating` coverage exercises icon and color selection (including array and
half-value forms), accessible labels and state, keyboard-sized/form behavior,
reset/readonly/disabled semantics, per-icon slots, and model updates.

The assertions target public rendered behavior and component interaction
contracts rather than fixed snapshots of prop or emit declarations.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test:specs --target components/option-group/QOptionGroup`
- `cd ui && pnpm test:specs --target components/rating/QRating`
- `cd ui && pnpm test QOptionGroup QRating`
  - 2 files, 49 tests passed
- Root `pnpm test`
  - 137 UI files, 1,397 UI tests passed
  - 10 Vite plugin usage tests passed
  - 75 Vite plugin runtime tests passed
- Root `pnpm lint:check`
- `git diff --cached --check`
