### PR TITLE
fix(QSelect): keep long selected values inside the parent — fix #18015

### DIFF
--- a/ui/src/components/select/QSelect.sass
+++ b/ui/src/components/select/QSelect.sass
@@ -1,4 +1,9 @@
 .q-select
+  // the value is nowrap (span.ellipsis), so without these the field grows past
+  // its parent instead of truncating -- main axis first, then the cross one (#18015)
+  min-width: 0
+  max-width: 100%
+
   &--without-input
     .q-field__control
       cursor: pointer

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -2957,6 +2957,42 @@ describe('[QSelect API]', () => {
     })
   })
 
+  describe('[Generic]', () => {
+    // the displayed value sits in a nowrap span.ellipsis, so the field's
+    // min-content width is the whole text: it must not become a floor that
+    // pushes the field past its parent instead of truncating (#18015)
+    const longValue =
+      'a selected value that is far too long to fit into a narrow parent'
+
+    function mountInParent(parentClass) {
+      return mount(
+        defineComponent({
+          render() {
+            return h('div', { class: parentClass, style: { width: '200px' } }, [
+              h(QSelect, { modelValue: longValue, options: [longValue] })
+            ])
+          }
+        })
+      )
+    }
+
+    test.each([
+      ['row', 'main'],
+      ['column', 'cross']
+    ])('truncates a long value inside a .%s parent (%s axis)', parentClass => {
+      const wrapper = mountInParent(parentClass)
+
+      const parentWidth = wrapper.element.getBoundingClientRect().width
+      const fieldWidth = wrapper
+        .get('.q-select')
+        .element.getBoundingClientRect().width
+      const value = wrapper.get('.q-field__native > span.ellipsis').element
+
+      expect(fieldWidth).toBeLessThanOrEqual(parentWidth)
+      expect(value.scrollWidth).toBeGreaterThan(value.clientWidth)
+    })
+  })
+
   describe('[Accessibility]', () => {
     test.each([
       ['focus target', false],


### PR DESCRIPTION
Fixes #18015

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

Strictly speaking there is one behavioral edge worth calling out (see "Trade-off" below): an explicit `width` larger than the parent is now clipped to the parent's width instead of overflowing it. Apps that relied on the overflow can opt out with `max-width: none`; `min-width` still wins over `max-width` per CSS, so `min-width: 500px` keeps working unchanged.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — not applicable, CSS-only change with no platform-specific code paths
- [ ] It's been tested on an Electron app — same
- [x] Any necessary documentation has been added or updated — no docs change needed: this restores the behavior the docs already imply, and no prop/API surface changes

**Other information:**

### The problem

QSelect always renders the selected value inside `<span class="ellipsis">` (`QSelect.js`, also for `use-chips`), and `.ellipsis` is `text-overflow: ellipsis; white-space: nowrap; overflow: hidden`. The truncation only takes effect when something outside the field constrains its width. Whenever the width is derived from content, the field grows to the full text length and overflows its parent:

- `.row` > QSelect without `.col`
- `.column` > QSelect — this is how the `#clearable` docs demo is laid out, which is what the issue reporter pointed at
- `QToolbar`, `QItem` > `QItemSection`
- a CSS grid track
- `use-chips`, `use-input`, `borderless dense` — same in every variant

### Root cause

`white-space: nowrap` makes the field's min-content width equal to the value's text width. The inner wrappers are already protected: `.q-field__native` / `.q-field__input` carry `min-width: 0` and `.q-field__control-container` gets `min-width: 0` from the `.row > .col` rule — but those only help once an outer width has been imposed.

The field root itself has no width constraint and its `overflow` is `visible`, so its automatic minimum size resolves to its min-content size. That is precisely why a plain `<div class="ellipsis">` inside `.row` truncates correctly while QSelect does not: the plain div has `overflow: hidden`, which zeroes the automatic minimum size.

Two axes are involved, which is why one property is not enough:

- **Main axis** (`.row`, grid track, horizontal scroll): the item's `min-width: auto` resolves to min-content, so it refuses to shrink → needs `min-width: 0`.
- **Cross axis** (`.column`, `QItemSection`, `QToolbar`): Quasar's `.column` is `flex-direction: column` **plus** `flex-wrap: wrap`, and with wrapping the cross size of a flex line is content-derived, so the stretched item ends up wider than the container. `min-width: 0` does nothing here → needs `max-width: 100%`.

### The fix

```sass
// ui/src/components/select/QSelect.sass
.q-select
  // the value is nowrap (span.ellipsis), so without these the field grows past
  // its parent instead of truncating -- main axis first, then the cross one (#18015)
  min-width: 0
  max-width: 100%
```

Scoped to `.q-select` rather than `.q-field` deliberately: QInput and slot-driven QField content are not affected by this problem (a QInput with a very long value measured identically in every variant tested), so there is no reason to widen the blast radius. Happy to move it to `.q-field` if you prefer it framework-wide.

### Verification

A 22-case matrix was rendered in the playground and measured in headless Chrome via CDP. Every case container is 388px wide; the selected value is ~555px. Numbers are the rendered field width; `!` means it overflows the container.

| Case | before | after |
| --- | --- | --- |
| `.row` > QSelect | 555 ! no ellipsis | 388 ✓ |
| `.column` > QSelect (docs demo layout) | 581 ! no ellipsis | 388 ✓ |
| QToolbar | 549 ! no ellipsis | 364 ✓ |
| QItem > QItemSection | 555 ! no ellipsis | 356 ✓ |
| `display: grid`, `1fr 1fr` | 555 ! no ellipsis | 190 ✓ |
| `use-chips` | 589 ! no ellipsis | 388 ✓ |
| `use-input` | 555 ! no ellipsis | 388 ✓ |
| `borderless dense` | 525 ! no ellipsis | 388 ✓ |
| `.row > .col`, `.q-gutter`, plain div, `width: 100%` | ok | unchanged |
| *control:* explicit `min-width: 500px` | 500 | 500 unchanged |
| *control:* horizontal scroll, `flex: 0 0 200px` | 555 (ignores the flex basis) | **200** — now honoured |
| *control:* parent `width: max-content` | 555 | unchanged |
| *control:* table cell | 555 | unchanged |
| *control:* QInput with a long value | 184 | unchanged |
| *control:* explicit `width: 500px` in a 388px parent | 500 ! | 388 — see trade-off |

The dropdown menu was checked separately: identical width with and without the fix (its width comes from the option content; `fit` only sets a minimum from the anchor), options render as before.

Regression coverage was added in `QSelect.test.js` under `[Generic]`: a select holding a long value is mounted inside a 200px `.row` parent and a 200px `.column` parent (the main-axis and cross-axis paths), asserting that the field stays within its parent and that the value span is actually truncated. Since the suite runs in a real Chromium through Vitest browser mode with `src/css/index.sass` loaded, these are real layout assertions — with the fix reverted both cases fail (`expected 419.640625 to be less than or equal to 200`).

`pnpm test:specs:check` passes, and `pnpm test` (the full ui suite) is green.

Cases that are deliberately **not** fixed, because their containers size from content by definition: `.row.inline`, a parent with `width: max-content`, and a table cell.

### Trade-off

An explicit `width` larger than the parent is now clipped to 100% (500px → 388px in the control case above). This is the one behavior change; the opt-out is `max-width: none` on the field. I judged this acceptable because a field wider than its own parent is almost always unintended, but it is your call — the alternative (`min-width: 0` only) leaves `.column` and `QItemSection`, i.e. the reported case, broken.

### Alternatives considered and rejected

- `contain: inline-size` on `.q-field` or `.q-field__control-container` — fixes truncation everywhere but collapses the field to 0–60px in any shrink-to-fit context (`.row`, `.row.inline`, `width: max-content`).
- `min-width: 0` on the `span.ellipsis` itself — no effect; clamping by a zero minimum does not reduce the element's min-content contribution.
- `min-width: 0` alone on the field root — fixes the main axis only; the reported `.column` case stays broken.

### Related observation (not addressed here)

`.column` > `div.ellipsis` overflows its container with no QSelect involved at all, because `.column` combines `flex-direction: column` with `flex-wrap: wrap` and the flex line's cross size is therefore content-derived. This PR fixes the reported symptom for QSelect; the general `.column` behavior may deserve a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `QSelect` layout behavior so long selected values remain constrained within their parent container.
  * Prevented selected text from overflowing in narrow flex-based layouts.

* **Tests**
  * Added coverage for truncation within row and column layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->