### PR TITLE
fix(QDialog): keep sticky content in place while the page scroll is locked — fix #18183

### DIFF
--- a/ui/playground/src/pages/web-tests/regression-sweep.vue
+++ b/ui/playground/src/pages/web-tests/regression-sweep.vue
@@ -326,6 +326,17 @@
       </div>
     </div>
 
+    <!-- S27: #18183 sticky content vs the page scroll lock; mounted only
+         while the scenario runs, so the bar cannot cover other fixtures -->
+    <template v-if="s27on">
+      <div class="s27-wrap">
+        <div class="s27-sticky">S27 sticky</div>
+      </div>
+      <q-dialog v-model="s27dlg">
+        <div class="bg-white q-pa-md">S27 dialog</div>
+      </q-dialog>
+    </template>
+
     <!-- S19: #12994 reveal QHeader must reappear when a route change
          happens while the Loading plugin keeps the page scroll-locked.
          Own window-scrolling layout: the bug lives in the non-container
@@ -405,6 +416,8 @@ function s26onHold() {
 function s26onRepeat() {
   s26counts.repeat++
 }
+const s27on = ref(false)
+const s27dlg = ref(false)
 // the "Multiple masks" docs pattern (docs/src/examples/QInput/MaskMultiple.vue)
 const s18mask = computed(() =>
   s18model.value !== null && s18model.value.length > 10
@@ -992,11 +1005,11 @@ async function s18() {
   )
 }
 
-// S19: #12994 -- while the Loading plugin holds the scroll lock, QLayout
-// suppresses the lock's synthetic scroll-to-top (#7012); when a route
-// change happens under the lock, the unlock skips the scroll restore, so
-// the layout used to keep the stale pre-navigation scroll state and a
-// reveal QHeader never reappeared at the top of the new page
+// S19: #12994 -- QLayout suppresses page scrolls for as long as the
+// Loading plugin holds the scroll lock (#7012); when a route change
+// happens under the lock, the unlock skips the scroll restore, so the
+// layout used to keep the stale pre-navigation scroll state and a reveal
+// QHeader never reappeared at the top of the new page
 async function s19() {
   s19on.value = true
   // scroll anchoring (Firefox especially) can nudge the position back up
@@ -1029,9 +1042,14 @@ async function s19() {
   const path = window.location.pathname
   $q.loading.show({ delay: 0 })
   await settle(400)
-  // a route change as prevent-scroll sees one: the pathname moves on
-  // while the lock is held (no popstate, the router stays put)
+  // a navigation as prevent-scroll sees one: the pathname moves on while
+  // the lock is held (no popstate, the router stays put) and the router's
+  // scroll behavior takes the new route to the top. That scroll is the
+  // navigation's, not the lock's -- the lock only clips the viewport and
+  // leaves the page where it is (#18183) -- and QLayout has to re-sync
+  // with it once the lock lifts
   history.pushState({}, '', path + '/s19-nav')
+  window.scrollTo(0, 0)
   $q.loading.hide()
   await settle(500)
 
@@ -1495,6 +1513,65 @@ async function s26() {
   )
 }
 
+// S27: #18183 -- the page scroll lock must leave the page in the flow. A
+// pinned (position: fixed) body puts sticky content inside a fixed subtree,
+// where Firefox stops applying the sticky offset and draws the element at
+// its static -- scrolled-away -- position, so it vanishes for as long as
+// the dialog is open. Clipping the viewport instead keeps both the scroll
+// position and the sticky bar exactly where they were
+async function s27() {
+  s27on.value = true
+  // the verdict panel above grows with every report, and scroll anchoring
+  // would compensate for it with real scrolls mid-measurement
+  document.documentElement.style.overflowAnchor = 'none'
+  await settle(300)
+
+  const bar = document.querySelector('.s27-sticky')
+  const wrap = document.querySelector('.s27-wrap')
+
+  // park the viewport in the middle of the tall block, where the bar has
+  // travelled with the page and is stuck to the top of the viewport
+  window.scrollTo(
+    0,
+    Math.round(window.scrollY + wrap.getBoundingClientRect().top + 800)
+  )
+  await settle(300)
+
+  const stuckTop = () => Math.abs(Math.round(bar.getBoundingClientRect().top))
+  const stuckBefore = stuckTop() <= 2
+  const yBefore = Math.round(window.scrollY)
+
+  s27dlg.value = true
+  await settle(400)
+
+  // iOS has no alternative to pinning the body, so there the contract is
+  // only that the page comes back on release; everywhere else the page may
+  // not move at all and the bar has to stay stuck while the dialog is open
+  const pinned = $q.platform.is.ios
+  const whileOpen =
+    pinned ||
+    (stuckTop() <= 2 && Math.abs(Math.round(window.scrollY) - yBefore) <= 2)
+
+  s27dlg.value = false
+  await settle(500)
+
+  const restored =
+    stuckTop() <= 2 && Math.abs(Math.round(window.scrollY) - yBefore) <= 2
+
+  s27on.value = false
+  document.documentElement.style.overflowAnchor = ''
+  await settle(200)
+  window.scrollTo(0, 0)
+  await settle(200)
+
+  report(
+    'S27 18183 sticky content survives the scroll lock',
+    stuckBefore && whileOpen && restored,
+    `stuck=${stuckBefore} whileOpen=${whileOpen} restored=${restored}` +
+      (pinned ? ' (pinned lock)' : '')
+  )
+}
+
 async function runAll() {
   lines.value = []
   results.length = 0
@@ -1527,7 +1604,8 @@ async function runAll() {
     s23,
     s24,
     s25,
-    s26
+    s26,
+    s27
   ]
   for (const scenario of scenarios) {
     try {
@@ -1580,6 +1658,17 @@ onMounted(() => {
   border: 1px dashed #ccc;
   padding: 8px;
   margin-bottom: 8px;
+}
+/* S27 probe: a tall block whose sticky bar stays pinned to the top of the
+   viewport while the page is scrolled through it */
+.s27-wrap {
+  height: 2000px;
+}
+.s27-sticky {
+  position: sticky;
+  top: 0;
+  height: 40px;
+  background: rgba(0, 128, 0, 0.4);
 }
 /* S14 probes: same declared offsets, one inside a QScrollArea and one not,
    so the two rects must agree. pointer-events stay off so they can never

--- a/ui/src/components/infinite-scroll/QInfiniteScroll.test.js
+++ b/ui/src/components/infinite-scroll/QInfiniteScroll.test.js
@@ -342,7 +342,7 @@ describe('[QInfiniteScroll API]', () => {
   })
 
   describe('[Generic]', () => {
-    test('does not poll while an overlay scroll-locks the page', async () => {
+    test('does not poll while an overlay scroll-locks the page', () => {
       // give the page real overflowing content, so window scrolling works
       const filler = document.createElement('div')
       filler.style.height = '3000px'
@@ -364,19 +364,18 @@ describe('[QInfiniteScroll API]', () => {
         // a Dialog or an overlay Drawer opens...
         preventScroll(true)
 
-        // ...pinning the window scroll position at 0, which reverse mode
-        // would misread as "scrolled to the top" and load over and over
-        await expect.poll(() => window.scrollY).toBe(0)
+        // ...and the page can still end up at the top while it is up: the
+        // app navigating underneath, or the lock pinning the page there on
+        // iOS. Reverse mode would misread that as "scrolled to the top"
+        // and load over and over
+        window.scrollTo(0, 0)
         window.dispatchEvent(new Event('scroll'))
 
         expect(wrapper.emitted()).not.toHaveProperty('load')
 
-        // closing the overlay restores the scroll position and polling
+        // closing the overlay brings polling back -- through the release
+        // listeners, since the page sits where no scroll event can fire
         preventScroll(false)
-        await expect.poll(() => window.scrollY).toBeGreaterThan(500)
-
-        window.scrollTo(0, 100)
-        window.dispatchEvent(new Event('scroll'))
 
         expect(wrapper.emitted('load')).toHaveLength(1)
       } finally {

--- a/ui/src/css/core/helpers.sass
+++ b/ui/src/css/core/helpers.sass
@@ -18,17 +18,30 @@
 
 .q-document--prevent-scroll
   overscroll-behavior: none !important
+
+// The default lock: clipping the viewport leaves the page in flow and at
+// its scroll position, so position: sticky content keeps sticking (#18183)
+// and there is no scroll position to lose and restore
+.q-document--clip-scroll
+  overflow: hidden !important
+
+// A clipped viewport stops painting its classic scrollbar, which would let
+// the page shift sideways into the freed space; reserving the gutter keeps
+// the layout still. Overlay scrollbars take up no space to begin with, so
+// the class is only applied when a scrollbar really occupied some
+.q-document--reserve-scrollbar
+  scrollbar-gutter: stable !important
+
+// iOS pans the page by touch no matter how the viewport is clipped, so
+// there the body gets pinned in place instead -- at the cost of sticky
+// content, which cannot stick inside a fixed subtree
+.q-document--pin-body
   body
     position: fixed !important
 
 /* body */
 .q-body--fullscreen-mixin
   position: fixed !important
-
-.q-body--force-scrollbar-x
-  overflow-x: scroll
-.q-body--force-scrollbar-y
-  overflow-y: scroll
 
 .q-no-input-spinner
   appearance: textfield !important

--- a/ui/src/utils/scroll/prevent-scroll.js
+++ b/ui/src/utils/scroll/prevent-scroll.js
@@ -12,16 +12,17 @@ let registered = 0,
   vpPendingUpdate = false,
   bodyLeft,
   bodyTop,
+  pinnedBody = false,
   routePath,
   closeTimer = null
 
-// notified when the lock releases WITHOUT emitting a scroll event --
-// either the route changed while locked (no scroll restore happens), or
-// the saved position is the one the page already sits at (the lock pins
-// the page at top, so a position saved at top restores as a no-op);
-// consumers that suppress scroll work while locked (QLayout,
-// QInfiniteScroll) re-sync through this since no scroll event will ever
-// fire for them
+// notified when the lock releases WITHOUT emitting a scroll event -- the
+// clipped page never lost its position, the route changed while locked (no
+// scroll restore happens), or the saved position is the one the page
+// already sits at (a pinned page sits at top, so a position saved at top
+// restores as a no-op); consumers that suppress scroll work while locked
+// (QLayout, QInfiniteScroll) re-sync through this since no scroll event
+// will ever fire for them
 const releaseListeners = new Set()
 
 export function addPreventScrollReleaseListener(fn) {
@@ -77,32 +78,38 @@ function apply(action) {
     hasViewport = window.visualViewport !== void 0
 
   if (action === 'add') {
-    const { overflowY, overflowX } = window.getComputedStyle(body)
-
     scrollPositionX = getHorizontalScrollPosition(window)
     scrollPositionY = getVerticalScrollPosition(window)
-    bodyLeft = body.style.left
-    bodyTop = body.style.top
 
     routePath = window.location.pathname
 
-    body.style.left = `-${scrollPositionX}px`
-    body.style.top = `-${scrollPositionY}px`
+    const classList = ['q-document--prevent-scroll']
 
-    if (
-      overflowX !== 'hidden' &&
-      (overflowX === 'scroll' || body.scrollWidth > window.innerWidth)
-    ) {
-      body.classList.add('q-body--force-scrollbar-x')
-    }
-    if (
-      overflowY !== 'hidden' &&
-      (overflowY === 'scroll' || body.scrollHeight > window.innerHeight)
-    ) {
-      body.classList.add('q-body--force-scrollbar-y')
+    pinnedBody = client.is.ios
+
+    if (pinnedBody) {
+      // iOS pans the page by touch whatever the viewport says, so the body
+      // gets pinned in place instead; sticky content cannot survive that
+      // (it ends up inside a fixed subtree), but nothing else holds there
+      bodyLeft = body.style.left
+      bodyTop = body.style.top
+      body.style.left = `-${scrollPositionX}px`
+      body.style.top = `-${scrollPositionY}px`
+      classList.push('q-document--pin-body')
+    } else {
+      // clipping the viewport leaves the page in flow and at its scroll
+      // position, so position: sticky content keeps sticking (#18183)
+      classList.push('q-document--clip-scroll')
+
+      // a classic scrollbar takes up layout space that the clipped viewport
+      // stops painting, and the page would shift sideways into it; overlay
+      // scrollbars take up none, so they need no gutter
+      if (window.innerWidth - document.documentElement.clientWidth > 0) {
+        classList.push('q-document--reserve-scrollbar')
+      }
     }
 
-    document.documentElement.classList.add('q-document--prevent-scroll')
+    document.documentElement.classList.add(...classList)
     document.qScrollPrevented = true
 
     if (client.is.ios) {
@@ -151,21 +158,28 @@ function apply(action) {
       }
     }
 
-    document.documentElement.classList.remove('q-document--prevent-scroll')
-    body.classList.remove(
-      'q-body--force-scrollbar-x',
-      'q-body--force-scrollbar-y'
+    document.documentElement.classList.remove(
+      'q-document--prevent-scroll',
+      'q-document--clip-scroll',
+      'q-document--reserve-scrollbar',
+      'q-document--pin-body'
     )
 
     document.qScrollPrevented = false
 
-    body.style.left = bodyLeft
-    body.style.top = bodyTop
+    if (pinnedBody) {
+      body.style.left = bodyLeft
+      body.style.top = bodyTop
+    }
 
-    // scroll back only if the route path has not changed AND the page is
-    // not already at the saved position (scrollTo emits nothing then);
-    // when no scroll event can fire, notify the release listeners instead
+    // only a pinned page has a position to scroll back to, and only when
+    // the route path has not changed AND the page is not already at the
+    // saved position (scrollTo emits nothing then); a clipped page kept
+    // its position all along, and if the app moved it meanwhile that move
+    // is not ours to undo. When no scroll event can fire, notify the
+    // release listeners instead
     if (
+      pinnedBody &&
       window.location.pathname === routePath &&
       (getHorizontalScrollPosition(window) !== scrollPositionX ||
         getVerticalScrollPosition(window) !== scrollPositionY)

--- a/ui/src/utils/scroll/prevent-scroll.test.js
+++ b/ui/src/utils/scroll/prevent-scroll.test.js
@@ -7,9 +7,11 @@ import preventScroll, {
   removePreventScrollReleaseListener
 } from './prevent-scroll.js'
 
-const forceScrollbarClasses = [
-  'q-body--force-scrollbar-x',
-  'q-body--force-scrollbar-y'
+const lockClasses = [
+  'q-document--prevent-scroll',
+  'q-document--clip-scroll',
+  'q-document--reserve-scrollbar',
+  'q-document--pin-body'
 ]
 
 const restoreFns = []
@@ -22,8 +24,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   vi.useRealTimers()
 
-  document.documentElement.classList.remove('q-document--prevent-scroll')
-  document.body.classList.remove(...forceScrollbarClasses)
+  document.documentElement.classList.remove(...lockClasses)
   document.body.removeAttribute('style')
 })
 
@@ -118,23 +119,57 @@ describe('[preventScroll API]', () => {
         expect(scrollTo).not.toHaveBeenCalled()
       })
 
-      test('locks the body in place at the current scroll position', () => {
+      test('clips the viewport, leaving the page where it is', async () => {
         makeDocumentScrollable()
         window.scrollTo(30, 180)
 
         preventScroll(true)
 
+        expect(
+          document.documentElement.classList.contains('q-document--clip-scroll')
+        ).toBe(true)
+
+        // the page stays in the flow, so it keeps its scroll position and
+        // needs no compensating body offsets -- that is what keeps
+        // position: sticky content sticking while locked (#18183)
+        expect(document.body.style.left).toBe('')
+        expect(document.body.style.top).toBe('')
+
+        // a body taken out of the flow only gets clamped to the top on the
+        // next frames, so give the position the same window to prove that
+        // nothing clamps it here
+        await new Promise(resolve => {
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        })
+
+        expect(window.scrollX).toBe(30)
+        expect(window.scrollY).toBe(180)
+      })
+
+      test('pins the body at the current scroll position on iOS', () => {
+        // iOS keeps panning a clipped page by touch, so there the body is
+        // pinned instead and the offsets stand in for the lost scrolling
+        mockPlatform({ ios: true, nativeMobile: false })
+        makeDocumentScrollable()
+        window.scrollTo(30, 180)
+
+        preventScroll(true)
+
+        expect(
+          document.documentElement.classList.contains('q-document--pin-body')
+        ).toBe(true)
         expect(document.body.style.left).toBe('-30px')
         expect(document.body.style.top).toBe('-180px')
       })
 
       test('restores the previous body offsets and scroll position', async () => {
+        // only the pinned (iOS) lock can lose the position: the body leaves
+        // the flow, so the browser clamps the page to the top
+        mockPlatform({ ios: true, nativeMobile: false })
         makeDocumentScrollable()
         document.body.style.left = '5px'
         document.body.style.top = '10px'
         window.scrollTo(30, 180)
-
-        const scrollTo = vi.spyOn(window, 'scrollTo')
 
         preventScroll(true)
 
@@ -142,6 +177,10 @@ describe('[preventScroll API]', () => {
         // position to 0 asynchronously; the restore is only observable
         // once the position got genuinely lost
         await expect.poll(() => window.scrollY).toBe(0)
+
+        // spied on only now: acquiring the lock scrolls the page itself
+        // on iOS, and those calls are not the restore under test
+        const scrollTo = vi.spyOn(window, 'scrollTo')
 
         preventScroll(false)
 
@@ -168,31 +207,44 @@ describe('[preventScroll API]', () => {
         expect(scrollTo).not.toHaveBeenCalled()
       })
 
-      test.each([
-        ['both axes', { width: 5000, height: 5000 }, forceScrollbarClasses],
-        [
-          'the vertical axis only',
-          { width: 50, height: 5000 },
-          ['q-body--force-scrollbar-y']
-        ],
-        ['neither axis', null, []]
-      ])('forces the scrollbar for %s', (_, fillerSize, expectedClasses) => {
-        // real body content decides which axes overflow the viewport
-        if (fillerSize !== null) makeDocumentScrollable(fillerSize)
+      test('reserves the gutter of a scrollbar that took up layout space', () => {
+        makeDocumentScrollable()
+        // the headless browser hides its scrollbars, so a classic one --
+        // the only kind that shrinks the viewport -- has to be faked
+        mockProperty(
+          document.documentElement,
+          'clientWidth',
+          window.innerWidth - 15
+        )
 
         preventScroll(true)
 
         expect(
-          forceScrollbarClasses.filter(cls =>
-            document.body.classList.contains(cls)
+          document.documentElement.classList.contains(
+            'q-document--reserve-scrollbar'
           )
-        ).toStrictEqual(expectedClasses)
+        ).toBe(true)
 
         preventScroll(false)
 
         expect(
-          forceScrollbarClasses.some(cls =>
-            document.body.classList.contains(cls)
+          document.documentElement.classList.contains(
+            'q-document--reserve-scrollbar'
+          )
+        ).toBe(false)
+      })
+
+      test('reserves no gutter when the scrollbar took up no space', () => {
+        // overlay scrollbars leave the viewport width alone, so there is
+        // nothing to reserve for them
+        makeDocumentScrollable()
+        mockProperty(document.documentElement, 'clientWidth', window.innerWidth)
+
+        preventScroll(true)
+
+        expect(
+          document.documentElement.classList.contains(
+            'q-document--reserve-scrollbar'
           )
         ).toBe(false)
       })
@@ -363,6 +415,9 @@ describe('[preventScroll API]', () => {
       })
 
       test('does not notify when the restore emits a scroll event', async () => {
+        // the pinned (iOS) lock is the one that loses the position and so
+        // has one to scroll back to on release
+        mockPlatform({ ios: true, nativeMobile: false })
         makeDocumentScrollable()
         window.scrollTo(30, 180)
 


### PR DESCRIPTION
Fixes #18183

Follow-up to #18191, which was closed with an invitation to redo it against current `dev`, scoped to this bug only.

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — not applicable: the iOS path is left byte-for-byte identical (see "iOS" below)
- [ ] It's been tested on an Electron app — not applicable: no platform-specific code touched
- [x] Any necessary documentation has been added or updated — no docs change needed: no public API and no documented behavior changes; the two CSS classes that disappear are internal and undocumented

**Other information:**

### The problem

With a `position: sticky` element on a scrollable page: scroll down, open a QDialog. In Firefox the sticky element disappears until the dialog closes; in Chrome it stays put (videos and StackBlitz repro in #18183).

### Root cause

Locking the page scroll pins the body and compensates the offset:

```sass
.q-document--prevent-scroll
  body
    position: fixed !important
```
```js
body.style.left = `-${scrollPositionX}px`
body.style.top = `-${scrollPositionY}px`
```

A sticky element inside a `position: fixed` subtree has no scrollport to stick to, so it gets no sticky offset — and its static position is `scrollPositionY` pixels above the viewport, because that is exactly how far the pinned body was shifted up. Firefox renders it there (i.e. off-screen); Blink clamps a sticky element inside a partially-offscreen fixed container into the viewport instead ([Bugzilla 1437761](https://bugzilla.mozilla.org/show_bug.cgi?id=1437761)), which is why Chrome looks correct. Nothing here is specific to QDialog: QDrawer in "mobile" behavior and the Loading plugin take the same lock.

### The fix

Clip the viewport instead of taking the page out of the flow:

```sass
.q-document--clip-scroll
  overflow: hidden !important
```

The page keeps its position in the flow and its scroll offset, so sticky content keeps sticking, and there is no scroll position to lose and restore when the lock lifts. As a side effect the page no longer jumps to the top under the lock (the `#7012` synthetic scroll simply does not happen any more).

Two details:

**Scrollbar gutter.** A clipped viewport stops painting its classic scrollbar, and the page would shift sideways into the freed space. The old fix for that (`q-body--force-scrollbar-x/y`, i.e. `overflow: scroll` on the body, propagated to the viewport) cannot work here — the root element's `overflow` no longer lets the body's propagate, and making the body its own scroll container would break sticky all over again. `scrollbar-gutter: stable` on the root reserves exactly the space the scrollbar had, and it shrinks the ICB the same way, so fixed overlays (the dialog backdrop, a QLayout header) keep their width too — measured 885px of a 900px viewport before, during and after the lock. Overlay scrollbars take up no space, so the class is only applied when `window.innerWidth - document.documentElement.clientWidth > 0`, which is false for them.

**iOS.** iOS pans the page by touch whatever the viewport says, so it keeps the pinned body, under its own class, along with the existing `visualViewport` plumbing. Its behavior is unchanged, including the scroll restore on release. Sticky content stays broken there — there is no alternative to pinning on that platform.

```sass
.q-document--prevent-scroll      // marker + overscroll-behavior, both modes
.q-document--clip-scroll         // everywhere but iOS
.q-document--reserve-scrollbar   // only when a classic scrollbar had space
.q-document--pin-body            // iOS
```

`q-body--force-scrollbar-x` and `q-body--force-scrollbar-y` are gone: they only ever existed to keep the pinned page's scrollbar, and the platform that still pins (iOS) has no classic scrollbars.

### Behavior notes

- The scroll position is only restored when the body was pinned. A clipped page never lost its position, and if the app moved it meanwhile (a router `scrollBehavior` on a navigation under an open Loading overlay, say), that move is the app's and not ours to undo.
- After a navigation that happens while the lock is held, the page no longer snaps to the top on its own — the router's scroll behavior decides, exactly as it does for a navigation without a lock. QLayout still re-syncs on release through the existing release listeners (#12994).
- `scrollbar-gutter` needs Safari 17.4+ (Chrome 94+, Firefox 97+). macOS uses overlay scrollbars by default, which need no gutter at all; only Safari 16.4–17.3 with "Always show scroll bars" can still see the old sideways shift.
- The gutter is reserved on the inline axis only, so a page with a *horizontal* scrollbar gains its height (~15px) while locked. The page content does not move (it is anchored top-left); only full-height fixed overlays get that much taller.

### Scope

- `ui/src/css/core/helpers.sass`
- `ui/src/utils/scroll/prevent-scroll.js`
- `ui/src/utils/scroll/prevent-scroll.test.js`
- `ui/playground/src/pages/web-tests/regression-sweep.vue` — new S27 scenario, plus S19 updated (see Validation)

### Validation

- `ui/src/utils/scroll/prevent-scroll.test.js`: the lock's two modes are covered separately — the default one clips the viewport and leaves the page (and `document.body.style`) alone, the iOS one pins the body at the offsets and is the only one that restores a scroll position on release. Plus the gutter: reserved when a classic scrollbar had layout space, skipped when it had none.
- `ui/playground/src/pages/web-tests/regression-sweep.vue`: new scenario **S27** — a sticky bar on a scrolled page, a QDialog opened over it, asserting the bar stays stuck and the page does not move, then that both survive the close. It fails on `dev` (`whileOpen=false`: the pinned page reads `scrollY: 0`) and passes with this change, in every engine the sweep drives.
- **S19** (#12994) had to move with the mechanism: it asserted that the page ends up at the top after a route change under the lock, which was a side effect of pinning the body — the page had nowhere else to go. The lock no longer moves the page, so the scenario now performs the navigation's own scroll-to-top, which is what a router does, and still asserts what #12994 is about: QLayout re-syncing with it once the lock lifts. It passes both before and after this change.
- `ui/src/components/infinite-scroll/QInfiniteScroll.test.js`: same reason — the scenario used the lock itself to put the page at the top. It now scrolls there explicitly while the lock is held (what an app navigating under an overlay, or the pinned lock on iOS, does), and still asserts that reverse mode neither polls under the lock nor misses the poll on release.

Everything below was run on Linux; iOS and Safari could not be exercised here (`pnpm test:sweep --ios` needs macOS + Xcode). The iOS path is unchanged by construction: it keeps the class that pins the body, the `visualViewport`/`onAppleScroll` plumbing and the scroll restore it always had.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page scroll locking across platforms, including iOS.
  * Preserved sticky positioning and scroll state while overlays or dialogs are active.
  * Improved scrollbar handling to prevent unwanted layout shifts.
  * Correctly restores scroll position when unlocking without route changes.

* **Tests**
  * Added regression coverage for sticky content during locked scrolling.
  * Expanded validation for iOS behavior, scrollbar handling, and overlay interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->