### PR TITLE
test(ui): cover floating action controls

### DIFF
--- a/ui/src/components/fab/QFab.test.js
+++ b/ui/src/components/fab/QFab.test.js
@@ -1,0 +1,584 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import { getRouter } from 'testing/runtime/router.js'
+
+import QFab from './QFab.js'
+
+function mountFab(props = {}, slots = {}, global = {}) {
+  return mount(QFab, {
+    props,
+    slots,
+    global
+  })
+}
+
+function getTrigger(wrapper) {
+  return wrapper.get('.q-btn')
+}
+
+function getLabel(wrapper) {
+  return wrapper.get('.q-fab__label')
+}
+
+function expectButtonType(wrapper, type) {
+  const button = getTrigger(wrapper)
+
+  if (type === 'a') {
+    expect(button.element.tagName).toBe('A')
+    expect(button.attributes('type')).toBeUndefined()
+  } else {
+    expect(button.element.tagName).toBe('BUTTON')
+    expect(button.attributes('type')).toBe(type)
+  }
+}
+
+describe('[QFab API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)type]', () => {
+      test('value "a" has effect', () => {
+        expectButtonType(mountFab({ type: 'a' }), 'a')
+      })
+
+      test('value "submit" has effect', () => {
+        expectButtonType(mountFab({ type: 'submit' }), 'submit')
+      })
+
+      test('value "button" has effect', () => {
+        expectButtonType(mountFab({ type: 'button' }), 'button')
+      })
+
+      test('value "reset" has effect', () => {
+        expectButtonType(mountFab({ type: 'reset' }), 'reset')
+      })
+    })
+
+    describe('[(prop)outline]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ outline: true })
+
+        expect(getTrigger(wrapper).classes()).toContain('q-btn--outline')
+      })
+    })
+
+    describe('[(prop)push]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ push: true })
+
+        expect(getTrigger(wrapper).classes()).toContain('q-btn--push')
+      })
+    })
+
+    describe('[(prop)flat]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ flat: true })
+
+        expect(getTrigger(wrapper).classes()).toContain('q-btn--flat')
+      })
+    })
+
+    describe('[(prop)unelevated]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ unelevated: true })
+
+        expect(getTrigger(wrapper).classes()).toContain('q-btn--unelevated')
+      })
+    })
+
+    describe('[(prop)padding]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ padding: '4px 8px' })
+
+        expect(getTrigger(wrapper).$style('padding')).toBe('4px 8px')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ color: 'primary' })
+
+        expect(getTrigger(wrapper).classes()).toContain('bg-primary')
+      })
+    })
+
+    describe('[(prop)text-color]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ textColor: 'dark' })
+
+        expect(getTrigger(wrapper).classes()).toContain('text-dark')
+      })
+    })
+
+    describe('[(prop)glossy]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ glossy: true })
+
+        expect(getTrigger(wrapper).classes()).toContain('glossy')
+      })
+    })
+
+    describe('[(prop)external-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({
+          externalLabel: true,
+          label: 'Create'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain('q-fab__label--external')
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ label: 'Create' })
+
+        expect(getLabel(wrapper).text()).toBe('Create')
+      })
+
+      test('type Number has effect', () => {
+        const wrapper = mountFab({ label: 42 })
+
+        expect(getLabel(wrapper).text()).toBe('42')
+      })
+    })
+
+    describe('[(prop)label-position]', () => {
+      test('value "top" has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelPosition: 'top'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-top'
+        )
+      })
+
+      test('value "right" has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelPosition: 'right'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-right'
+        )
+      })
+
+      test('value "bottom" has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelPosition: 'bottom'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-bottom'
+        )
+      })
+
+      test('value "left" has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelPosition: 'left'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-left'
+        )
+      })
+    })
+
+    describe('[(prop)hide-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({
+          hideLabel: true,
+          label: 'Create'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-hidden'
+        )
+      })
+
+      test('type null has effect', () => {
+        const wrapper = mountFab({
+          externalLabel: true,
+          hideLabel: null,
+          label: 'Create',
+          modelValue: false
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--external-hidden'
+        )
+      })
+    })
+
+    describe('[(prop)label-class]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelClass: 'custom-label'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain('custom-label')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelClass: ['custom-label', 'emphasis']
+        })
+
+        expect(getLabel(wrapper).classes()).toEqual(
+          expect.arrayContaining(['custom-label', 'emphasis'])
+        )
+      })
+
+      test('type Object has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelClass: {
+            'custom-label': true,
+            unused: false
+          }
+        })
+
+        expect(getLabel(wrapper).classes()).toContain('custom-label')
+        expect(getLabel(wrapper).classes()).not.toContain('unused')
+      })
+    })
+
+    describe('[(prop)label-style]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelStyle: 'color: red'
+        })
+
+        expect(getLabel(wrapper).attributes('style')).toContain('color: red')
+      })
+
+      test('type Array has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelStyle: ['color: red', { fontSize: '12px' }]
+        })
+
+        expect(getLabel(wrapper).attributes('style')).toContain('color: red')
+        expect(getLabel(wrapper).attributes('style')).toContain(
+          'font-size: 12px'
+        )
+      })
+
+      test('type Object has effect', () => {
+        const wrapper = mountFab({
+          label: 'Create',
+          labelStyle: { color: 'red' }
+        })
+
+        expect(getLabel(wrapper).attributes('style')).toContain('color: red')
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ square: true })
+
+        expect(wrapper.classes()).toContain('q-fab--form-square')
+        expect(getTrigger(wrapper).classes()).toContain('q-btn--square')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountFab({ disable: true })
+
+        expect(getTrigger(wrapper).attributes('aria-disabled')).toBe('true')
+
+        await getTrigger(wrapper).trigger('click')
+
+        expect(wrapper.classes()).toContain('q-fab--closed')
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        const wrapper = mountFab({ tabindex: 100 })
+
+        expect(getTrigger(wrapper).attributes('tabindex')).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        const wrapper = mountFab({ tabindex: '2' })
+
+        expect(getTrigger(wrapper).attributes('tabindex')).toBe('2')
+      })
+    })
+
+    describe('[(prop)model-value]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ modelValue: true })
+
+        expect(wrapper.classes()).toContain('q-fab--opened')
+        expect(getTrigger(wrapper).attributes('aria-expanded')).toBe('true')
+        expect(
+          wrapper.get('.q-fab__actions').attributes('aria-hidden')
+        ).toBeUndefined()
+      })
+
+      test('type null has effect', () => {
+        const wrapper = mountFab({ modelValue: null })
+
+        expect(wrapper.classes()).toContain('q-fab--closed')
+        expect(getTrigger(wrapper).attributes('aria-expanded')).toBe('false')
+        expect(wrapper.get('.q-fab__actions').attributes('aria-hidden')).toBe(
+          'true'
+        )
+      })
+    })
+
+    describe('[(prop)icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ icon: 'add' })
+
+        expect(wrapper.get('.q-fab__icon').text()).toBe('add')
+      })
+    })
+
+    describe('[(prop)active-icon]', () => {
+      test('type String has effect', () => {
+        const wrapper = mountFab({ activeIcon: 'close' })
+
+        expect(wrapper.get('.q-fab__active-icon').text()).toBe('close')
+      })
+    })
+
+    describe('[(prop)hide-icon]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountFab({ hideIcon: true })
+
+        expect(wrapper.find('.q-fab__icon-holder').exists()).toBe(false)
+      })
+    })
+
+    describe('[(prop)direction]', () => {
+      test('value "up" has effect', () => {
+        const wrapper = mountFab({ direction: 'up' })
+
+        expect(wrapper.get('.q-fab__actions').classes()).toContain(
+          'q-fab__actions--up'
+        )
+      })
+
+      test('value "right" has effect', () => {
+        const wrapper = mountFab({ direction: 'right' })
+
+        expect(wrapper.get('.q-fab__actions').classes()).toContain(
+          'q-fab__actions--right'
+        )
+      })
+
+      test('value "down" has effect', () => {
+        const wrapper = mountFab({ direction: 'down' })
+
+        expect(wrapper.get('.q-fab__actions').classes()).toContain(
+          'q-fab__actions--down'
+        )
+      })
+
+      test('value "left" has effect', () => {
+        const wrapper = mountFab({ direction: 'left' })
+
+        expect(wrapper.get('.q-fab__actions').classes()).toContain(
+          'q-fab__actions--left'
+        )
+      })
+    })
+
+    describe('[(prop)vertical-actions-align]', () => {
+      test('value "left" has effect', () => {
+        const wrapper = mountFab({ verticalActionsAlign: 'left' })
+
+        expect(wrapper.classes()).toContain('q-fab--align-left')
+      })
+
+      test('value "center" has effect', () => {
+        const wrapper = mountFab({ verticalActionsAlign: 'center' })
+
+        expect(wrapper.classes()).toContain('q-fab--align-center')
+      })
+
+      test('value "right" has effect', () => {
+        const wrapper = mountFab({ verticalActionsAlign: 'right' })
+
+        expect(wrapper.classes()).toContain('q-fab--align-right')
+      })
+    })
+
+    describe('[(prop)persistent]', () => {
+      test('type Boolean has effect', async () => {
+        const router = await getRouter(['/one', '/two'])
+        const wrapper = mountFab(
+          { persistent: true },
+          {},
+          { plugins: [router] }
+        )
+
+        wrapper.vm.show()
+        await router.push('/two')
+
+        expect(wrapper.classes()).toContain('q-fab--opened')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        const wrapper = mountFab(
+          {},
+          { default: () => 'Floating action content' }
+        )
+
+        expect(wrapper.get('.q-fab__actions').text()).toBe(
+          'Floating action content'
+        )
+      })
+    })
+
+    describe('[(slot)tooltip]', () => {
+      test('renders the content', () => {
+        const wrapper = mountFab({}, { tooltip: () => 'Create a new record' })
+
+        expect(getTrigger(wrapper).text()).toContain('Create a new record')
+      })
+    })
+
+    describe('[(slot)icon]', () => {
+      test('renders the content', () => {
+        const wrapper = mountFab(
+          {},
+          { icon: ({ opened }) => `Custom icon: ${opened}` }
+        )
+
+        expect(wrapper.get('.q-fab__icon').text()).toBe('Custom icon: false')
+      })
+    })
+
+    describe('[(slot)active-icon]', () => {
+      test('renders the content', () => {
+        const wrapper = mountFab(
+          { modelValue: true },
+          { 'active-icon': ({ opened }) => `Active icon: ${opened}` }
+        )
+
+        expect(wrapper.get('.q-fab__active-icon').text()).toBe(
+          'Active icon: true'
+        )
+      })
+    })
+
+    describe('[(slot)label]', () => {
+      test('renders the content', () => {
+        const wrapper = mountFab(
+          {},
+          { label: ({ opened }) => `Custom label: ${opened}` }
+        )
+
+        expect(getLabel(wrapper).text()).toBe('Custom label: false')
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)update:model-value]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountFab({
+          modelValue: false,
+          'onUpdate:modelValue': () => {}
+        })
+
+        await getTrigger(wrapper).trigger('click')
+
+        expect(wrapper.emitted('update:modelValue')).toStrictEqual([[true]])
+      })
+    })
+
+    describe('[(event)show]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountFab()
+
+        await getTrigger(wrapper).trigger('click')
+
+        expect(wrapper.emitted('show')).toHaveLength(1)
+        expect(wrapper.emitted('show')[0][0]).toBeInstanceOf(Event)
+      })
+    })
+
+    describe('[(event)before-show]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountFab()
+
+        await getTrigger(wrapper).trigger('click')
+
+        expect(wrapper.emitted('beforeShow')).toHaveLength(1)
+        expect(wrapper.emitted('beforeShow')[0][0]).toBeInstanceOf(Event)
+      })
+    })
+
+    describe('[(event)hide]', () => {
+      test('is emitting', () => {
+        const wrapper = mountFab({ modelValue: true })
+        const evt = new Event('click')
+
+        wrapper.vm.hide(evt)
+
+        expect(wrapper.emitted('hide')).toStrictEqual([[evt]])
+      })
+    })
+
+    describe('[(event)before-hide]', () => {
+      test('is emitting', () => {
+        const wrapper = mountFab({ modelValue: true })
+        const evt = new Event('click')
+
+        wrapper.vm.hide(evt)
+
+        expect(wrapper.emitted('beforeHide')).toStrictEqual([[evt]])
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)show]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountFab()
+
+        expect(wrapper.vm.show()).toBeUndefined()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.classes()).toContain('q-fab--opened')
+      })
+    })
+
+    describe('[(method)hide]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountFab({ modelValue: true })
+
+        expect(wrapper.vm.hide()).toBeUndefined()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.classes()).toContain('q-fab--closed')
+      })
+    })
+
+    describe('[(method)toggle]', () => {
+      test('should be callable', async () => {
+        const wrapper = mountFab()
+
+        expect(wrapper.vm.toggle()).toBeUndefined()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.classes()).toContain('q-fab--opened')
+      })
+    })
+  })
+})

