### PR TITLE
fix(ui): Handle null-prototype objects in deepEqual

### DIFF
--- a/ui/src/utils/is/is.js
+++ b/ui/src/utils/is/is.js
@@ -99,7 +99,8 @@ export function isDeepEqual(a, b) {
     if (
       typeof a.valueOf === 'function' &&
       typeof b.valueOf === 'function' &&
-      a.valueOf !== Object.prototype.valueOf
+      a.valueOf !== Object.prototype.valueOf &&
+      b.valueOf !== Object.prototype.valueOf
     ) {
       return a.valueOf() === b.valueOf()
     }
@@ -107,7 +108,8 @@ export function isDeepEqual(a, b) {
     if (
       typeof a.toString === 'function' &&
       typeof b.toString === 'function' &&
-      a.toString !== Object.prototype.toString
+      a.toString !== Object.prototype.toString &&
+      b.toString !== Object.prototype.toString
     ) {
       return a.toString() === b.toString()
     }

--- a/ui/src/utils/is/is.js
+++ b/ui/src/utils/is/is.js
@@ -96,11 +96,19 @@ export function isDeepEqual(a, b) {
       return a.source === b.source && a.flags === b.flags
     }
 
-    if (a.valueOf !== Object.prototype.valueOf) {
+    if (
+      typeof a.valueOf === 'function' &&
+      typeof b.valueOf === 'function' &&
+      a.valueOf !== Object.prototype.valueOf
+    ) {
       return a.valueOf() === b.valueOf()
     }
 
-    if (a.toString !== Object.prototype.toString) {
+    if (
+      typeof a.toString === 'function' &&
+      typeof b.toString === 'function' &&
+      a.toString !== Object.prototype.toString
+    ) {
       return a.toString() === b.toString()
     }
 

--- a/ui/src/utils/is/is.test.js
+++ b/ui/src/utils/is/is.test.js
@@ -116,6 +116,19 @@ describe('[is API]', () => {
         expect(is.deepEqual(a, b)).toBe(true)
         expect(is.deepEqual(a, c)).toBe(false)
       })
+
+      test.each(['valueOf', 'toString'])(
+        'uses %s only when both objects override it',
+        method => {
+          const a = { value: 1 }
+          const b = Object.assign(Object.create({ [method]: () => 'custom' }), {
+            value: 1
+          })
+
+          expect(is.deepEqual(a, b)).toBe(true)
+          expect(is.deepEqual(b, a)).toBe(true)
+        }
+      )
     })
 
     describe('[(function)object]', () => {

--- a/ui/src/utils/is/is.test.js
+++ b/ui/src/utils/is/is.test.js
@@ -107,6 +107,15 @@ describe('[is API]', () => {
       ])('distinguishes %s instances by content', (_, a, b) => {
         expect(is.deepEqual(a, b)).toBe(false)
       })
+
+      test('handles objects without Object.prototype', () => {
+        const a = Object.assign(Object.create(null), { value: 1 })
+        const b = Object.assign(Object.create(null), { value: 1 })
+        const c = Object.assign(Object.create(null), { value: 2 })
+
+        expect(is.deepEqual(a, b)).toBe(true)
+        expect(is.deepEqual(a, c)).toBe(false)
+      })
     })
 
     describe('[(function)object]', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Problem**

`is.deepEqual()` throws for objects created with `Object.create(null)` because those objects do not inherit callable `valueOf()` or `toString()` methods.

**Solution**

Only use custom conversion methods when both operands provide callable, non-native methods. Objects without `Object.prototype`, and asymmetric overrides, then use the existing structural key comparison.

**Validation**

- [x] Submitted against `dev`.
- [x] Focused browser suite: 79 passed; regression failed before the fix with the expected `TypeError`.
- [x] Specs validation for `utils/is/is` passed.
- [x] Root formatting and lint checks passed.
- [x] Full UI test run passed: build 11, unit 6,206, hydration 143, hydration-PWA 6, UMD 78, SSR E2E 239.
- [x] After the review follow-up, focused tests, Specs validation, formatting and lint were rerun on the final head.
- [x] Documentation remains accurate; no API, types, or options changed.
- [ ] Cordova/Electron manual testing — not applicable to this platform-independent utility fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deep equality comparisons for objects when one or both values lack custom `valueOf` or `toString` methods.
  - Correctly handles objects that use default conversion methods or have no standard object prototype.

- **Tests**
  - Added regression coverage for comparing objects with asymmetric `valueOf` or `toString` implementations in either operand order.
  - Retained coverage for prototype-less objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->