### PR TITLE
fix(QSplitter): don't remount the separator content when disable is toggled #12668

### DIFF
--- a/ui/src/components/splitter/QSplitter.js
+++ b/ui/src/components/splitter/QSplitter.js
@@ -1,4 +1,4 @@
-import { computed, h, nextTick, ref, watch } from 'vue'
+import { computed, h, nextTick, ref, watch, withDirectives } from 'vue'
 
 import TouchPan from '../../directives/touch-pan/TouchPan.js'
 
@@ -9,7 +9,7 @@ import useDark, {
 import useId from '../../composables/use-id/use-id.js'
 
 import { createComponent } from '../../utils/private.create/create.js'
-import { hDir, hMergeSlot, hSlot } from '../../utils/private.render/render.js'
+import { hMergeSlot, hSlot } from '../../utils/private.render/render.js'
 import { stopAndPrevent } from '../../utils/event/event.js'
 
 export default /*#__PURE__*/ createComponent({
@@ -149,7 +149,9 @@ export default /*#__PURE__*/ createComponent({
     const sepDirective = computed(() => [
       [
         TouchPan,
-        pan,
+        // TouchPan only acquires while its value is a function; detaching the
+        // directive instead would re-create the separator content (#12668)
+        props.disable ? void 0 : pan,
         void 0,
         {
           [props.horizontal ? 'vertical' : 'horizontal']: true,
@@ -293,13 +295,13 @@ export default /*#__PURE__*/ createComponent({
             onKeydown: props.disable ? void 0 : onSeparatorKeydown
           },
           [
-            hDir(
-              'div',
-              { class: 'q-splitter__separator-area absolute-full' },
-              hSlot(slots.separator),
-              'sep',
-              !props.disable,
-              () => sepDirective.value
+            withDirectives(
+              h(
+                'div',
+                { class: 'q-splitter__separator-area absolute-full' },
+                hSlot(slots.separator)
+              ),
+              sepDirective.value
             )
           ]
         ),

--- a/ui/src/components/splitter/QSplitter.test.js
+++ b/ui/src/components/splitter/QSplitter.test.js
@@ -1,6 +1,6 @@
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import QSplitter from './QSplitter.js'
 
@@ -26,8 +26,12 @@ function getSeparator(wrapper) {
   return wrapper.get('.q-splitter__separator')
 }
 
+function getPanContext(wrapper) {
+  return wrapper.get('.q-splitter__separator-area').element.__qtouchpan
+}
+
 function getPanHandler(wrapper) {
-  return wrapper.get('.q-splitter__separator-area').element.__qtouchpan.handler
+  return getPanContext(wrapper).handler
 }
 
 function startPan(wrapper) {
@@ -125,14 +129,45 @@ describe('[QSplitter API]', () => {
     })
 
     describe('[(prop)disable]', () => {
-      test('type Boolean has effect', () => {
+      test('type Boolean has effect', async () => {
         const wrapper = mountSplitter({ disable: true })
+        const area = wrapper.get('.q-splitter__separator-area')
 
         expect(wrapper.classes()).toContain('q-splitter--disabled')
         expect(getSeparator(wrapper).attributes('aria-disabled')).toBe('true')
-        expect(
-          wrapper.get('.q-splitter__separator-area').element.__qtouchpan
-        ).toBeUndefined()
+
+        await area.trigger('mousedown', { button: 0 })
+
+        expect(getPanContext(wrapper).event).toBeUndefined()
+
+        await wrapper.setProps({ disable: false })
+        await area.trigger('mousedown', { button: 0 })
+
+        expect(getPanContext(wrapper).event).toBeDefined()
+
+        wrapper.unmount()
+      })
+
+      test('toggling it keeps the separator content mounted', async () => {
+        const unmountedFn = vi.fn()
+        const Probe = defineComponent({
+          name: 'SeparatorProbe',
+          unmounted: unmountedFn,
+          render: () => h('span', 'Separator content')
+        })
+
+        const wrapper = mountSplitter({}, { separator: () => h(Probe) })
+        const probeEl = wrapper.get('span').element
+
+        await wrapper.setProps({ disable: true })
+
+        expect(unmountedFn).not.toHaveBeenCalled()
+        expect(wrapper.get('span').element).toBe(probeEl)
+
+        await wrapper.setProps({ disable: false })
+
+        expect(unmountedFn).not.toHaveBeenCalled()
+        expect(wrapper.get('span').element).toBe(probeEl)
       })
     })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Other information:**

### What breaks

`ui/src/components/splitter/QSplitter.js:296` renders the separator area through `hDir()` with `!props.disable` as its condition. `hDir()` bakes that condition into the vnode key (`ui/src/utils/private.render/render.js:43`, `data.key = key + condition`), so flipping `disable` flips the key between `septrue` and `sepfalse` and Vue destroys and rebuilds the whole `separator` slot.

Anything the devland put in that slot goes with it: an icon or image reloads (the docs page explicitly covers images in the separator slot), a QTooltip or QMenu anchored there is torn down, and any component state inside it is lost. Nothing about the rendered separator otherwise differs between the two states, so the remount is pure loss.

This is the same defect class as `fix(QIntersection)` (#18531, #12668) and `fix(QChip/QPullToRefresh)` (fb37b499, #12668). QSplitter is the last `hDir` call site still keyed on `!props.disable`.

### The fix

`QSplitter.js` now keeps the directive attached and disarms it in place, exactly the way QPullToRefresh was fixed: TouchPan only acquires a gesture while `typeof ctx.handler === 'function'` (`ui/src/utils/private.touch/touch.js:54`), so passing `void 0` as its value while disabled makes it inert, and `updated()` swaps the handler back without re-creating anything. The `hDir()` call becomes a plain `withDirectives()`.

A disabled splitter therefore carries an inert directive instead of none. Everything else is unchanged: the `q-splitter--disabled` class, `aria-disabled`, the removal from the Tab order and the already separately gated `onKeydown` all still key off `props.disable`.

No public API, SSR, hydration, platform, accessibility or security implications, so no docs page needed an update.

### How it was proved

`ui/src/components/splitter/QSplitter.test.js` gains `toggling it keeps the separator content mounted` under `[(prop)disable]`: it mounts a probe component in the `separator` slot, toggles `disable` on and back off, and asserts the probe was never unmounted and that its DOM node is identical.

The existing `type Boolean has effect` test asserted `__qtouchpan` was `undefined` while disabled, which is the implementation detail this change intentionally alters. It now asserts the observable contract instead, mirroring the QPullToRefresh test: a `mousedown` starts no pan while disabled, and does once the prop is cleared.

Counterfactual, with only the source fix reverted (the test file untouched):

```
 FAIL  |ui (chromium)| src/components/splitter/QSplitter.test.js > [QSplitter API] > [Props] > [(prop)disable] > toggling it keeps the separator content mounted
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:
  1st vi.fn() call: Array []
  Number of calls: 1

 - src/components/splitter/QSplitter.test.js:164:33
    162|         await wrapper.setProps({ disable: true })
    163|
    164|         expect(unmountedFn).not.toHaveBeenCalled()
       |                                 ^

 Test Files  1 failed (1)
      Tests  2 failed | 45 passed (47)
```

(the second red is `type Boolean has effect`, which throws `TypeError: Cannot read properties of undefined (reading 'event')` because the old code detaches the directive entirely.)

Restoring the fix returns all 47 to green.

### Validation

- `pnpm test:unit src/components/splitter/QSplitter.test.js`: 47 passed
- `pnpm test` (ui, all six suites): test:build 2 files, test:unit 264 files, test:hydration 89 files, test:hydration:pwa 2 files, test:umd 4 files, test:e2e:ssr all green
- `pnpm test:specs --target QSplitter`: OK
- `pnpm exec oxfmt --check ./ui/src/components/splitter`: all matched files use the correct format
- `pnpm exec oxlint ./ui/src/components/splitter`: clean
- `git diff --check`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved splitter behavior when disabled: touch-pan interactions are now correctly prevented.
  - Re-enabling the splitter restores touch-pan interaction as expected.
  - Preserved separator slot content and its DOM element when toggling the disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->