### PR TITLE
fix(QDialog,QMenu,QTooltip): finish pending transition on keep-alive deactivation — fix #18201

### DIFF
--- a/ui/src/components/dialog/QDialog.js
+++ b/ui/src/components/dialog/QDialog.js
@@ -4,6 +4,7 @@ import {
   getCurrentInstance,
   h,
   onBeforeUnmount,
+  onDeactivated,
   ref,
   watch
 } from 'vue'
@@ -109,7 +110,8 @@ export default /*#__PURE__*/ createComponent({
     let shakeTimeout = null,
       refocusTarget = null,
       isMaximized = false,
-      avoidAutoClose = false
+      avoidAutoClose = false,
+      finishTransition = null
 
     const hideOnRouteChange = computed(
       () => !props.persistent && !props.noRouteDismiss && !props.seamless
@@ -194,6 +196,25 @@ export default /*#__PURE__*/ createComponent({
       }
     })
 
+    // The tail of a show/hide transition (portal teardown, the 'show'/
+    // 'hide' event) runs on a timer that useTimeout cancels when a
+    // <keep-alive> page holding this dialog gets deactivated. Keep the
+    // finisher at hand so deactivation can run it right away, or else
+    // the portal is left in the DOM and the model stays stuck (#18201).
+    // Should removeTimeout() if this gets removed.
+    function registerTransitionEnd(fn) {
+      finishTransition = () => {
+        finishTransition = null
+        fn()
+      }
+
+      registerTimeout(finishTransition, props.transitionDuration)
+    }
+
+    onDeactivated(() => {
+      finishTransition?.()
+    })
+
     function handleShow(evt) {
       addToHistory()
 
@@ -212,8 +233,7 @@ export default /*#__PURE__*/ createComponent({
         registerTick(focus)
       }
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         if ($q.platform.is.ios) {
           if (!props.seamless && document.activeElement) {
             const { top, bottom } =
@@ -247,7 +267,7 @@ export default /*#__PURE__*/ createComponent({
         showPortal(true) // done showing portal
         animating.value = false
         emit('show', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function handleHide(evt) {
@@ -269,12 +289,11 @@ export default /*#__PURE__*/ createComponent({
         })
       }
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         hidePortal(true) // done hiding, now destroy
         animating.value = false
         emit('hide', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function handleRouteChange() {

--- a/ui/src/components/dialog/QDialog.test.js
+++ b/ui/src/components/dialog/QDialog.test.js
@@ -9,7 +9,8 @@ import {
   vi
 } from 'vitest'
 
-import { defineComponent, h } from 'vue'
+import { KeepAlive, defineComponent, h } from 'vue'
+import { useRoute } from 'vue-router'
 
 import QDialog from './QDialog.js'
 import useFullscreen, {
@@ -1156,6 +1157,53 @@ describe('[QDialog API]', () => {
         'q-animate--scale'
       )
       expect(wrapper.emitted()).not.toHaveProperty('shake')
+    })
+
+    test('finishes a pending hide when its keep-alive page deactivates', async () => {
+      const router = await getRouter(['/home', '/account'])
+      const onHide = vi.fn()
+      const getPortalEl = () =>
+        document.body.querySelector('[id^="q-portal--dialog"]')
+
+      const KeptAlivePage = defineComponent({
+        name: 'KeptAlivePage',
+        setup() {
+          return () => h(QDialog, { modelValue: true, onHide }, () => 'content')
+        }
+      })
+
+      const Host = defineComponent({
+        name: 'Host',
+        setup() {
+          const route = useRoute()
+
+          return () =>
+            h(KeepAlive, null, {
+              default: () => (route.path === '/home' ? h(KeptAlivePage) : null)
+            })
+        }
+      })
+
+      await router.push('/home')
+
+      wrapper = mount(Host, {
+        global: {
+          plugins: [router]
+        }
+      })
+      await flushPromises()
+      await vi.runAllTimers()
+
+      expect(getPortalEl()).not.toBe(null)
+
+      // routing away hides the dialog and deactivates the page holding it
+      // within the same tick, which cancels the hide transition's timer
+      await router.push('/account')
+      await flushPromises()
+      await vi.runAllTimers()
+
+      expect(onHide).toHaveBeenCalledTimes(1)
+      expect(getPortalEl()).toBe(null)
     })
   })
 })

--- a/ui/src/components/menu/QMenu.js
+++ b/ui/src/components/menu/QMenu.js
@@ -5,6 +5,7 @@ import {
   h,
   nextTick,
   onBeforeUnmount,
+  onDeactivated,
   ref,
   watch
 } from 'vue'
@@ -140,6 +141,7 @@ export default /*#__PURE__*/ createComponent({
       stopAnchorTracking,
       avoidAutoClose,
       hoverTimer = null,
+      finishTransition = null,
       // set while the current "show" was triggered by hovering the anchor,
       // in which case the menu must leave focus wherever it already is
       hoverShown = false
@@ -357,6 +359,25 @@ export default /*#__PURE__*/ createComponent({
       }
     }
 
+    // The tail of a show/hide transition (portal teardown, the 'show'/
+    // 'hide' event) runs on a timer that useTimeout cancels when a
+    // <keep-alive> page holding this menu gets deactivated. Keep the
+    // finisher at hand so deactivation can run it right away, or else
+    // the portal is left in the DOM and the model stays stuck (#18201).
+    // Should removeTimeout() if this gets removed.
+    function registerTransitionEnd(fn) {
+      finishTransition = () => {
+        finishTransition = null
+        fn()
+      }
+
+      registerTimeout(finishTransition, props.transitionDuration)
+    }
+
+    onDeactivated(() => {
+      finishTransition?.()
+    })
+
     function handleShow(evt) {
       // a hover-triggered open must not steal focus from wherever the
       // user currently is, nor hand it anywhere when hiding
@@ -428,8 +449,7 @@ export default /*#__PURE__*/ createComponent({
         if (!props.noFocus && !hoverShown) focus()
       })
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         // required in order to avoid the "double-tap needed" issue
         if ($q.platform.is.ios) {
           // if auto-close, then this click should
@@ -441,7 +461,7 @@ export default /*#__PURE__*/ createComponent({
         updatePosition()
         showPortal(true) // done showing portal
         emit('show', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function handleHide(evt) {
@@ -470,11 +490,10 @@ export default /*#__PURE__*/ createComponent({
         })
       }
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         hidePortal(true) // done hiding, now destroy
         emit('hide', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function handleRouteChange() {

--- a/ui/src/components/menu/QMenu.test.js
+++ b/ui/src/components/menu/QMenu.test.js
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { KeepAlive, defineComponent, h } from 'vue'
+import { useRoute } from 'vue-router'
 
 import { getRouter } from 'testing/runtime/router.js'
 import { client } from '../../plugins/platform/Platform.js'
@@ -1671,6 +1672,57 @@ describe('[QMenu API]', () => {
       expect(getMenu().style.top).toBe('170px')
 
       await vi.runAllTimersAsync()
+    })
+
+    test('finishes a pending hide when its keep-alive page deactivates', async () => {
+      const router = await getRouter(['/home', '/account'])
+      const onHide = vi.fn()
+      const getPortalEl = () =>
+        document.body.querySelector('[id^="q-portal--menu"]')
+
+      const KeptAlivePage = defineComponent({
+        name: 'KeptAlivePage',
+        setup() {
+          return () =>
+            h('div', { class: 'my-anchor', tabindex: 0 }, [
+              h(QMenu, { modelValue: true, onHide }, () => 'Menu content')
+            ])
+        }
+      })
+
+      const Host = defineComponent({
+        name: 'Host',
+        setup() {
+          const route = useRoute()
+
+          return () =>
+            h(KeepAlive, null, {
+              default: () => (route.path === '/home' ? h(KeptAlivePage) : null)
+            })
+        }
+      })
+
+      await router.push('/home')
+
+      activeWrapper = mount(Host, {
+        attachTo: document.body,
+        global: {
+          plugins: [router]
+        }
+      })
+      await flushPromises()
+      await vi.runAllTimersAsync()
+
+      expect(getPortalEl()).not.toBe(null)
+
+      // routing away hides the menu and deactivates the page holding it
+      // within the same tick, which cancels the hide transition's timer
+      await router.push('/account')
+      await flushPromises()
+      await vi.runAllTimersAsync()
+
+      expect(onHide).toHaveBeenCalledTimes(1)
+      expect(getPortalEl()).toBe(null)
     })
   })
 

--- a/ui/src/components/tooltip/QTooltip.js
+++ b/ui/src/components/tooltip/QTooltip.js
@@ -4,6 +4,7 @@ import {
   getCurrentInstance,
   h,
   onBeforeUnmount,
+  onDeactivated,
   ref,
   watch
 } from 'vue'
@@ -121,6 +122,7 @@ export default /*#__PURE__*/ createComponent({
       observer,
       removeNonSelectableTimer,
       hasNonSelectable = false,
+      finishTransition = null,
       // the pointerType of the contact interaction (touch or a pressed
       // stylus) driving the current show, if any; the hide side needs it
       // because its events can't tell us themselves
@@ -198,6 +200,25 @@ export default /*#__PURE__*/ createComponent({
       )
     }
 
+    // The tail of a show/hide transition (portal teardown, the 'show'/
+    // 'hide' event) runs on a timer that useTimeout cancels when a
+    // <keep-alive> page holding this tooltip gets deactivated. Keep the
+    // finisher at hand so deactivation can run it right away, or else
+    // the portal is left behind in the DOM (#18201).
+    // Should removeTimeout() if this gets removed.
+    function registerTransitionEnd(fn) {
+      finishTransition = () => {
+        finishTransition = null
+        fn()
+      }
+
+      registerTimeout(finishTransition, props.transitionDuration)
+    }
+
+    onDeactivated(() => {
+      finishTransition?.()
+    })
+
     function handleShow(evt) {
       showPortal()
       addAriaDescription()
@@ -247,11 +268,10 @@ export default /*#__PURE__*/ createComponent({
         )
       }
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         showPortal(true) // done showing portal
         emit('show', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function handleHide(evt) {
@@ -260,11 +280,10 @@ export default /*#__PURE__*/ createComponent({
 
       anchorCleanup()
 
-      // should removeTimeout() if this gets removed
-      registerTimeout(() => {
+      registerTransitionEnd(() => {
         hidePortal(true) // done hiding, now destroy
         emit('hide', evt)
-      }, props.transitionDuration)
+      })
     }
 
     function anchorCleanup() {

--- a/ui/src/components/tooltip/QTooltip.test.js
+++ b/ui/src/components/tooltip/QTooltip.test.js
@@ -1,7 +1,9 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { KeepAlive, defineComponent, h } from 'vue'
+import { useRoute } from 'vue-router'
 
+import { getRouter } from 'testing/runtime/router.js'
 import { validatePosition } from '../../utils/private.position-engine/position-engine.js'
 import QTooltip from './QTooltip.js'
 
@@ -787,6 +789,57 @@ describe('[QTooltip API]', () => {
       await vi.runAllTimersAsync()
 
       expect(getTooltip()).toBeNull()
+    })
+
+    test('finishes a pending hide when its keep-alive page deactivates', async () => {
+      const router = await getRouter(['/home', '/account'])
+      const onHide = vi.fn()
+      const getPortalEl = () =>
+        document.body.querySelector('[id^="q-portal--tooltip"]')
+
+      const KeptAlivePage = defineComponent({
+        name: 'KeptAlivePage',
+        setup() {
+          return () =>
+            h('div', { class: 'my-anchor', tabindex: 0 }, [
+              h(QTooltip, { modelValue: true, onHide }, () => 'Tip')
+            ])
+        }
+      })
+
+      const Host = defineComponent({
+        name: 'Host',
+        setup() {
+          const route = useRoute()
+
+          return () =>
+            h(KeepAlive, null, {
+              default: () => (route.path === '/home' ? h(KeptAlivePage) : null)
+            })
+        }
+      })
+
+      await router.push('/home')
+
+      activeWrapper = mount(Host, {
+        attachTo: document.body,
+        global: {
+          plugins: [router]
+        }
+      })
+      await flushPromises()
+      await vi.runAllTimersAsync()
+
+      expect(getPortalEl()).not.toBe(null)
+
+      // routing away hides the tooltip and deactivates the page holding it
+      // within the same tick, which cancels the hide transition's timer
+      await router.push('/account')
+      await flushPromises()
+      await vi.runAllTimersAsync()
+
+      expect(onHide).toHaveBeenCalledTimes(1)
+      expect(getPortalEl()).toBe(null)
     })
   })
 


### PR DESCRIPTION
Fixes #18201

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — not applicable: the change touches no platform-specific code path (the iOS branches inside the affected timers are untouched)
- [ ] It's been tested on an Electron app — same
- [x] Any necessary documentation has been added or updated — no docs change needed: no public API, prop, event or default changes; this restores the documented lifecycle (`hide` is emitted whenever a popup closes)

**Other information:**

### The problem

Reproduction from the issue: a page held by `<keep-alive>` renders a `QSelect` with `behavior="dialog"`. Open the selection dialog, press the browser's back button (the dialog closes and the app navigates away), then come back to the page — clicking the select no longer opens the dialog, and an empty portal `div` is left behind in `body`.

### Root cause

`QDialog.handleHide()` emits `beforeHide` synchronously but defers the end of the transition by `transitionDuration`:

```js
registerTimeout(() => {
  hidePortal(true) // done hiding, now destroy
  animating.value = false
  emit('hide', evt)
}, props.transitionDuration)
```

`useTimeout()` cancels its timer on `onDeactivated` (`ui/src/composables/use-timeout/use-timeout.js`), which is correct for the delayed work it usually guards. But a route change drives both sides of this at once:

1. the route ref changes; `RouterView` re-renders first (lower instance id) and `<keep-alive>` deactivates the page, queueing the deactivation hooks as post-render effects;
2. the `hideOnRouteChange` watcher in `QDialog` then runs `hide()` → `handleHide()`, which registers the transition timer;
3. the queued `onDeactivated` hooks flush afterwards and clear that timer.

So `hidePortal(true)` and `emit('hide')` never happen. Two consequences:

- the portal node stays in the DOM (empty, since `showing` is already `false`) and its proxy stays in `portalProxyList`;
- `QSelect` resets `dialog.value` in `onDialogHide` — the handler for that lost event — so its model stays `true` forever. Re-activating the page and clicking the control calls `showPopup()`, which sets `dialog.value = true` again: no change, no dialog.

`behavior="dialog"` is the visible victim because the menu path resets QSelect's state in `onBeforeHide` (synchronous), while the dialog path only does it in `onHide`. `QMenu` and `QTooltip` share the same deferred-tail pattern and leak the portal node the same way.

### The fix

Keep the transition's finisher at hand and run it synchronously if the component is deactivated before its timer fires:

```js
// The tail of a show/hide transition (portal teardown, the 'show'/
// 'hide' event) runs on a timer that useTimeout cancels when a
// <keep-alive> page holding this dialog gets deactivated. Keep the
// finisher at hand so deactivation can run it right away, or else
// the portal is left in the DOM and the model stays stuck (#18201).
// Should removeTimeout() if this gets removed.
function registerTransitionEnd(fn) {
  finishTransition = () => {
    finishTransition = null
    fn()
  }

  registerTimeout(finishTransition, props.transitionDuration)
}

onDeactivated(() => {
  finishTransition?.()
})
```

Both transition timers (`handleShow` and `handleHide`) go through `registerTransitionEnd`, in `QDialog`, `QMenu` and `QTooltip`.

`useTimeout()` itself is deliberately left alone: it is a public composable, and cancelling deferred work on deactivation is its correct semantics — a tooltip's open delay, for instance, must not fire for a page the user has left.

The finisher always reflects the last transition that was started, so running it on deactivation lands the portal in a state consistent with `showing`. In `QTooltip` the delayed show/hide share `useTimeout`'s single timer slot with the transition; if one of them preempts a transition timer, the leftover finisher still resolves the portal correctly (it either completes the show that is in effect, or tears down the portal of the hide that already happened).

### Scope

- `ui/src/components/dialog/QDialog.js`
- `ui/src/components/menu/QMenu.js`
- `ui/src/components/tooltip/QTooltip.js`
- one `[Generic]` test per component

No behavior changes outside of `<keep-alive>` deactivation: without a live transition the new hook is a no-op.

### Out of scope

A popup that is fully shown (no transition in flight) when its keep-alive page deactivates still stays mounted in `body`: Vue moves only the Teleport anchors on deactivation, not the teleported content. That is a separate concern (`<keep-alive>` without a route change, e.g. tabs) and is not what #18201 describes.

### Validation

- New test per component: *"finishes a pending hide when its keep-alive page deactivates"* — mounts the component inside `<KeepAlive>` behind a route, then routes away, which hides it and deactivates the page within the same tick. Each test fails on `dev` (the `hide` handler is never called, the portal node survives) and passes with the fix.
- `pnpm test` (ui): every suite green — unit (260 files), hydration (89 files), hydration:pwa, umd, build, e2e:ssr.
- `pnpm test:specs --target` for QDialog, QMenu, QTooltip: ✅.
- Manual check in a real browser (playground page with `<keep-alive>` around a `QSelect behavior="dialog"`, driven headless over CDP):
  - before the fix — after the back navigation one `div[id^="q-portal--dialog"]` is left in `body` and the restored page's select no longer opens;
  - after the fix — no portal node is left and clicking the select opens the dialog again.
- `pnpm lint` and `git diff --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dialogs, menus, and tooltips remaining open or leaving portal elements behind when navigating away from cached pages.
  - Ensured pending show/hide transitions complete immediately when a cached page is deactivated.
  - Corrected model state and event handling after deactivation.

- **Tests**
  - Added regression coverage for dialogs, menus, and tooltips during cached-page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->