### PR TITLE
docs(QCheckbox;QToggle;QRadio): #18499 add name so QItem label clicks toggle

### DIFF
--- a/docs/src/examples/QCheckbox/InaList.vue
+++ b/docs/src/examples/QCheckbox/InaList.vue
@@ -10,7 +10,7 @@
 
         <q-item tag="label" v-ripple>
           <q-item-section avatar>
-            <q-checkbox v-model="color" val="teal" color="teal" />
+            <q-checkbox v-model="color" val="teal" color="teal" name="teal" />
           </q-item-section>
           <q-item-section>
             <q-item-label>Teal</q-item-label>
@@ -19,7 +19,7 @@
 
         <q-item tag="label" v-ripple>
           <q-item-section avatar>
-            <q-checkbox v-model="color" val="orange" color="orange" />
+            <q-checkbox v-model="color" val="orange" color="orange" name="orange" />
           </q-item-section>
           <q-item-section>
             <q-item-label>Orange</q-item-label>
@@ -29,7 +29,7 @@
 
         <q-item tag="label" v-ripple>
           <q-item-section avatar top>
-            <q-checkbox v-model="color" val="cyan" color="cyan" />
+            <q-checkbox v-model="color" val="cyan" color="cyan" name="cyan" />
           </q-item-section>
           <q-item-section>
             <q-item-label>Cyan</q-item-label>

--- a/docs/src/examples/QRadio/InaList.vue
+++ b/docs/src/examples/QRadio/InaList.vue
@@ -9,7 +9,7 @@
 
       <q-item tag="label" v-ripple>
         <q-item-section avatar>
-          <q-radio v-model="color" val="teal" color="teal" />
+          <q-radio v-model="color" val="teal" color="teal" name="color" />
         </q-item-section>
         <q-item-section>
           <q-item-label>Teal</q-item-label>
@@ -18,7 +18,7 @@
 
       <q-item tag="label" v-ripple>
         <q-item-section avatar>
-          <q-radio v-model="color" val="orange" color="orange" />
+          <q-radio v-model="color" val="orange" color="orange" name="color" />
         </q-item-section>
         <q-item-section>
           <q-item-label>Orange</q-item-label>
@@ -28,7 +28,7 @@
 
       <q-item tag="label" v-ripple>
         <q-item-section avatar top>
-          <q-radio v-model="color" val="cyan" color="cyan" />
+          <q-radio v-model="color" val="cyan" color="cyan" name="color" />
         </q-item-section>
         <q-item-section>
           <q-item-label>Cyan</q-item-label>

--- a/docs/src/examples/QToggle/List.vue
+++ b/docs/src/examples/QToggle/List.vue
@@ -6,7 +6,7 @@
           <q-item-label>Battery too low</q-item-label>
         </q-item-section>
         <q-item-section avatar>
-          <q-toggle color="blue" v-model="notifications" val="battery" />
+          <q-toggle color="blue" v-model="notifications" val="battery" name="battery" />
         </q-item-section>
       </q-item>
 
@@ -16,7 +16,7 @@
           <q-item-label caption>Allow notification</q-item-label>
         </q-item-section>
         <q-item-section avatar>
-          <q-toggle color="green" v-model="notifications" val="friend" />
+          <q-toggle color="green" v-model="notifications" val="friend" name="friend" />
         </q-item-section>
       </q-item>
 
@@ -28,7 +28,7 @@
           >
         </q-item-section>
         <q-item-section avatar>
-          <q-toggle color="red" v-model="notifications" val="picture" />
+          <q-toggle color="red" v-model="notifications" val="picture" name="picture" />
         </q-item-section>
       </q-item>
     </q-list>


### PR DESCRIPTION
Since 2.23.4 (only inject the native input when it can be submitted), QCheckbox, QRadio and QToggle no longer render their hidden native input unless a `name` is set. The "in a list" examples wrap each control in a `q-item` with `tag="label"` and relied on that native input to forward clicks from the item to the control, so clicking the item text stopped toggling it.

Adding a `name` to each control in the affected examples brings the native input back and restores the documented behavior.

Fixes #18499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox, radio button, and toggle examples by assigning explicit names.
  * Radio button examples now correctly share a group, ensuring only one option can be selected at a time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->