### PR TITLE
fix(QMenu/QTooltip): keep a flipped popup capped so growth can't escape the viewport

### DIFF
--- a/ui/src/composables/private.use-position-engine/engine/core.js
+++ b/ui/src/composables/private.use-position-engine/engine/core.js
@@ -204,7 +204,7 @@ export function applyBoundary({
         space = spaceAbove
       }
 
-      if (space < height) res.maxHeight = space + 'px'
+      res.maxHeight = space + 'px'
     }
   }
 
@@ -234,7 +234,7 @@ export function applyBoundary({
         space = spaceLeft
       }
 
-      if (space < width) res.maxWidth = space + 'px'
+      res.maxWidth = space + 'px'
     }
   }
 

--- a/ui/src/composables/private.use-position-engine/engine/core.js
+++ b/ui/src/composables/private.use-position-engine/engine/core.js
@@ -105,12 +105,16 @@ export function parsePosition(pos, rtl) {
  * (the room is measured from the anchor line each placement would use,
  * not from the anchor's edge against the viewport middle, which used
  * to flip an anchor straddling the middle towards the SMALLER side,
- * #16443) and, when its natural size exceeds even the space that
- * placement has, a max size capped to that space. A popup that fits
- * the mirrored side stays uncapped: a cap at its own measured size would
- * round a fractional natural size down (offsetWidth/offsetHeight are
- * integers) and wrap or scroll content that fit before the flip. How
- * the returned origins/caps are then EXPRESSED is the engines'
+ * #16443) and a max size capped to that space, whether or not its
+ * natural size already fit there: content can grow after this pass,
+ * and the flipped side has already anchored the popup's far edge, so a
+ * popup left uncapped there would grow past the opposite viewport edge
+ * with no scroll position able to reveal the overflow (#18536). The cap
+ * is the fractional space itself (getBoundingClientRect), never the
+ * popup's own measured size, so it never rounds a fractional natural
+ * size down (offsetWidth/offsetHeight are integers) and wraps or
+ * scrolls content that fit before the flip. How the returned
+ * origins/caps are then EXPRESSED is the engines'
  * business: anchor() insets on the native engine, pixel top/left on the
  * fallback; either way the popup keeps tracking its anchor and only the
  * flip/cap decision itself is frozen at measure time. The element does
@@ -205,7 +209,7 @@ export function applyBoundary({
       }
 
       // combined through CSS min(), never JS, so a smaller caller maxHeight
-      // prop stays in force instead of being widened back to `space`
+      // prop stays in force instead of being widened back to `space` (#18536)
       res.maxHeight = maxHeight ? `min(${space}px, ${maxHeight})` : `${space}px`
     }
   }

--- a/ui/src/composables/private.use-position-engine/engine/core.js
+++ b/ui/src/composables/private.use-position-engine/engine/core.js
@@ -204,7 +204,9 @@ export function applyBoundary({
         space = spaceAbove
       }
 
-      res.maxHeight = space + 'px'
+      // combined through CSS min(), never JS, so a smaller caller maxHeight
+      // prop stays in force instead of being widened back to `space`
+      res.maxHeight = maxHeight ? `min(${space}px, ${maxHeight})` : `${space}px`
     }
   }
 
@@ -234,7 +236,7 @@ export function applyBoundary({
         space = spaceLeft
       }
 
-      res.maxWidth = space + 'px'
+      res.maxWidth = maxWidth ? `min(${space}px, ${maxWidth})` : `${space}px`
     }
   }
 

--- a/ui/src/composables/private.use-position-engine/engine/core.test.js
+++ b/ui/src/composables/private.use-position-engine/engine/core.test.js
@@ -302,10 +302,12 @@ describe('[core API]', () => {
         expect(res.maxWidth).toBe(`${viewportWidth - 20}px`)
       })
 
