### PR TITLE
fix(debounce): guard reentrant immediate calls

### DIFF
--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -357,7 +357,7 @@ If your App uses JavaScript to accomplish taxing tasks, a debounce function is e
 
 Debouncing enforces that a function not be called again until a certain amount of time has passed without it being called. As in "execute this function only if 100 milliseconds have passed without it being called."
 
-With `immediate: true`, the wait period starts before the callback runs, so calls made from within that callback are debounced too.
+When `immediate` is `true`, the wait period starts before the callback runs, so calls made from within that callback are debounced too.
 
 A quick example: you have a resize listener on the window which does some element dimension calculations and (possibly) repositions a few elements. That isn't a heavy task in itself but being repeatedly fired after numerous resizes will really slow your App down. So why not limit the rate at which the function can fire?
 

--- a/docs/src/pages/quasar-utils/other-utils.md
+++ b/docs/src/pages/quasar-utils/other-utils.md
@@ -357,6 +357,8 @@ If your App uses JavaScript to accomplish taxing tasks, a debounce function is e
 
 Debouncing enforces that a function not be called again until a certain amount of time has passed without it being called. As in "execute this function only if 100 milliseconds have passed without it being called."
 
+With `immediate: true`, the wait period starts before the callback runs, so calls made from within that callback are debounced too.
+
 A quick example: you have a resize listener on the window which does some element dimension calculations and (possibly) repositions a few elements. That isn't a heavy task in itself but being repeatedly fired after numerous resizes will really slow your App down. So why not limit the rate at which the function can fire?
 
 ```js

--- a/ui/src/utils/debounce/debounce.js
+++ b/ui/src/utils/debounce/debounce.js
@@ -3,6 +3,7 @@ export default function debounce(fn, wait = 250, immediate) {
   let timer = null
 
   function debounced(...args) {
+    const callNow = immediate && timer === null
     const later = () => {
       timer = null
       if (!immediate) fn.apply(this, args)
@@ -10,11 +11,10 @@ export default function debounce(fn, wait = 250, immediate) {
 
     if (timer !== null) {
       clearTimeout(timer)
-    } else if (immediate) {
-      fn.apply(this, args)
     }
 
     timer = setTimeout(later, wait)
+    if (callNow) fn.apply(this, args)
   }
 
   debounced.cancel = () => {

--- a/ui/src/utils/debounce/debounce.test.js
+++ b/ui/src/utils/debounce/debounce.test.js
@@ -71,6 +71,19 @@ describe('[debounce API]', () => {
         expect(callback).not.toHaveBeenCalled()
       })
 
+      test('debounces calls made from the immediate callback', () => {
+        const callback = vi.fn(() => {
+          if (callback.mock.calls.length === 1) fn()
+        })
+        const fn = debounce(callback, 100, true)
+
+        fn()
+        expect(callback).toHaveBeenCalledTimes(1)
+        vi.advanceTimersByTime(100)
+        fn()
+        expect(callback).toHaveBeenCalledTimes(2)
+      })
+
       test('should execute with correct args when called again from within timeout', () => {
         const callback = vi.fn()
         const fn = debounce(callback, 100)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**

An immediate debounced callback can call itself again before the timer is assigned, causing a second leading invocation within the same wait window. Independently reproduced on current `dev`:

```js
let calls = 0
const fn = debounce(() => {
  if (++calls === 1) fn()
}, 100, true)
fn()
// Previously calls === 2; expected 1.
```

Schedule the timer before invoking the callback, retaining the initial leading-edge decision. The regression also checks that another leading invocation is allowed after the wait. The public signature is unchanged; existing trailing, cancellation and receiver/argument tests remain intact.

Validation:
- Targeted debounce test: regression failed before the fix (expected 1 call, received 2); all 15 tests passed after.
- `pnpm --dir ui test:specs --target utils/debounce/debounce`: passed.
- `pnpm lint`: passed.
- Full root `pnpm test`: passed (6,246 unit, 143 hydration, 78 UMD, 11 build, 6 hydration-PWA and 239 SSR tests). Four SSR routes required the suite's automatic retry: intersection-6-iframe, regression-sweep, screen-height and tree-perf.
- `git diff --check`: passed.

Cordova and Electron application tests were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed immediate debounce behavior so calls made within the callback are correctly delayed and debounced.

- **Documentation**
  - Clarified that the debounce wait period starts before an immediate callback runs.

- **Tests**
  - Added coverage verifying nested calls are delayed and execute only after the debounce period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->