### PR TITLE
fix(QTable): #10445 separator borders leak into tables rendered in slots

### DIFF
--- a/ui/src/components/table/QTable.sass
+++ b/ui/src/components/table/QTable.sass
@@ -192,18 +192,19 @@
  * Separators
  */
 .q-table--horizontal-separator, .q-table--cell-separator
-  thead th, tbody tr:not(:last-child) > td
-    border-bottom-width: 1px
+  > table, > .q-table__middle > table
+    > thead > tr > th, > tbody > tr:not(:last-child) > td
+      border-bottom-width: 1px
 
 .q-table--vertical-separator, .q-table--cell-separator
-  td, th
-    border-left-width: 1px
-  thead tr:last-child th,
-  &.q-table--loading tr:nth-last-child(2) th
+  > table, > .q-table__middle > table
+    > * > tr > * + *
+      border-left-width: 1px
+    > thead > tr:last-child > th
+      border-bottom-width: 1px
+  &.q-table--loading > .q-table__middle > table > thead > tr:nth-last-child(2) > th
     border-bottom-width: 1px
-  td:first-child, th:first-child
-    border-left: 0
-  .q-table__top
+  > .q-table__top
     border-bottom: 1px solid $table-border-color
 
 /*
@@ -290,5 +291,5 @@ body.desktop .q-table > tbody > tr:not(.q-tr--no-hover):hover > td:not(.q-td--no
         background: $table-dark-selected-background
 
   &.q-table--vertical-separator, &.q-table--cell-separator
-    .q-table__top
+    > .q-table__top
       border-color: $table-dark-border-color

--- a/ui/src/components/table/QTable.separator-scoping.test.js
+++ b/ui/src/components/table/QTable.separator-scoping.test.js
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, test } from 'vitest'
+
+// The Quasar stylesheet is loaded into jsdom by testing/vitest.setup.js
+// ("import 'quasar/src/css/index.sass'"), so the border widths below are the
+// ones that QTable.sass actually produces.
+
+const separatorList = ['horizontal', 'vertical', 'cell', 'none']
+
+// a hand-written table that a user drops into a slot; it carries no Quasar
+// class, so it must never pick up the parent's separators
+const plainTable =
+  '<table>' +
+  '<thead><tr><th data-t="slot-th-1"></th><th data-t="slot-th-2"></th></tr></thead>' +
+  '<tbody>' +
+  '<tr><td data-t="slot-td-1"></td><td data-t="slot-td-2"></td></tr>' +
+  '<tr><td></td><td></td></tr>' +
+  '</tbody></table>'
+
+// a nested QMarkupTable that asks for its own vertical separators
+const nestedMarkupTable =
+  '<div class="q-markup-table q-table__container q-table--vertical-separator">' +
+  '<table class="q-table"><tbody>' +
+  '<tr><td data-t="inner-td-1"></td><td data-t="inner-td-2"></td></tr>' +
+  '<tr><td></td><td></td></tr>' +
+  '</tbody></table></div>'
+
+function nestedTable(separator) {
+  return (
+    `<div class="q-table__container q-table--${separator}-separator">` +
+    '<div class="q-table__middle"><table class="q-table">' +
+    '<thead><tr><th data-t="inner-th-1"></th><th data-t="inner-th-2"></th></tr></thead>' +
+    '<tbody>' +
+    '<tr><td data-t="inner-td-1"></td><td data-t="inner-td-2"></td></tr>' +
+    '<tr><td></td><td></td></tr>' +
+    '</tbody></table></div></div>'
+  )
+}
+
+// QTable renders container > .q-table__middle > table
+function createTable(separator, innerHtml = '') {
+  return createFixture(
+    `<div class="q-table__container q-table--${separator}-separator">` +
+      '<div class="q-table__middle"><table class="q-table">' +
+      '<thead><tr><th data-t="own-th-1"></th><th data-t="own-th-2"></th></tr></thead>' +
+      '<tbody>' +
+      '<tr><td data-t="own-td-1"></td><td data-t="own-td-2"></td></tr>' +
+      `<tr><td colspan="2">${innerHtml}</td></tr>` +
+      '</tbody></table></div></div>'
+  )
+}
+
+// QMarkupTable renders container > table, without the .q-table__middle wrapper
+function createMarkupTable(separator, innerHtml = '') {
+  return createFixture(
+    '<div class="q-markup-table q-table__container ' +
+      `q-table--${separator}-separator"><table class="q-table">` +
+      '<thead><tr><th data-t="own-th-1"></th><th data-t="own-th-2"></th></tr></thead>' +
+      '<tbody>' +
+      '<tr><td data-t="own-td-1"></td><td data-t="own-td-2"></td></tr>' +
+      `<tr><td colspan="2">${innerHtml}</td></tr>` +
+      '</tbody></table></div>'
+  )
+}
+
+function createFixture(html) {
+  const el = document.createElement('div')
+  el.innerHTML = html
+  document.body.append(el)
+
+  return {
+    // data attributes instead of ids: jsdom resolves "#id" through
+    // document.getElementById, which picks the wrong node when a previous
+    // fixture is still attached
+    border(name, side) {
+      const target = el.querySelector(`[data-t="${name}"]`)
+      expect(
+        target,
+        `[data-t="${name}"] is missing from the fixture`
+      ).not.toBeNull()
+      return getComputedStyle(target)[
+        side === 'left' ? 'borderLeftWidth' : 'borderBottomWidth'
+      ]
+    }
+  }
+}
+
+// what the component should draw for its own cells
+function getOwnExpectation(separator) {
+  return {
+    thLeft: separator === 'vertical' || separator === 'cell' ? '1px' : '0px',
+    // "thead th" for horizontal/cell, "thead tr:last-child th" for vertical
+    thBottom: separator === 'none' ? '0px' : '1px',
+    tdLeft: separator === 'vertical' || separator === 'cell' ? '1px' : '0px',
+    tdBottom: separator === 'horizontal' || separator === 'cell' ? '1px' : '0px'
+  }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('[QTable separator scoping]', () => {
+  describe('[the separators still reach the component own cells]', () => {
+    for (const separator of separatorList) {
+      test(`QTable separator="${separator}"`, () => {
+        const fixture = createTable(separator)
+        const expected = getOwnExpectation(separator)
+
+        expect(fixture.border('own-th-2', 'left')).toBe(expected.thLeft)
+        expect(fixture.border('own-th-2', 'bottom')).toBe(expected.thBottom)
+        expect(fixture.border('own-td-2', 'left')).toBe(expected.tdLeft)
+        expect(fixture.border('own-td-2', 'bottom')).toBe(expected.tdBottom)
+        // first column never gets a left border
+        expect(fixture.border('own-td-1', 'left')).toBe('0px')
+      })
+
+      test(`QMarkupTable separator="${separator}"`, () => {
+        const fixture = createMarkupTable(separator)
+        const expected = getOwnExpectation(separator)
+
+        expect(fixture.border('own-th-2', 'left')).toBe(expected.thLeft)
+        expect(fixture.border('own-th-2', 'bottom')).toBe(expected.thBottom)
+        expect(fixture.border('own-td-2', 'left')).toBe(expected.tdLeft)
+        expect(fixture.border('own-td-2', 'bottom')).toBe(expected.tdBottom)
+        expect(fixture.border('own-td-1', 'left')).toBe('0px')
+      })
+    }
+  })
+
+  describe('[a table in a slot does not inherit the separators]', () => {
+    for (const separator of separatorList) {
+      test(`QTable separator="${separator}"`, () => {
+        const fixture = createTable(separator, plainTable)
+
+        for (const name of ['slot-th-2', 'slot-td-2']) {
+          expect(fixture.border(name, 'left')).toBe('0px')
+          expect(fixture.border(name, 'bottom')).toBe('0px')
+        }
+      })
+
+      test(`QMarkupTable separator="${separator}"`, () => {
+        const fixture = createMarkupTable(separator, plainTable)
+
+        for (const name of ['slot-th-2', 'slot-td-2']) {
+          expect(fixture.border(name, 'left')).toBe('0px')
+          expect(fixture.border(name, 'bottom')).toBe('0px')
+        }
+      })
+    }
+  })
+
+  describe('[a nested table keeps the separators it asks for]', () => {
+    for (const separator of separatorList) {
+      test(`QMarkupTable separator="vertical" inside separator="${separator}"`, () => {
+        const fixture = createTable(separator, nestedMarkupTable)
+
+        expect(fixture.border('inner-td-2', 'left')).toBe('1px')
+        expect(fixture.border('inner-td-2', 'bottom')).toBe('0px')
+        expect(fixture.border('inner-td-1', 'left')).toBe('0px')
+      })
+    }
+
+    test('QTable separator="cell" inside separator="none"', () => {
+      const fixture = createTable('none', nestedTable('cell'))
+
+      expect(fixture.border('inner-th-2', 'left')).toBe('1px')
+      expect(fixture.border('inner-th-2', 'bottom')).toBe('1px')
+      expect(fixture.border('inner-td-2', 'left')).toBe('1px')
+      expect(fixture.border('inner-td-2', 'bottom')).toBe('1px')
+    })
+
+    test('QTable separator="none" inside separator="cell"', () => {
+      const fixture = createTable('cell', nestedTable('none'))
+
+      for (const name of ['inner-th-2', 'inner-td-2']) {
+        expect(fixture.border(name, 'left')).toBe('0px')
+        expect(fixture.border(name, 'bottom')).toBe('0px')
+      }
+    })
+  })
+})


### PR DESCRIPTION
# fix(QTable): scope separator borders to the table's own cells

**The `separator` classes sit on the outer container, but their rules used unscoped descendant selectors (`td, th`, `thead th`), so every `<table>` a user renders inside a body/expand slot silently inherited the parent's separator borders — this anchors the rules to the container's own table with child combinators.**

Closes #10445 (open since 2021-08). The only comment on that ticket asked for a codepen to test with, so this PR ships a **self-verdicting** repro instead of a screenshot: a single HTML file that measures its own borders and prints `PASS`/`FAIL`.

## The diff

The runtime change is one Sass file — no JS, no public API change. (The commit also adds a test file; diffstat is 2 files, +193/-8.)

```diff
diff --git a/ui/src/components/table/QTable.sass b/ui/src/components/table/QTable.sass
index 8f13f8e253..a0f6d57208 100644
--- a/ui/src/components/table/QTable.sass
+++ b/ui/src/components/table/QTable.sass
@@ -192,18 +192,19 @@
  * Separators
  */
 .q-table--horizontal-separator, .q-table--cell-separator
