### PR TITLE
fix(QSelect): allow cancelling keyboard actions

### DIFF
--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -270,7 +270,7 @@ When QSelect is focused:
   - select the next option starting with that letter (after the current focused one) if the first key in buffer is typed multiple times
   - select the next option (starting with the current focused one) that matches the typed text (the match is fuzzy - the option label should start with the first letter and contain all the letters)
 
-You can prevent QSelect's action for a key by preventing its `keydown` event; for example, `@keydown.enter.prevent` keeps <kbd>ENTER</kbd> from opening the list of options.
+You can prevent QSelect's action for most keys by preventing its `keydown` event; for example, `@keydown.enter.prevent` keeps <kbd>ENTER</kbd> from opening the list of options. The exception is <kbd>ESC</kbd>, whose handling (closing the list of options) is tied to the `keyup` event and cannot be cancelled this way.
 
 When the list of options is opened:
 

--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -270,6 +270,8 @@ When QSelect is focused:
   - select the next option starting with that letter (after the current focused one) if the first key in buffer is typed multiple times
   - select the next option (starting with the current focused one) that matches the typed text (the match is fuzzy - the option label should start with the first letter and contain all the letters)
 
+You can prevent QSelect's action for a key by preventing its `keydown` event; for example, `@keydown.enter.prevent` keeps <kbd>ENTER</kbd> from opening the list of options.
+
 When the list of options is opened:
 
 - pressing <kbd>ARROW UP</kbd> or <kbd>ARROW DOWN</kbd> will navigate up or down in the list of options

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -759,7 +759,7 @@ export default /*#__PURE__*/ createComponent({
     function onTargetKeydown(e) {
       emit('keydown', e)
 
-      if (shouldIgnoreKey(e)) return
+      if (e.defaultPrevented === true || shouldIgnoreKey(e)) return
 
       const newValueModeValid =
         inputValue.value.length !== 0 &&

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -759,7 +759,7 @@ export default /*#__PURE__*/ createComponent({
     function onTargetKeydown(e) {
       emit('keydown', e)
 
-      if (e.defaultPrevented === true || shouldIgnoreKey(e)) return
+      if (shouldIgnoreKey(e) || e.defaultPrevented === true) return
 
       const newValueModeValid =
         inputValue.value.length !== 0 &&

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -759,7 +759,7 @@ export default /*#__PURE__*/ createComponent({
     function onTargetKeydown(e) {
       emit('keydown', e)
 
-      if (shouldIgnoreKey(e) || e.defaultPrevented === true) return
+      if (shouldIgnoreKey(e) || e.defaultPrevented) return
 
       const newValueModeValid =
         inputValue.value.length !== 0 &&

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -1391,6 +1391,28 @@ describe('[QSelect API]', () => {
         expect(input.attributes('aria-autocomplete')).toBe('list')
         expect(input.attributes('readonly')).toBeUndefined()
       })
+
+      test('preventing keydown cancels the internal keyboard handling', async () => {
+        const defaultWrapper = mountSelect({ useInput: true })
+
+        await defaultWrapper.get('input').trigger('keydown', { keyCode: 13 })
+        await flushPromises()
+
+        expect(defaultWrapper.findComponent({ name: 'QPortal' }).exists()).toBe(
+          true
+        )
+
+        const wrapper = mountSelect({
+          useInput: true,
+          onKeydown: evt => evt.preventDefault()
+        })
+
+        await wrapper.get('input').trigger('keydown', { keyCode: 13 })
+        await flushPromises()
+
+        expect(wrapper.emitted('keydown')).toHaveLength(1)
+        expect(wrapper.findComponent({ name: 'QPortal' }).exists()).toBe(false)
+      })
     })
 
     describe('[(prop)maxlength]', () => {

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -1398,8 +1398,8 @@ describe('[QSelect API]', () => {
         await defaultWrapper.get('input').trigger('keydown', { keyCode: 13 })
         await flushPromises()
 
-        expect(defaultWrapper.findComponent({ name: 'QPortal' }).exists()).toBe(
-          true
+        expect(defaultWrapper.get('input').attributes('aria-expanded')).toBe(
+          'true'
         )
 
         const wrapper = mountSelect({
@@ -1411,7 +1411,18 @@ describe('[QSelect API]', () => {
         await flushPromises()
 
         expect(wrapper.emitted('keydown')).toHaveLength(1)
-        expect(wrapper.findComponent({ name: 'QPortal' }).exists()).toBe(false)
+        expect(wrapper.get('input').attributes('aria-expanded')).toBe('false')
+
+        wrapper.vm.showPopup()
+        await flushPromises()
+        wrapper.vm.setOptionIndex(1)
+
+        await wrapper.get('input').trigger('keydown', { keyCode: 13 })
+        await flushPromises()
+
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+        expect(wrapper.vm.getOptionIndex()).toBe(1)
+        expect(wrapper.get('input').attributes('aria-expanded')).toBe('true')
       })
     })
 


### PR DESCRIPTION
## Summary

- respect cancellation of QSelect's emitted `keydown` event before applying internal keyboard actions
- preserve the existing Enter behavior when consumers do not prevent the event
- document how to keep Enter from opening the options list

## Root cause

QSelect emitted its `keydown` event synchronously, but continued processing the key even when a consumer called `preventDefault()`. This meant an application could observe Enter but could not cancel QSelect's built-in open/select behavior.

## User impact

Consumers can now use handlers such as `@keydown.enter.prevent` to opt out of QSelect's Enter action without requiring a new component prop. Existing behavior is unchanged unless the event is explicitly prevented.

## Validation

- `cd ui && pnpm build`
- `cd ui && pnpm test QSelect` (200 tests passed)
- `cd ui && pnpm test:specs --target components/select/QSelect`
- `pnpm test` (all workspace suites passed)
- `pnpm lint`
- `git diff --check`

Related to https://github.com/quasarframework/quasar/discussions/18506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QSelect now respects prevented keyboard events, allowing custom handlers to cancel built-in actions such as opening the popup or confirming a focused option with Enter.
  * Prevented actions no longer update the selected value, while the focused option remains unchanged.

* **Documentation**
  * Added guidance and an example for preventing QSelect keyboard actions with `keydown` event modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->