### PR TITLE
fix(QSelect): render fall-through attributes only on the focus target

### DIFF
--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -1739,16 +1739,10 @@ export default /*#__PURE__*/ createComponent({
           }
         }
 
-        const attrs =
-          props.useInput || !isTarget
-            ? void 0
-            : state.splitAttrs.attributes.value
-
         return h(
           'div',
           {
             class: 'q-field__native row items-center',
-            ...attrs,
             ...state.splitAttrs.listeners.value
           },
           child

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -3029,6 +3029,7 @@ describe('[QSelect API]', () => {
         expect(
           wrapper.get('input[role="combobox"]').attributes('aria-label')
         ).toBe('Preferred car')
+        expect(wrapper.findAll('[aria-label="Preferred car"]').length).toBe(1)
       }
     )
 

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -3029,7 +3029,7 @@ describe('[QSelect API]', () => {
         expect(
           wrapper.get('input[role="combobox"]').attributes('aria-label')
         ).toBe('Preferred car')
-        expect(wrapper.findAll('[aria-label="Preferred car"]').length).toBe(1)
+        expect(wrapper.findAll('[aria-label="Preferred car"]')).toHaveLength(1)
       }
     )
 


### PR DESCRIPTION
Without `use-input`, QSelect spreads the fall-through attributes onto both the `.q-select__focus-target` input and the `.q-field__native` wrapper around it, so anything passed to the component renders twice. QTable trips over this on its own, since it gives its rows-per-page select an `aria-label`, which is enough to break `getByLabel()` in Playwright and Testing Library with a strict-mode violation. The copy on the wrapper is dead weight for screen readers too: it is a plain `div`, and `aria-label` is ignored on a generic role.

The wrapper no longer receives the attributes, leaving them on the focus target only, which is what the `use-input` branch already did and what QInput, QFile and QField do. Fall-through listeners stay on the wrapper, untouched. The existing fall-through `aria-label` test only looked at `input[role="combobox"]`, a selector the wrapper never matched, so it now also asserts the attribute lands on exactly one element.

One consequence worth naming: a fall-through `id` used to survive on the wrapper and now reaches nothing, since the focus target sets `id` from `targetUid` after the spread. QInput has behaved that way all along, and the supported way to pick the control's id is the `for` prop, which the label points at too.

Validation: `cd ui && pnpm test:unit` (260 files, 5654 tests passed), `pnpm test:hydration` (141 passed), `pnpm test:specs --target components/select` (ok), `pnpm lint` (only the four pre-existing missing-`.quasar/tsconfig.json` errors).

Fixes #18519


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the native select wrapper’s rendered markup while preserving event listener behavior.
  - Ensured supplied accessibility labels are rendered exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->