### PR TITLE
fix(QSelect): map a lazy loaded model value on its own (fix #17983)

### DIFF
--- a/docs/src/pages/vue-components/select.md
+++ b/docs/src/pages/vue-components/select.md
@@ -133,6 +133,10 @@ The following example shows a glimpse of how you can play with lazy loading the 
 While options are being loaded, the default loading spinner takes the place of the dropdown icon so the field keeps a constant width. For this reason, when `hide-dropdown-icon` is used the default spinner is not displayed at all (it would make the field's width jump); supply a `loading` slot if you still want an inline indicator in that case.
 :::
 
+::: tip
+When the model already holds a value and `map-options` is used, there is nothing to map it against until the options are loaded, so the field would display the raw value. Starting with v2.27, QSelect asks for them on its own in this case: it calls your `@filter` handler once with an empty search string and without opening the menu, so the correct label shows up without any user interaction. The same happens when the model value arrives later (a record loaded from the server, for instance). A value that the loaded options do not contain is not requested again.
+:::
+
 You can dynamically load new options when scroll reaches the end:
 
 <DocExample title="Dynamic loading options" file="OptionsDynamic" />

--- a/ui/src/components/select/QSelect.js
+++ b/ui/src/components/select/QSelect.js
@@ -5,6 +5,7 @@ import {
   nextTick,
   onBeforeUnmount,
   onBeforeUpdate,
+  onMounted,
   onUpdated,
   ref,
   watch
@@ -191,6 +192,7 @@ export default /*#__PURE__*/ createComponent({
     let filterTimer = null,
       inputValueTimer = null,
       innerValueCache,
+      prefetchDone = false,
       hasDialog,
       userInputValue,
       filterId = null,
@@ -511,6 +513,10 @@ export default /*#__PURE__*/ createComponent({
     )
 
     watch(() => props.fillInput, resetInputValue)
+
+    // not immediate: the initial run happens in onMounted, since filtering
+    // must not be triggered while the component is still setting up
+    watch(innerValue, prefetchUnmappedOptions)
 
     watch(menu, updateMenu)
 
@@ -1265,7 +1271,10 @@ export default /*#__PURE__*/ createComponent({
           }
         },
         () => {
-          if (state.focused.value && filterId === localFilterId) {
+          if (
+            (keepClosed || state.focused.value) &&
+            filterId === localFilterId
+          ) {
             clearTimeout(filterId)
             state.innerLoading.value = false
             innerLoadingIndicator.value = false
@@ -1274,6 +1283,31 @@ export default /*#__PURE__*/ createComponent({
           if (menu.value) menu.value = false
         }
       )
+    }
+
+    // mapOptions has nothing to look the model up into while the options are
+    // still lazy loading, so the field would display the raw model value;
+    // ask the filter handler for them once, without opening the menu
+    function prefetchUnmappedOptions() {
+      if (
+        prefetchDone ||
+        props.onFilter === void 0 ||
+        !props.mapOptions ||
+        // options are already in: an empty filter won't add a missing value
+        virtualScrollLength.value !== 0 ||
+        // a model holding whole options already carries its labels
+        innerValue.value.every(opt => Object(opt) === opt)
+      ) {
+        return
+      }
+
+      prefetchDone = true
+
+      // innerLoading is only turned off on the tick after the options land,
+      // so the innerValue watcher skips resetInputValue() -- do it here
+      filter('', true, () => {
+        resetInputValue()
+      })
     }
 
     function getMenu() {
@@ -1569,6 +1603,7 @@ export default /*#__PURE__*/ createComponent({
 
     onBeforeUpdate(updatePreState)
     onUpdated(updateMenuPosition)
+    onMounted(prefetchUnmappedOptions)
 
     updatePreState()
 

--- a/ui/src/components/select/QSelect.test.js
+++ b/ui/src/components/select/QSelect.test.js
@@ -1647,6 +1647,124 @@ describe('[QSelect API]', () => {
         // the model value is looked up in the options to get its label
         expect(wrapper.get('.q-field__native').text()).toBe('B')
       })
+
+      test('asks the filter handler for lazy loaded options (#17983)', async () => {
+        const onFilter = vi.fn()
+        const wrapper = mountSelect({
+          modelValue: 2,
+          options: [],
+          mapOptions: true,
+          emitValue: true,
+          onFilter
+        })
+
+        await flushPromises()
+
+        // there is nothing to map the model against yet, so the options are
+        // requested right away and the menu stays closed
+        expect(onFilter).toHaveBeenCalledOnce()
+        expect(onFilter.mock.calls[0][0]).toBe('')
+        expect(wrapper.findComponent({ name: 'QPortal' }).exists()).toBe(false)
+
+        await wrapper.setProps({ options: objectOptions })
+        onFilter.mock.calls[0][1]()
+        await flushPromises()
+
+        expect(wrapper.get('.q-field__native').text()).toBe('B')
+        expect(wrapper.findComponent({ name: 'QPortal' }).exists()).toBe(false)
+      })
+
+      test('only asks for options it cannot map', async () => {
+        const onFilter = vi.fn()
+
+        // the options are already loaded
+        mountSelect({
+          modelValue: 2,
+          options: objectOptions,
+          mapOptions: true,
+          emitValue: true,
+          onFilter
+        })
+
+        // there is no model value to map
+        mountSelect({
+          modelValue: null,
+          options: [],
+          mapOptions: true,
+          emitValue: true,
+          onFilter
+        })
+
+        // no mapping was asked for
+        mountSelect({
+          modelValue: 2,
+          options: [],
+          emitValue: true,
+          onFilter
+        })
+
+        // the model holds whole options, which carry their own labels
+        mountSelect({
+          modelValue: objectOptions[1],
+          options: [],
+          mapOptions: true,
+          onFilter
+        })
+
+        await flushPromises()
+
+        expect(onFilter).not.toHaveBeenCalled()
+      })
+
+      test('maps a model value that arrives after mounting', async () => {
+        const onFilter = vi.fn()
+        const wrapper = mountSelect({
+          modelValue: null,
+          options: [],
+          mapOptions: true,
+          emitValue: true,
+          onFilter
+        })
+
+        await flushPromises()
+
+        expect(onFilter).not.toHaveBeenCalled()
+
+        await wrapper.setProps({ modelValue: 2 })
+        await flushPromises()
+
+        expect(onFilter).toHaveBeenCalledOnce()
+
+        // a value the loaded options do not hold must not keep asking
+        await wrapper.setProps({ modelValue: 4 })
+        await flushPromises()
+
+        expect(onFilter).toHaveBeenCalledOnce()
+      })
+
+      test('fills the input with the mapped label', async () => {
+        const onFilter = vi.fn()
+        const wrapper = mountSelect({
+          modelValue: 2,
+          options: [],
+          mapOptions: true,
+          emitValue: true,
+          useInput: true,
+          fillInput: true,
+          hideSelected: true,
+          onFilter
+        })
+
+        await flushPromises()
+
+        expect(wrapper.get('input').element.value).toBe('2')
+
+        await wrapper.setProps({ options: objectOptions })
+        onFilter.mock.calls[0][1]()
+        await flushPromises()
+
+        expect(wrapper.get('input').element.value).toBe('B')
+      })
     })
 
     describe('[(prop)disable-tab-selection]', () => {
@@ -2990,6 +3108,27 @@ describe('[QSelect API]', () => {
 
       expect(fieldWidth).toBeLessThanOrEqual(parentWidth)
       expect(value.scrollWidth).toBeGreaterThan(value.clientWidth)
+    })
+
+    test('drops the loading state when an unfocused filtering is aborted', async () => {
+      const onFilter = vi.fn((val, update, abort) => {
+        abort()
+      })
+
+      // the mapping of the model value triggers a filtering while the
+      // component is not focused; aborting it has to clear the indicator
+      const wrapper = mountSelect({
+        modelValue: 2,
+        options: [],
+        mapOptions: true,
+        emitValue: true,
+        onFilter
+      })
+
+      await flushPromises()
+
+      expect(onFilter).toHaveBeenCalledOnce()
+      expect(wrapper.find('.q-field__append .q-spinner').exists()).toBe(false)
     })
   })
 


### PR DESCRIPTION
Fixes #17983

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app — not applicable: no platform-specific code path is touched
- [ ] It's been tested on an Electron app — same
- [x] Any necessary documentation has been added or updated — a tip in the "Lazy loading" section of the QSelect docs page; no public API was added

**Other information:**

### The problem

Reproduction from the issue ([CodePen](https://codepen.io/Stormalong42/pen/qEERrMN)): a QSelect with lazy loaded options (`@filter`), `map-options` and `emit-value`, whose model already holds a value. The field displays the raw value (`twt`) instead of its label (`Twitter`). Opening the menu once — anything that loads the options — makes it correct.

### Root cause

`map-options` maps the model in `innerValue` through `getOption()`:

```js
function getOption(value, valueCache) {
  const fn = opt => isDeepEqual(getOptionValue.value(opt), value)
  return props.options.find(fn) || valueCache.find(fn) || value
}
```

With lazy loading, `props.options` is still empty on the first render and the cache of previously mapped values is empty too, so the raw model value is what falls out and what the field displays.

The options only arrive when `filter()` runs, and it is called from `showPopup()`, from typing into the input and from `new-value-mode` — always as the result of a user interaction. Before the first popup, QSelect has no label to show and no way to obtain one.

### The fix

Let QSelect ask for the options itself, in exactly the case where the display is objectively wrong:

```js
function prefetchUnmappedOptions() {
  if (
    prefetchDone ||
    props.onFilter === void 0 ||
    !props.mapOptions ||
    // options are already in: an empty filter won't add a missing value
    virtualScrollLength.value !== 0 ||
    // a model holding whole options already carries its labels
    innerValue.value.every(opt => Object(opt) === opt)
  ) {
    return
  }

  prefetchDone = true
  filter('', true, () => { resetInputValue() })
}
```

It reuses the `keepClosed` mode `filter()` already has, so the options are fetched with an empty search string and no popup is shown. The check runs from `onMounted` and from a `watch(innerValue, …)` — a form that fetches its record lands the model value after mounting, which is the common shape of the lazy-loading case — with `prefetchDone` capping it at one request per component instance.

Doing this behind a new opt-in prop was the other option, and it was rejected: it would leave the wrong label in place for everyone who does not know about the prop, which is the bug being reported here.

The `afterUpdateFn` argument is not decoration. With `use-input` + `fill-input`, the input's text comes from the `innerValue` watcher, which bails out while `state.innerLoading` is set — and that flag is only cleared on the tick *after* the options land, i.e. after `innerValue` has already recomputed. `afterUpdateFn` runs past that point, so `resetInputValue()` there is what puts the label into the input.

The same code path needed one more fix: in the keep-closed mode, the `abort()` callback of `filter()` only cleared the loading state when the component was focused, so an aborted prefetch (no network, a handler that gives up) would have left the spinner in place forever. Its condition is now the same one the `update()` callback uses.

### Behavior notes

- Nothing happens when the options are already loaded, when the model is empty, when `map-options` is off, or when the model holds whole option objects (those carry their own labels) — no existing setup gains a request it did not make before.
- A value that the loaded options do not contain (a deleted record, server-side pagination) is requested once and never again.
- The regular loading indicator shows while the prefetch is in flight, exactly as it does for any other filtering.
- If the user opens the select while a prefetch is in flight, `showPopup()` → `filter()` supersedes it through the existing `filterId` bookkeeping.
- SSR is unaffected: `onMounted` does not run on the server, so the server-rendered markup keeps the raw value and the swap happens after hydration.

### Scope

- `ui/src/components/select/QSelect.js`
- `ui/src/components/select/QSelect.test.js`
- `docs/src/pages/vue-components/select.md`

### Validation

- Five new tests in `QSelect.test.js`: the issue's scenario (the handler is called once with `''`, no menu is rendered, the label shows up), the cases that must *not* request anything, a model value arriving after mounting (and not requesting again for the next missing one), the `use-input` + `fill-input` input text, and the aborted prefetch dropping the loading state (in `[Generic]`). Four of them fail on `dev`; the fifth is the negative one that guards the conditions.
- `pnpm test:specs --target components/select/QSelect`: ✅.
- `pnpm test:unit`: 260 files / 5741 tests green. Full `pnpm test`: every suite green except one unrelated flake of the parallel runner (`QTree > virtual scroll keyboard navigation reaches rows outside the slice`), which passes on its own (121/121) and lives in a component this PR does not touch.
- Manual check in a real browser (playground page driven headless over CDP), four scenarios — the issue's own, `use-input` + `fill-input`, a model value arriving 2s after mounting, and a handler that calls `abort()`. With the fix they render "Twitter" / "Facebook" / "Google" with no interaction and the aborted one drops its spinner; on the reverted fix the same page shows "twt" / "fb" / "goog" and the handler is never called.
- `pnpm lint` and `git diff --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved lazy loading for select fields using mapped values.
  * Automatically retrieves missing options for selected values without opening the dropdown.
  * Supports values that arrive after the component loads and updates displayed labels once options are available.

* **Bug Fixes**
  * Prevented unnecessary requests for values that are already available.
  * Ensured loading indicators clear correctly when filtering is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->