### PR TITLE
docs: update UI extension links

### DIFF
--- a/docs/src/assets/links.integrations.js
+++ b/docs/src/assets/links.integrations.js
@@ -89,12 +89,12 @@ export const ecosystemParts = [
       {
         label: 'QMarkdown',
         icon: mdiLanguageMarkdown,
-        path: 'https://github.com/quasarframework/app-extension-qmarkdown'
+        path: 'https://github.com/quasarframework/quasar-ui-qmarkdown'
       },
       {
         label: 'QMediaPlayer',
         icon: mdiTelevisionPlay,
-        path: 'https://github.com/quasarframework/app-extension-qmediaplayer'
+        path: 'https://github.com/quasarframework/quasar-ui-qmediaplayer'
       },
       {
         label: 'All AEs',

--- a/docs/src/pages/app-extensions/discover.md
+++ b/docs/src/pages/app-extensions/discover.md
@@ -24,15 +24,14 @@ Below is a list of official app-extensions created by members of the Quasar team
 
 ### Components
 
-| Alias                                                                                       | Description                                                                                                               |
-| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [@quasar/qmediaplayer](https://github.com/quasarframework/app-extension-qmediaplayer)       | HTML5 video and audio player                                                                                              |
-| [@quasar/qflashcard](https://github.com/quasarframework/app-extension-qflashcard)           | Show some information and reveal more with CSS Transition Mashups                                                         |
-| [@quasar/qoverlay](https://github.com/quasarframework/app-extension-qoverlay)               | Overlays simplified. Add any component on top of the overlay                                                              |
-| [@quasar/qactivity](https://github.com/quasarframework/app-extension-qactivity)             | Create activity timelines                                                                                                 |
-| [@quasar/qmarkdown](https://github.com/quasarframework/quasar-ui-qmarkdown)                 | Markdown for your pages                                                                                                   |
-| [@quasar/qpdfviewer](https://github.com/quasarframework/app-extension-qpdfviewer/tree/next) | View PDF documents in your Quasar app                                                                                     |
-| [@quasar/qcalendar](https://github.com/quasarframework/quasar-ui-qcalendar)                 | Calendar for Quasar                                                                                                       |
-| [@quasar/qscroller](https://github.com/quasarframework/app-extension-qscroller)             | Many scrolling components, including QScroller, QTimeScroller, QDateScroller, QDateTimeScroller and scrolling time ranges |
-| [@quasar/qwindow](https://github.com/quasarframework/app-extension-qwindow)                 | Floating, movable, resizable interactive windows for Quasar                                                               |
-| [@quasar/qiconpicker](https://github.com/quasarframework/quasar-ui-qiconpicker)             | Icon Picker for your Quasar apps                                                                                          |
+| Alias                                                                             | Description                                                                                                               |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [@quasar/qmediaplayer](https://github.com/quasarframework/quasar-ui-qmediaplayer) | HTML5 video and audio player                                                                                              |
+| [@quasar/qflashcard](https://github.com/quasarframework/quasar-ui-qflashcard)     | Show some information and reveal more with CSS Transition Mashups                                                         |
+| [@quasar/qoverlay](https://github.com/quasarframework/quasar-ui-qoverlay)         | Overlays simplified. Add any component on top of the overlay                                                              |
+| [@quasar/qactivity](https://github.com/quasarframework/quasar-ui-qactivity)       | Create activity timelines                                                                                                 |
+| [@quasar/qmarkdown](https://github.com/quasarframework/quasar-ui-qmarkdown)       | Markdown for your pages                                                                                                   |
+| [@quasar/qcalendar](https://github.com/quasarframework/quasar-ui-qcalendar)       | Calendar for Quasar                                                                                                       |
+| [@quasar/qscroller](https://github.com/quasarframework/quasar-ui-qscroller)       | Many scrolling components, including QScroller, QTimeScroller, QDateScroller, QDateTimeScroller and scrolling time ranges |
+| [@quasar/qwindow](https://github.com/quasarframework/quasar-ui-qwindow)           | Floating, movable, resizable interactive windows for Quasar                                                               |
+| [@quasar/qiconpicker](https://github.com/quasarframework/quasar-ui-qiconpicker)   | Icon Picker for your Quasar apps                                                                                          |

--- a/docs/src/pages/app-extensions/discover.md
+++ b/docs/src/pages/app-extensions/discover.md
@@ -24,14 +24,14 @@ Below is a list of official app-extensions created by members of the Quasar team
 
 ### Components
 
-| Alias                                                                             | Description                                                                                                               |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [@quasar/qmediaplayer](https://github.com/quasarframework/quasar-ui-qmediaplayer) | HTML5 video and audio player                                                                                              |
-| [@quasar/qflashcard](https://github.com/quasarframework/quasar-ui-qflashcard)     | Show some information and reveal more with CSS Transition Mashups                                                         |
-| [@quasar/qoverlay](https://github.com/quasarframework/quasar-ui-qoverlay)         | Overlays simplified. Add any component on top of the overlay                                                              |
-| [@quasar/qactivity](https://github.com/quasarframework/quasar-ui-qactivity)       | Create activity timelines                                                                                                 |
-| [@quasar/qmarkdown](https://github.com/quasarframework/quasar-ui-qmarkdown)       | Markdown for your pages                                                                                                   |
-| [@quasar/qcalendar](https://github.com/quasarframework/quasar-ui-qcalendar)       | Calendar for Quasar                                                                                                       |
-| [@quasar/qscroller](https://github.com/quasarframework/quasar-ui-qscroller)       | Many scrolling components, including QScroller, QTimeScroller, QDateScroller, QDateTimeScroller and scrolling time ranges |
-| [@quasar/qwindow](https://github.com/quasarframework/quasar-ui-qwindow)           | Floating, movable, resizable interactive windows for Quasar                                                               |
-| [@quasar/qiconpicker](https://github.com/quasarframework/quasar-ui-qiconpicker)   | Icon Picker for your Quasar apps                                                                                          |
+| Alias                                                                             | Description                                                               |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [@quasar/qmediaplayer](https://github.com/quasarframework/quasar-ui-qmediaplayer) | Refined HTML5 audio and video controls for Vue and Quasar applications    |
+| [@quasar/qflashcard](https://github.com/quasarframework/quasar-ui-qflashcard)     | CSS transition flashcards for revealing additional content                |
+| [@quasar/qoverlay](https://github.com/quasarframework/quasar-ui-qoverlay)         | Fullscreen and component-scoped overlays for Vue and Quasar applications  |
+| [@quasar/qactivity](https://github.com/quasarframework/quasar-ui-qactivity)       | Compact activity lists and timelines for Quasar applications              |
+| [@quasar/qmarkdown](https://github.com/quasarframework/quasar-ui-qmarkdown)       | Render and customize Markdown content in Quasar applications              |
+| [@quasar/qcalendar](https://github.com/quasarframework/quasar-ui-qcalendar)       | Configurable calendars, schedulers, agendas, resources and task views     |
+| [@quasar/qscroller](https://github.com/quasarframework/quasar-ui-qscroller)       | String, time, date, date-time and range scrollers for Quasar applications |
+| [@quasar/qwindow](https://github.com/quasarframework/quasar-ui-qwindow)           | Floating, movable and resizable window panels for Quasar applications     |
+| [@quasar/qiconpicker](https://github.com/quasarframework/quasar-ui-qiconpicker)   | An icon picker for Vue and Quasar applications                            |

--- a/docs/src/pages/vue-components/video.md
+++ b/docs/src/pages/vue-components/video.md
@@ -5,10 +5,10 @@ keys: QVideo
 examples: QVideo
 ---
 
-Using the QVideo component makes embedding a video like Youtube easy. It also resizes to fit the container by default.
+Using the QVideo component makes embedding a video like YouTube easy. It also resizes to fit the container by default.
 
 ::: tip
-You may also want to check our own HTML 5 video player component: [QMediaPlayer](https://github.com/quasarframework/quasar-ui-qmediaplayer), which is far more advanced than QVideo (which essentially is an iframe pointing to embedded Youtube videos).
+You may also want to check our own HTML 5 video player component: [QMediaPlayer](https://github.com/quasarframework/quasar-ui-qmediaplayer), which is far more advanced than QVideo (which essentially is an iframe pointing to embedded YouTube videos).
 :::
 
 <DocApi file="QVideo" />

--- a/docs/src/pages/vue-components/video.md
+++ b/docs/src/pages/vue-components/video.md
@@ -8,7 +8,7 @@ examples: QVideo
 Using the QVideo component makes embedding a video like Youtube easy. It also resizes to fit the container by default.
 
 ::: tip
-You may also want to check our own HTML 5 video player component: [QMediaPlayer](https://github.com/quasarframework/app-extension-qmediaplayer), which is far more advanced than QVideo (which essentially is an iframe pointing to embedded Youtube videos).
+You may also want to check our own HTML 5 video player component: [QMediaPlayer](https://github.com/quasarframework/quasar-ui-qmediaplayer), which is far more advanced than QVideo (which essentially is an iframe pointing to embedded Youtube videos).
 :::
 
 <DocApi file="QVideo" />


### PR DESCRIPTION
## Summary

- remove QPdfViewer from the maintained official component extensions list
- update renamed UI extension repositories to their canonical `quasar-ui-*` URLs
- refresh the component descriptions with concise, feature-focused wording based on each project README
- update the related QMarkdown integration and QMediaPlayer documentation links

## Motivation

Several documentation links still used the former `app-extension-*` repository names and relied on GitHub redirects. QPdfViewer is no longer actively maintained and should not be listed with the maintained official component extensions. The existing descriptions also varied in detail and style.

## Validation

- verified canonical repository names through the GitHub API
- compared descriptions against the current project READMEs
- `pnpm lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated QMarkdown and QMediaPlayer links to their current Quasar UI repositories.
  - Refreshed the app extensions component table with revised descriptions and repository links.
  - Removed the obsolete QPDFViewer entry.
  - Updated the QMediaPlayer documentation reference to its current repository.
  - Corrected capitalization of “YouTube” in the QVideo documentation for improved consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->