### PR TITLE
fix(Ripple): the argument and the modifiers follow runtime changes

### DIFF
--- a/ui/src/directives/ripple/Ripple.js
+++ b/ui/src/directives/ripple/Ripple.js
@@ -158,6 +158,8 @@ function setOptions(ctx, { modifiers, value, arg }) {
   const cfg = { ...ctx.cfg, ...modifiers, ...value }
   const keyCodes = cfg.keyCodes || 13
 
+  ctx.arg = arg
+  ctx.modifiers = modifiers
   ctx.early = cfg.early === true
   ctx.stop = cfg.stop === true
   ctx.center = cfg.center === true
@@ -195,6 +197,8 @@ export default /*#__PURE__*/ createDirective(
           const ctx = {
             cfg: cfg.ripple,
             enabled: binding.value !== false,
+            arg: void 0,
+            modifiers: void 0,
             early: false,
             stop: false,
             center: false,
@@ -211,18 +215,23 @@ export default /*#__PURE__*/ createDirective(
         },
 
         updated(el, binding) {
-          if (binding.oldValue !== binding.value) {
-            const ctx = el.__qripple
-            if (ctx !== void 0) {
-              ctx.enabled = binding.value !== false
+          const ctx = el.__qripple
+          if (ctx === void 0) return
 
-              if (ctx.enabled && Object(binding.value) === binding.value) {
-                setOptions(ctx, binding)
-              }
+          const { value, oldValue, arg, modifiers } = binding
 
-              bind(el, ctx)
-            }
+          ctx.enabled = value !== false
+
+          if (
+            ctx.enabled &&
+            (value !== oldValue ||
+              arg !== ctx.arg ||
+              modifiers !== ctx.modifiers)
+          ) {
+            setOptions(ctx, binding)
           }
+
+          bind(el, ctx)
         },
 
         beforeUnmount(el) {

--- a/ui/src/directives/ripple/Ripple.test.js
+++ b/ui/src/directives/ripple/Ripple.test.js
@@ -387,6 +387,67 @@ describe('[Ripple API]', () => {
       expect(wrapper.findAll('.q-ripple').length).toBe(2)
     })
 
+    test('follows the argument and the modifiers when they change at runtime', async () => {
+      const arg = ref('orange-5')
+      const modifiers = ref({})
+      const TestComponent = defineComponent({
+        setup() {
+          return () =>
+            withDirectives(h('div'), [
+              [Ripple, void 0, arg.value, modifiers.value]
+            ])
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      await wrapper.trigger('click')
+
+      expect(wrapper.findAll('.q-ripple').length).toBe(1)
+      expect(wrapper.get('.q-ripple').classes()).toContain('text-orange-5')
+
+      arg.value = 'red'
+      modifiers.value = { early: true }
+      await flushPromises()
+
+      // the click listener gave way to the early (pointerdown) one
+      await wrapper.trigger('click')
+
+      expect(wrapper.findAll('.q-ripple').length).toBe(1)
+
+      firePointer(wrapper, 'pointerdown', { pointerId: 7 })
+
+      const ripples = wrapper.findAll('.q-ripple')
+
+      expect(ripples.length).toBe(2)
+      expect(ripples[1].classes()).toContain('text-red')
+    })
+
+    test('drops the object options when the value goes back to true', async () => {
+      const val = ref({ color: 'red' })
+      const TestComponent = defineComponent({
+        setup() {
+          return () => withDirectives(h('div'), [[Ripple, val.value]])
+        }
+      })
+
+      const wrapper = mount(TestComponent)
+
+      await wrapper.trigger('click')
+
+      expect(wrapper.get('.q-ripple').classes()).toContain('text-red')
+
+      val.value = true
+      await flushPromises()
+
+      await wrapper.trigger('click')
+
+      const ripples = wrapper.findAll('.q-ripple')
+
+      expect(ripples.length).toBe(2)
+      expect(ripples[1].classes()).not.toContain('text-red')
+    })
+
     test('ignores every trigger while disabled and reacts again once re-enabled', async () => {
       const val = ref(false)
       const TestComponent = defineComponent({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

**Other information:**

### The bug

`v-ripple`'s `updated()` hook only looks at the directive value:

```js
updated(el, binding) {
  if (binding.oldValue !== binding.value) {
    ...
    if (ctx.enabled && Object(binding.value) === binding.value) {
      setOptions(ctx, binding)
    }
    ...
  }
}
```

`setOptions()` is the only place the argument and the modifiers are read, so both are frozen at mount:

1. `v-ripple:[color]` with no value: the value is `undefined` on every render, so the guard never opens and the ripple keeps its mount-time color forever.
2. A modifiers object that changes while the value reference does not: `early` / `stop` / `center` / `keyCodes` stay stale.
3. Setting the value back to `true` after an object: the `Object(value) === value` check skips `setOptions()`, so the object's options survive. Mount with `true` and update to `true` end up with different settings for the same input.

Case 2 happens with Quasar's own QBtn. `rippleProps` is `computed(() => ({ center: props.round }))` and the `ripple` computed does not read `props.round`, so toggling `round` at runtime hands the directive a new modifiers object and the same value reference. The ripple keeps starting from the press point instead of the center (or the other way round).

### How to reproduce

```html
<q-btn :round="isRound" icon="star" label="x" @click="isRound = !isRound" />
```

The first click makes the button round, but the ripple keeps originating from the press point. Same for a dynamic argument:

```html
<div v-ripple:[color]>tap me</div>
```

Changing `color` has no effect after the first render.

### Root cause

`updated()` gated everything on the value reference, and `setOptions()` (the only reader of `binding.arg` and `binding.modifiers`) was reachable only through that gate and only for object values.

### The fix

`updated()` now re-derives the options whenever the value, the argument or the modifiers object differs from the one the context was built with, and `setOptions()` records the argument and the modifiers on the context for that comparison. This is the shape the four touch directives were given in 4e7f7b6 and ScrollFire in ee88f70; `v-ripple` was the remaining directive with a documented argument that never re-read it.

As noted in 4e7f7b6, the identity check only skips work for `withDirectives()` callers holding a stable object (QBtn, QChip, QTab and StepHeader all pass one from a computed); a compiled template passes a new modifiers object on every host re-render, exactly as before this PR.

### Tests

Two tests added to `Ripple.test.js`:

- `follows the argument and the modifiers when they change at runtime`: mounts with `arg = 'orange-5'` and empty modifiers, asserts the click ripple is `text-orange-5`, then switches to `arg = 'red'` and `{ early: true }` and asserts that a click no longer produces a ripple (the early listener replaced the click one) while a `pointerdown` produces a `text-red` one.
- `drops the object options when the value goes back to true`: mounts with `{ color: 'red' }`, then sets the value to `true` and asserts the next ripple is not `text-red`.

Both fail on `dev` (`expected 2 to be 1` and `expected [ 'q-ripple', 'text-red' ] to not include 'text-red'`) and pass with the fix. `pnpm test:specs:check`, the full `src/directives` unit suite, the ripple hydration test and the QBtn / QChip / QTabs / QStepper suites all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ripple effects now react correctly when their color or modifiers change at runtime.
  - Switching the “early” interaction modifier now updates the ripple trigger appropriately.
  - Object-based ripple options are cleared when changing back to the default enabled state.
- **Tests**
  - Added coverage for dynamic ripple configuration changes and option resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->