### PR TITLE
docs: add Fontawesome-Pro Kits guide (supersedes #16099)

### DIFF
--- a/docs/src/pages/options/installing-icon-libraries.md
+++ b/docs/src/pages/options/installing-icon-libraries.md
@@ -55,7 +55,7 @@ In case you follow this path, do not also add the icon sets that you want in `/q
 
 ## Using Fontawesome-Pro
 
-If you have a Fontawesome v6 Pro license and want to use it instead of the Fontawesome Free version, follow these instructions:
+If you have a Fontawesome Pro license and want to use it instead of the Fontawesome Free version, follow these instructions:
 
 1. Open the [Linked Accounts section](https://fontawesome.com/account) in Fontawesome's user account page to grab the npm TOKENID (login if necessary).
 2. Create or append TOKENID into the `.npmrc` file (file path same as package.json):
@@ -120,7 +120,7 @@ Since the default `font-weight` for fontawesome-pro is `light` or `fal`, some ic
 
 For instance, to override the `fal` version of the close icon for chips, do this:
 
-_First_, find the icon used for chip close in Quasar Fontawesome v6 Pro [icon-set source](https://github.com/quasarframework/quasar/blob/dev/ui/icon-set/fontawesome-v7-pro.js).
+_First_, find the icon used for chip close in Quasar Fontawesome Pro [icon-set source](https://github.com/quasarframework/quasar/blob/dev/ui/icon-set/fontawesome-v7-pro.js).
 
 (Alternatively, you can check inside the render function of the component you are overriding.)
 
@@ -141,3 +141,60 @@ export default ({ app }) => {
   app.config.globalProperties.$q.iconSet.chip.remove = 'fas fa-times-circle'
 }
 ```
+
+If you want to change most (or all) of the icons that the framework uses, then make a copy of the [icon-set source](https://github.com/quasarframework/quasar/blob/dev/ui/icon-set/fontawesome-v7-pro.js) inside your app source, change the icon styles and names as you see fit, then apply the whole set at once:
+
+```js
+import '@fortawesome/fontawesome-pro/css/fontawesome.min.css'
+import '@fortawesome/fontawesome-pro/css/solid.min.css'
+import '@fortawesome/fontawesome-pro/css/light.min.css'
+
+import iconSet from './my-fontawesome-pro-icon-set'
+
+// example
+export default ({ app }) => {
+  app.config.globalProperties.$q.iconSet.set(iconSet)
+}
+```
+
+## Using Fontawesome-Pro Kits
+
+[Font Awesome Kits](https://fontawesome.com/kits) allow you to build a custom icon package which contains only the icon styles and individual icons that you actually use (plus any custom icons that you upload to the kit). A Pro plan allows you to download such a kit and host it from your app itself, in which case you do not need the npm registry token or the `@fortawesome/fontawesome-pro` package from the previous section.
+
+1. Create a [kit](https://fontawesome.com/kits) in your Font Awesome account and configure the icons that it should include.
+
+::: warning
+If you also set `iconSet: 'fontawesome-v7-pro'` in the `/quasar.config` file (step 4 below), then the kit must include the Light style icons referenced by the Quasar [icon-set source](https://github.com/quasarframework/quasar/blob/dev/ui/icon-set/fontawesome-v7-pro.js), otherwise the icons used internally by the framework components will not render. Alternatively, override the icon set from the boot file (step 6 below) so that it only points to icons that your kit contains.
+:::
+
+2. Download the kit for self-hosting and pick the Web Fonts flavor of it (the Quasar icon sets rely on the webfont CSS classes).
+
+3. Copy the kit's `css` and `webfonts` folders into your app, e.g. into `src/css/fontawesome-kit/`. Keep the two folders siblings of each other, because the CSS files reference the fonts through a relative `../webfonts` path.
+
+4. Create a new boot file and register it, while making sure that the free version is not loaded as well:
+
+```bash
+quasar new boot fontawesome-pro [--format ts]
+```
+
+```js
+boot: [
+  ...
+  'fontawesome-pro' // Add boot file
+],
+extras: [
+  // 'fontawesome-v7' // Disable free version!
+],
+framework: {
+  // if you want Quasar to use Fontawesome for its icons
+  iconSet: 'fontawesome-v7-pro'
+}
+```
+
+5. Edit `/src/boot/fontawesome-pro.js` to load the kit's CSS (`all.css` covers every style that you included in the kit; you can also pick the individual per-style files next to it):
+
+```js
+import 'src/css/fontawesome-kit/css/all.css'
+```
+
+6. (Optional) Override the default icons the same way as in the previous section, importing the kit CSS instead of the `@fortawesome/fontawesome-pro` files.


### PR DESCRIPTION
Adds a "Using Fontawesome-Pro Kits" section to the Installing Icon Libraries page, plus a short example for replacing the whole framework icon set at once. Based on the material contributed by @gregveres in #16099, updated for the current Fontawesome v7 docs: a self-hosted kit download needs no npm registry token or `@fortawesome/fontawesome-pro` package, so those steps were dropped, and a warning was added that a subsetted kit must include the Light style icons referenced by `fontawesome-v7-pro` (or the icon set must be overridden). Also fixes two leftover "v6" mentions in the existing Pro section.

Docs-only change. Validated with the docs dev server: the page compiles, the new heading id is emitted without collisions, step numbering and the warning block render correctly.