-  thead th, tbody tr:not(:last-child) > td
-    border-bottom-width: 1px
+  > table, > .q-table__middle > table
+    > thead > tr > th, > tbody > tr:not(:last-child) > td
+      border-bottom-width: 1px
 
 .q-table--vertical-separator, .q-table--cell-separator
-  td, th
-    border-left-width: 1px
-  thead tr:last-child th,
-  &.q-table--loading tr:nth-last-child(2) th
+  > table, > .q-table__middle > table
+    > * > tr > * + *
+      border-left-width: 1px
+    > thead > tr:last-child > th
+      border-bottom-width: 1px
+  &.q-table--loading > .q-table__middle > table > thead > tr:nth-last-child(2) > th
     border-bottom-width: 1px
-  td:first-child, th:first-child
-    border-left: 0
-  .q-table__top
+  > .q-table__top
     border-bottom: 1px solid $table-border-color
 
 /*
@@ -290,5 +291,5 @@ body.desktop .q-table > tbody > tr:not(.q-tr--no-hover):hover > td:not(.q-td--no
         background: $table-dark-selected-background
 
   &.q-table--vertical-separator, &.q-table--cell-separator
-    .q-table__top
+    > .q-table__top
       border-color: $table-dark-border-color
```

Both DOM shapes have to be covered, which is why each rule lists two prefixes:

| Component | Renders |
|---|---|
| `QTable` | `container > .q-table__middle > table` |
| `QMarkupTable` | `container > table` |

## Why each part of the selector is load-bearing

Every step has to be a **child** combinator, because a single descendant step anywhere in the chain re-admits the nested table — which is the entire bug. That isn't an assertion; each element was removed one at a time and re-measured against the 88-check matrix:

| mutation | wrong /88 | what breaks |
|---|---|---|
| *(the diff as submitted)* | **0** | — |
| weaken the **cell** step → `> * > tr td` | 16 | leaks come back |
| weaken the **table** step → `container table` | 25 | reverts to the original bug exactly |
| drop `> table` (QMarkupTable shape) | 11 | QMarkupTable's **own** separators vanish |
| drop `> .q-table__middle > table` (QTable shape) | 34 | QTable's **own** separators vanish |

The two failure kinds are the point: weakening a combinator brings back **leaks**, while dropping either container shape destroys a component's **own** borders. Both shapes are needed because QTable renders `container > .q-table__middle > table` while QMarkupTable renders `container > table` — and `> *` would be wrong, since `.q-table__top` is also a direct child.

`> * > tr > * + *` says "every cell after the first gets a left border", which is what the old set-then-reset-on-`:first-child` pair was spelling out the long way. It emits one rule fewer and *lowers* specificity to (0,1,2), against (0,1,3) for the set/reset form.

The `.q-table__top` rules get the same anchoring: they were leaking a title-bar border onto a nested QTable, and it is the same class and the same defect as the rules directly above them.

<details>
<summary><strong>Alternatives that look simpler and are not</strong></summary>

- **Put the separator class on the `<table>` instead of the container**, so no chain is needed. Not possible: `.q-table__top` is a *preceding sibling* of `.q-table__middle`, so nothing on the table can reach back up and across to it without `:has()`; `.q-table--loading` is on the container too. The class would have to live on **both** nodes. It would also mean threading a QTable-specific class through `get-table-middle.js`, which is shared with `QVirtualScroll` — a public component with no notion of separators.
- **`:where()` to keep specificity low.** A leading child combinator can't go inside `:where()`, so the only available form wraps the container class — landing at (0,0,3), which then *loses* to `.q-table thead, td, th { border-width: 0 }` at (0,1,1) and erases every separator.
- **`table:not(table table)` or any `:not()`-based "nearest container wins".** A nested table is `table table` from its *own* container's perspective too, so it excludes itself from the rule that should keep its borders.
- **A Sass mixin for the repeated anchor.** `ui/src/**/*.sass` contains zero mixin definitions; adding one for two call sites introduces a codebase-first pattern and hides the selector this change is about.
- **`:nth-last-child(1 of :not(.q-table__progress))`** to merge the `--loading` special case. Inside the declared browser support matrix, but jsdom silently matches nothing, so it would quietly zero the header border in the test suite.

</details>

## Verify it in 30 seconds

`qtable-separator-10445.html` is attached to this PR (it is not committed). It loads Quasar, builds 22 fixtures containing 48 tables, measures **89 computed border widths (88 scored + 1 informational)**, and writes the verdict into `#verdict`. Nothing needs to be eyeballed.

