### PR TITLE
fix(QIntersection): don't remount the content when disable is toggled #12668

### DIFF
--- a/docs/src/examples/Intersection/Disable.vue
+++ b/docs/src/examples/Intersection/Disable.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="relative-position">
+    <div class="example-area q-pa-lg scroll">
+      <div class="example-filler" />
+
+      <div
+        v-intersection="enabled ? onIntersection : false"
+        class="example-observed text-center rounded-borders"
+      >
+        Observed Element
+      </div>
+
+      <div class="example-filler" />
+    </div>
+
+    <div
+      class="example-state rounded-borders absolute-top q-mt-md q-ml-md q-mr-lg text-white"
+      :class="visibleClass"
+    >
+      <div class="text-center">{{ visible ? 'Visible' : 'Hidden' }}</div>
+
+      <q-toggle v-model="enabled" label="Observe" dense />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const enabled = ref(true)
+const visible = ref(false)
+
+const visibleClass = computed(
+  () => `bg-${visible.value ? 'positive' : 'negative'}`
+)
+
+function onIntersection(entry) {
+  visible.value = entry.isIntersecting
+}
+</script>
+
+<style lang="sass" scoped>
+.example-state
+  background: #ccc
+  font-size: 20px
+  color: #282a37
+  padding: 10px
+  opacity: 0.8
+
+.example-observed
+  width: 100%
+  font-size: 20px
+  color: #ccc
+  background: #424242
+  padding: 10px
+
+.example-area
+  height: 300px
+
+.example-filler
+  height: 500px
+</style>

--- a/docs/src/pages/vue-directives/intersection.md
+++ b/docs/src/pages/vue-directives/intersection.md
@@ -63,6 +63,12 @@ By passing in an Object as the directive's value (instead of a Function), you ca
 
 <DocExample title="Supplying configuration Object" file="ObjectForm" no-edit />
 
+### Disable
+
+Passing in Boolean `false` instead of a Function or an Object disables the directive: the Intersection Observer is dropped until a handler is supplied again. The DOM element is untouched in the process, so whatever it wraps keeps its state.
+
+<DocExample title="Disable" file="Disable" no-edit />
+
 ### Advanced
 
 Below is a more advanced example of what you can do. The code takes advantage of the HTML `data` attribute. Basically, by setting `data-id` with the index of the element in a loop, this can be retrieved via the passed in `entry` to the handler as `entry.target.dataset.id`. If you are unfamiliar with the `data` attribute you can read more [here](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) about using it.

--- a/ui/src/components/intersection/QIntersection.js
+++ b/ui/src/components/intersection/QIntersection.js
@@ -57,7 +57,12 @@ export default /*#__PURE__*/ createComponent({
     )
 
     const directives = computed(() => [
-      [Intersection, intersectionProps.value, void 0, { once: props.once }]
+      [
+        Intersection,
+        props.disable ? false : intersectionProps.value,
+        void 0,
+        { once: props.once }
+      ]
     ])
 
     const transitionStyle = computed(
@@ -111,11 +116,9 @@ export default /*#__PURE__*/ createComponent({
         { class: 'q-intersection' },
         child,
         'main',
-        // must not depend on transient state: hDir bakes it into the vnode
-        // key, and a flip re-creates the whole content (#17099-class; a
-        // once + ssrPrerender instance used to remount right after the
-        // client takeover)
-        !props.disable,
+        // hDir bakes this into the vnode key, so a flip re-creates the whole
+        // content (#17099); disabling goes through the directive value (#12668)
+        true,
         () => directives.value
       )
     }

--- a/ui/src/components/intersection/QIntersection.test.js
+++ b/ui/src/components/intersection/QIntersection.test.js
@@ -1,4 +1,4 @@
-import { Transition, nextTick } from 'vue'
+import { Transition, defineComponent, h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -181,6 +181,39 @@ describe('[QIntersection API]', () => {
 
         expect(wrapper.text()).toBe('Hidden content')
         expect(observers).toHaveLength(0)
+      })
+
+      test('toggling it keeps the content mounted', async () => {
+        const mountedFn = vi.fn()
+        const unmountedFn = vi.fn()
+        const Probe = defineComponent({
+          name: 'ContentProbe',
+          mounted: mountedFn,
+          unmounted: unmountedFn,
+          render: () => h('span', 'Visible content')
+        })
+
+        const wrapper = mount(QIntersection, {
+          slots: { default: () => h(Probe) }
+        })
+
+        show()
+        await nextTick()
+
+        const contentEl = wrapper.get('span').element
+        expect(mountedFn).toHaveBeenCalledOnce()
+
+        await wrapper.setProps({ disable: true })
+
+        expect(unmountedFn).not.toHaveBeenCalled()
+        expect(wrapper.get('span').element).toBe(contentEl)
+        expect(observers[0].disconnect).toHaveBeenCalledOnce()
+
+        await wrapper.setProps({ disable: false })
+
+        expect(unmountedFn).not.toHaveBeenCalled()
+        expect(wrapper.get('span').element).toBe(contentEl)
+        expect(observers).toHaveLength(2)
       })
     })
   })