-      test('leaves a popup that fits the mirrored side uncapped', () => {
-        // a cap at the popup's own measured size would round a
-        // fractional natural size down (offsetWidth/offsetHeight are
-        // integers) and wrap or scroll content that fit before the flip
+      test('caps a popup that fits the mirrored side at the available space', () => {
+        // the cap is the fractional space (getBoundingClientRect), never
+        // the popup's own measured size (offsetWidth/offsetHeight are
+        // integers): rounding that down would wrap or scroll content
+        // that fit before the flip. Content that grows after this pass
+        // still needs a bound, so the flipped side always gets one (#18536)
         const { clientWidth: viewportWidth, clientHeight: viewportHeight } =
           document.documentElement
         const anchorEl = createAnchor({
@@ -324,8 +326,8 @@ describe('[core API]', () => {
 
         expect(res.anchorOrigin).toStrictEqual(origin('top right'))
         expect(res.selfOrigin).toStrictEqual(origin('bottom right'))
-        expect(res.maxHeight).toBeNull()
-        expect(res.maxWidth).toBeNull()
+        expect(res.maxHeight).toBe(`${viewportHeight - 60}px`)
+        expect(res.maxWidth).toBe(`${viewportWidth - 20}px`)
       })
 
       test('measures the natural size by lifting previous caps', () => {

--- a/ui/src/composables/private.use-position-engine/engine/core.test.js
+++ b/ui/src/composables/private.use-position-engine/engine/core.test.js
@@ -330,6 +330,31 @@ describe('[core API]', () => {
         expect(res.maxWidth).toBe(`${viewportWidth - 20}px`)
       })
 
+      test('keeps a smaller caller maxHeight/maxWidth in force through min()', () => {
+        // the flipped-side space can be roomier than a caller-supplied
+        // maxHeight/maxWidth prop; the cap must not widen back to it
+        const { clientWidth: viewportWidth, clientHeight: viewportHeight } =
+          document.documentElement
+        const anchorEl = createAnchor({
+          top: viewportHeight - 60,
+          left: viewportWidth - 120,
+          width: 100,
+          height: 30
+        })
+
+        const res = applyBoundary({
+          el: createTarget({ width: 150.5, height: 50.5 }),
+          anchorEl,
+          anchorOrigin: origin('bottom left'),
+          selfOrigin: origin('top left'),
+          maxHeight: '200px',
+          maxWidth: '300px'
+        })
+
+        expect(res.maxHeight).toBe(`min(${viewportHeight - 60}px, 200px)`)
+        expect(res.maxWidth).toBe(`min(${viewportWidth - 20}px, 300px)`)
+      })
+
       test('measures the natural size by lifting previous caps', () => {
         const anchorEl = createAnchor({
           top: 100,


### PR DESCRIPTION
`applyBoundary()` only wrote a `max-height`/`max-width` cap for a flipped popup when the flipped side didn't have room for it (`space < size`). #18533 added that condition so a popup that already fit wouldn't get its fractional natural size rounded down by a cap at its own integer `offsetWidth`/`offsetHeight`.

The side effect: a popup that fits when it opens now gets no cap at all. The flip already anchored its far edge to the anchor line, so content added afterward (async rows, a QSelect's `before-options`/`after-options` slot re-rendering on its own without touching QSelect's `onUpdated`) grows the popup past the opposite viewport edge. Once it's past `y = 0` there's no scroll position that brings the rows back, since the overflow is in the box's position, not its scroller.

This keeps the cap at `space` (from `getBoundingClientRect`, fractional) instead of the popup's own measured size, so it never squeezes content that already fit, but it's now always applied once a flip decision is made. That's enough to stop later growth from escaping the viewport without reintroducing the rounding issue #18533 fixed.

Updated the existing `position-engine` test that asserted a fitting flipped popup stays uncapped, since that's the behavior this changes.

Fixes #18536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Popups repositioned to the opposite side now consistently respect the available viewport height and width.
  - Prevents popup content from growing beyond the space available after repositioning.
  - Preserves caller-specified size limits, ensuring popups do not exceed their configured maximum dimensions, even when more space is available after repositioning.

- **Tests**
  - Expanded positioning coverage to verify viewport constraints and explicit maximum dimensions remain effective after repositioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->