### PR TITLE
test(ui): cover selection controls

### DIFF
--- a/ui/src/components/checkbox/QCheckbox.test.js
+++ b/ui/src/components/checkbox/QCheckbox.test.js
@@ -1,0 +1,333 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QCheckbox from './QCheckbox.js'
+
+function mountCheckbox(props = {}, slots = {}) {
+  return mount(QCheckbox, {
+    props: {
+      modelValue: false,
+      ...props
+    },
+    slots
+  })
+}
+
+function getUpdate(wrapper) {
+  return wrapper.emitted('update:modelValue')[0]
+}
+
+describe('[QCheckbox API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          name: 'agreement'
+        })
+        const input = wrapper.get('input[type="checkbox"]')
+
+        expect(input.attributes('name')).toBe('agreement')
+        expect(input.attributes('value')).toBe('true')
+        expect(input.element.checked).toBe(true)
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({ size: '16px' })
+
+        expect(wrapper.get('.q-checkbox__inner').$style('font-size')).toBe(
+          '16px'
+        )
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountCheckbox({ modelValue: true })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'q-checkbox__inner--truthy'
+        )
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: ['car', 'building'],
+          val: 'car'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('[(prop)val]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: ['car', 'building'],
+          val: 'car'
+        })
+
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'q-checkbox__inner--truthy'
+        )
+      })
+    })
+
+    describe('[(prop)true-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: 'Agreed',
+          trueValue: 'Agreed'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('[(prop)false-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: 'Disagree',
+          falseValue: 'Disagree'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('false')
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'q-checkbox__inner--falsy'
+        )
+      })
+    })
+
+    describe('[(prop)indeterminate-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: 0,
+          indeterminateValue: 0
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('mixed')
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'q-checkbox__inner--indet'
+        )
+      })
+    })
+
+    describe('[(prop)toggle-order]', () => {
+      test('value "tf" has effect', async () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'tf'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(false)
+      })
+
+      test('value "ft" has effect', async () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'ft'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(null)
+      })
+    })
+
+    describe('[(prop)toggle-indeterminate]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'ft'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(null)
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({
+          label: 'I agree with the Terms and Conditions'
+        })
+
+        expect(wrapper.get('.q-checkbox__label').text()).toBe(
+          'I agree with the Terms and Conditions'
+        )
+      })
+    })
+
+    describe('[(prop)left-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountCheckbox({ leftLabel: true })
+
+        expect(wrapper.classes()).toContain('reverse')
+      })
+    })
+
+    describe('[(prop)checked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          checkedIcon: 'visibility'
+        })
+
+        expect(wrapper.get('.q-checkbox__icon').text()).toBe('visibility')
+      })
+    })
+
+    describe('[(prop)unchecked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({ uncheckedIcon: 'visibility_off' })
+
+        expect(wrapper.get('.q-checkbox__icon').text()).toBe('visibility_off')
+      })
+    })
+
+    describe('[(prop)indeterminate-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: null,
+          indeterminateIcon: 'help'
+        })
+
+        expect(wrapper.get('.q-checkbox__icon').text()).toBe('help')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({
+          modelValue: true,
+          color: 'primary'
+        })
+
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)keep-color]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountCheckbox({
+          color: 'primary',
+          keepColor: true
+        })
+
+        expect(wrapper.get('.q-checkbox__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountCheckbox({ dark: true })
+
+        expect(wrapper.classes()).toContain('q-checkbox--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mountCheckbox({ dark: null })
+
+        expect(wrapper.classes()).not.toContain('q-checkbox--dark')
+
+        try {
+          wrapper.vm.$q.dark.set(true)
+          await flushPromises()
+
+          expect(wrapper.classes()).toContain('q-checkbox--dark')
+        } finally {
+          wrapper.vm.$q.dark.set(false)
+        }
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountCheckbox({ dense: true })
+
+        expect(wrapper.classes()).toContain('q-checkbox--dense')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountCheckbox({ disable: true })
+
+        expect(wrapper.classes()).toContain('disabled')
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
+        expect(wrapper.attributes('tabindex')).toBe('-1')
+
+        await wrapper.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountCheckbox({ tabindex: 100 })
+
+        expect(wrapper.attributes('tabindex')).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountCheckbox({ tabindex: '2' })
+
+        expect(wrapper.attributes('tabindex')).toBe('2')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const wrapper = mountCheckbox(
+          {},
+          { default: () => 'Custom checkbox label' }
+        )
+
+        expect(wrapper.get('.q-checkbox__label').text()).toBe(
+          'Custom checkbox label'
+        )
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountCheckbox()
+
+        await wrapper.trigger('click')
+
+        const [value, evt] = getUpdate(wrapper)
+        expect(value).toBe(true)
+        expect(evt).toBeInstanceOf(Event)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)toggle]', () => {
+      test('should be callable', () => {
+        const wrapper = mountCheckbox()
+
+        expect(wrapper.vm.toggle()).toBeUndefined()
+        expect(getUpdate(wrapper)[0]).toBe(true)
+      })
+    })
+  })
+})