```bash
# the bug, straight off the CDN — no checkout needed
open qtable-separator-10445.html                 # ?build=cdn is the default → FAIL

# the fix
cp qtable-separator-10445.html .                 # repo root
cd ui && pnpm build && cd ..
open 'qtable-separator-10445.html?build=dist'    # → PASS
```

| Build | Quasar | Verdict |
|---|---|---|
| jsDelivr `quasar@2.23.3` (current release) | 2.23.3 | **FAIL — 25/88 wrong** |
| `dev` built locally, before this patch | 2.23.2 | **FAIL — 25/88 wrong** |
| `dev` + this patch | 2.23.2 | **PASS — 88/88 correct** |

Identical counts in Chromium, Firefox and WebKit (Playwright 1.62.0). The 25 failures are all leaked borders; the 32 control checks that assert each component still draws *its own* separators pass in every build, so the stylesheet is provably loaded in the failing runs too.

<details>
<summary><strong>Root cause</strong></summary>

`QTable` puts the separator class on the container, not the table:

```js
`q-table__container q-table--${ props.separator }-separator column no-wrap`
```

The rules then reached into it with descendant selectors, so `.q-table--cell-separator td` matched a `td` at *any* depth — including one belonging to a completely different table that the user rendered in a slot.

The borders become *visible* because of a second, benign descendant rule in the same file:

