### PR TITLE
fix(QInput): allow cancelling mask keyboard actions

### DIFF
--- a/docs/src/pages/vue-components/input.md
+++ b/docs/src/pages/vue-components/input.md
@@ -190,6 +190,8 @@ The `reverse-fill-mask` is useful if you want to force the user to fill the mask
 
 <DocExample title="Filling the mask in reverse" file="MaskFillReverse" />
 
+You can prevent the mask's own handling of a key by preventing its `keydown` event; for example, `@keydown.left.prevent` keeps <kbd>ARROW LEFT</kbd> from moving the cursor over the mask literals.
+
 ### Custom mask tokens <q-badge label="v2.18.4+" />
 
 You can also define custom mask tokens on top of the default ones or even override some/all of the [default ones](https://github.com/quasarframework/quasar/blob/dev/ui/src/components/input/use-mask.js#L15).

--- a/ui/src/components/input/use-mask.js
+++ b/ui/src/components/input/use-mask.js
@@ -575,6 +575,7 @@ export default function useMask(props, emit, emitValue, inputRef) {
 
     if (
       shouldIgnoreKey(e) ||
+      e.defaultPrevented ||
       e.altKey // let browser handle these
     ) {
       return

--- a/ui/src/components/input/use-mask.test.js
+++ b/ui/src/components/input/use-mask.test.js
@@ -371,7 +371,8 @@ describe('[useMask API]', () => {
 
       test.each([
         ['ALT is held', { keyCode: 39, altKey: true }],
-        ['the key is a modifier', { keyCode: 16 }]
+        ['the key is a modifier', { keyCode: 16 }],
+        ['the event was prevented', { keyCode: 39, defaultPrevented: true }]
       ])('leaves the cursor alone when %s', (_, eventProps) => {
         const { mask, input } = createMask({
           modelValue: '12345',


### PR DESCRIPTION
`onMaskedKeydown` emits `keydown` first, then runs its own cursor logic, but it never checks whether the consumer already prevented the event. On a masked QInput a handler like `@keydown.left.prevent` fires, and the mask still moves the caret across the mask literals afterwards.

This adds `e.defaultPrevented` to the early return, the same guard #18507 added to QSelect's `onTargetKeydown`. Behavior is unchanged unless the event is explicitly prevented.

Validation: `cd ui && pnpm test:unit` (260 files, 5425 tests passed), `pnpm test:specs --target components/input/use-mask`, `pnpm lint`, `git diff --check`.

Fixes #18514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Masked inputs now respect keyboard events that have already been canceled, preventing unintended mask processing.
  - Improved cursor behavior when navigation keys are prevented, including movement across mask literals.

- **Documentation**
  - Added guidance and an example explaining how canceling keydown events affects input masks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->