--- a/ui/src/components/radio/QRadio.test.js
+++ b/ui/src/components/radio/QRadio.test.js
@@ -1,0 +1,223 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QRadio from './QRadio.js'
+
+function mountRadio(props = {}, slots = {}) {
+  return mount(QRadio, {
+    props: {
+      modelValue: 'other',
+      val: 'car',
+      ...props
+    },
+    slots
+  })
+}
+
+function getUpdate(wrapper) {
+  return wrapper.emitted('update:modelValue')[0]
+}
+
+describe('[QRadio API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({
+          modelValue: 'car',
+          name: 'vehicle'
+        })
+        const input = wrapper.get('input[type="radio"]')
+
+        expect(input.attributes('name')).toBe('vehicle')
+        expect(input.attributes('value')).toBe('car')
+        expect(input.element.checked).toBe(true)
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({ size: '16px' })
+
+        expect(wrapper.get('.q-radio__inner').$style('font-size')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountRadio({ modelValue: 'car' })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+        expect(wrapper.get('.q-radio__inner').classes()).toContain(
+          'q-radio__inner--truthy'
+        )
+      })
+    })
+
+    describe('[(prop)val]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountRadio({
+          modelValue: 50,
+          val: 50
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({ label: 'Car' })
+
+        expect(wrapper.get('.q-radio__label').text()).toBe('Car')
+        expect(wrapper.attributes('aria-label')).toBe('Car')
+      })
+    })
+
+    describe('[(prop)left-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountRadio({ leftLabel: true })
+
+        expect(wrapper.classes()).toContain('reverse')
+      })
+    })
+
+    describe('[(prop)checked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({
+          modelValue: 'car',
+          checkedIcon: 'visibility'
+        })
+
+        expect(wrapper.get('.q-radio__icon').text()).toBe('visibility')
+      })
+    })
+
+    describe('[(prop)unchecked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({ uncheckedIcon: 'visibility_off' })
+
+        expect(wrapper.get('.q-radio__icon').text()).toBe('visibility_off')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountRadio({
+          modelValue: 'car',
+          color: 'primary'
+        })
+
+        expect(wrapper.get('.q-radio__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)keep-color]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountRadio({
+          color: 'primary',
+          keepColor: true
+        })
+
+        expect(wrapper.get('.q-radio__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountRadio({ dark: true })
+
+        expect(wrapper.classes()).toContain('q-radio--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mountRadio({ dark: null })
+
+        expect(wrapper.classes()).not.toContain('q-radio--dark')
+
+        try {
+          wrapper.vm.$q.dark.set(true)
+          await flushPromises()
+
+          expect(wrapper.classes()).toContain('q-radio--dark')
+        } finally {
+          wrapper.vm.$q.dark.set(false)
+        }
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountRadio({ dense: true })
+
+        expect(wrapper.classes()).toContain('q-radio--dense')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountRadio({ disable: true })
+
+        expect(wrapper.classes()).toContain('disabled')
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
+        expect(wrapper.attributes('tabindex')).toBe('-1')
+
+        await wrapper.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountRadio({ tabindex: 100 })
+
+        expect(wrapper.attributes('tabindex')).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountRadio({ tabindex: '2' })
+
+        expect(wrapper.attributes('tabindex')).toBe('2')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const wrapper = mountRadio({}, { default: () => 'Custom radio label' })
+
+        expect(wrapper.get('.q-radio__label').text()).toBe('Custom radio label')
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountRadio()
+
+        await wrapper.trigger('click')
+
+        const [value, evt] = getUpdate(wrapper)
+        expect(value).toBe('car')
+        expect(evt).toBeInstanceOf(Event)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)set]', () => {
+      test('should be callable', () => {
+        const wrapper = mountRadio()
+
+        expect(wrapper.vm.set()).toBeUndefined()
+        expect(getUpdate(wrapper)[0]).toBe('car')
+      })
+    })
+  })
+})