```sass
.q-table
  thead, td, th
    border-style: solid
    border-width: 0
```

A nested plain `<table>` is a descendant of the outer `table.q-table`, so its cells already have `border-style: solid` at width `0`. They are invisible until a separator rule supplies a width — which is exactly what leaked. So fixing only the separator widths is sufficient; the `border-style` leak needs no change.

Consistent with that, the observed failures localise perfectly:

| Outer `separator` | Leaks |
|---|---|
| `none` | nothing (no rules exist) |
| `horizontal` | bottom borders only |
| `vertical` | left borders + the `thead tr:last-child th` bottom border |
| `cell` | all four |
</details>

<details>
<summary><strong>The full 88-check matrix</strong></summary>

Every group below is measured for `separator` = `horizontal` / `vertical` / `cell` / `none` unless noted.

| Group | Checks | What it pins down |
|---|---|---|
| Control — `QTable` own cells | 16 | the fix must not stop the component drawing its own separators |
| Control — `QMarkupTable` own cells | 16 | same, for the `container > table` shape |
| Plain `<table>` in a `#body` slot | 16 | the reported bug |
| Plain `<table>` inside `QMarkupTable` | 8 | `horizontal` + `cell` only |
| Plain `<table>` in an expansion row | 4 | `separator="cell"` |
| **Nested `QMarkupTable separator="vertical"`** | 20 | **must KEEP its own borders** |
| `QTable` in `QTable` | 8 | `none`-in-`cell` loses borders, `cell`-in-`none` keeps them |

