### PR TITLE
fix(ui): compare binary data by content

### DIFF
--- a/ui/src/utils/is/is.js
+++ b/ui/src/utils/is/is.js
@@ -68,6 +68,17 @@ export function isDeepEqual(a, b) {
       return true
     }
 
+    if (a.constructor === ArrayBuffer) {
+      return isDeepEqual(new Uint8Array(a), new Uint8Array(b))
+    }
+
+    if (a.constructor === DataView) {
+      return isDeepEqual(
+        new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
+        new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
+      )
+    }
+
     // oxlint-disable-next-line eqeqeq
     if (a.buffer != null && a.buffer.constructor === ArrayBuffer) {
       length = a.length

--- a/ui/src/utils/is/is.test.js
+++ b/ui/src/utils/is/is.test.js
@@ -15,6 +15,12 @@ describe('[is API]', () => {
         ['Infinity', Infinity, Infinity],
         ['Date', new Date(150), new Date(150)],
         ['RegExp', /./, /./],
+        ['ArrayBuffer', Uint8Array.of(1).buffer, Uint8Array.of(1).buffer],
+        [
+          'DataView',
+          new DataView(Uint8Array.of(0, 1, 0).buffer, 1, 1),
+          new DataView(Uint8Array.of(2, 1, 2).buffer, 1, 1)
+        ],
         ['Array', [1, 2, 3], [1, 2, 3]],
         [
           'Map',
@@ -70,6 +76,17 @@ describe('[is API]', () => {
         ['5, Set()', 5, new Set([5])],
         ['5, Fn', 5, () => 5]
       ])('deepEqual(%s)', (_, a, b) => {
+        expect(is.deepEqual(a, b)).toBe(false)
+      })
+
+      test.each([
+        ['ArrayBuffer', Uint8Array.of(1).buffer, Uint8Array.of(2).buffer],
+        [
+          'DataView',
+          new DataView(Uint8Array.of(1).buffer),
+          new DataView(Uint8Array.of(2).buffer)
+        ]
+      ])('distinguishes %s instances by content', (_, a, b) => {
         expect(is.deepEqual(a, b)).toBe(false)
       })
     })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

`is.deepEqual()` treated every pair of ArrayBuffers with the same constructor as equal because ArrayBuffer contents are not enumerable. DataView comparisons could also loop indefinitely because the existing ArrayBuffer-view path iterated a missing `.length` property.

This compares ArrayBuffer bytes through Uint8Array views and handles each DataView's exposed byte range. Existing typed-array comparison behavior is unchanged.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated, or explained in the PR's description

No documentation change is needed: this restores the documented ArrayBuffer support of `is.deepEqual()` without changing its API.

Validation:

- `pnpm --dir ui exec vitest run -c test/vitest.config.js src/utils/is/is.test.js` — 70 passed
- `pnpm lint:check` — passed
- `git diff --check` — passed

The aggregate `pnpm test` baseline was also attempted. Its build/spec checks and many browser tests passed, but parallel browser suites exhausted the host file-watcher limit (`ENOSPC`); the isolated affected suite is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep equality comparisons for `ArrayBuffer` and `DataView` values by checking their byte contents.
  * Prevents matching binary data from being treated as different, or differing data as equivalent.

* **Tests**
  * Added coverage for matching and non-matching `ArrayBuffer` and `DataView` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->