### PR TITLE
fix(uk): correct grammar errors and russianisms in Ukrainian lang pack

### DIFF
--- a/ui/lang/uk.js
+++ b/ui/lang/uk.js
@@ -60,7 +60,7 @@ export default {
   },
   table: {
     noData: 'Немає даних',
-    noResults: 'Співпадінь не знайдено',
+    noResults: 'Збігів не знайдено',
     loading: 'Завантаження...',
     selectedRecords: rows =>
       rows > 0
@@ -73,7 +73,7 @@ export default {
     recordsPerPage: 'Рядків на сторінці:',
     allRows: 'Усі',
     pagination: (start, end, total) => start + '-' + end + ' з ' + total,
-    columns: 'Колонки',
+    columns: 'Стовпці',
     selectAllRows: 'Вибрати всі рядки',
     selectRow: 'Вибрати рядок'
   },
@@ -113,15 +113,15 @@ export default {
     underline: 'Підкреслений',
     unorderedList: 'Маркований список',
     orderedList: 'Нумерований список',
-    subscript: 'Підрядковий',
-    superscript: 'Надрядковий',
+    subscript: 'Нижній індекс',
+    superscript: 'Верхній індекс',
     hyperlink: 'Гіперпосилання',
-    toggleFullscreen: 'Повноекранний режим',
+    toggleFullscreen: 'Перемкнути повноекранний режим',
     quote: 'Цитата',
-    left: 'Вирівнювання по лівому краю',
-    center: 'Вирівнювання по центру',
-    right: 'Вирівнювання по правому краю',
-    justify: 'Вирівнювання по ширині',
+    left: 'Вирівняти ліворуч',
+    center: 'Вирівняти за центром',
+    right: 'Вирівняти праворуч',
+    justify: 'Вирівняти за шириною',
     print: 'Друк',
     outdent: 'Зменшити відступ',
     indent: 'Збільшити відступ',
@@ -130,7 +130,7 @@ export default {
     fontSize: 'Розмір шрифту',
     align: 'Вирівнювання',
     hr: 'Вставити горизонтальну лінію',
-    undo: 'Відмінити',
+    undo: 'Скасувати',
     redo: 'Повторити',
     heading1: 'Заголовок 1',
     heading2: 'Заголовок 2',
@@ -138,20 +138,20 @@ export default {
     heading4: 'Заголовок 4',
     heading5: 'Заголовок 5',
     heading6: 'Заголовок 6',
-    paragraph: 'Параграф',
+    paragraph: 'Абзац',
     code: 'Код',
     size1: 'Дуже маленький',
     size2: 'Маленький',
     size3: 'Нормальний',
-    size4: 'Середній',
+    size4: 'Середньо-великий',
     size5: 'Великий',
     size6: 'Дуже великий',
-    size7: 'Величезний',
-    defaultFont: 'Шрифт за замовчуванням',
-    viewSource: 'Переглянути джерело'
+    size7: 'Максимальний',
+    defaultFont: 'Типовий шрифт',
+    viewSource: 'Переглянути код'
   },
   tree: {
     noNodes: 'Немає доступних вузлів',
-    noResults: 'Співпадінь не знайдено'
+    noResults: 'Збігів не знайдено'
   }
 }

--- a/ui/lang/uk.js
+++ b/ui/lang/uk.js
@@ -45,12 +45,14 @@ export default {
     format24h: true,
     pluralDay: 'днів',
     prevMonth: 'Попередній місяць',
-    nextMonth: 'Наступного місяця',
+    nextMonth: 'Наступний місяць',
     prevYear: 'Попередній рік',
-    nextYear: 'Наступного року',
+    nextYear: 'Наступний рік',
     today: 'Сьогодні',
-    prevRangeYears: range => `Попередній ${range} роки`,
-    nextRangeYears: range => `Далі ${range} роки`,
+    prevRangeYears: range =>
+      `Попередні ${range} ${plurals(range, ['рік', 'роки', 'років'])}`,
+    nextRangeYears: range =>
+      `Наступні ${range} ${plurals(range, ['рік', 'роки', 'років'])}`,
     hour: 'Година',
     minute: 'Хвилина',
     second: 'Секунда',
@@ -62,11 +64,12 @@ export default {
     loading: 'Завантаження...',
     selectedRecords: rows =>
       rows > 0
-        ? rows +
+        ? 'Обрано ' +
+          rows +
           ' ' +
-          plurals(rows, ['рядок обраний', 'рядки обрані', 'рядків обрано']) +
+          plurals(rows, ['рядок', 'рядки', 'рядків']) +
           '.'
-        : 'Жодного рядку не обрано.',
+        : 'Жодного рядка не обрано.',
     recordsPerPage: 'Рядків на сторінці:',
     allRows: 'Усі',
     pagination: (start, end, total) => start + '-' + end + ' з ' + total,


### PR DESCRIPTION
Audited `ui/lang/uk.js` against `ui/lang/en-US.js` — no missing or extra keys (passes the shape validator as-is), but found real grammar bugs and a cluster of russianisms/calques matching `ru.js` almost one-for-one.

## Commit 1 — grammar bugs
- `date.nextMonth`/`nextYear` used genitive case ("Наступного місяця" reads as "of next month") — corrected to nominative.
- `date.prevRangeYears`/`nextRangeYears` built the plural form manually instead of using the file's own `plurals()` helper, producing invalid output like "Попередній 10 роки" — now uses `plurals()` like the rest of the file does.
- `table.selectedRecords` (both the 0-case and the n-case) had wrong genitive/register — corrected.

## Commit 2 — russianisms, calques, mistranslations
16 lines across `editor`, `table`, and `tree`, e.g.:
- `table.noResults`/`tree.noResults`: "Співпадінь" (calque of "совпадение") → "Збігів"
- `editor.paragraph`: "Параграф" (false friend — a numbered section, not a text paragraph) → "Абзац"
- `editor.undo`: "Відмінити" (calque of "отменить"; "відмінити" actually means "to decline/inflect") → "Скасувати"
- `editor.subscript`/`superscript`: "Підрядковий"/"Надрядковий" (mirror ru "подстрочный"/"надстрочный", mean "interlinear/literal" in Ukrainian) → "Нижній індекс"/"Верхній індекс"
- `editor.left`/`center`/`right`/`justify`: "Вирівнювання по …" (ru locative pattern) → "Вирівняти ліворуч/за центром/праворуч/за шириною"
- `editor.viewSource`: "Переглянути джерело" reads as "view the water source" → "Переглянути код"
- `table.columns`: "Колонки" → "Стовпці" (standard Ukrainian table terminology)

Left unchanged, out of scope: a few pre-existing stylistic inconsistencies (`label.select` vs the `Вибрати` used elsewhere, a plain hyphen vs en dash in `table.pagination`) — none are grammatically wrong, just non-uniform, and fixing them would widen the diff without fixing a bug.

## Verification
- Structure validator (`ui/build/build.lang.js`): `VALIDATOR OK - 72 packs`, `ui/lang/index.json` unchanged.
- `oxfmt --check ui/lang/uk.js`: passes.
- `oxlint --deny-warnings ui/lang/uk.js`: zero diagnostics.
- Only `ui/lang/uk.js` touched — 26 insertions / 23 deletions across both commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Ukrainian translations across calendar, table, editor, and tree components.
  * Improved calendar navigation labels and year-range pluralization.
  * Revised table result and selected-row messages.
  * Corrected and refined editor labels and tree result text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->