The nested-`QMarkupTable` group is the load-bearing one: it is what separates a correct fix from a fix that merely stops all nested borders. See "refuted alternatives".

Raw per-engine output, patched vs unpatched vs CDN:

```
engine     build       quasar    scored  correct  wrong  verdict
chromium   unpatched   2.23.2    88      63       25     FAIL
chromium   patched     2.23.2    88      88       0      PASS
chromium   cdn         2.23.3    88      63       25     FAIL
firefox    unpatched   2.23.2    88      63       25     FAIL
firefox    patched     2.23.2    88      88       0      PASS
firefox    cdn         2.23.3    88      63       25     FAIL
webkit     unpatched   2.23.2    88      63       25     FAIL
webkit     patched     2.23.2    88      88       0      PASS
webkit     cdn         2.23.3    88      63       25     FAIL
```
</details>

<details>
<summary><strong>Regression test — seen to fail without the fix</strong></summary>

`ui/src/components/table/QTable.separator-scoping.test.js`, 22 tests. `testing/vitest.setup.js` already imports `quasar/src/css/index.sass`, so jsdom resolves the real compiled stylesheet and `getComputedStyle` returns the same widths the browser does — the test measures behaviour, not selector text.

**With the fix reverted (`QTable.sass` back to `dev`):**

