### PR TITLE
feat(cli): add internal update notifier package

### DIFF
--- a/cli/bin/quasar.js
+++ b/cli/bin/quasar.js
@@ -10,10 +10,11 @@ if (
 // oxlint-disable-next-line import/no-unassigned-import
 import '../lib/node-version-check.js'
 
-import { cliPkg } from '../lib/cli-pkg.js'
-import updateNotifier from 'update-notifier'
+import { notifyUpdate } from '@quasar/update-notifier'
 
-updateNotifier({ pkg: cliPkg }).notify()
+import { cliPkg } from '../lib/cli-pkg.js'
+
+notifyUpdate(cliPkg)
 
 let cmd = process.argv[2]
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -47,13 +47,13 @@
     "@hono/node-server": "^2.0.12",
     "@quasar/art": "workspace:^",
     "@quasar/ssl-certificate": "workspace:^",
+    "@quasar/update-notifier": "workspace:^",
     "ci-info": "^4.4.0",
     "cross-spawn": "^7.0.6",
     "fs-extra": "^11.4.0",
     "hono": "^4.12.34",
     "kolorist": "^1.8.0",
-    "open": "^11.0.0",
-    "update-notifier": "^7.3.1"
+    "open": "^11.0.0"
   },
   "engines": {
     "node": ">= 20.20.0"

--- a/create-quasar/bin/create-quasar.js
+++ b/create-quasar/bin/create-quasar.js
@@ -21,8 +21,8 @@ const { showCliBanner } = await import('@quasar/art')
 
 const { runningPackageManager } = await import('../lib/running-pm.js')
 if (!runningPackageManager) {
-  const { default: updateNotifier } = await import('update-notifier')
-  updateNotifier({ pkg: cliPkg }).notify()
+  const { notifyUpdate } = await import('@quasar/update-notifier')
+  notifyUpdate(cliPkg)
 }
 
 showCliBanner()

--- a/create-quasar/package.json
+++ b/create-quasar/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@clack/prompts": "^1.7.0",
     "@quasar/art": "workspace:^",
+    "@quasar/update-notifier": "workspace:^",
     "ci-info": "^4.4.0",
     "cross-spawn": "^7.0.6",
     "fs-extra": "^11.4.0",
     "kolorist": "^1.8.0",
-    "tinyglobby": "^0.2.17",
-    "update-notifier": "^7.3.1"
+    "tinyglobby": "^0.2.17"
   },
   "engines": {
     "node": ">=20"

--- a/icongenie/bin/icongenie.js
+++ b/icongenie/bin/icongenie.js
@@ -9,10 +9,10 @@ if (
 
 await import('../lib/utils/node-version-check.js')
 
-const { default: updateNotifier } = await import('update-notifier')
 const { packageJson } = await import('../lib/utils/package-json.js')
+const { notifyUpdate } = await import('@quasar/update-notifier')
 
-updateNotifier({ pkg: packageJson }).notify()
+notifyUpdate(packageJson)
 
 const commands = ['generate', 'verify', 'profile', 'help']
 

--- a/icongenie/package.json
+++ b/icongenie/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@quasar/art": "^1.0.0",
+    "@quasar/update-notifier": "^1.0.0",
     "ci-info": "^4.4.0",
     "cross-spawn": "^7.0.6",
     "elementtree": "^0.1.7",
@@ -61,8 +62,7 @@
     "sharp": "^0.35.3",
     "svgo": "^4.0.1",
     "tinyglobby": "^0.2.10",
-    "untildify": "^6.0.0",
-    "update-notifier": "^7.0.0"
+    "untildify": "^6.0.0"
   },
   "engines": {
     "node": ">= 22.22.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "oxfmt && oxlint --fix --no-error-on-unmatched-pattern",
     "lint:check": "oxfmt --check && oxlint --no-error-on-unmatched-pattern",
     "lint:ui:check": "oxfmt --check ./ui && oxlint --no-error-on-unmatched-pattern ./ui",
-    "test": "pnpm build && pnpm --filter @quasar/update-notifier test && pnpm --filter quasar test:specs:ci && pnpm --filter quasar test && pnpm --filter @quasar/vite-plugin test",
+    "test": "pnpm build && pnpm --filter quasar test:specs:ci && pnpm --filter quasar test && pnpm --filter @quasar/vite-plugin test && pnpm --filter @quasar/update-notifier test",
     "build": "pnpm --filter quasar build",
     "vite-ecosystem-ci:build": "pnpm build",
     "vite-ecosystem-ci:test": "pnpm --filter @quasar/vite-plugin test",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "oxfmt && oxlint --fix --no-error-on-unmatched-pattern",
     "lint:check": "oxfmt --check && oxlint --no-error-on-unmatched-pattern",
     "lint:ui:check": "oxfmt --check ./ui && oxlint --no-error-on-unmatched-pattern ./ui",
-    "test": "pnpm build && pnpm --filter quasar test:specs:ci && pnpm --filter quasar test && pnpm --filter @quasar/vite-plugin test",
+    "test": "pnpm build && pnpm --filter @quasar/update-notifier test && pnpm --filter quasar test:specs:ci && pnpm --filter quasar test && pnpm --filter @quasar/vite-plugin test",
     "build": "pnpm --filter quasar build",
     "vite-ecosystem-ci:build": "pnpm build",
     "vite-ecosystem-ci:test": "pnpm --filter @quasar/vite-plugin test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@quasar/ssl-certificate':
         specifier: workspace:^
         version: link:../utils/ssl-certificate
+      '@quasar/update-notifier':
+        specifier: workspace:^
+        version: link:../utils/update-notifier
       ci-info:
         specifier: ^4.4.0
         version: 4.4.0
@@ -236,9 +239,6 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
-      update-notifier:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   create-quasar:
     dependencies:
@@ -248,6 +248,9 @@ importers:
       '@quasar/art':
         specifier: workspace:^
         version: link:../utils/art
+      '@quasar/update-notifier':
+        specifier: workspace:^
+        version: link:../utils/update-notifier
       ci-info:
         specifier: ^4.4.0
         version: 4.4.0
@@ -263,9 +266,6 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
-      update-notifier:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   docs:
     dependencies:
@@ -546,6 +546,8 @@ importers:
       selfsigned:
         specifier: ^5.5.0
         version: 5.5.0
+
+  utils/update-notifier: {}
 
   vite-plugin:
     dependencies:
@@ -1844,18 +1846,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@pnpm/config.env-replace@1.1.0':
-    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
-    engines: {node: '>=12.22.0'}
-
-  '@pnpm/network.ca-file@1.0.2':
-    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
-    engines: {node: '>=12.22.0'}
-
-  '@pnpm/npm-conf@3.0.2':
-    resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
-    engines: {node: '>=12'}
-
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -2495,9 +2485,6 @@ packages:
   animate.css@4.1.1:
     resolution: {integrity: sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==}
 
-  ansi-align@3.0.1:
-    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2589,9 +2576,6 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  atomically@2.1.1:
-    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2655,10 +2639,6 @@ packages:
 
   bootstrap-icons@1.13.1:
     resolution: {integrity: sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==}
-
-  boxen@8.0.1:
-    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
-    engines: {node: '>=18'}
 
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
@@ -2735,10 +2715,6 @@ packages:
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
 
-  camelcase@8.0.0:
-    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
-    engines: {node: '>=16'}
-
   caniuse-lite@1.0.30001797:
     resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
@@ -2788,10 +2764,6 @@ packages:
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
     engines: {node: '>= 10.0'}
-
-  cli-boxes@3.0.0:
-    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
-    engines: {node: '>=10'}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -2881,10 +2853,6 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
-  configstore@7.1.0:
-    resolution: {integrity: sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==}
-    engines: {node: '>=18'}
-
   constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
@@ -2958,10 +2926,6 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -3037,10 +3001,6 @@ packages:
     resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
     engines: {node: '>=20'}
 
-  dot-prop@9.0.0:
-    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
-    engines: {node: '>=18'}
-
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -3101,9 +3061,6 @@ packages:
   elementtree@0.1.7:
     resolution: {integrity: sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==}
     engines: {node: '>= 0.4.0'}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3177,10 +3134,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-goat@4.0.0:
-    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
-    engines: {node: '>=12'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -3379,10 +3332,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3433,10 +3382,6 @@ packages:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
 
-  global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
-
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -3448,9 +3393,6 @@ packages:
   got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
-
-  graceful-fs@4.2.10:
-    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -3573,10 +3515,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   ini@4.1.3:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3657,11 +3595,6 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-in-ci@1.0.0:
-    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
     engines: {node: '>=20'}
@@ -3670,10 +3603,6 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
-
-  is-installed-globally@1.0.0:
-    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
-    engines: {node: '>=18'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3686,10 +3615,6 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
-  is-npm@6.1.0:
-    resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -3697,10 +3622,6 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3917,14 +3838,6 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
-
-  ky@1.14.3:
-    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
-    engines: {node: '>=18'}
-
-  latest-version@9.0.0:
-    resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
-    engines: {node: '>=18'}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -4360,10 +4273,6 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json@10.0.1:
-    resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
-    engines: {node: '>=18'}
-
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -4596,10 +4505,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pupa@3.3.0:
-    resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
-    engines: {node: '>=12.20'}
-
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
 
@@ -4617,10 +4522,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   read-binary-file-arch@1.0.6:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
@@ -4667,14 +4568,6 @@ packages:
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
     engines: {node: '>=4'}
-
-  registry-auth-token@5.1.1:
-    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
-    engines: {node: '>=14'}
-
-  registry-url@6.0.1:
-    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
-    engines: {node: '>=12'}
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
@@ -5110,10 +5003,6 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -5167,19 +5056,9 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  stubborn-fs@2.0.0:
-    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
-
-  stubborn-utils@1.0.2:
-    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   subsume@4.0.0:
     resolution: {integrity: sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==}
@@ -5388,10 +5267,6 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
-
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
@@ -5549,10 +5424,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  update-notifier@7.3.1:
-    resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
-    engines: {node: '>=18'}
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -5760,9 +5631,6 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
-  when-exit@2.1.5:
-    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
-
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -5798,10 +5666,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  widest-line@5.0.0:
-    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
-    engines: {node: '>=18'}
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
@@ -5867,10 +5731,6 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5893,10 +5753,6 @@ packages:
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
-
-  xdg-basedir@5.1.0:
-    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
-    engines: {node: '>=12'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -7421,18 +7277,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pnpm/config.env-replace@1.1.0': {}
-
-  '@pnpm/network.ca-file@1.0.2':
-    dependencies:
-      graceful-fs: 4.2.10
-
-  '@pnpm/npm-conf@3.0.2':
-    dependencies:
-      '@pnpm/config.env-replace': 1.1.0
-      '@pnpm/network.ca-file': 1.0.2
-      config-chain: 1.1.13
-
   '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.2.2':
@@ -8061,10 +7905,6 @@ snapshots:
 
   animate.css@4.1.1: {}
 
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -8185,11 +8025,6 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  atomically@2.1.1:
-    dependencies:
-      stubborn-fs: 2.0.0
-      when-exit: 2.1.5
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -8249,17 +8084,6 @@ snapshots:
     optional: true
 
   bootstrap-icons@1.13.1: {}
-
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
 
   bplist-creator@0.1.0:
     dependencies:
@@ -8368,8 +8192,6 @@ snapshots:
       pascal-case: 3.1.2
       tslib: 2.8.1
 
-  camelcase@8.0.0: {}
-
   caniuse-lite@1.0.30001797: {}
 
   ccount@2.0.1: {}
@@ -8406,8 +8228,6 @@ snapshots:
   clean-css@5.3.3:
     dependencies:
       source-map: 0.6.1
-
-  cli-boxes@3.0.0: {}
 
   cli-highlight@2.1.11:
     dependencies:
@@ -8494,13 +8314,6 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
-  configstore@7.1.0:
-    dependencies:
-      atomically: 2.1.1
-      dot-prop: 9.0.0
-      graceful-fs: 4.2.11
-      xdg-basedir: 5.1.0
-
   constantinople@4.0.1:
     dependencies:
       '@babel/parser': 7.29.7
@@ -8585,8 +8398,6 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-extend@0.6.0: {}
-
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -8656,10 +8467,6 @@ snapshots:
   dot-prop@10.2.0:
     dependencies:
       type-fest: 5.8.0
-
-  dot-prop@9.0.0:
-    dependencies:
-      type-fest: 4.41.0
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -8754,8 +8561,6 @@ snapshots:
   elementtree@0.1.7:
     dependencies:
       sax: 1.1.4
-
-  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -8865,8 +8670,6 @@ snapshots:
     optional: true
 
   escalade@3.2.0: {}
-
-  escape-goat@4.0.0: {}
 
   escape-html@1.0.3: {}
 
@@ -9068,8 +8871,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.6.0: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9150,10 +8951,6 @@ snapshots:
       serialize-error: 7.0.1
     optional: true
 
-  global-directory@4.0.1:
-    dependencies:
-      ini: 4.1.1
-
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -9174,8 +8971,6 @@ snapshots:
       lowercase-keys: 2.0.0
       p-cancelable: 2.1.1
       responselike: 2.0.1
-
-  graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
 
@@ -9311,8 +9106,6 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ini@4.1.1: {}
-
   ini@4.1.3: {}
 
   internal-slot@1.1.0:
@@ -9398,18 +9191,11 @@ snapshots:
       is-extglob: 2.1.1
     optional: true
 
-  is-in-ci@1.0.0: {}
-
   is-in-ssh@1.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
-
-  is-installed-globally@1.0.0:
-    dependencies:
-      global-directory: 4.0.1
-      is-path-inside: 4.0.0
 
   is-map@2.0.3: {}
 
@@ -9417,16 +9203,12 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
-  is-npm@6.1.0: {}
-
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-obj@1.0.1: {}
-
-  is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -9629,12 +9411,6 @@ snapshots:
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
-
-  ky@1.14.3: {}
-
-  latest-version@9.0.0:
-    dependencies:
-      package-json: 10.0.1
 
   lazy-val@1.0.5: {}
 
@@ -10077,13 +9853,6 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json@10.0.1:
-    dependencies:
-      ky: 1.14.3
-      registry-auth-token: 5.1.1
-      registry-url: 6.0.1
-      semver: 7.8.5
-
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -10329,10 +10098,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pupa@3.3.0:
-    dependencies:
-      escape-goat: 4.0.0
-
   pvtsutils@1.3.6:
     dependencies:
       tslib: 2.8.1
@@ -10344,13 +10109,6 @@ snapshots:
   quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   read-binary-file-arch@1.0.6:
     dependencies:
@@ -10422,14 +10180,6 @@ snapshots:
       regjsparser: 0.13.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.1
-
-  registry-auth-token@5.1.1:
-    dependencies:
-      '@pnpm/npm-conf': 3.0.2
-
-  registry-url@6.0.1:
-    dependencies:
-      rc: 1.2.8
 
   regjsgen@0.8.0: {}
 
@@ -10903,12 +10653,6 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.9
@@ -10984,15 +10728,7 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strip-json-comments@2.0.1: {}
-
   strip-json-comments@3.1.1: {}
-
-  stubborn-fs@2.0.0:
-    dependencies:
-      stubborn-utils: 1.0.2
-
-  stubborn-utils@1.0.2: {}
 
   subsume@4.0.0:
     dependencies:
@@ -11181,8 +10917,6 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.41.0: {}
-
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -11335,19 +11069,6 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-notifier@7.3.1:
-    dependencies:
-      boxen: 8.0.1
-      chalk: 5.6.2
-      configstore: 7.1.0
-      is-in-ci: 1.0.0
-      is-installed-globally: 1.0.0
-      is-npm: 6.1.0
-      latest-version: 9.0.0
-      pupa: 3.3.0
-      semver: 7.8.5
-      xdg-basedir: 5.1.0
 
   utf8-byte-length@1.0.5: {}
 
@@ -11676,8 +11397,6 @@ snapshots:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
 
-  when-exit@2.1.5: {}
-
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -11735,10 +11454,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
 
   wildcard@2.0.1: {}
 
@@ -11874,12 +11589,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
@@ -11893,8 +11602,6 @@ snapshots:
     dependencies:
       simple-plist: 1.3.1
       uuid: 7.0.3
-
-  xdg-basedir@5.1.0: {}
 
   xml-name-validator@5.0.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - utils/art
   - utils/render-ssr-error
   - utils/ssl-certificate
+  - utils/update-notifier
   - docs
 
 # The packages below are not included. Use their individual folders.

--- a/utils/update-notifier/README.md
+++ b/utils/update-notifier/README.md
@@ -1,0 +1,29 @@
+![Quasar Framework logo](https://cdn.quasar.dev/logo-v2/header.png)
+
+# Quasar Update Notifier
+
+> **Used internally by Quasar CLI(s).**
+
+<img src="https://img.shields.io/npm/v/%40quasar/update-notifier.svg?label=@quasar/update-notifier">
+
+## Chat Support
+
+Ask questions at the official community Discord server: [https://chat.quasar.dev](https://chat.quasar.dev)
+
+## Community Forum
+
+Ask questions at the official community forum: [https://forum.quasar.dev](https://forum.quasar.dev)
+
+## Contributing
+
+I'm excited if you want to contribute to Quasar under any form (report bugs, write a plugin, fix an issue, write a new feature). Please read the [Contributing Guide](../../CONTRIBUTING.md).
+
+## Semver
+
+Quasar is following [Semantic Versioning 2.0](https://semver.org/).
+
+## License
+
+Copyright (c) 2026-present Razvan Stoenescu
+
+[MIT License](http://en.wikipedia.org/wiki/MIT_License)

--- a/utils/update-notifier/README.md
+++ b/utils/update-notifier/README.md
@@ -4,7 +4,7 @@
 
 > **Used internally by Quasar CLI(s).**
 
-<img src="https://img.shields.io/npm/v/%40quasar/update-notifier.svg?label=@quasar/update-notifier">
+<img alt="@quasar/update-notifier npm version" src="https://img.shields.io/npm/v/%40quasar/update-notifier.svg?label=@quasar/update-notifier">
 
 ## Chat Support
 

--- a/utils/update-notifier/package.json
+++ b/utils/update-notifier/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@quasar/update-notifier",
+  "version": "1.0.0",
+  "description": "Dependency-free update notifier for Quasar CLI(s)",
+  "homepage": "https://quasar.dev",
+  "bugs": "https://github.com/quasarframework/quasar/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Razvan Stoenescu",
+    "email": "razvan.stoenescu@gmail.com",
+    "url": "https://github.com/quasarframework"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/quasarframework/quasar"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://donate.quasar.dev"
+  },
+  "files": [
+    "src"
+  ],
+  "type": "module",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "exports": "./src/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "node --test test/index.test.js"
+  },
+  "engines": {
+    "node": ">= 20"
+  }
+}

--- a/utils/update-notifier/src/index.js
+++ b/utils/update-notifier/src/index.js
@@ -1,0 +1,1 @@
+export { notifyUpdate } from './internal.js'

--- a/utils/update-notifier/src/internal.js
+++ b/utils/update-notifier/src/internal.js
@@ -148,6 +148,14 @@ export async function checkForUpdate({ cacheFile, name, version }) {
   })
 }
 
+function startBackgroundCheck(cacheFile, name, version) {
+  spawn(
+    process.execPath,
+    [fileURLToPath(moduleUrl), backgroundCheckFlag, cacheFile, name, version],
+    { detached: true, stdio: 'ignore' }
+  ).unref()
+}
+
 export function notifyUpdate({ name, version }) {
   if (!name || !version || isDisabled()) return
 
@@ -157,14 +165,11 @@ export function notifyUpdate({ name, version }) {
 
   if (!cache) {
     writeCache(cacheFile, { checkedAt: now })
+    startBackgroundCheck(cacheFile, name, version)
     return
   }
 
   const latest = cache.latest
-  if (latest !== void 0) {
-    writeCache(cacheFile, { checkedAt: cache.checkedAt })
-  }
-
   if (
     process.stdout.isTTY &&
     process.env.npm_lifecycle_event === void 0 &&
@@ -176,15 +181,12 @@ export function notifyUpdate({ name, version }) {
       name
     })
     process.once('exit', () => console.error(`\n${message}\n`))
+    writeCache(cacheFile, { checkedAt: cache.checkedAt })
   }
 
   if (now - cache.checkedAt < checkInterval) return
 
-  spawn(
-    process.execPath,
-    [fileURLToPath(moduleUrl), backgroundCheckFlag, cacheFile, name, version],
-    { detached: true, stdio: 'ignore' }
-  ).unref()
+  startBackgroundCheck(cacheFile, name, version)
 }
 
 if (process.argv[2] === backgroundCheckFlag) {

--- a/utils/update-notifier/src/internal.js
+++ b/utils/update-notifier/src/internal.js
@@ -1,0 +1,202 @@
+import { spawn } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const backgroundCheckFlag = '--quasar-update-notifier-check'
+const checkInterval = 24 * 60 * 60 * 1000
+const moduleUrl = import.meta.url
+
+function getCacheFile(packageName) {
+  const cacheDir =
+    process.env.XDG_CACHE_HOME ||
+    process.env.LOCALAPPDATA ||
+    join(homedir(), '.cache')
+
+  return join(
+    cacheDir,
+    'quasar',
+    'update-notifier',
+    `${encodeURIComponent(packageName)}.json`
+  )
+}
+
+function readCache(cacheFile) {
+  try {
+    return JSON.parse(readFileSync(cacheFile, 'utf8'))
+  } catch {
+    return void 0
+  }
+}
+
+function writeCache(cacheFile, value) {
+  try {
+    mkdirSync(dirname(cacheFile), { recursive: true })
+    writeFileSync(cacheFile, JSON.stringify(value))
+  } catch {
+    // An update check must never interfere with the command being run.
+  }
+}
+
+function parseVersion(version) {
+  if (typeof version !== 'string') return void 0
+
+  const match = version.match(
+    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?(?:\+[\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*)?$/
+  )
+
+  if (!match) return void 0
+
+  return {
+    core: match.slice(1, 4),
+    prerelease: match[4]?.split('.')
+  }
+}
+
+function compareNumeric(left, right) {
+  if (left.length !== right.length) return left.length > right.length
+  return left > right
+}
+
+export function isNewerVersion(latest, current) {
+  const next = parseVersion(latest)
+  const installed = parseVersion(current)
+
+  if (!next || !installed) return false
+
+  for (let index = 0; index < 3; index++) {
+    if (next.core[index] !== installed.core[index]) {
+      return compareNumeric(next.core[index], installed.core[index])
+    }
+  }
+
+  if (!next.prerelease) return installed.prerelease !== void 0
+  if (!installed.prerelease) return false
+
+  const length = Math.max(next.prerelease.length, installed.prerelease.length)
+
+  for (let index = 0; index < length; index++) {
+    const nextId = next.prerelease[index]
+    const installedId = installed.prerelease[index]
+
+    if (nextId === installedId) continue
+    if (nextId === void 0) return false
+    if (installedId === void 0) return true
+
+    const nextIsNumber = /^\d+$/.test(nextId)
+    const installedIsNumber = /^\d+$/.test(installedId)
+
+    if (nextIsNumber && installedIsNumber) {
+      return compareNumeric(nextId, installedId)
+    }
+
+    if (nextIsNumber !== installedIsNumber) return installedIsNumber
+
+    return nextId > installedId
+  }
+
+  return false
+}
+
+export function renderNotification({ current, latest, name }) {
+  const command = `npm i -g ${name}`
+  const firstLine = `Update available ${current} → ${latest}`
+  const secondLine = `Run ${command} to update`
+  const contentWidth = Math.max(firstLine.length, secondLine.length)
+  const border = '─'.repeat(contentWidth + 2)
+  const line = value => `│ ${value.padEnd(contentWidth)} │`
+
+  return [`╭${border}╮`, line(firstLine), line(secondLine), `╰${border}╯`].join(
+    '\n'
+  )
+}
+
+function isDisabled() {
+  const ci = process.env.CI
+
+  return (
+    'NO_UPDATE_NOTIFIER' in process.env ||
+    process.env.NODE_ENV === 'test' ||
+    (ci !== void 0 && ci !== '' && ci !== '0' && ci !== 'false') ||
+    process.argv.includes('--no-update-notifier')
+  )
+}
+
+export async function checkForUpdate({ cacheFile, name, version }) {
+  const registry = new URL(
+    process.env.npm_config_registry || 'https://registry.npmjs.org'
+  )
+  if (!registry.pathname.endsWith('/')) registry.pathname += '/'
+
+  const packagePath = encodeURIComponent(name)
+  const url = new URL(`-/package/${packagePath}/dist-tags`, registry)
+  const response = await fetch(url, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(30_000)
+  })
+
+  if (!response.ok) {
+    throw new Error(`Registry responded with ${response.status}`)
+  }
+
+  const { latest } = await response.json()
+
+  writeCache(cacheFile, {
+    checkedAt: Date.now(),
+    latest: isNewerVersion(latest, version) ? latest : void 0
+  })
+}
+
+export function notifyUpdate({ name, version }) {
+  if (!name || !version || isDisabled()) return
+
+  const cacheFile = getCacheFile(name)
+  const cache = readCache(cacheFile)
+  const now = Date.now()
+
+  if (!cache) {
+    writeCache(cacheFile, { checkedAt: now })
+    return
+  }
+
+  const latest = cache.latest
+  if (latest !== void 0) {
+    writeCache(cacheFile, { checkedAt: cache.checkedAt })
+  }
+
+  if (
+    process.stdout.isTTY &&
+    process.env.npm_lifecycle_event === void 0 &&
+    isNewerVersion(latest, version)
+  ) {
+    const message = renderNotification({
+      current: version,
+      latest,
+      name
+    })
+    process.once('exit', () => console.error(`\n${message}\n`))
+  }
+
+  if (now - cache.checkedAt < checkInterval) return
+
+  spawn(
+    process.execPath,
+    [fileURLToPath(moduleUrl), backgroundCheckFlag, cacheFile, name, version],
+    { detached: true, stdio: 'ignore' }
+  ).unref()
+}
+
+if (process.argv[2] === backgroundCheckFlag) {
+  const cacheFile = process.argv[3]
+  const name = process.argv[4]
+  const version = process.argv[5]
+
+  try {
+    await checkForUpdate({ cacheFile, name, version })
+  } catch {
+    // A background update check failing does not need to be reported.
+  }
+
+  process.exit()
+}

--- a/utils/update-notifier/test/index.test.js
+++ b/utils/update-notifier/test/index.test.js
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+import {
+  checkForUpdate,
+  isNewerVersion,
+  notifyUpdate,
+  renderNotification
+} from '../src/internal.js'
+
+const versionComparisons = [
+  ['2.0.0', '1.0.0', true],
+  ['1.1.0', '1.0.9', true],
+  ['1.0.1', '1.0.0', true],
+  ['1.0.0', '1.0.0', false],
+  ['1.0.0', '2.0.0', false],
+  ['1.0.0', '1.0.0-beta.1', true],
+  ['1.0.0-beta.2', '1.0.0-beta.1', true],
+  ['1.0.0-beta.10', '1.0.0-beta.2', true],
+  ['1.0.0-beta', '1.0.0-1', true],
+  ['1.0.0-beta.1', '1.0.0-beta', true],
+  ['1.0.0+new', '1.0.0+old', false],
+  ['100000000000000000000.0.0', '99999999999999999999.0.0', true],
+  [void 0, '1.0.0', false],
+  ['not-semver', '1.0.0', false]
+]
+
+test('exposes only the notifier as public API', async () => {
+  const publicApi = await import('../src/index.js')
+  assert.deepEqual(Object.keys(publicApi), ['notifyUpdate'])
+})
+
+test('compares SemVer versions', () => {
+  for (const [latest, current, expected] of versionComparisons) {
+    assert.equal(
+      isNewerVersion(latest, current),
+      expected,
+      `${latest} > ${current}`
+    )
+  }
+})
+
+test('renders a dependency-free update message', () => {
+  assert.equal(
+    renderNotification({
+      current: '1.0.0',
+      latest: '2.0.0',
+      name: '@quasar/cli'
+    }),
+    [
+      '╭────────────────────────────────────╮',
+      '│ Update available 1.0.0 → 2.0.0     │',
+      '│ Run npm i -g @quasar/cli to update │',
+      '╰────────────────────────────────────╯'
+    ].join('\n')
+  )
+})
+
+test('checks the configured registry and caches an available update', async t => {
+  const directory = await mkdtemp(join(tmpdir(), 'quasar-update-notifier-'))
+  const cacheFile = join(directory, 'cache.json')
+  let requestedUrl
+  const server = createServer((request, response) => {
+    requestedUrl = request.url
+    response.setHeader('content-type', 'application/json')
+    response.end('{"latest":"2.0.0"}')
+  })
+
+  t.after(async () => {
+    await new Promise(resolve => {
+      server.close(resolve)
+    })
+    await rm(directory, { recursive: true })
+  })
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const { port } = server.address()
+  const previousRegistry = process.env.npm_config_registry
+  process.env.npm_config_registry = `http://127.0.0.1:${port}/registry`
+
+  try {
+    await checkForUpdate({
+      cacheFile,
+      name: '@quasar/cli',
+      version: '1.0.0'
+    })
+  } finally {
+    if (previousRegistry === void 0) {
+      delete process.env.npm_config_registry
+    } else {
+      process.env.npm_config_registry = previousRegistry
+    }
+  }
+
+  assert.equal(requestedUrl, '/registry/-/package/%40quasar%2Fcli/dist-tags')
+  assert.equal(JSON.parse(await readFile(cacheFile, 'utf8')).latest, '2.0.0')
+})
+
+test('consumes a cached update after one invocation', async t => {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'quasar-update-notifier-'))
+  const cacheDirectory = join(cacheRoot, 'quasar', 'update-notifier')
+  const cacheFile = join(cacheDirectory, '%40quasar%2Ftest.json')
+  const previousCacheHome = process.env.XDG_CACHE_HOME
+
+  t.after(async () => {
+    if (previousCacheHome === void 0) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = previousCacheHome
+    }
+
+    await rm(cacheRoot, { recursive: true })
+  })
+
+  await mkdir(cacheDirectory, { recursive: true })
+  await writeFile(
+    cacheFile,
+    JSON.stringify({ checkedAt: Date.now(), latest: '2.0.0' })
+  )
+  process.env.XDG_CACHE_HOME = cacheRoot
+
+  notifyUpdate({ name: '@quasar/test', version: '1.0.0' })
+
+  const cache = JSON.parse(await readFile(cacheFile, 'utf8'))
+  assert.equal(typeof cache.checkedAt, 'number')
+  assert.equal('latest' in cache, false)
+})

--- a/utils/update-notifier/test/index.test.js
+++ b/utils/update-notifier/test/index.test.js
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 import { test } from 'node:test'
 
 import {
@@ -11,6 +14,34 @@ import {
   notifyUpdate,
   renderNotification
 } from '../src/internal.js'
+
+const execFileAsync = promisify(execFile)
+const notifierEnvironmentKeys = [
+  'CI',
+  'NODE_ENV',
+  'NO_UPDATE_NOTIFIER',
+  'npm_lifecycle_event'
+]
+
+function enableNotifier(t) {
+  const previous = Object.fromEntries(
+    notifierEnvironmentKeys.map(key => [key, process.env[key]])
+  )
+
+  for (const key of notifierEnvironmentKeys) {
+    delete process.env[key]
+  }
+
+  t.after(() => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === void 0) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+}
 
 const versionComparisons = [
   ['2.0.0', '1.0.0', true],
@@ -102,7 +133,75 @@ test('checks the configured registry and caches an available update', async t =>
   assert.equal(JSON.parse(await readFile(cacheFile, 'utf8')).latest, '2.0.0')
 })
 
-test('consumes a cached update after one invocation', async t => {
+test('starts the first update check immediately', async t => {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'quasar-update-notifier-'))
+  const cacheFile = join(
+    cacheRoot,
+    'quasar',
+    'update-notifier',
+    '%40quasar%2Ftest.json'
+  )
+  const server = createServer((request, response) => {
+    response.setHeader('content-type', 'application/json')
+    response.end('{"latest":"2.0.0"}')
+  })
+
+  t.after(async () => {
+    await new Promise(resolve => {
+      server.close(resolve)
+    })
+    await rm(cacheRoot, { recursive: true })
+  })
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const environment = {
+    ...process.env,
+    XDG_CACHE_HOME: cacheRoot,
+    npm_config_registry: `http://127.0.0.1:${server.address().port}/`
+  }
+  delete environment.CI
+  delete environment.NODE_ENV
+  delete environment.NO_UPDATE_NOTIFIER
+  delete environment.npm_lifecycle_event
+
+  const notifierUrl = pathToFileURL(
+    join(import.meta.dirname, '../src/index.js')
+  ).href
+  await execFileAsync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `import { notifyUpdate } from '${notifierUrl}'; notifyUpdate({ name: '@quasar/test', version: '1.0.0' })`
+    ],
+    { env: environment }
+  )
+
+  let cache
+  const timeout = Date.now() + 5000
+
+  while (Date.now() < timeout) {
+    try {
+      cache = JSON.parse(await readFile(cacheFile, 'utf8'))
+      if (cache.latest === '2.0.0') break
+    } catch {
+      // The detached check may not have written its result yet.
+    }
+
+    await new Promise(resolve => {
+      setTimeout(resolve, 25)
+    })
+  }
+
+  assert.equal(cache?.latest, '2.0.0')
+})
+
+test('preserves a cached update when notification output is suppressed', async t => {
+  enableNotifier(t)
+
   const cacheRoot = await mkdtemp(join(tmpdir(), 'quasar-update-notifier-'))
   const cacheDirectory = join(cacheRoot, 'quasar', 'update-notifier')
   const cacheFile = join(cacheDirectory, '%40quasar%2Ftest.json')
@@ -124,6 +223,50 @@ test('consumes a cached update after one invocation', async t => {
     JSON.stringify({ checkedAt: Date.now(), latest: '2.0.0' })
   )
   process.env.XDG_CACHE_HOME = cacheRoot
+
+  notifyUpdate({ name: '@quasar/test', version: '1.0.0' })
+
+  const cache = JSON.parse(await readFile(cacheFile, 'utf8'))
+  assert.equal(typeof cache.checkedAt, 'number')
+  assert.equal(cache.latest, '2.0.0')
+})
+
+test('consumes a cached update when its notification is scheduled', async t => {
+  enableNotifier(t)
+
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'quasar-update-notifier-'))
+  const cacheDirectory = join(cacheRoot, 'quasar', 'update-notifier')
+  const cacheFile = join(cacheDirectory, '%40quasar%2Ftest.json')
+  const previousCacheHome = process.env.XDG_CACHE_HOME
+  const previousIsTTY = process.stdout.isTTY
+
+  t.after(async () => {
+    if (previousCacheHome === void 0) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = previousCacheHome
+    }
+
+    if (previousIsTTY === void 0) {
+      delete process.stdout.isTTY
+    } else {
+      process.stdout.isTTY = previousIsTTY
+    }
+
+    await rm(cacheRoot, { recursive: true })
+  })
+
+  await mkdir(cacheDirectory, { recursive: true })
+  await writeFile(
+    cacheFile,
+    JSON.stringify({ checkedAt: Date.now(), latest: '2.0.0' })
+  )
+  process.env.XDG_CACHE_HOME = cacheRoot
+  process.stdout.isTTY = true
+  t.mock.method(process, 'once', event => {
+    assert.equal(event, 'exit')
+    return process
+  })
 
   notifyUpdate({ name: '@quasar/test', version: '1.0.0' })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It is submitted to the dev branch (or v[X] branch)
- [ ] When resolving a specific issue, it is referenced in the PR title
- [ ] It has been tested on a Cordova (iOS, Android) app
- [ ] It has been tested on an Electron app
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR description.

If adding a **new feature**, the PR description includes:

- [x] A convincing reason for adding this feature. Discussion #18497 contains the original dependency analysis.

**Other information:**

This addresses the dependency concern raised in discussion #18497 without introducing duplicated source or relying on a third-party replacement.

The new @quasar/update-notifier package follows the same model as Quasar internal packages such as @quasar/art and @quasar/ssl-certificate: it is independently publishable from the monorepo but identified as used internally by Quasar CLI(s). It is not intended to require a public community release announcement.

The package has no runtime dependencies and exposes one public function, notifyUpdate. @quasar/cli, create-quasar, and @quasar/icongenie all consume that single implementation. The notifier provides daily cached checks, detached registry requests that do not delay commands, one-shot terminal notifications, SemVer comparison, custom registry support, and opt-outs for CI, npm scripts, tests, and explicit environment or CLI flags.

Publishing order: @quasar/update-notifier@1.0.0 must be published before releasing updated CLI consumers. IconGenie remains outside the root pnpm workspace and therefore declares the published ^1.0.0 dependency directly.

This removes update-notifier and its transitive dependency chain from the workspace lockfile. There are no SSR, hydration, platform, accessibility, or security contract changes. No quasar.dev documentation is needed because this remains internal CLI behavior; the package README labels it accordingly.

Validation:

- pnpm lint
- pnpm --filter @quasar/update-notifier test (5 tests passed)
- pnpm test (260 UI files / 5,156 tests plus all Vite plugin usage and runtime suites passed)
- isolated npm installation of packed @quasar/update-notifier, @quasar/cli, create-quasar, and @quasar/icongenie artifacts
- packed CLI smoke tests: quasar 5.0.4, create-quasar 5.0.9, and icongenie 6.1.2
- verified the published export surface contains only notifyUpdate
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update notifications across Quasar command-line tools.
  * Notifications detect newer versions and display them when appropriate.
  * Added cached and background update checks with configurable registry support.

* **Documentation**
  * Added documentation covering usage, support, contributions, licensing, and versioning.

* **Tests**
  * Added coverage for version comparisons, notification rendering, registry checks, caching, and notification conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->