--- a/ui/src/components/intersection/QIntersection.test.js
+++ b/ui/src/components/intersection/QIntersection.test.js
@@ -67,9 +67,10 @@ describe('[QIntersection API]', () => {
       })
 
       test('toggling disable does not re-arm it', async () => {
+        const slotContent = 'Visible content'
         const wrapper = mount(QIntersection, {
           props: { once: true },
-          slots: { default: () => 'Visible content' }
+          slots: { default: () => slotContent }
         })
 
         show()
@@ -80,7 +81,7 @@ describe('[QIntersection API]', () => {
 
         // once means once: re-enabling must not start observing again
         expect(observers).toHaveLength(1)
-        expect(wrapper.text()).toBe('Visible content')
+        expect(wrapper.text()).toBe(slotContent)
       })
     })
 

--- a/ui/src/components/intersection/QIntersection.test.js
+++ b/ui/src/components/intersection/QIntersection.test.js
@@ -65,6 +65,23 @@ describe('[QIntersection API]', () => {
         expect(wrapper.text()).toBe('Visible content')
         expect(observers[0].disconnect).toHaveBeenCalledOnce()
       })
+
+      test('toggling disable does not re-arm it', async () => {
+        const wrapper = mount(QIntersection, {
+          props: { once: true },
+          slots: { default: () => 'Visible content' }
+        })
+
+        show()
+        await nextTick()
+
+        await wrapper.setProps({ disable: true })
+        await wrapper.setProps({ disable: false })
+
+        // once means once: re-enabling must not start observing again
+        expect(observers).toHaveLength(1)
+        expect(wrapper.text()).toBe('Visible content')
+      })
     })
 
     describe('[(prop)ssr-prerender]', () => {

--- a/ui/src/directives/intersection/Intersection.js
+++ b/ui/src/directives/intersection/Intersection.js
@@ -9,6 +9,16 @@ const defaultCfg = {
 }
 
 function update(el, ctx, value) {
+  // the cached cfg is what a re-enable rebuilds the observer from, and a
+  // queued callback must find no handler left to run
+  if (value === false) {
+    ctx.observer?.disconnect()
+    ctx.observer = void 0
+    ctx.cfg = void 0
+    ctx.handler = void 0
+    return
+  }
+
   let handler, cfg, changed
 
   if (typeof value === 'function') {

--- a/ui/src/directives/intersection/Intersection.json
+++ b/ui/src/directives/intersection/Intersection.json
@@ -4,10 +4,11 @@
   },
 
   "value": {
-    "type": ["Object", "Function"],
-    "desc": "Function to call when scrolling occurs (identical to description of 'handler' prop of the Object form); If using the Object form, it is HIGHLY recommended to reference it from your vue component scope, otherwise the directive update cycle will continuously recreate the observer which hits performance hard",
+    "type": ["Boolean", "Object", "Function"],
+    "desc": "Boolean false to disable the directive (the observer is dropped and recreated when a handler is supplied again); Function to call when scrolling occurs (identical to description of 'handler' prop of the Object form); If using the Object form, it is HIGHLY recommended to reference it from your vue component scope, otherwise the directive update cycle will continuously recreate the observer which hits performance hard",
     "examples": [
       "# v-intersection=\"myFunction\"",
+      "# v-intersection=\"isEnabled ? myFunction : false\"",
       "# v-intersection=\"{ handler: myFunction, cfg: { root: myScrollingParentEl, rootMargin: '10px 20px 30px 40px', threshold: [0, 0.25, 0.5, 0.75, 1] } }\""
     ],
 

--- a/ui/src/directives/intersection/Intersection.test.js
+++ b/ui/src/directives/intersection/Intersection.test.js
@@ -55,6 +55,28 @@ describe('[Intersection API]', () => {
       expect(observers[0].disconnect).toHaveBeenCalledOnce()
     })
 
+    test('as Boolean false leaves no handler for a queued entry', async () => {
+      const handler = vi.fn(() => true)
+      const value = ref(handler)
+      const TestComponent = defineComponent({
+        render: () => withDirectives(h('div'), [[Intersection, value.value]])
+      })
+
+      mount(TestComponent)
+      const observer = observers[0]
+
+      value.value = false
+      await nextTick()
+
+      // the observer callback reads the ctx at call time, so an entry queued
+      // before the disable must find no handler and no observer to touch
+      observer.callback([{ isIntersecting: true, rootBounds: {} }])
+      observer.callback([{ isIntersecting: true, rootBounds: null }])
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(observer.unobserve).not.toHaveBeenCalled()
+    })
+
     test('as Object', () => {
       const handler = vi.fn(() => true)
       const root = document.createElement('div')

--- a/ui/src/directives/intersection/Intersection.test.js
+++ b/ui/src/directives/intersection/Intersection.test.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { defineComponent, h, withDirectives } from 'vue'
+import { defineComponent, h, nextTick, ref, withDirectives } from 'vue'
 
 import Intersection from './Intersection.js'
 
@@ -30,6 +30,31 @@ afterEach(() => {
 
 describe('[Intersection API]', () => {
   describe('[Value]', () => {
+    test('as Boolean', async () => {
+      const handler = vi.fn(() => true)
+      const value = ref(false)
+      const TestComponent = defineComponent({
+        render: () => withDirectives(h('div'), [[Intersection, value.value]])
+      })
+
+      const wrapper = mount(TestComponent)
+
+      expect(observers).toHaveLength(0)
+      expect(wrapper.element.__qvisible).toBeDefined()
+
+      value.value = handler
+      await nextTick()
+
+      expect(observers).toHaveLength(1)
+      expect(observers[0].observe).toHaveBeenCalledWith(wrapper.element)
+
+      value.value = false
+      await nextTick()
+
+      expect(observers).toHaveLength(1)
+      expect(observers[0].disconnect).toHaveBeenCalledOnce()
+    })
+
     test('as Object', () => {
       const handler = vi.fn(() => true)
       const root = document.createElement('div')


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch
- [x] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated

**Other information:**

Fixes #12668.

## The bug

`hDir()` writes `data.key = key + condition` (`ui/src/utils/private.render/render.js:43`), so whatever is passed as its `condition` ends up in the vnode key. `QIntersection` passed `!props.disable` there (`ui/src/components/intersection/QIntersection.js:118` before this PR), so toggling `disable` flipped the root key between `maintrue` and `mainfalse`, Vue saw a different vnode type and destroyed/rebuilt the whole subtree.

That contradicts the component's own API description for `disable`, "Disable visibility observable (content will remain as it was, visible or hidden)", and it is a v1 -> v2 regression per the issue.

It is the same class as c434fc1c ("hDir bakes its condition into the vnode key"), which removed the transient `isRuntimeSsrPreHydration` part of that condition last week. `!props.disable` was the remaining key flip.

## The fix

The `hDir` condition is now the constant `true`, so the key never changes. Disabling is expressed through the directive value instead: `QIntersection` passes `false` when `disable` is set, and the `Intersection` directive treats Boolean `false` as "no observer", disconnecting it and clearing the cached `cfg`/`handler` so a re-enable rebuilds the observer from scratch.

Mounting with `disable` still creates no `IntersectionObserver` at all, which the pre-existing `[(prop)disable]` test asserts.

### Public API

This widens the accepted `v-intersection` value from `Object | Function` to `Boolean | Object | Function`; only `false` is special, everything else keeps its current meaning. `v-ripple` (`binding.value !== false`, `Ripple.json` declares `["Boolean", "Object"]`) and `v-close-popup` already accept a Boolean the same way. `Intersection.json`, the generated `IntersectionValue` type and the directive docs page are updated together, and the docs page gets a `Disable` example alongside Ripple's.

### Behavior change beyond the fix

With `once`, an observer that has already fired is no longer re-armed by toggling `disable` off and on again. The re-arming only happened because the element was recreated, and it contradicted `once`.

## Blast radius

`hDir` has 11 other call sites; none of them are touched and `render.js` is unchanged. Worth noting separately: `QChip` (`ui/src/components/chip/QChip.js:254`) passes `props.ripple !== false && !props.disable` as its `hDir` condition and has the same latent key flip. I left it alone here to keep this PR to one logical change.

## Validation

Everything run from `/ui` unless stated.

- `pnpm test` (all five suites): unit 264 files / 5950 tests, hydration 89 / 142, hydration-pwa 2 / 6, umd 4 / 78, e2e-ssr 1 / 239, build 1 / 9. All pass.
- Baseline on `dev` before the change: unit 264 / 5948, hydration 89 / 142. The two new tests are the delta.
- `pnpm test:specs:check`: 264 files OK, exit 0.
- Root `pnpm lint:check`: "All matched files use the correct format", no oxlint findings in the changed files. (Two pre-existing `tsconfig-error` lines for the `app-vite` playgrounds, whose gitignored `.quasar/` is not generated in this checkout, are unrelated.)
- `/docs` `pnpm test`: unit 63 / 303, e2e-ssr 1 / 317 routes, SSG build clean, so the new example page renders and hydrates without console output.
- `git diff --check` clean.

Counterfactual for the new tests, both against the browser-mode Chromium suite:

Reverting only `QIntersection.js`:

```
FAIL src/components/intersection/QIntersection.test.js > [QIntersection API] > [Props] > [(prop)disable] > toggling it keeps the content mounted
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 ❯ src/components/intersection/QIntersection.test.js:208:33
    208|         expect(unmountedFn).not.toHaveBeenCalled()
```

Reverting only `Intersection.js` (3 failures, including the pre-existing `disable` test):

```
FAIL src/components/intersection/QIntersection.test.js > ... > [(prop)disable] > type Boolean has effect
AssertionError: expected [ <Anonymous Class>{ …(5) } ] to have a length of +0 but got 1
FAIL src/directives/intersection/Intersection.test.js > [Intersection API] > [Value] > as Boolean
AssertionError: expected [ <Anonymous Class>{ …(5) } ] to have a length of +0 but got 1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for disabling the `v-intersection` directive by setting its value to `false`.
  - Re-enabling the directive automatically resumes observation.
  - Disabling preserves the observed element and its content.

- **Bug Fixes**
  - Disabling now cleanly stops observation and prevents outdated callbacks from running.
  - One-time observation remains inactive after being disabled.

- **Documentation**
  - Added guidance and an interactive example demonstrating conditional directive enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->