```
 ✓ [the separators still reach the component own cells] > QTable separator="horizontal"
 ✓ [the separators still reach the component own cells] > QMarkupTable separator="horizontal"
 ✓ [the separators still reach the component own cells] > QTable separator="vertical"
 ✓ [the separators still reach the component own cells] > QMarkupTable separator="vertical"
 ✓ [the separators still reach the component own cells] > QTable separator="cell"
 ✓ [the separators still reach the component own cells] > QMarkupTable separator="cell"
 ✓ [the separators still reach the component own cells] > QTable separator="none"
 ✓ [the separators still reach the component own cells] > QMarkupTable separator="none"
 × [a table in a slot does not inherit the separators] > QTable separator="horizontal"
 × [a table in a slot does not inherit the separators] > QMarkupTable separator="horizontal"
 × [a table in a slot does not inherit the separators] > QTable separator="vertical"
 × [a table in a slot does not inherit the separators] > QMarkupTable separator="vertical"
 × [a table in a slot does not inherit the separators] > QTable separator="cell"
 × [a table in a slot does not inherit the separators] > QMarkupTable separator="cell"
 ✓ [a table in a slot does not inherit the separators] > QTable separator="none"
 ✓ [a table in a slot does not inherit the separators] > QMarkupTable separator="none"
 × [a nested table keeps the separators it asks for] > QMarkupTable separator="vertical" inside separator="horizontal"
 ✓ [a nested table keeps the separators it asks for] > QMarkupTable separator="vertical" inside separator="vertical"
 × [a nested table keeps the separators it asks for] > QMarkupTable separator="vertical" inside separator="cell"
 ✓ [a nested table keeps the separators it asks for] > QMarkupTable separator="vertical" inside separator="none"
 ✓ [a nested table keeps the separators it asks for] > QTable separator="cell" inside separator="none"
 × [a nested table keeps the separators it asks for] > QTable separator="none" inside separator="cell"

AssertionError: expected '1px' to be '0px' // Object.is equality

 Test Files  1 failed (1)
      Tests  9 failed | 13 passed (22)
```

The 13 that still pass are exactly the ones that *should*: the whole control group, plus `separator="none"` (nothing to leak) and the nested combinations whose axes do not collide.

**With the fix applied:**

