### PR TITLE
fix(QFabAction): restore the fallback state when used outside a QFab

### DIFF
--- a/ui/src/components/fab/QFabAction.js
+++ b/ui/src/components/fab/QFabAction.js
@@ -41,10 +41,16 @@ export default /*#__PURE__*/ createComponent({
   emits: ['click'],
 
   setup(props, { slots, emit }) {
-    const $fab = inject(fabKey, () => ({
-      showing: { value: true },
-      onChildClick: noop
-    }))
+    // the factory flag is required: without it Vue injects this function
+    // as-is, leaving a QFabAction used outside a QFab with no fallback
+    const $fab = inject(
+      fabKey,
+      () => ({
+        showing: { value: true },
+        onChildClick: noop
+      }),
+      true
+    )
 
     const { formClass, stacked, labelProps } = useFab(props, $fab.showing)
 

--- a/ui/src/components/fab/QFabAction.test.js
+++ b/ui/src/components/fab/QFabAction.test.js
@@ -492,5 +492,24 @@ describe('[QFabAction API]', () => {
         expect(rendered).not.toContain(name)
       }
     })
+
+    test('falls back to a standalone state outside of a QFab', async () => {
+      const wrapper = mount(QFabAction, {
+        props: {
+          externalLabel: true,
+          hideLabel: null,
+          label: 'Create'
+        }
+      })
+
+      expect(getButton(wrapper).attributes('aria-disabled')).toBeUndefined()
+      expect(getLabel(wrapper).classes()).not.toContain(
+        'q-fab__label--external-hidden'
+      )
+
+      await getButton(wrapper).trigger('click')
+
+      expect(wrapper.emitted('click')).toHaveLength(1)
+    })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [x] Any necessary documentation has been added or updated in the docs or explained in the PR's description.

**Other information:**

`QFabAction` declares an `inject()` fallback so it still works when it is not
nested inside a `QFab`:

```js
const $fab = inject(fabKey, () => ({
  showing: { value: true },
  onChildClick: noop
}))
```

The fallback is written as a factory, but `inject()` only calls a function
default when its third argument (`treatDefaultAsFactory`) is `true`. Without
it Vue hands back the function itself, so `$fab` is that arrow function and
`$fab.showing` is `undefined`.

The very next lines read it, in `useFab(props, $fab.showing)` and in

```js
const isDisabled = computed(() => props.disable || !$fab.showing.value)
```

so rendering a standalone `QFabAction` throws during setup's render:

```
TypeError: Cannot read properties of undefined (reading 'value')
 at ComputedRefImpl.fn src/components/fab/QFabAction.js:56:70
```

`$fab.onChildClick(e)` in `click()` would throw for the same reason. The
fallback was therefore dead code: the only path it exists for is the one it
cannot survive.

Passing the flag makes the intended fallback object materialize, so a
standalone `QFabAction` renders enabled and with a visible label, and its
click handler is the documented no-op instead of a crash.

This is only about the no-provider path. Inside a `QFab` the injected value
comes from `provide(fabKey, ...)` and never touched the default, which is why
the existing specs (they all provide `fabKey`) did not catch it.

Verified with a new spec in `QFabAction.test.js` that mounts the component
without providing `fabKey`. Reverting the one-line source change turns it red
with the `TypeError` above; the rest of the fab suite (138 tests) stays green
either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone `QFabAction` usage outside a `QFab`.
  * Standalone actions now remain visible and enabled, support external labels, maintain their own state, and emit click events correctly.

* **Tests**
  * Added coverage for `QFabAction` behavior when used independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->