### PR TITLE
fix(app-vite): deadlock in dev with circular dependencies

### DIFF
--- a/app-vite/lib/plugins/rolldown.virtual-entry.js
+++ b/app-vite/lib/plugins/rolldown.virtual-entry.js
@@ -1,5 +1,7 @@
 import path from 'node:path'
 
+const escapeRE = str => str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+
 export function quasarRolldownVirtualEntry({
   inputFile,
   targetFile,
@@ -9,38 +11,49 @@ export function quasarRolldownVirtualEntry({
     .relative(path.dirname(inputFile), targetFile)
     .replaceAll('\\', '/')
 
+  const bootstrapFile = `\0quasar:virtual-entry-bootstrap:${inputFile}`
+
   /**
    * Static ESM imports evaluate dependencies before the importing module's
-   * body. Use a dynamic import when bootstrap code must run before the target,
-   * while preserving the existing static import for all other entries.
+   * body, and in source order. Bootstrap code therefore gets a module of its
+   * own, so that it still runs before the target while both are imported
+   * statically.
+   *
+   * A dynamic import would give the same ordering, but it makes Rolldown defer
+   * the whole target graph into async module initializers, which deadlock when
+   * the app has circular imports.
    */
   const code =
     beforeImportCode === void 0
       ? `import './${importPath}'`
-      : `${beforeImportCode}\n\nawait import('./${importPath}')`
+      : `import ${JSON.stringify(bootstrapFile)}\nimport './${importPath}'`
 
-  // native (Rust-side) filtering: only the virtual entry itself
-  // reaches the JS handlers
-  const inputFileRE = new RegExp(
-    `^${inputFile.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}$`
+  // native (Rust-side) filtering: only the virtual entry and its bootstrap
+  // module reach the JS handlers
+  const idRE = new RegExp(
+    `^(${escapeRE(inputFile)}|${escapeRE(bootstrapFile)})$`
   )
 
   return {
     name: 'quasar:virtual-entry',
 
     resolveId: {
-      filter: { id: inputFileRE },
+      filter: { id: idRE },
 
       handler(source) {
-        return source === inputFile ? inputFile : null
+        return source === inputFile || source === bootstrapFile ? source : null
       }
     },
 
     load: {
-      filter: { id: inputFileRE },
+      filter: { id: idRE },
 
       handler(id) {
-        return id === inputFile ? code : null
+        if (id === inputFile) return code
+        if (id === bootstrapFile) {
+          return { code: beforeImportCode, moduleSideEffects: 'no-treeshake' }
+        }
+        return null
       }
     }
   }


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [x] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

**Other information:**

Since https://github.com/quasarframework/quasar/pull/18470 my macOS dev build has a deadlock. The virtual entry that adds `dock.setIcon` changes the app's main file to `await import()`. In turn, Rolldown defers the entire target graph into async module initializers (`__esmMin(async () => …)`). Those memoize the in-flight promise, so a circular import self-awaits and deadlocks permanently. In other words, the main process stays alive with an idle event loop, no window, no error, and no code from the app ever runs.

Circular imports are valid ESM and never deadlock natively: evaluation is synchronous depth-first and simply does not re-enter a module that is already evaluating (and my code worked fine before updating to rolldown). Prod builds are unaffected because they use a static entry.

One alternative would be to drop `beforeImportCode` and instead edit [electron-devserver.js](https://github.com/quasarframework/quasar/blob/dev/app-vite/lib/modes/electron/electron-devserver.js#L211-L212) to write a small bootstrap file that sets the icon. IMO this is a better solution, but requires more changes. Let me know what you prefer and I can make the change.

To reproduce the issue, add 2 files that import each other and run dev server.

Note: this was debugged, and parts of the fix were generated by Claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of virtual entry points to ensure bootstrap code executes reliably before the target module.
  * Fixed special-character handling in virtual entry identifiers.
  * Preserved required bootstrap code during module optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->