```
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

**Placement note.** The file is `QTable.separator-scoping.test.js`, not `QTable.test.js`. `QTable` has no spec file yet and is not in `ignoredTestFiles.conf`, so writing into `QTable.test.js` would have committed me to the Specs script's full-API contract for the whole component — far beyond this fix. `getTargetList()` filters any path matching `/test/`, so this supplementary file is invisible to the validator; `test:specs:ci` still exits 0 and writes nothing. Happy to fold these cases into `QTable.test.js` whenever that file is written.
</details>

<details>
<summary><strong>Refuted alternatives — why not a one-liner</strong></summary>

Both tempting one-liners were **built and measured**, not reasoned about. Same 88-check harness, Chromium:

| Attempt | Result |
|---|---|
| A. keep the descendant rules, add `table table td, table table th { border-width: 0 }` | **FAIL — 19/88 wrong** |
| B. exclude nested cells in place: `td:not(table table td), th:not(table table th)` | **FAIL — 16/88 wrong** |
| This PR | **PASS — 88/88** |

**A fails twice over.** It breaks 8 nested-`QMarkupTable` checks — the reset `(0,1,3)` out-specifies that table's own `.q-table--vertical-separator td` `(0,1,1)`, so a nested table that explicitly asked for `separator="vertical"` loses its borders. And it does not even close the leak: 9 bottom-border checks still fail, because `:not(:last-child)` and `:last-child` push the original rules to `(0,2,3)`, which *beats* the reset. Specificity, not coverage, is what defeats it:

```
.q-table--horizontal-separator tbody tr:not(:last-child) > td   (0,2,3)  ← wins
.q-table--horizontal-separator table table td                   (0,1,3)
```

**B closes the leak completely — 0 leak failures — and is still wrong.** It breaks 16 checks, all of them nested tables that legitimately asked for their own separators: a nested table's cells *are* `table table td`, so the `:not()` excludes them from their **own** container's rule too. This is precisely the trap the matrix exists to catch, and it is why the diff anchors to the container instead of blacklisting nesting.
</details>

<details>
<summary><strong>Behaviour change and what I did NOT verify</strong></summary>

**Behaviour change 1 (intended, but it is a change).** Anyone who currently relies on a hand-written `<table>` in a slot picking up the parent's separator borders will lose those borders. That is the bug being fixed, and the workaround is to give the inner table its own `QMarkupTable` with the `separator` it wants — which now works reliably. I judged this low-risk, since inheriting is not documented anywhere and the ticket reports it as unwanted; flag it if you would rather it went into a major.

**Behaviour change 2 — the fix makes separator borders harder to override.** This is the part I am least comfortable with, so I am stating it plainly rather than burying it. The new selectors are considerably more specific than the old ones, and that raises the bar for user overrides:

| | old | new |
|---|---|---|
| width rule | `.q-table--vertical-separator td` `(0,1,1)` | `(0,1,3)` markup / `(0,2,3)` QTable branch |
| first-column reset | `(0,2,1)` | `(0,3,3)` |

So a user override reached through `table-class`, e.g. `.my-table td { border-left-width: 0 }` `(0,1,1)`, used to tie-and-win on source order against the old rule and now loses outright. Anyone doing that needs more specificity or `!important` after this lands. I can add `:where()` to hold the old specificity if you would prefer that — it would keep overrides working exactly as before — but it changes browser-support floor, so I did not assume it.

**Behaviour change 3 — a `QMarkupTable` whose rows are not wrapped in `thead`/`tbody`.** `> * > tr` requires a row-group, so markup like `<q-markup-table><tr>…</tr></q-markup-table>` (valid HTML, and reachable because Vue renders `table > tr` directly rather than going through the HTML parser's tbody insertion) no longer gets vertical/cell left borders. Reasoning from the compiled selectors rather than a measurement: `dev` gave such markup *only* the left borders — its horizontal rules are `thead th` / `tbody tr:not(:last-child) > td`, which already never matched a row-group-less table — so the delta is confined to those left borders. Every Quasar example wraps rows in `thead`/`tbody`. Say the word and I will extend the vertical block to `> tr, > * > tr` to restore exact parity; I left it out to keep the selector list short.

**Not verified — stated rather than implied:**

- **Dark mode.** Not swept. The only dark separator rule is `.q-table--dark.q-table--vertical-separator .q-table__top { border-color }`, which this diff does not touch, but I did not measure a dark fixture.
- **RTL.** Not swept. `postcss-rtlcss` flips `border-left` in the `.rtl` bundle; the diff changes only the selector prefix, not the properties, so it should transform the same way — unverified.
- **`.q-table__top` still leaks.** `.q-table--vertical-separator .q-table__top` is still a descendant selector, so a `QTable` nested inside a `vertical`/`cell` parent gets an unwanted title-bar border. Measured and confirmed (`1px`, expected `0px`) — the MRE reports it as an explicitly **informational** row excluded from the verdict. Left alone deliberately to keep this diff to the reported defect; happy to fix it here or in a follow-up.
- **Virtual scrolling / grid mode / `q-table--loading`.** The `loading` selector was re-anchored to `> .q-table__middle > table > thead > tr:nth-last-child(2) > th` after confirming in `QTable.js` that the progress `<tr>` is appended inside `thead`. Not exercised at runtime — no fixture toggles `loading`, and grid mode was not tested at all.
- **Visual/screenshot diffing.** None. Every number here is a `getComputedStyle` border width, not a rendered-pixel comparison.
- **The unit test uses hand-built DOM, not mounted components.** It asserts against the two documented shapes written out by hand, so it verifies the *stylesheet*, not that `QTable.js` keeps rendering those shapes. The 88-check MRE does mount real components and is what covers that half; the two are complementary and neither alone is sufficient.
- **CI.** Not yet observed green — reported below from local runs only. Note the `tests-on-pr.yml` `paths` filter is `ui/**/*.js`, so a Sass-only change would not have triggered the UI suite; adding the test file does.

**Second-lineage review.** I had a non-Claude model (GPT-5.2-codex, high reasoning, read-only) attack the diff before opening this, specifically to find DOM shapes whose own separators the new selectors miss. Its verdict: *"mergeable as code, with the specificity tradeoff disclosed and the PR body cleaned up. Confidence: 8/10 that the fix is correct and complete for issue 10445's reported cell-border leak."*

It raised the override-specificity cost and the row-group-less-`QMarkupTable` case above — both are now disclosed because of it. It independently confirmed the render paths against the source (`get-table-middle.js`, `QVirtualScroll.js` line 202 for the virtual-scroll path, `QMarkupTable.js` line 47), the `(0,2,3)` vs `(0,1,3)` specificity arithmetic, and the `border-style: solid` mechanism. It also flagged that npm's latest was `2.23.2`, which I checked and rejected — `registry.npmjs.org` reports `dist-tags.latest = 2.23.3`, published 2026-07-28, and the CDN build under test self-reported `Quasar.version === '2.23.3'`. Its grid-mode claim I verified by hand: `.q-table--grid .q-table__middle thead, th { border: 0 !important }` suppresses those separators regardless of this change.

**Local validation:**

| Command | Result |
|---|---|
| `vitest run` (full UI suite, from `ui/testing`) | 105 files, **1201 passed**, 0 skipped |
| `vitest run QTable.separator-scoping` | 22 passed / 9 failed with the fix reverted |
| `node ./testing/specs/script.js --ci` | exit 0, no files written |
| `oxfmt --check` + `oxlint` on the new test | clean |
| `git diff --check` | clean |
</details>

---

## Screenshots — before / after

Rendered at 2× from the MRE below: left column is the published 2.23.3 build, right column is this branch built locally. Same page, same markup; only the stylesheet differs.

**The bug — a plain `<table>` in a `#body` slot inherits the parent's `separator="cell"` borders**