--- a/ui/src/components/fab/QFabAction.test.js
+++ b/ui/src/components/fab/QFabAction.test.js
@@ -1,0 +1,448 @@
+import { ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+
+import { getRouter } from 'testing/runtime/router.js'
+
+import QFabAction from './QFabAction.js'
+import { fabKey } from '../../utils/private.symbols/symbols.js'
+
+function mountAction(props = {}, slots = {}, global = {}) {
+  const fab = {
+    showing: ref(true),
+    onChildClick: () => {}
+  }
+
+  return mount(QFabAction, {
+    props,
+    slots,
+    global: {
+      ...global,
+      provide: {
+        [fabKey]: fab,
+        ...global.provide
+      }
+    }
+  })
+}
+
+function getButton(wrapper) {
+  return wrapper.get('.q-btn')
+}
+
+function getLabel(wrapper) {
+  return wrapper.get('.q-fab__label')
+}
+
+function expectButtonType(wrapper, type) {
+  const button = getButton(wrapper)
+
+  if (type === 'a') {
+    expect(button.element.tagName).toBe('A')
+    expect(button.attributes('type')).toBeUndefined()
+  } else {
+    expect(button.element.tagName).toBe('BUTTON')
+    expect(button.attributes('type')).toBe(type)
+  }
+}
+
+describe('[QFabAction API]', () => {
+  describe('[Props]', () => {
+    describe('[(prop)type]', () => {
+      test('value "a" has effect', () => {
+        expectButtonType(mountAction({ type: 'a' }), 'a')
+      })
+
+      test('value "submit" has effect', () => {
+        expectButtonType(mountAction({ type: 'submit' }), 'submit')
+      })
+
+      test('value "button" has effect', () => {
+        expectButtonType(mountAction({ type: 'button' }), 'button')
+      })
+
+      test('value "reset" has effect', () => {
+        expectButtonType(mountAction({ type: 'reset' }), 'reset')
+      })
+    })
+
+    describe('[(prop)outline]', () => {
+      test('type Boolean has effect', () => {
+        expect(getButton(mountAction({ outline: true })).classes()).toContain(
+          'q-btn--outline'
+        )
+      })
+    })
+
+    describe('[(prop)push]', () => {
+      test('type Boolean has effect', () => {
+        expect(getButton(mountAction({ push: true })).classes()).toContain(
+          'q-btn--push'
+        )
+      })
+    })
+
+    describe('[(prop)flat]', () => {
+      test('type Boolean has effect', () => {
+        expect(getButton(mountAction({ flat: true })).classes()).toContain(
+          'q-btn--flat'
+        )
+      })
+    })
+
+    describe('[(prop)unelevated]', () => {
+      test('type Boolean has effect', () => {
+        expect(
+          getButton(mountAction({ unelevated: true })).classes()
+        ).toContain('q-btn--unelevated')
+      })
+    })
+
+    describe('[(prop)padding]', () => {
+      test('type String has effect', () => {
+        expect(
+          getButton(mountAction({ padding: '4px 8px' })).$style('padding')
+        ).toBe('4px 8px')
+      })
+    })
+
+    describe('[(prop)color]', () => {
+      test('type String has effect', () => {
+        expect(
+          getButton(mountAction({ color: 'primary' })).classes()
+        ).toContain('bg-primary')
+      })
+    })
+
+    describe('[(prop)text-color]', () => {
+      test('type String has effect', () => {
+        expect(
+          getButton(mountAction({ textColor: 'dark' })).classes()
+        ).toContain('text-dark')
+      })
+    })
+
+    describe('[(prop)glossy]', () => {
+      test('type Boolean has effect', () => {
+        expect(getButton(mountAction({ glossy: true })).classes()).toContain(
+          'glossy'
+        )
+      })
+    })
+
+    describe('[(prop)external-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountAction({
+          externalLabel: true,
+          label: 'Create'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain('q-fab__label--external')
+      })
+    })
+
+    describe('[(prop)label]', () => {
+      test('type String has effect', () => {
+        expect(getLabel(mountAction({ label: 'Create' })).text()).toBe('Create')
+      })
+
+      test('type Number has effect', () => {
+        expect(getLabel(mountAction({ label: 42 })).text()).toBe('42')
+      })
+    })
+
+    describe('[(prop)label-position]', () => {
+      test('value "top" has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelPosition: 'top' })
+          ).classes()
+        ).toContain('q-fab__label--internal-top')
+      })
+
+      test('value "right" has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelPosition: 'right' })
+          ).classes()
+        ).toContain('q-fab__label--internal-right')
+      })
+
+      test('value "bottom" has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelPosition: 'bottom' })
+          ).classes()
+        ).toContain('q-fab__label--internal-bottom')
+      })
+
+      test('value "left" has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelPosition: 'left' })
+          ).classes()
+        ).toContain('q-fab__label--internal-left')
+      })
+    })
+
+    describe('[(prop)hide-label]', () => {
+      test('type Boolean has effect', () => {
+        const wrapper = mountAction({
+          hideLabel: true,
+          label: 'Create'
+        })
+
+        expect(getLabel(wrapper).classes()).toContain(
+          'q-fab__label--internal-hidden'
+        )
+      })
+
+      test('type null has effect', () => {
+        const wrapper = mountAction({
+          externalLabel: true,
+          hideLabel: null,
+          label: 'Create'
+        })
+
+        expect(getLabel(wrapper).classes()).not.toContain(
+          'q-fab__label--external-hidden'
+        )
+      })
+    })
+
+    describe('[(prop)label-class]', () => {
+      test('type String has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelClass: 'custom-label' })
+          ).classes()
+        ).toContain('custom-label')
+      })
+
+      test('type Array has effect', () => {
+        expect(
+          getLabel(
+            mountAction({
+              label: 'Create',
+              labelClass: ['custom-label', 'emphasis']
+            })
+          ).classes()
+        ).toEqual(expect.arrayContaining(['custom-label', 'emphasis']))
+      })
+
+      test('type Object has effect', () => {
+        const label = getLabel(
+          mountAction({
+            label: 'Create',
+            labelClass: {
+              'custom-label': true,
+              unused: false
+            }
+          })
+        )
+
+        expect(label.classes()).toContain('custom-label')
+        expect(label.classes()).not.toContain('unused')
+      })
+    })
+
+    describe('[(prop)label-style]', () => {
+      test('type String has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelStyle: 'color: red' })
+          ).attributes('style')
+        ).toContain('color: red')
+      })
+
+      test('type Array has effect', () => {
+        const style = getLabel(
+          mountAction({
+            label: 'Create',
+            labelStyle: ['color: red', { fontSize: '12px' }]
+          })
+        ).attributes('style')
+
+        expect(style).toContain('color: red')
+        expect(style).toContain('font-size: 12px')
+      })
+
+      test('type Object has effect', () => {
+        expect(
+          getLabel(
+            mountAction({ label: 'Create', labelStyle: { color: 'red' } })
+          ).attributes('style')
+        ).toContain('color: red')
+      })
+    })
+
+    describe('[(prop)square]', () => {
+      test('type Boolean has effect', () => {
+        const button = getButton(mountAction({ square: true }))
+
+        expect(button.classes()).toContain('q-fab--form-square')
+        expect(button.classes()).toContain('q-btn--square')
+      })
+    })
+
+    describe('[(prop)disable]', () => {
+      test('type Boolean has effect', async () => {
+        const wrapper = mountAction({ disable: true })
+
+        expect(getButton(wrapper).attributes('aria-disabled')).toBe('true')
+
+        await getButton(wrapper).trigger('click')
+
+        expect(wrapper.emitted('click')).toBeUndefined()
+      })
+    })
+
+    describe('[(prop)tabindex]', () => {
+      test('type Number has effect', () => {
+        expect(
+          getButton(mountAction({ tabindex: 100 })).attributes('tabindex')
+        ).toBe('100')
+      })
+
+      test('type String has effect', () => {
+        expect(
+          getButton(mountAction({ tabindex: '2' })).attributes('tabindex')
+        ).toBe('2')
+      })
+    })
+
+    describe('[(prop)icon]', () => {
+      test('type String has effect', () => {
+        expect(mountAction({ icon: 'add' }).get('.q-icon').text()).toBe('add')
+      })
+    })
+
+    describe('[(prop)anchor]', () => {
+      test('value "start" has effect', () => {
+        expect(getButton(mountAction({ anchor: 'start' })).classes()).toContain(
+          'self-end'
+        )
+      })
+
+      test('value "center" has effect', () => {
+        expect(
+          getButton(mountAction({ anchor: 'center' })).classes()
+        ).toContain('self-center')
+      })
+
+      test('value "end" has effect', () => {
+        expect(getButton(mountAction({ anchor: 'end' })).classes()).toContain(
+          'self-start'
+        )
+      })
+    })
+
+    describe('[(prop)to]', () => {
+      test('type String has effect', async () => {
+        const router = await getRouter('/target')
+        const wrapper = mountAction(
+          { to: '/target' },
+          {},
+          { plugins: [router] }
+        )
+
+        expect(getButton(wrapper).attributes('href')).toBe('/target')
+
+        await getButton(wrapper).trigger('click')
+        await flushPromises()
+
+        expect(router.currentRoute.value.path).toBe('/target')
+      })
+
+      test('type Object has effect', async () => {
+        const router = await getRouter('/target')
+        const wrapper = mountAction(
+          { to: { path: '/target' } },
+          {},
+          { plugins: [router] }
+        )
+
+        expect(getButton(wrapper).attributes('href')).toBe('/target')
+
+        await getButton(wrapper).trigger('click')
+        await flushPromises()
+
+        expect(router.currentRoute.value.path).toBe('/target')
+      })
+    })
+
+    describe('[(prop)replace]', () => {
+      test('type Boolean has effect', async () => {
+        const router = await getRouter('/target')
+        const replace = vi.spyOn(router, 'replace')
+        const wrapper = mountAction(
+          {
+            replace: true,
+            to: '/target'
+          },
+          {},
+          { plugins: [router] }
+        )
+
+        await getButton(wrapper).trigger('click')
+        await flushPromises()
+
+        expect(replace).toHaveBeenCalledWith('/target')
+      })
+    })
+  })
+
+  describe('[Slots]', () => {
+    describe('[(slot)default]', () => {
+      test('renders the content', () => {
+        expect(
+          getButton(mountAction({}, { default: () => 'Action content' })).text()
+        ).toContain('Action content')
+      })
+    })
+
+    describe('[(slot)icon]', () => {
+      test('renders the content', () => {
+        const wrapper = mountAction(
+          {},
+          { icon: () => '<custom-action-icon />' }
+        )
+
+        expect(getButton(wrapper).text()).toContain('<custom-action-icon />')
+      })
+    })
+
+    describe('[(slot)label]', () => {
+      test('renders the content', () => {
+        const wrapper = mountAction({}, { label: () => 'Custom action label' })
+
+        expect(getLabel(wrapper).text()).toBe('Custom action label')
+      })
+    })
+  })
+
+  describe('[Events]', () => {
+    describe('[(event)click]', () => {
+      test('is emitting', async () => {
+        const wrapper = mountAction()
+
+        await getButton(wrapper).trigger('click')
+
+        expect(wrapper.emitted('click')).toHaveLength(1)
+        expect(wrapper.emitted('click')[0][0]).toBeInstanceOf(Event)
+      })
+    })
+  })
+
+  describe('[Methods]', () => {
+    describe('[(method)click]', () => {
+      test('should be callable', () => {
+        const wrapper = mountAction()
+        const evt = new Event('click')
+
+        expect(wrapper.vm.click(evt)).toBeUndefined()
+        expect(wrapper.emitted('click')).toStrictEqual([[evt]])
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add generated-structure-compliant behavioral tests for QFab
- add generated-structure-compliant behavioral tests for QFabAction
- cover rendering, accessibility state, routing, events, slots, and public methods without fixing the API to stale declaration snapshots

## Validation

- cd ui && pnpm build
- cd ui && pnpm test:specs --target components/fab/QFab
- cd ui && pnpm test QFab QFabAction (2 files, 100 tests)
- pnpm test (137 UI files / 1,448 tests; 10 Vite usage tests; 75 Vite runtime tests)
- pnpm lint:ui:check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for floating action buttons and their actions.
  * Verified styling, labels, icons, slots, accessibility attributes, disabled states, navigation, and route replacement.
  * Covered open/close behavior, emitted events, model updates, persistent behavior, and public component methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->