### PR TITLE
fix(app-vite): resolve BEX bridge send() with the responder's payload

### DIFF
--- a/app-vite/exports/bex/private/bex-bridge.js
+++ b/app-vite/exports/bex/private/bex-bridge.js
@@ -339,7 +339,7 @@ export class BexBridge {
       }
     }
 
-    await promise
+    return promise
   }
 
   /**


### PR DESCRIPTION
`BexBridge.send()` ended with `await promise` as the last statement of an `async` method, so the responder's payload was awaited and then thrown away. Every call resolved `undefined`, even though `types/bex/bridge.d.ts` declares `Promise<BexEventResponse<T>>` and the docs show the returned value being used. Since the declared type is correct, TypeScript flags nothing and the failure only shows up later as a `TypeError` on the response.

Returning the promise instead of awaiting it makes the resolved value reach the caller. No other behavior changes: rejections still propagate the same way.

Verified by driving two `BexBridge` instances (app + background) over a stubbed `chrome.runtime` port pair: `bridge.on('sum', ({ payload }) => payload.a + payload.b)` gives `undefined` before the change and `3` after. Also ran `pnpm test:unit` in `/app-vite` (70 files, 552 tests, all passing) and `pnpm lint` at the root, which only reports the pre-existing missing `.quasar/tsconfig.json` errors.

Fixes #18517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge message handling by returning response promises directly, enabling callers to receive results more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->