| unpatched 2.23.3 | patched |
|---|---|
| ![unpatched](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots10445/leak-qtable-cell--unpatched.png) | ![patched](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots10445/leak-qtable-cell--patched.png) |

The nested table's cell borders disappear; the parent QTable keeps its own separators.

**A nested QTable with `separator="none"` inside an outer `separator="cell"`**

| unpatched 2.23.3 | patched |
|---|---|
| ![unpatched](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots10445/qinq-none-in-cell--unpatched.png) | ![patched](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/shots10445/qinq-none-in-cell--patched.png) |

**The regression guard — a nested QMarkupTable that sets its own `separator="vertical"` must KEEP it.**
Rather than show two lookalike images: the rendering is **pixel-identical** between the two builds, sha1 `3bd2a12cc38514c0` for both. The fix provably does not disturb this case, which is what the two tempting one-liners got wrong.

📄 MRE: [`mre/10445.html`](https://raw.githubusercontent.com/evnchn/quasar/uc-assets/mre/10445.html) — open it and it self-reports; `?build=cdn` for the published build, `?build=dist` against a local `ui/dist`. Re-run independently just now: **unpatched FAIL 25/88 wrong, patched PASS 88/88.**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table separator styling to apply borders consistently to table cells.
  * Prevented separator styles from unintentionally affecting nested or slotted tables.
  * Refined dark-mode styling for table sections.

* **Tests**
  * Added comprehensive coverage for separator behavior across standard, markup, nested, and slotted tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->