--- a/ui/src/components/toggle/QToggle.test.js
+++ b/ui/src/components/toggle/QToggle.test.js
@@ -1,0 +1,346 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QToggle from './QToggle.js'
+
+function mountToggle(props = {}, slots = {}) {
+  return mount(QToggle, {
+    props: {
+      modelValue: false,
+      ...props
+    },
+    slots
+  })
+}
+
+function getUpdate(wrapper) {
+  return wrapper.emitted('update:modelValue')[0]
+}
+
+describe('[QToggle API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)name]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          name: 'notifications'
+        })
+        const input = wrapper.get('input[type="checkbox"]')
+
+        expect(input.attributes('name')).toBe('notifications')
+        expect(input.attributes('value')).toBe('true')
+        expect(input.element.checked).toBe(true)
+      })
+    })
+
+    describe('[(prop)size]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({ size: '16px' })
+
+        expect(wrapper.get('.q-toggle__inner').$style('font-size')).toBe('16px')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountToggle({ modelValue: true })
+
+        expect(wrapper.attributes('role')).toBe('switch')
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: ['car', 'building'],
+          val: 'car'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('[(prop)val]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: ['car', 'building'],
+          val: 'car'
+        })
+
+        expect(wrapper.get('.q-toggle__inner').classes()).toContain(
+          'q-toggle__inner--truthy'
+        )
+      })
+    })
+
+    describe('[(prop)true-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: 'Enabled',
+          trueValue: 'Enabled'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('true')
+      })
+    })
+
+    describe('[(prop)false-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: 'Disabled',
+          falseValue: 'Disabled'
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('false')
+      })
+    })
+
+    describe('[(prop)indeterminate-value]', () => {
+      test('type Any has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: 0,
+          indeterminateValue: 0
+        })
+
+        expect(wrapper.attributes('aria-checked')).toBe('mixed')
+      })
+    })
+
+    describe('[(prop)toggle-order]', () => {
+      test('value "tf" has effect', async () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'tf'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(false)
+      })
+
+      test('value "ft" has effect', async () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'ft'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(null)
+      })
+    })
+
+    describe('[(prop)toggle-indeterminate]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          toggleIndeterminate: true,
+          toggleOrder: 'ft'
+        })
+
+        await wrapper.trigger('click')
+
+        expect(getUpdate(wrapper)[0]).toBe(null)
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({ label: 'Notifications' })
+
+        expect(wrapper.get('.q-toggle__label').text()).toBe('Notifications')
+      })
+    })
+
+    describe('[(prop)left-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountToggle({ leftLabel: true })
+
+        expect(wrapper.classes()).toContain('reverse')
+      })
+    })
+
+    describe('[(prop)checked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          checkedIcon: 'visibility'
+        })
+
+        expect(wrapper.get('.q-toggle__thumb .q-icon').text()).toBe(
+          'visibility'
+        )
+      })
+    })
+
+    describe('[(prop)unchecked-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({ uncheckedIcon: 'visibility_off' })
+
+        expect(wrapper.get('.q-toggle__thumb .q-icon').text()).toBe(
+          'visibility_off'
+        )
+      })
+    })
+
+    describe('[(prop)indeterminate-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: null,
+          indeterminateIcon: 'help'
+        })
+
+        expect(wrapper.get('.q-toggle__thumb .q-icon').text()).toBe('help')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          color: 'primary'
+        })
+
+        expect(wrapper.get('.q-toggle__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)keep-color]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountToggle({
+          color: 'primary',
+          keepColor: true
+        })
+
+        expect(wrapper.get('.q-toggle__inner').classes()).toContain(
+          'text-primary'
+        )
+      })
+    })
+
+    describe('[(prop)dark]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountToggle({ dark: true })
+
+        expect(wrapper.classes()).toContain('q-toggle--dark')
+      })
+
+      test('type null has effect', async () => {
+        const wrapper = mountToggle({ dark: null })
+
+        expect(wrapper.classes()).not.toContain('q-toggle--dark')
+
+        try {
+          wrapper.vm.$q.dark.set(true)
+          await flushPromises()
+
+          expect(wrapper.classes()).toContain('q-toggle--dark')
+        } finally {
+          wrapper.vm.$q.dark.set(false)
+        }
+      })
+    })
+
+    describe('[(prop)dense]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountToggle({ dense: true })
+
+        expect(wrapper.classes()).toContain('q-toggle--dense')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountToggle({ disable: true })
+
+        expect(wrapper.classes()).toContain('disabled')
+        expect(wrapper.attributes('aria-disabled')).toBe('true')
+
+        await wrapper.trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountToggle({ tabindex: 100 })
+
+        expect(wrapper.attributes('tabindex')).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountToggle({ tabindex: '2' })
+
+        expect(wrapper.attributes('tabindex')).toBe('2')
+      })
+    })
+
+    describe('[(prop)icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({ icon: 'notifications' })
+
+        expect(wrapper.get('.q-toggle__thumb .q-icon').text()).toBe(
+          'notifications'
+        )
+      })
+    })
+
+    describe('[(prop)icon-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountToggle({
+          modelValue: true,
+          icon: 'notifications',
+          iconColor: 'accent'
+        })
+
+        expect(wrapper.get('.q-toggle__thumb .q-icon').classes()).toContain(
+          'text-accent'
+        )
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const wrapper = mountToggle(
+          {},
+          { default: () => 'Custom toggle label' }
+        )
+
+        expect(wrapper.get('.q-toggle__label').text()).toBe(
+          'Custom toggle label'
+        )
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountToggle()
+
+        await wrapper.trigger('click')
+
+        const [value, evt] = getUpdate(wrapper)
+        expect(value).toBe(true)
+        expect(evt).toBeInstanceOf(Event)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)toggle]', () => {
+      test('should be callable', () => {
+        const wrapper = mountToggle()
+
+        expect(wrapper.vm.toggle()).toBeUndefined()
+        expect(getUpdate(wrapper)[0]).toBe(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

Continue the generated component-test coverage series in small,
independently reviewable batches of no more than ten test files.

## What changed

Adds generated-Specs-compliant behavioral coverage for:

- `QCheckbox`
- `QRadio`
- `QToggle`

The tests exercise form input integration, custom true/false/indeterminate and
array values, accessible state, toggle ordering, icons and colors, dark/dense
and disabled presentation, keyboard focus attributes, slots, emitted model
updates, and exposed interaction methods.

The assertions target rendered behavior and interaction contracts rather than
fixed snapshots of prop or emit declarations.

## Developer impact

There is no production or public API change. The new suites protect the shared
selection-control contract across checkbox, radio, and toggle components.

## Validation

- `cd ui && pnpm build`
- precise `pnpm test:specs --target ...` validation for all three components
- `cd ui && pnpm test QCheckbox QRadio QToggle`
  - 3 files, 75 tests passed
- root `pnpm test`
  - 138 UI files, 1,423 UI tests passed
  - 10 Vite plugin usage tests passed
  - 75 Vite plugin runtime tests passed
- root `pnpm lint:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive automated coverage for checkbox, radio, and toggle components.
  - Verified selection states, labels, icons, colors, sizing, dark mode, dense mode, disabled behavior, keyboard attributes, and custom slot content.
  - Added interaction coverage for toggling, indeterminate states, emitted model updates, and component methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->